### PR TITLE
feat(returns): expose session.returns on the WIT component (Phase 3, #1847)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,6 +3651,7 @@ dependencies = [
  "rustledger-core",
  "rustledger-loader",
  "rustledger-parser",
+ "rustledger-returns",
  "serde_json",
  "thiserror 2.0.19",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "rustledger-ops",
  "rustledger-parser",
  "rustledger-query",
+ "rustledger-returns",
  "rustledger-validate",
  "serde_json",
  "wit-bindgen 0.59.0",
@@ -3455,10 +3456,13 @@ name = "rustledger-ffi-component-tests"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "rustledger-booking",
  "rustledger-core",
  "rustledger-ffi-wasi",
  "rustledger-importer",
  "rustledger-ops",
+ "rustledger-query",
+ "rustledger-returns",
  "tempfile",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -527,18 +527,14 @@ impl BookingEngine {
     /// Apply ONE posting to the running inventories, returning an error if it
     /// reduces a lot that is not held.
     ///
-    /// The per-posting core of [`Self::apply`] (which ignores a reduction
-    /// failure, per its booked-input contract; this method surfaces it). Public
-    /// so a consumer that realizes only a SUBSET of a transaction's postings —
-    /// e.g. the returns engine valuing only its in-scope investment accounts —
-    /// can book exactly those and leave an unrelated account's over-sell (which
-    /// the loader may have re-merged un-booked) untouched, rather than aborting
-    /// on a posting it never values.
+    /// The per-posting core shared by [`Self::apply`] (which ignores a reduction
+    /// failure, per its booked-input contract) and [`Self::try_apply`] (which
+    /// surfaces it).
     ///
     /// # Errors
     /// Returns the reduce error when the posting reduces a lot that is not held
     /// (an over-sell / unbooked-input contract violation).
-    pub fn try_apply_posting(
+    fn try_apply_posting(
         &mut self,
         posting: &Posting,
         date: rustledger_core::NaiveDate,
@@ -585,8 +581,7 @@ impl BookingEngine {
     /// in-loop `debug_assert` below catches a violating caller in debug builds.
     /// A caller that CANNOT guarantee booked input (e.g. valuing a returns scope
     /// over a ledger whose loader re-merged a booking-failed transaction) must
-    /// apply per posting with [`Self::try_apply_posting`], which surfaces the
-    /// failure as an `Err`.
+    /// use [`Self::try_apply`] instead, which surfaces the failure as an `Err`.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
@@ -595,11 +590,32 @@ impl BookingEngine {
                 "apply() reduction failed — the transaction must be booked \
                  before apply() (postings filled, costs resolved); applying an \
                  unbooked reduction silently over-sells inventory. Use \
-                 try_apply_posting() if the input may be unbooked."
+                 try_apply() if the input may be unbooked."
             );
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;
         }
+    }
+
+    /// Fallible [`Self::apply`]: apply a transaction's postings, but return an
+    /// error the moment a reduction has no matching lot instead of
+    /// `debug_assert`-ing (debug) or silently over-selling (release).
+    ///
+    /// For consumers that realize inventory over a stream they cannot guarantee
+    /// is booked — the returns engine values a scope over `Ledger.directives`,
+    /// which the loader re-merges booking-FAILED transactions into in their
+    /// un-booked shape — so the failure becomes a clean `Err` at the boundary
+    /// rather than a wasm trap or a wrong figure.
+    ///
+    /// # Errors
+    /// Returns [`BookingError::Inventory`] on the first posting that reduces a
+    /// lot not held. Postings before it have already been applied (the caller is
+    /// expected to discard the engine on error).
+    pub fn try_apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
+        for posting in &txn.postings {
+            self.try_apply_posting(posting, txn.date)?;
+        }
+        Ok(())
     }
 
     /// Book and interpolate a transaction.

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -524,6 +524,46 @@ impl BookingEngine {
         })
     }
 
+    /// Apply one posting to the running inventories. The per-posting core shared
+    /// by [`Self::apply`] (which ignores a reduction failure, per its booked-input
+    /// contract) and [`Self::try_apply`] (which surfaces it).
+    ///
+    /// # Errors
+    /// Returns the reduce error when the posting reduces a lot that is not held
+    /// (an over-sell / unbooked-input contract violation).
+    fn apply_posting(
+        &mut self,
+        posting: &Posting,
+        date: rustledger_core::NaiveDate,
+    ) -> Result<(), BookingError> {
+        let Some(IncompleteAmount::Complete(units)) = &posting.units else {
+            return Ok(());
+        };
+        // Resolve the per-account booking method before mutably borrowing the
+        // inventories map.
+        let method = self.method_for(&posting.account);
+        let inv = self.inventories.entry(posting.account.clone()).or_default();
+
+        // Reduction vs augmentation — the single source for this decision
+        // (`Inventory::is_booking_reduction`), shared with the Late validator so
+        // the two can't drift (including the #1182 NONE gate that previously had
+        // to be maintained in both crates).
+        if inv.is_booking_reduction(units, posting.cost.as_ref(), method) {
+            // `reduce` only errors when the lot it would match is missing — a
+            // "must book first" precondition violation.
+            inv.reduce(units, posting.cost.as_ref(), method)
+                .map_err(|e| convert_core_booking_error(e, &posting.account))?;
+        } else {
+            // Add to inventory via the canonical cost-resolve shared with the Late
+            // validator, `build_balances`, and the query engine (see
+            // `CostSpec::resolve`). `apply`'s callers book first, which fills the
+            // inferred currency into `cost_spec.currency`; direct-`apply` tests use
+            // explicit-currency fixtures, which need no inference.
+            inv.add(Position::from_posting(units, posting.cost.as_ref(), date));
+        }
+        Ok(())
+    }
+
     /// Apply a transaction's postings to the running inventories (update
     /// balances).
     ///
@@ -533,60 +573,46 @@ impl BookingEngine {
     /// units and resolved costs, as produced by [`Self::book_and_interpolate`]
     /// or the free [`book`](crate::book) function. Applying an *unbooked*
     /// transaction can silently over-sell an inventory: a reduction with no
-    /// matching lot yet is dropped (its `reduce` error is otherwise ignored).
-    /// The loader pipeline guarantees this ordering; the in-loop `debug_assert`
-    /// below catches a violating caller in debug builds.
+    /// matching lot yet is dropped (its `reduce` error is ignored, historical
+    /// release behavior). The loader pipeline guarantees this ordering; the
+    /// in-loop `debug_assert` below catches a violating caller in debug builds.
+    /// A caller that CANNOT guarantee booked input (e.g. valuing a returns scope
+    /// over a ledger whose loader re-merged a booking-failed transaction) must
+    /// use [`Self::try_apply`] instead, which surfaces the failure as an `Err`.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
-            if let Some(IncompleteAmount::Complete(units)) = &posting.units {
-                // Resolve the per-account booking method before mutably
-                // borrowing the inventories map.
-                let method = self.method_for(&posting.account);
-                let inv = self.inventories.entry(posting.account.clone()).or_default();
-
-                // Reduction vs augmentation — the single source for this decision
-                // (`Inventory::is_booking_reduction`), shared with the Late
-                // validator so the two can't drift (including the #1182 NONE gate
-                // that previously had to be maintained in both crates).
-                let is_reduction = inv.is_booking_reduction(units, posting.cost.as_ref(), method);
-
-                if is_reduction {
-                    // Reduce from inventory. `reduce` only errors when the lot
-                    // it would match is missing — a "must book first" precondition
-                    // violation (see the fn-level doc). In release builds the
-                    // historical behavior (ignore) is kept; in debug builds we
-                    // surface the unbooked-apply bug instead of silently
-                    // over-selling.
-                    let reduced = inv.reduce(units, posting.cost.as_ref(), method);
-                    debug_assert!(
-                        reduced.is_ok(),
-                        "apply() reduction failed — the transaction must be booked \
-                         before apply() (postings filled, costs resolved); applying \
-                         an unbooked reduction silently over-sells inventory"
-                    );
-                    // `reduced` is consumed only by the debug assertion above;
-                    // release builds keep the historical ignore-the-Result behavior.
-                    let _ = reduced;
-                } else {
-                    // Add to inventory via the canonical cost-resolve shared with
-                    // the Late validator, `build_balances`, and the query engine.
-                    // Its per-unit / date / label handling matches the block this
-                    // replaced (see `CostSpec::resolve`). The old inline price /
-                    // cross-posting cost-currency inference is unnecessary here:
-                    // `apply` is contracted to run on *booked* transactions (the
-                    // `debug_assert` above; the production pipeline always
-                    // `book_and_interpolate`s first), and booking fills the
-                    // inferred currency into `cost_spec.currency`. Tests that call
-                    // `apply` directly use explicit-currency fixtures, which need
-                    // no inference.
-                    inv.add(Position::from_posting(
-                        units,
-                        posting.cost.as_ref(),
-                        txn.date,
-                    ));
-                }
-            }
+            let reduced = self.apply_posting(posting, txn.date);
+            debug_assert!(
+                reduced.is_ok(),
+                "apply() reduction failed — the transaction must be booked \
+                 before apply() (postings filled, costs resolved); applying an \
+                 unbooked reduction silently over-sells inventory. Use \
+                 try_apply() if the input may be unbooked."
+            );
+            // Release builds keep the historical ignore-and-continue behavior.
+            let _ = reduced;
         }
+    }
+
+    /// Fallible [`Self::apply`]: apply a transaction's postings, but return an
+    /// error the moment a reduction has no matching lot instead of
+    /// `debug_assert`-ing (debug) or silently over-selling (release).
+    ///
+    /// For consumers that realize inventory over a stream they cannot guarantee
+    /// is booked — the returns engine values a scope over `Ledger.directives`,
+    /// which the loader re-merges booking-FAILED transactions into in their
+    /// un-booked shape — so the failure becomes a clean `Err` at the boundary
+    /// rather than a wasm trap or a wrong figure.
+    ///
+    /// # Errors
+    /// Returns [`BookingError::Inventory`] on the first posting that reduces a
+    /// lot not held. Postings before it have already been applied (the caller is
+    /// expected to discard the engine on error).
+    pub fn try_apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
+        for posting in &txn.postings {
+            self.apply_posting(posting, txn.date)?;
+        }
+        Ok(())
     }
 
     /// Book and interpolate a transaction.

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -527,13 +527,13 @@ impl BookingEngine {
     /// Apply ONE posting to the running inventories, returning an error if it
     /// reduces a lot that is not held.
     ///
-    /// The per-posting core shared by [`Self::apply`] (which ignores a reduction
-    /// failure, per its booked-input contract) and [`Self::try_apply`] (which
-    /// surfaces it). Public so a consumer that realizes only a SUBSET of a
-    /// transaction's postings — e.g. the returns engine valuing only its
-    /// in-scope investment accounts — can book exactly those and leave an
-    /// unrelated account's over-sell (which the loader may have re-merged
-    /// un-booked) untouched, rather than aborting on a posting it never values.
+    /// The per-posting core of [`Self::apply`] (which ignores a reduction
+    /// failure, per its booked-input contract; this method surfaces it). Public
+    /// so a consumer that realizes only a SUBSET of a transaction's postings —
+    /// e.g. the returns engine valuing only its in-scope investment accounts —
+    /// can book exactly those and leave an unrelated account's over-sell (which
+    /// the loader may have re-merged un-booked) untouched, rather than aborting
+    /// on a posting it never values.
     ///
     /// # Errors
     /// Returns the reduce error when the posting reduces a lot that is not held
@@ -585,7 +585,8 @@ impl BookingEngine {
     /// in-loop `debug_assert` below catches a violating caller in debug builds.
     /// A caller that CANNOT guarantee booked input (e.g. valuing a returns scope
     /// over a ledger whose loader re-merged a booking-failed transaction) must
-    /// use [`Self::try_apply`] instead, which surfaces the failure as an `Err`.
+    /// apply per posting with [`Self::try_apply_posting`], which surfaces the
+    /// failure as an `Err`.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
@@ -594,32 +595,11 @@ impl BookingEngine {
                 "apply() reduction failed — the transaction must be booked \
                  before apply() (postings filled, costs resolved); applying an \
                  unbooked reduction silently over-sells inventory. Use \
-                 try_apply() if the input may be unbooked."
+                 try_apply_posting() if the input may be unbooked."
             );
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;
         }
-    }
-
-    /// Fallible [`Self::apply`]: apply a transaction's postings, but return an
-    /// error the moment a reduction has no matching lot instead of
-    /// `debug_assert`-ing (debug) or silently over-selling (release).
-    ///
-    /// For consumers that realize inventory over a stream they cannot guarantee
-    /// is booked — the returns engine values a scope over `Ledger.directives`,
-    /// which the loader re-merges booking-FAILED transactions into in their
-    /// un-booked shape — so the failure becomes a clean `Err` at the boundary
-    /// rather than a wasm trap or a wrong figure.
-    ///
-    /// # Errors
-    /// Returns [`BookingError::Inventory`] on the first posting that reduces a
-    /// lot not held. Postings before it have already been applied (the caller is
-    /// expected to discard the engine on error).
-    pub fn try_apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
-        for posting in &txn.postings {
-            self.try_apply_posting(posting, txn.date)?;
-        }
-        Ok(())
     }
 
     /// Book and interpolate a transaction.

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -524,14 +524,21 @@ impl BookingEngine {
         })
     }
 
-    /// Apply one posting to the running inventories. The per-posting core shared
-    /// by [`Self::apply`] (which ignores a reduction failure, per its booked-input
-    /// contract) and [`Self::try_apply`] (which surfaces it).
+    /// Apply ONE posting to the running inventories, returning an error if it
+    /// reduces a lot that is not held.
+    ///
+    /// The per-posting core shared by [`Self::apply`] (which ignores a reduction
+    /// failure, per its booked-input contract) and [`Self::try_apply`] (which
+    /// surfaces it). Public so a consumer that realizes only a SUBSET of a
+    /// transaction's postings — e.g. the returns engine valuing only its
+    /// in-scope investment accounts — can book exactly those and leave an
+    /// unrelated account's over-sell (which the loader may have re-merged
+    /// un-booked) untouched, rather than aborting on a posting it never values.
     ///
     /// # Errors
     /// Returns the reduce error when the posting reduces a lot that is not held
     /// (an over-sell / unbooked-input contract violation).
-    fn apply_posting(
+    pub fn try_apply_posting(
         &mut self,
         posting: &Posting,
         date: rustledger_core::NaiveDate,
@@ -581,7 +588,7 @@ impl BookingEngine {
     /// use [`Self::try_apply`] instead, which surfaces the failure as an `Err`.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
-            let reduced = self.apply_posting(posting, txn.date);
+            let reduced = self.try_apply_posting(posting, txn.date);
             debug_assert!(
                 reduced.is_ok(),
                 "apply() reduction failed — the transaction must be booked \
@@ -610,7 +617,7 @@ impl BookingEngine {
     /// expected to discard the engine on error).
     pub fn try_apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
         for posting in &txn.postings {
-            self.apply_posting(posting, txn.date)?;
+            self.try_apply_posting(posting, txn.date)?;
         }
         Ok(())
     }

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -607,6 +607,12 @@ impl BookingEngine {
     /// un-booked shape — so the failure becomes a clean `Err` at the boundary
     /// rather than a wasm trap or a wrong figure.
     ///
+    /// This catches the ONE un-booked shape the booking engine can detect: a
+    /// reduction with no matching lot. A posting with elided/uninterpolated units
+    /// is still SKIPPED (as in [`Self::apply`]) — interpolation is a separate
+    /// pass this engine does not run — so a caller that must also reject elided
+    /// input checks `units` for [`IncompleteAmount::Complete`] itself.
+    ///
     /// # Errors
     /// Returns [`BookingError::Inventory`] on the first posting that reduces a
     /// lot not held. Postings before it have already been applied (the caller is

--- a/crates/rustledger-ffi-component-tests/Cargo.toml
+++ b/crates/rustledger-ffi-component-tests/Cargo.toml
@@ -16,10 +16,13 @@ wasmtime = { workspace = true, features = ["component-model"] }
 wasmtime-wasi.workspace = true
 anyhow = "1"
 tempfile.workspace = true
+rustledger-booking.workspace = true
 rustledger-core.workspace = true
 rustledger-ffi-wasi.workspace = true
 rustledger-importer = { workspace = true, features = ["toml-config"] }
 rustledger-ops.workspace = true
+rustledger-query.workspace = true
+rustledger-returns.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -714,12 +714,13 @@ fn session_format_honors_display_precision() -> Result<()> {
 }
 
 /// `session.returns` (WIT 3.9.0, #1847): the component's returns over the held
-/// ledger must equal a NATIVE `rustledger_returns::compute_returns` over the
-/// same booked, pad-expanded stream + price index (the CLI's exact composition).
-/// Drift guard across the wasm boundary — the decimal fields (rust_decimal, pure
-/// integer arithmetic) must match byte-for-byte; the two `f64` rates are
-/// compared within a tolerance, since wasm and native float can differ by an ULP
-/// in the XIRR/TWR iteration.
+/// ledger must equal the NATIVE `rustledger_query::scope_returns` over the same
+/// booked, pad-expanded stream — the SAME composition the CLI's `report returns`
+/// calls, so this pins the wasm surface against the CLI's returns path, not a
+/// private re-implementation. Drift guard across the wasm boundary: the decimal
+/// fields (rust_decimal, pure integer arithmetic) must match byte-for-byte; the
+/// two `f64` rates are compared within a tolerance, since wasm and native float
+/// can differ by an ULP in the XIRR/TWR iteration.
 #[test]
 fn session_returns_matches_native_engine() -> Result<()> {
     if !component_path().exists() {
@@ -758,18 +759,7 @@ option \"operating_currency\" \"USD\"
         .map_err(|e| anyhow::anyhow!("returns failed: {e}"))?;
     handle.resource_drop(&mut store)?;
 
-    // Native reference: the exact engine + inputs the CLI uses.
-    struct Oracle<'a>(&'a rustledger_query::PriceDatabase);
-    impl rustledger_returns::PriceOracle for Oracle<'_> {
-        fn convert(
-            &self,
-            amount: &rustledger_core::Amount,
-            to_currency: &str,
-            date: rustledger_core::NaiveDate,
-        ) -> Option<rustledger_core::Amount> {
-            self.0.convert(amount, to_currency, date)
-        }
-    }
+    // Native reference: the shared helper both the CLI and the component call.
     let native = rustledger_ffi_wasi::helpers::load_source(LEDGER);
     assert!(
         native.errors.is_empty(),
@@ -778,9 +768,8 @@ option \"operating_currency\" \"USD\"
     );
     let padded = rustledger_booking::merge_with_padding(&native.directives);
     let scope = rustledger_returns::Scope::new(investments.clone(), income.clone());
-    let db = rustledger_query::PriceDatabase::from_directives(&padded);
     let end = "2021-01-01".parse().expect("date");
-    let direct = rustledger_returns::compute_returns(&padded, &scope, "USD", &Oracle(&db), end)
+    let direct = rustledger_query::scope_returns(&padded, &scope, "USD", end)
         .expect("native engine computes");
 
     // Decimal fields: exact (rust_decimal is deterministic across targets).

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -713,6 +713,103 @@ fn session_format_honors_display_precision() -> Result<()> {
     Ok(())
 }
 
+/// `session.returns` (WIT 3.9.0, #1847): the component's returns over the held
+/// ledger must equal a NATIVE `rustledger_returns::compute_returns` over the
+/// same booked, pad-expanded stream + price index (the CLI's exact composition).
+/// Drift guard across the wasm boundary — the decimal fields (rust_decimal, pure
+/// integer arithmetic) must match byte-for-byte; the two `f64` rates are
+/// compared within a tolerance, since wasm and native float can differ by an ULP
+/// in the XIRR/TWR iteration.
+#[test]
+fn session_returns_matches_native_engine() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    const LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:Invest:Broker
+2020-01-01 open Assets:Cash
+2020-01-01 open Income:Dividends
+2020-01-01 * \"Buy 10 ACME\"
+  Assets:Invest:Broker  10 ACME {100 USD}
+  Assets:Cash
+2020-07-01 * \"Dividend\"
+  Assets:Cash  20 USD
+  Income:Dividends
+2021-01-01 price ACME  120 USD
+";
+    let investments = vec!["Assets:Invest".to_string()];
+    let income = vec!["Income".to_string()];
+
+    // Component side: hold the ledger and ask for returns over the boundary.
+    let (mut store, inst) = instantiate()?;
+    let session = inst.rustledger_ledger_ledger().session();
+    let handle = session.call_constructor(&mut store, LEDGER)?;
+    let via = session
+        .call_returns(
+            &mut store,
+            handle,
+            &investments,
+            &income,
+            "USD",
+            "2021-01-01",
+        )?
+        .map_err(|e| anyhow::anyhow!("returns failed: {e}"))?;
+    handle.resource_drop(&mut store)?;
+
+    // Native reference: the exact engine + inputs the CLI uses.
+    struct Oracle<'a>(&'a rustledger_query::PriceDatabase);
+    impl rustledger_returns::PriceOracle for Oracle<'_> {
+        fn convert(
+            &self,
+            amount: &rustledger_core::Amount,
+            to_currency: &str,
+            date: rustledger_core::NaiveDate,
+        ) -> Option<rustledger_core::Amount> {
+            self.0.convert(amount, to_currency, date)
+        }
+    }
+    let native = rustledger_ffi_wasi::helpers::load_source(LEDGER);
+    assert!(
+        native.errors.is_empty(),
+        "fixture must load without errors ({} found)",
+        native.errors.len()
+    );
+    let padded = rustledger_booking::merge_with_padding(&native.directives);
+    let scope = rustledger_returns::Scope::new(investments.clone(), income.clone());
+    let db = rustledger_query::PriceDatabase::from_directives(&padded);
+    let end = "2021-01-01".parse().expect("date");
+    let direct = rustledger_returns::compute_returns(&padded, &scope, "USD", &Oracle(&db), end)
+        .expect("native engine computes");
+
+    // Decimal fields: exact (rust_decimal is deterministic across targets).
+    assert_eq!(via.cash_flows, u32::try_from(direct.cash_flows).unwrap());
+    assert_eq!(via.invested, direct.invested.to_string());
+    assert_eq!(via.distributions, direct.distributions.to_string());
+    assert_eq!(via.current_value, direct.current_value.to_string());
+
+    // Rates: within tolerance (wasm vs native float).
+    let approx = |a: Option<f64>, b: Option<f64>| match (a, b) {
+        (Some(x), Some(y)) => (x - y).abs() < 1e-9,
+        (None, None) => true,
+        _ => false,
+    };
+    assert!(
+        approx(via.money_weighted, direct.money_weighted),
+        "MWR drift: component {:?} vs native {:?}",
+        via.money_weighted,
+        direct.money_weighted
+    );
+    assert!(
+        approx(via.time_weighted, direct.time_weighted),
+        "TWR drift: component {:?} vs native {:?}",
+        via.time_weighted,
+        direct.time_weighted
+    );
+    Ok(())
+}
+
 /// The stateful `resource session` (#173): construct once, then info/query/
 /// clamp run against the held ledger. Crucially `clamp` operates on the held
 /// core directives, so cost basis survives with no WIT->core->WIT round-trip.

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -30,6 +30,7 @@ rustledger-loader.workspace = true
 rustledger-ops.workspace = true
 rustledger-parser.workspace = true
 rustledger-query.workspace = true
+rustledger-returns.workspace = true
 rustledger-validate.workspace = true
 # Reused for the loader orchestration (`load_source`) and the core->DTO
 # conversion (`directive_to_json`); the component maps those DTOs into WIT

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1831,19 +1831,25 @@ impl SessionState {
     /// pad-expanded stream `query` builds (reused via the `padded` cell), so the
     /// two surfaces cannot compute different figures for one ledger.
     ///
-    /// Like `session.format`, this does NOT trap on recovered load errors: per
-    /// the resource's contract those surface via `info().errors`, and returns is
-    /// computed over the held (possibly error-recovered) directives exactly as
-    /// the CLI report renders over them.
+    /// Refuses (a clean `Err`, never a trap) when the held ledger has load
+    /// errors — the same guard `query` applies. Unlike `format`, which only
+    /// renders directive text, returns REALIZES inventory, and the loader
+    /// re-merges a booking-failed transaction into the held directives in its
+    /// un-booked shape; realizing that contract-violating stream can
+    /// `debug_assert`-trap the booking engine (over-sell with no matching lot).
+    /// The resource contract is "load failures surface via `info().errors`, not
+    /// a trap" — so a realizing op surfaces them as an `Err` rather than risk the
+    /// trap the convention forbids. (`format`/`filter`/`clamp` don't realize, so
+    /// they proceed.)
     ///
     /// `investments`/`income` are the scope's account-name prefixes; `currency`
     /// is the single reporting currency (empty → the ledger's first
     /// `operating_currency`); `end` is the horizon + terminal-valuation date.
     ///
     /// # Errors
-    /// `Err(message)` when `end` is empty/unparseable, no reporting currency
-    /// resolves (empty `currency` and no `operating_currency`), or a
-    /// boundary/terminal flow cannot be priced.
+    /// `Err(message)` when the held ledger has load errors, `end` is
+    /// empty/unparseable, no reporting currency resolves (empty `currency` and
+    /// no `operating_currency`), or a boundary/terminal flow cannot be priced.
     pub fn returns(
         &self,
         investments: &[String],
@@ -1851,6 +1857,14 @@ impl SessionState {
         currency: &str,
         end: &str,
     ) -> Result<out::ReturnsResult, String> {
+        // See the doc comment: returns realizes inventory, so — like `query`, and
+        // unlike the text-only `format` — it must not run over a load-errored
+        // (possibly un-booked) stream. Surface the errors as a clean Err.
+        if !self.errors.is_empty() {
+            return Err(
+                "ledger has load errors; cannot compute returns (see info().errors)".to_string(),
+            );
+        }
         let end_date: NaiveDate = end
             .parse()
             .map_err(|_| format!("invalid end-date {end:?} (expected YYYY-MM-DD)"))?;
@@ -2913,35 +2927,51 @@ option \"operating_currency\" \"USD\"
     }
 
     #[test]
-    fn returns_computes_despite_recovered_load_errors() {
-        // Per the resource contract (see `from-file`: load failures surface via
-        // `info().errors`, not a trap) and matching `session.format`, returns
-        // does NOT refuse on a recovered load error — it computes over the held
-        // directives exactly as the CLI `report returns` renders over them. Here
-        // a garbage line is a recovered parse error; the surrounding investment
-        // activity still loads and still produces a return.
-        const RECOVERED: &str = "\
+    fn returns_refuses_on_load_errors() {
+        // returns realizes inventory, so — like `query` and unlike text-only
+        // `format` — it must refuse (clean Err) on a load-errored ledger rather
+        // than realize a contract-violating (possibly un-booked) stream. A parse
+        // error triggers the guard:
+        const PARSE_ERR: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:Invest:Broker
+this line is not a valid directive @#$
+";
+        let state = SessionState::from_source(PARSE_ERR);
+        assert!(!state.info().errors.is_empty(), "fixture must load-error");
+        let (inv, inc) = scope_args();
+        assert!(state.returns(&inv, &inc, "USD", "2021-01-01").is_err());
+    }
+
+    #[test]
+    fn returns_refuses_on_booking_error_without_trapping() {
+        // The dangerous case the guard exists for: a booking-FAILED transaction
+        // (here selling 10 units when only 5 were bought, empty cost forcing a
+        // lot match) is re-merged into the held directives in its un-booked
+        // shape. Realizing that would `debug_assert`-trap the booking engine
+        // (over-sell) — this native test would ABORT without the guard. With it,
+        // the load error is caught first and returns cleanly errs. (Regression
+        // guard for the #1849 second-review finding.)
+        const OVERSELL: &str = "\
 option \"operating_currency\" \"USD\"
 2020-01-01 open Assets:Invest:Broker
 2020-01-01 open Assets:Cash
-this line is not a valid directive @#$
-2020-01-01 * \"Buy 10 ACME\"
-  Assets:Invest:Broker  10 ACME {100 USD}
+2020-01-01 * \"Buy 5 ACME\"
+  Assets:Invest:Broker  5 ACME {100 USD}
   Assets:Cash
-2021-01-01 price ACME  120 USD
+2020-06-01 * \"Sell 10 — more than held\"
+  Assets:Invest:Broker  -10 ACME {}
+  Assets:Cash  1000 USD
 ";
-        let state = SessionState::from_source(RECOVERED);
+        let state = SessionState::from_source(OVERSELL);
         assert!(
             !state.info().errors.is_empty(),
-            "fixture must produce a recovered load error"
+            "over-sell must surface as a booking load error"
         );
         let (inv, inc) = scope_args();
-        let r = state
-            .returns(&inv, &inc, "USD", "2021-01-01")
-            .expect("returns computes over the recovered directives");
         assert!(
-            r.money_weighted.is_some(),
-            "the recovered investment activity must still yield a return"
+            state.returns(&inv, &inc, "USD", "2021-01-01").is_err(),
+            "returns must refuse (not trap) on a booking-errored ledger"
         );
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -13,9 +13,9 @@
 //! cases. (Custom-directive arguments additionally carry their `value-type` tag
 //! via the WIT `typed-value` record.)
 
-use rustledger_core::{Directive, MetaValue, Metadata};
+use rustledger_core::{Amount, Directive, MetaValue, Metadata, NaiveDate};
 use rustledger_ffi_wasi as ffi;
-use rustledger_query::{Executor, IntervalUnit, Value, parse as parse_query};
+use rustledger_query::{Executor, IntervalUnit, PriceDatabase, Value, parse as parse_query};
 use serde_json::Value as Json;
 
 use crate::exports::rustledger::ledger::ledger as out;
@@ -1535,6 +1535,26 @@ fn sanitize_options(mut provided: wit::LedgerOptions) -> wit::LedgerOptions {
 /// per-directive provenance, plus the load metadata, normalized across the
 /// source and file load paths. Errors are pre-converted to WIT form (the file
 /// path's failure case has only a message, not a rich `ffi::Error`).
+/// Adapts the query engine's [`PriceDatabase`] to the returns engine's
+/// [`rustledger_returns::PriceOracle`] trait, so `session.returns` prices flows
+/// from the held ledger's `price` directives + implicit transaction prices.
+///
+/// Deliberate duplicate of the CLI's `PriceDbOracle`
+/// (`crates/rustledger/src/cmd/report_cmd/returns.rs`): that one is
+/// `pub(super)` and unreachable from here, and `rustledger-returns` is a leaf
+/// crate (no `rustledger-query` dependency) so the adapter cannot live beside
+/// the trait it implements. The body is a pure pass-through to
+/// [`PriceDatabase::convert`], so the compiler enforces agreement — a signature
+/// change on either canonical surface fails to build rather than drifting
+/// silently. If a third consumer appears, hoist this into a shared home.
+struct PriceDbOracle<'a>(&'a PriceDatabase);
+
+impl rustledger_returns::PriceOracle for PriceDbOracle<'_> {
+    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
+        self.0.convert(amount, to_currency, date)
+    }
+}
+
 pub struct SessionState {
     directives: Vec<rustledger_core::Directive>,
     lines: Vec<u32>,
@@ -1821,6 +1841,75 @@ impl SessionState {
         };
         rustledger_parser::format::canonicalize_directives(self.directives.iter(), &config)
             .map_err(|e| e.to_string())
+    }
+
+    /// Investment returns over the held ledger (WIT 3.9.0, #1847): the
+    /// `rledger report returns` engine ([`rustledger_returns::compute_returns`])
+    /// over the boundary, so a host charts returns without re-deriving the
+    /// cash-flow extraction or the XIRR/TWR math. Runs on the same booked,
+    /// pad-expanded stream `query` builds (the returns engine's documented input
+    /// contract, reused via the `padded` cell) and builds the price index the
+    /// same way the CLI's `report returns` does — the boundary shares the exact
+    /// engine and inputs the CLI uses, so the two cannot drift.
+    ///
+    /// `investments`/`income` are the scope's account-name prefixes; `currency`
+    /// is the single reporting currency (empty → the ledger's first
+    /// `operating_currency`); `end` is the horizon + terminal-valuation date.
+    ///
+    /// # Errors
+    /// `Err(message)` when the held ledger has load errors, `end` is
+    /// empty/unparseable, no reporting currency resolves (empty `currency` and
+    /// no `operating_currency`), or a boundary/terminal flow cannot be priced.
+    pub fn returns(
+        &self,
+        investments: &[String],
+        income: &[String],
+        currency: &str,
+        end: &str,
+    ) -> Result<out::ReturnsResult, String> {
+        if !self.errors.is_empty() {
+            return Err("ledger has load errors; cannot compute returns".to_string());
+        }
+        let end_date: NaiveDate = end
+            .parse()
+            .map_err(|_| format!("invalid end-date {end:?} (expected YYYY-MM-DD)"))?;
+        // Reporting currency: the caller's, else the ledger's first operating
+        // currency, else an actionable error (returns are single-currency).
+        let reporting_currency = if currency.is_empty() {
+            self.options
+                .operating_currency
+                .first()
+                .cloned()
+                .ok_or_else(|| {
+                    "no reporting currency: pass a currency or set \
+                 `option \"operating_currency\" \"…\"`"
+                        .to_string()
+                })?
+        } else {
+            currency.to_string()
+        };
+        let directives = self
+            .padded
+            .get_or_init(|| rustledger_booking::merge_with_padding(&self.directives));
+        let scope = rustledger_returns::Scope::new(investments.to_vec(), income.to_vec());
+        let price_db = PriceDatabase::from_directives(directives);
+        let oracle = PriceDbOracle(&price_db);
+        let returns = rustledger_returns::compute_returns(
+            directives,
+            &scope,
+            &reporting_currency,
+            &oracle,
+            end_date,
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(out::ReturnsResult {
+            cash_flows: u32::try_from(returns.cash_flows).unwrap_or(u32::MAX),
+            invested: returns.invested.to_string(),
+            distributions: returns.distributions.to_string(),
+            current_value: returns.current_value.to_string(),
+            money_weighted: returns.money_weighted,
+            time_weighted: returns.time_weighted,
+        })
     }
 
     pub fn clamp(&self, begin: &str, end: &str) -> Vec<wit::Directive> {
@@ -2717,5 +2806,155 @@ mod importer_tests {
         assert!(import_extract("bank.csv", CSV.as_bytes(), "not = [valid").is_err());
         // Missing `name` is a schema violation, same as the CLI.
         assert!(import_extract("bank.csv", CSV.as_bytes(), "account = \"Assets:Bank\"").is_err());
+    }
+}
+
+/// `session.returns` (WIT 3.9.0, #1847): the returns engine over the boundary.
+#[cfg(test)]
+mod returns_tests {
+    use super::{PriceDatabase, PriceDbOracle, SessionState};
+
+    const LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:Invest:Broker
+2020-01-01 open Assets:Cash
+2020-01-01 open Income:Dividends
+
+2020-01-01 * \"Buy 10 ACME\"
+  Assets:Invest:Broker  10 ACME {100 USD}
+  Assets:Cash
+
+2020-07-01 * \"Dividend\"
+  Assets:Cash  20 USD
+  Income:Dividends
+
+2021-01-01 price ACME  120 USD
+";
+
+    fn scope_args() -> (Vec<String>, Vec<String>) {
+        (
+            vec!["Assets:Invest".to_string()],
+            vec!["Income".to_string()],
+        )
+    }
+
+    /// Drift guard (canonical-function discipline): `session.returns` must equal
+    /// a direct [`rustledger_returns::compute_returns`] over the SAME booked,
+    /// pad-expanded stream + price index. The session op only wires the scope /
+    /// currency / horizon and maps the `Returns` struct, so any divergence in
+    /// that wiring — wrong stream, dropped scope arg, a wrongly mapped field —
+    /// trips this.
+    #[test]
+    fn returns_matches_direct_engine() {
+        let state = SessionState::from_source(LEDGER);
+        assert!(
+            state.info().errors.is_empty(),
+            "fixture must load: {:?}",
+            state.info().errors
+        );
+        let (inv, inc) = scope_args();
+
+        let via = state
+            .returns(&inv, &inc, "USD", "2021-01-01")
+            .expect("returns computes");
+
+        // Recompute directly through the engine over identical inputs.
+        let padded = rustledger_booking::merge_with_padding(&state.directives);
+        let scope = rustledger_returns::Scope::new(inv, inc);
+        let db = PriceDatabase::from_directives(&padded);
+        let oracle = PriceDbOracle(&db);
+        let end = "2021-01-01".parse().expect("date");
+        let direct = rustledger_returns::compute_returns(&padded, &scope, "USD", &oracle, end)
+            .expect("direct engine computes");
+
+        // Decimal fields (rust_decimal → deterministic) are exact strings.
+        assert_eq!(via.cash_flows, u32::try_from(direct.cash_flows).unwrap());
+        assert_eq!(via.invested, direct.invested.to_string());
+        assert_eq!(via.distributions, direct.distributions.to_string());
+        assert_eq!(via.current_value, direct.current_value.to_string());
+        // Rates are the same in-process computation, so identical; compare with
+        // a tolerance anyway (clippy forbids exact float `==`).
+        let same_rate = |a: Option<f64>, b: Option<f64>| match (a, b) {
+            (Some(x), Some(y)) => (x - y).abs() < 1e-12,
+            (None, None) => true,
+            _ => false,
+        };
+        assert!(same_rate(via.money_weighted, direct.money_weighted));
+        assert!(same_rate(via.time_weighted, direct.time_weighted));
+
+        // Value anchors (numeric parse tolerates 1000 vs 1000.00 formatting).
+        assert!((via.invested.parse::<f64>().unwrap() - 1000.0).abs() < 1e-9);
+        assert!((via.current_value.parse::<f64>().unwrap() - 1200.0).abs() < 1e-9);
+        assert!(
+            via.money_weighted.is_some_and(|r| r > 0.0),
+            "a held gain must yield a positive money-weighted return, got {:?}",
+            via.money_weighted
+        );
+    }
+
+    /// Empty `currency` falls back to the ledger's first `operating_currency`,
+    /// matching the CLI's `--currency`-optional behavior.
+    #[test]
+    fn returns_currency_falls_back_to_operating() {
+        let state = SessionState::from_source(LEDGER);
+        let (inv, inc) = scope_args();
+        let explicit = state.returns(&inv, &inc, "USD", "2021-01-01").unwrap();
+        let fallback = state.returns(&inv, &inc, "", "2021-01-01").unwrap();
+        assert_eq!(explicit.invested, fallback.invested);
+        assert_eq!(explicit.current_value, fallback.current_value);
+        // Same computation, so the money-weighted rate matches (tolerance
+        // comparison — clippy forbids exact float `==`).
+        match (explicit.money_weighted, fallback.money_weighted) {
+            (Some(a), Some(b)) => assert!((a - b).abs() < 1e-12),
+            (None, None) => {}
+            other => panic!("currency fallback changed the rate: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn returns_rejects_bad_end_date() {
+        let state = SessionState::from_source(LEDGER);
+        let (inv, inc) = scope_args();
+        assert!(state.returns(&inv, &inc, "USD", "").is_err());
+        assert!(state.returns(&inv, &inc, "USD", "not-a-date").is_err());
+    }
+
+    #[test]
+    fn returns_errors_without_reporting_currency() {
+        // No `operating_currency` and an empty `currency` arg → actionable error
+        // rather than a return silently reported in the wrong currency.
+        const NO_CCY: &str = "\
+2020-01-01 open Assets:Invest:Broker
+2020-01-01 open Assets:Cash
+2020-01-01 * \"Buy\"
+  Assets:Invest:Broker  10 ACME {100 USD}
+  Assets:Cash
+2021-01-01 price ACME  120 USD
+";
+        let state = SessionState::from_source(NO_CCY);
+        let (inv, inc) = scope_args();
+        let err = state.returns(&inv, &inc, "", "2021-01-01").unwrap_err();
+        assert!(err.contains("reporting currency"), "got: {err}");
+    }
+
+    #[test]
+    fn returns_surfaces_load_errors() {
+        // A parse error surfaces at load (`load_source` runs parse + book), so
+        // returns refuses rather than reporting a bogus number over a broken
+        // ledger. Mirrors `query`'s guard on `self.errors`; semantic checks
+        // (imbalance, unopened accounts) are `ledger.validate`'s job and are
+        // deliberately not run on this surface.
+        const BAD: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:Invest:Broker
+this line is not a valid directive @#$
+";
+        let state = SessionState::from_source(BAD);
+        assert!(
+            !state.info().errors.is_empty(),
+            "fixture must produce a load error"
+        );
+        let (inv, inc) = scope_args();
+        assert!(state.returns(&inv, &inc, "USD", "2021-01-01").is_err());
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2974,4 +2974,62 @@ option \"operating_currency\" \"USD\"
             "returns must refuse (not trap) on a booking-errored ledger"
         );
     }
+
+    #[test]
+    fn returns_from_entries_oversell_errors_not_traps() {
+        // A `from_entries` session holds directives UN-booked with `errors:
+        // vec![]`, so the load-error guard is bypassed (the #1849 third-review
+        // gap). The engine-level `try_apply` fix is what closes this path: an
+        // over-sell (reduce 10 of an empty-cost lot only 5 were bought into)
+        // makes compute_returns — hence returns() — return a clean Err instead of
+        // trapping. This native test would abort without that fix.
+        use rustledger_core::{Amount, CostNumber, CostSpec, Decimal, Posting, Transaction};
+        let dt = |m, day| rustledger_core::naive_date(2020, m, day).unwrap();
+        let buy = Transaction::new(dt(1, 1), "buy")
+            .with_synthesized_posting(
+                Posting::new(
+                    "Assets:Invest:Broker",
+                    Amount::new(Decimal::from(5), "ACME"),
+                )
+                .with_cost(
+                    CostSpec::empty()
+                        .with_number(CostNumber::PerUnit {
+                            value: Decimal::from(100),
+                        })
+                        .with_currency("USD"),
+                ),
+            )
+            .with_synthesized_posting(Posting::new(
+                "Assets:Cash",
+                Amount::new(Decimal::from(-500), "USD"),
+            ));
+        let sell = Transaction::new(dt(6, 1), "oversell")
+            .with_synthesized_posting(
+                Posting::new(
+                    "Assets:Invest:Broker",
+                    Amount::new(Decimal::from(-10), "ACME"),
+                )
+                .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(Posting::new(
+                "Assets:Cash",
+                Amount::new(Decimal::from(1000), "USD"),
+            ));
+        let core = [
+            rustledger_core::Directive::Transaction(buy),
+            rustledger_core::Directive::Transaction(sell),
+        ];
+        let wit: Vec<_> = core
+            .iter()
+            .map(|d| super::directive_from_core(d, 0, "<test>"))
+            .collect();
+        let state = SessionState::from_entries(&wit);
+        // The guard cannot help here — from_entries carries no load errors.
+        assert!(state.info().errors.is_empty());
+        let (inv, inc) = scope_args();
+        assert!(
+            state.returns(&inv, &inc, "USD", "2020-12-31").is_err(),
+            "engine fix must make an un-booked from_entries session err, not trap"
+        );
+    }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1868,8 +1868,7 @@ impl SessionState {
                 .first()
                 .cloned()
                 .ok_or_else(|| {
-                    "no reporting currency: pass a currency or set \
-                 `option \"operating_currency\" \"…\"`"
+                    "no reporting currency: pass a currency or set `option \"operating_currency\"`"
                         .to_string()
                 })?
         } else {

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1831,15 +1831,15 @@ impl SessionState {
     /// pad-expanded stream `query` builds (reused via the `padded` cell), so the
     /// two surfaces cannot compute different figures for one ledger.
     ///
-    /// Does NOT refuse on load errors — it computes over the held (possibly
-    /// error-recovered) directives exactly as the CLI's `report returns` renders
-    /// over them, the beancount/fava model where a report renders over
-    /// loaded-with-errors entries and the errors surface separately (here via
-    /// `info().errors`). This is safe because the returns engine realizes through
-    /// the booking engine's fallible `try_apply`: an un-booked reduction in a
-    /// VALUED account surfaces as `err` (never a trap), while a booking error in
-    /// an account outside the returns scope is skipped, not fatal. So a host
-    /// gets the same figures as the CLI for one ledger, broken or not.
+    /// A parse-recovered load error does not block it — it computes over the held
+    /// directives just as the CLI's `report returns` renders over them (errors
+    /// surface separately, here via `info().errors`). But a BOOKING error (an
+    /// un-booked reduction the loader re-merged) is fatal: the returns engine
+    /// realizes through the booking engine's fallible path, so it returns a clean
+    /// `err` rather than trap or emit a figure computed over a contract-violating
+    /// stream. This is stricter than beangrow (which discards errors and reports
+    /// a number regardless) — deliberately: run `rledger check` to find the
+    /// booking error, then re-run. The CLI and this op agree on every ledger.
     ///
     /// `investments`/`income` are the scope's account-name prefixes; `currency`
     /// is the single reporting currency (empty → the ledger's first
@@ -1847,8 +1847,9 @@ impl SessionState {
     ///
     /// # Errors
     /// `Err(message)` when `end` is empty/unparseable, no reporting currency
-    /// resolves (empty `currency` and no `operating_currency`), or an in-scope
-    /// boundary/terminal flow cannot be priced or is un-booked.
+    /// resolves (empty `currency` and no `operating_currency`), a boundary/
+    /// terminal flow cannot be priced, or the ledger has a booking error
+    /// (un-booked reduction).
     pub fn returns(
         &self,
         investments: &[String],

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -13,9 +13,9 @@
 //! cases. (Custom-directive arguments additionally carry their `value-type` tag
 //! via the WIT `typed-value` record.)
 
-use rustledger_core::{Amount, Directive, MetaValue, Metadata, NaiveDate};
+use rustledger_core::{Directive, MetaValue, Metadata, NaiveDate};
 use rustledger_ffi_wasi as ffi;
-use rustledger_query::{Executor, IntervalUnit, PriceDatabase, Value, parse as parse_query};
+use rustledger_query::{Executor, IntervalUnit, Value, parse as parse_query};
 use serde_json::Value as Json;
 
 use crate::exports::rustledger::ledger::ledger as out;
@@ -1535,26 +1535,6 @@ fn sanitize_options(mut provided: wit::LedgerOptions) -> wit::LedgerOptions {
 /// per-directive provenance, plus the load metadata, normalized across the
 /// source and file load paths. Errors are pre-converted to WIT form (the file
 /// path's failure case has only a message, not a rich `ffi::Error`).
-/// Adapts the query engine's [`PriceDatabase`] to the returns engine's
-/// [`rustledger_returns::PriceOracle`] trait, so `session.returns` prices flows
-/// from the held ledger's `price` directives + implicit transaction prices.
-///
-/// Deliberate duplicate of the CLI's `PriceDbOracle`
-/// (`crates/rustledger/src/cmd/report_cmd/returns.rs`): that one is
-/// `pub(super)` and unreachable from here, and `rustledger-returns` is a leaf
-/// crate (no `rustledger-query` dependency) so the adapter cannot live beside
-/// the trait it implements. The body is a pure pass-through to
-/// [`PriceDatabase::convert`], so the compiler enforces agreement — a signature
-/// change on either canonical surface fails to build rather than drifting
-/// silently. If a third consumer appears, hoist this into a shared home.
-struct PriceDbOracle<'a>(&'a PriceDatabase);
-
-impl rustledger_returns::PriceOracle for PriceDbOracle<'_> {
-    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
-        self.0.convert(amount, to_currency, date)
-    }
-}
-
 pub struct SessionState {
     directives: Vec<rustledger_core::Directive>,
     lines: Vec<u32>,
@@ -1844,22 +1824,26 @@ impl SessionState {
     }
 
     /// Investment returns over the held ledger (WIT 3.9.0, #1847): the
-    /// `rledger report returns` engine ([`rustledger_returns::compute_returns`])
-    /// over the boundary, so a host charts returns without re-deriving the
-    /// cash-flow extraction or the XIRR/TWR math. Runs on the same booked,
-    /// pad-expanded stream `query` builds (the returns engine's documented input
-    /// contract, reused via the `padded` cell) and builds the price index the
-    /// same way the CLI's `report returns` does — the boundary shares the exact
-    /// engine and inputs the CLI uses, so the two cannot drift.
+    /// `rledger report returns` engine over the boundary, so a host charts
+    /// returns without re-deriving the cash-flow extraction or the XIRR/TWR
+    /// math. Delegates to [`rustledger_query::scope_returns`] — the *same*
+    /// composition the CLI's `report returns` calls — over the same booked,
+    /// pad-expanded stream `query` builds (reused via the `padded` cell), so the
+    /// two surfaces cannot compute different figures for one ledger.
+    ///
+    /// Like `session.format`, this does NOT trap on recovered load errors: per
+    /// the resource's contract those surface via `info().errors`, and returns is
+    /// computed over the held (possibly error-recovered) directives exactly as
+    /// the CLI report renders over them.
     ///
     /// `investments`/`income` are the scope's account-name prefixes; `currency`
     /// is the single reporting currency (empty → the ledger's first
     /// `operating_currency`); `end` is the horizon + terminal-valuation date.
     ///
     /// # Errors
-    /// `Err(message)` when the held ledger has load errors, `end` is
-    /// empty/unparseable, no reporting currency resolves (empty `currency` and
-    /// no `operating_currency`), or a boundary/terminal flow cannot be priced.
+    /// `Err(message)` when `end` is empty/unparseable, no reporting currency
+    /// resolves (empty `currency` and no `operating_currency`), or a
+    /// boundary/terminal flow cannot be priced.
     pub fn returns(
         &self,
         investments: &[String],
@@ -1867,9 +1851,6 @@ impl SessionState {
         currency: &str,
         end: &str,
     ) -> Result<out::ReturnsResult, String> {
-        if !self.errors.is_empty() {
-            return Err("ledger has load errors; cannot compute returns".to_string());
-        }
         let end_date: NaiveDate = end
             .parse()
             .map_err(|_| format!("invalid end-date {end:?} (expected YYYY-MM-DD)"))?;
@@ -1892,17 +1873,13 @@ impl SessionState {
             .padded
             .get_or_init(|| rustledger_booking::merge_with_padding(&self.directives));
         let scope = rustledger_returns::Scope::new(investments.to_vec(), income.to_vec());
-        let price_db = PriceDatabase::from_directives(directives);
-        let oracle = PriceDbOracle(&price_db);
-        let returns = rustledger_returns::compute_returns(
-            directives,
-            &scope,
-            &reporting_currency,
-            &oracle,
-            end_date,
-        )
-        .map_err(|e| e.to_string())?;
+        let returns =
+            rustledger_query::scope_returns(directives, &scope, &reporting_currency, end_date)
+                .map_err(|e| e.to_string())?;
         Ok(out::ReturnsResult {
+            // usize -> u32: a cash-flow count is one per boundary-crossing
+            // posting, so it cannot approach u32::MAX in any real ledger; the
+            // saturating clamp is unreachable defensive code, not a lossy path.
             cash_flows: u32::try_from(returns.cash_flows).unwrap_or(u32::MAX),
             invested: returns.invested.to_string(),
             distributions: returns.distributions.to_string(),
@@ -2812,7 +2789,7 @@ mod importer_tests {
 /// `session.returns` (WIT 3.9.0, #1847): the returns engine over the boundary.
 #[cfg(test)]
 mod returns_tests {
-    use super::{PriceDatabase, PriceDbOracle, SessionState};
+    use super::SessionState;
 
     const LEDGER: &str = "\
 option \"operating_currency\" \"USD\"
@@ -2839,13 +2816,12 @@ option \"operating_currency\" \"USD\"
     }
 
     /// Drift guard (canonical-function discipline): `session.returns` must equal
-    /// a direct [`rustledger_returns::compute_returns`] over the SAME booked,
-    /// pad-expanded stream + price index. The session op only wires the scope /
-    /// currency / horizon and maps the `Returns` struct, so any divergence in
-    /// that wiring — wrong stream, dropped scope arg, a wrongly mapped field —
-    /// trips this.
+    /// [`rustledger_query::scope_returns`] over the same booked, pad-expanded
+    /// stream. That helper is the SAME composition the CLI's `report returns`
+    /// calls, so equality here pins the component against the CLI's returns path
+    /// — not merely against a private copy of the engine wiring.
     #[test]
-    fn returns_matches_direct_engine() {
+    fn returns_matches_shared_helper() {
         let state = SessionState::from_source(LEDGER);
         assert!(
             state.info().errors.is_empty(),
@@ -2858,20 +2834,19 @@ option \"operating_currency\" \"USD\"
             .returns(&inv, &inc, "USD", "2021-01-01")
             .expect("returns computes");
 
-        // Recompute directly through the engine over identical inputs.
+        // The shared helper both surfaces route through (CLI report_returns and
+        // session.returns), so agreement here == CLI parity, not a self-check.
         let padded = rustledger_booking::merge_with_padding(&state.directives);
         let scope = rustledger_returns::Scope::new(inv, inc);
-        let db = PriceDatabase::from_directives(&padded);
-        let oracle = PriceDbOracle(&db);
         let end = "2021-01-01".parse().expect("date");
-        let direct = rustledger_returns::compute_returns(&padded, &scope, "USD", &oracle, end)
-            .expect("direct engine computes");
+        let shared = rustledger_query::scope_returns(&padded, &scope, "USD", end)
+            .expect("shared helper computes");
 
         // Decimal fields (rust_decimal → deterministic) are exact strings.
-        assert_eq!(via.cash_flows, u32::try_from(direct.cash_flows).unwrap());
-        assert_eq!(via.invested, direct.invested.to_string());
-        assert_eq!(via.distributions, direct.distributions.to_string());
-        assert_eq!(via.current_value, direct.current_value.to_string());
+        assert_eq!(via.cash_flows, u32::try_from(shared.cash_flows).unwrap());
+        assert_eq!(via.invested, shared.invested.to_string());
+        assert_eq!(via.distributions, shared.distributions.to_string());
+        assert_eq!(via.current_value, shared.current_value.to_string());
         // Rates are the same in-process computation, so identical; compare with
         // a tolerance anyway (clippy forbids exact float `==`).
         let same_rate = |a: Option<f64>, b: Option<f64>| match (a, b) {
@@ -2879,8 +2854,8 @@ option \"operating_currency\" \"USD\"
             (None, None) => true,
             _ => false,
         };
-        assert!(same_rate(via.money_weighted, direct.money_weighted));
-        assert!(same_rate(via.time_weighted, direct.time_weighted));
+        assert!(same_rate(via.money_weighted, shared.money_weighted));
+        assert!(same_rate(via.time_weighted, shared.time_weighted));
 
         // Value anchors (numeric parse tolerates 1000 vs 1000.00 formatting).
         assert!((via.invested.parse::<f64>().unwrap() - 1000.0).abs() < 1e-9);
@@ -2938,23 +2913,35 @@ option \"operating_currency\" \"USD\"
     }
 
     #[test]
-    fn returns_surfaces_load_errors() {
-        // A parse error surfaces at load (`load_source` runs parse + book), so
-        // returns refuses rather than reporting a bogus number over a broken
-        // ledger. Mirrors `query`'s guard on `self.errors`; semantic checks
-        // (imbalance, unopened accounts) are `ledger.validate`'s job and are
-        // deliberately not run on this surface.
-        const BAD: &str = "\
+    fn returns_computes_despite_recovered_load_errors() {
+        // Per the resource contract (see `from-file`: load failures surface via
+        // `info().errors`, not a trap) and matching `session.format`, returns
+        // does NOT refuse on a recovered load error — it computes over the held
+        // directives exactly as the CLI `report returns` renders over them. Here
+        // a garbage line is a recovered parse error; the surrounding investment
+        // activity still loads and still produces a return.
+        const RECOVERED: &str = "\
 option \"operating_currency\" \"USD\"
 2020-01-01 open Assets:Invest:Broker
+2020-01-01 open Assets:Cash
 this line is not a valid directive @#$
+2020-01-01 * \"Buy 10 ACME\"
+  Assets:Invest:Broker  10 ACME {100 USD}
+  Assets:Cash
+2021-01-01 price ACME  120 USD
 ";
-        let state = SessionState::from_source(BAD);
+        let state = SessionState::from_source(RECOVERED);
         assert!(
             !state.info().errors.is_empty(),
-            "fixture must produce a load error"
+            "fixture must produce a recovered load error"
         );
         let (inv, inc) = scope_args();
-        assert!(state.returns(&inv, &inc, "USD", "2021-01-01").is_err());
+        let r = state
+            .returns(&inv, &inc, "USD", "2021-01-01")
+            .expect("returns computes over the recovered directives");
+        assert!(
+            r.money_weighted.is_some(),
+            "the recovered investment activity must still yield a return"
+        );
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1831,25 +1831,24 @@ impl SessionState {
     /// pad-expanded stream `query` builds (reused via the `padded` cell), so the
     /// two surfaces cannot compute different figures for one ledger.
     ///
-    /// Refuses (a clean `Err`, never a trap) when the held ledger has load
-    /// errors — the same guard `query` applies. Unlike `format`, which only
-    /// renders directive text, returns REALIZES inventory, and the loader
-    /// re-merges a booking-failed transaction into the held directives in its
-    /// un-booked shape; realizing that contract-violating stream can
-    /// `debug_assert`-trap the booking engine (over-sell with no matching lot).
-    /// The resource contract is "load failures surface via `info().errors`, not
-    /// a trap" — so a realizing op surfaces them as an `Err` rather than risk the
-    /// trap the convention forbids. (`format`/`filter`/`clamp` don't realize, so
-    /// they proceed.)
+    /// Does NOT refuse on load errors — it computes over the held (possibly
+    /// error-recovered) directives exactly as the CLI's `report returns` renders
+    /// over them, the beancount/fava model where a report renders over
+    /// loaded-with-errors entries and the errors surface separately (here via
+    /// `info().errors`). This is safe because the returns engine realizes through
+    /// the booking engine's fallible `try_apply`: an un-booked reduction in a
+    /// VALUED account surfaces as `err` (never a trap), while a booking error in
+    /// an account outside the returns scope is skipped, not fatal. So a host
+    /// gets the same figures as the CLI for one ledger, broken or not.
     ///
     /// `investments`/`income` are the scope's account-name prefixes; `currency`
     /// is the single reporting currency (empty → the ledger's first
     /// `operating_currency`); `end` is the horizon + terminal-valuation date.
     ///
     /// # Errors
-    /// `Err(message)` when the held ledger has load errors, `end` is
-    /// empty/unparseable, no reporting currency resolves (empty `currency` and
-    /// no `operating_currency`), or a boundary/terminal flow cannot be priced.
+    /// `Err(message)` when `end` is empty/unparseable, no reporting currency
+    /// resolves (empty `currency` and no `operating_currency`), or an in-scope
+    /// boundary/terminal flow cannot be priced or is un-booked.
     pub fn returns(
         &self,
         investments: &[String],
@@ -1857,14 +1856,6 @@ impl SessionState {
         currency: &str,
         end: &str,
     ) -> Result<out::ReturnsResult, String> {
-        // See the doc comment: returns realizes inventory, so — like `query`, and
-        // unlike the text-only `format` — it must not run over a load-errored
-        // (possibly un-booked) stream. Surface the errors as a clean Err.
-        if !self.errors.is_empty() {
-            return Err(
-                "ledger has load errors; cannot compute returns (see info().errors)".to_string(),
-            );
-        }
         let end_date: NaiveDate = end
             .parse()
             .map_err(|_| format!("invalid end-date {end:?} (expected YYYY-MM-DD)"))?;
@@ -2927,11 +2918,12 @@ option \"operating_currency\" \"USD\"
     }
 
     #[test]
-    fn returns_refuses_on_load_errors() {
-        // returns realizes inventory, so — like `query` and unlike text-only
-        // `format` — it must refuse (clean Err) on a load-errored ledger rather
-        // than realize a contract-violating (possibly un-booked) stream. A parse
-        // error triggers the guard:
+    fn returns_proceeds_over_recovered_load_error() {
+        // Like the CLI report (beancount/fava model), returns does NOT refuse on
+        // a recovered load error — it computes over the held directives, and the
+        // error surfaces separately via info().errors. Here a garbage line is a
+        // recovered parse error with no investment activity, so returns is a clean
+        // (empty) result, not an Err.
         const PARSE_ERR: &str = "\
 option \"operating_currency\" \"USD\"
 2020-01-01 open Assets:Invest:Broker
@@ -2940,18 +2932,20 @@ this line is not a valid directive @#$
         let state = SessionState::from_source(PARSE_ERR);
         assert!(!state.info().errors.is_empty(), "fixture must load-error");
         let (inv, inc) = scope_args();
-        assert!(state.returns(&inv, &inc, "USD", "2021-01-01").is_err());
+        assert!(
+            state.returns(&inv, &inc, "USD", "2021-01-01").is_ok(),
+            "a recovered parse error must not block the report (errors are in info())"
+        );
     }
 
     #[test]
-    fn returns_refuses_on_booking_error_without_trapping() {
-        // The dangerous case the guard exists for: a booking-FAILED transaction
-        // (here selling 10 units when only 5 were bought, empty cost forcing a
-        // lot match) is re-merged into the held directives in its un-booked
-        // shape. Realizing that would `debug_assert`-trap the booking engine
-        // (over-sell) — this native test would ABORT without the guard. With it,
-        // the load error is caught first and returns cleanly errs. (Regression
-        // guard for the #1849 second-review finding.)
+    fn returns_errors_on_in_scope_booking_error() {
+        // A booking-FAILED transaction (selling 10 units when only 5 were bought,
+        // empty cost forcing a lot match) is re-merged into the held directives
+        // UN-booked. Realizing it would `debug_assert`-trap the booking engine
+        // (over-sell) — this native test would ABORT without the engine's fallible
+        // `try_apply`. With it, an IN-SCOPE over-sell surfaces as a clean Err (no
+        // guard involved). Regression guard for the #1849 second-review finding.
         const OVERSELL: &str = "\
 option \"operating_currency\" \"USD\"
 2020-01-01 open Assets:Invest:Broker
@@ -2971,7 +2965,7 @@ option \"operating_currency\" \"USD\"
         let (inv, inc) = scope_args();
         assert!(
             state.returns(&inv, &inc, "USD", "2021-01-01").is_err(),
-            "returns must refuse (not trap) on a booking-errored ledger"
+            "an in-scope over-sell must surface as a clean Err, not trap"
         );
     }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -41,11 +41,13 @@ use exports::rustledger::ledger::format::Guest as FormatGuest;
 use exports::rustledger::ledger::importer::{ExtractResult, Guest as ImporterGuest};
 use exports::rustledger::ledger::ledger::{
     BatchResult, Guest as LedgerGuest, GuestSession, LedgerOptions, LoadResult, QueryResult,
-    Session, ValidateResult,
+    ReturnsResult, Session, ValidateResult,
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. 3.8 adds
+/// The Component-Model api-version this build implements. 3.9 adds
+/// `session.returns` (investment returns — money-weighted XIRR +
+/// time-weighted TWR — over the held ledger, #1847); 3.8 adds
 /// `session.format` (render the held entries honoring the ledger's
 /// `display-precision`, #1766); 3.7 added
 /// `session.from-entries-with-options` (the session carries the
@@ -58,7 +60,7 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 /// encrypted (`.gpg`/`.asc`) ledgers can be decrypted by the host (#1667);
 /// 3.1 added the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
 /// `expand-pads` parameter on `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.8";
+const API_VERSION: &str = "3.9";
 
 struct Component;
 
@@ -153,6 +155,17 @@ impl GuestSession for LedgerSession {
 
     fn format(&self) -> Result<String, String> {
         self.state.format()
+    }
+
+    fn returns(
+        &self,
+        investments: Vec<String>,
+        income: Vec<String>,
+        currency: String,
+        end_date: String,
+    ) -> Result<ReturnsResult, String> {
+        self.state
+            .returns(&investments, &income, &currency, &end_date)
     }
 }
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -559,14 +559,16 @@ interface ledger {
     /// `end-date` (`YYYY-MM-DD`) is both the horizon (later flows are excluded)
     /// and the terminal-valuation date; unlike the CLI it is required, since a
     /// component has no reliable clock. Prices come from the held entries'
-    /// `price` directives and implicit transaction prices. Because returns
-    /// REALIZES inventory (unlike the text-only `format`), a load-errored ledger
-    /// can carry an un-booked, booking-failed transaction that would trap the
-    /// engine — so, like `query`, this refuses on load errors with a clean
-    /// `err` rather than risk the trap the contract forbids (inspect them via
-    /// `info().errors`). Fallible: returns `err(message)` on held load errors, an
-    /// empty/unparseable `end-date`, no resolvable reporting currency, or a
-    /// boundary/terminal flow that cannot be priced.
+    /// `price` directives and implicit transaction prices. This computes over the
+    /// held (possibly error-recovered) directives just as the CLI's `report
+    /// returns` renders over them — the beancount/fava model, where a report
+    /// renders over loaded-with-errors entries and errors surface separately (via
+    /// `info().errors`). It stays safe because the engine realizes through a
+    /// fallible path: an un-booked reduction in a VALUED account surfaces as
+    /// `err` (never a trap), and a booking error outside the returns scope is
+    /// skipped. Fallible: returns `err(message)` on an empty/unparseable
+    /// `end-date`, no resolvable reporting currency, or an in-scope
+    /// boundary/terminal flow that cannot be priced or is un-booked.
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.8.0;
+package rustledger:ledger@3.9.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -392,6 +392,23 @@ interface ledger {
     errors: list<error>,
   }
 
+  /// Investment returns for one scope, as computed by `rledger report returns`
+  /// (money-weighted XIRR + time-weighted TWR) — see `session.returns`
+  /// (WIT 3.9.0, #1847). The three amount fields are decimal strings (matching
+  /// `amount.number`) to preserve full precision; `cash-flows` is the number of
+  /// dated boundary flows the return was computed over. The two rates are
+  /// annualized fractions (0.1 = 10%) and `none` when undefined — money-weighted
+  /// when there are fewer than two flows or no sign change; time-weighted when a
+  /// sub-period cannot be priced.
+  record returns-result {
+    cash-flows: u32,
+    invested: string,
+    distributions: string,
+    current-value: string,
+    money-weighted: option<f64>,
+    time-weighted: option<f64>,
+  }
+
   /// Load + run several queries in one parse (replaces `query.batch`).
   record batch-result {
     load: load-result,
@@ -528,6 +545,23 @@ interface ledger {
     /// remains a report/query rendering concern). Fallible: a held entry
     /// that cannot be re-rendered fails the call.
     format: func() -> result<string, string>;
+    /// Investment returns over the held ledger (WIT 3.9.0, #1847) — the
+    /// `rledger report returns` engine over the boundary, so a host UI can
+    /// chart returns without re-deriving cash-flow extraction or the XIRR/TWR
+    /// math. `investments` and `income` are account-name prefixes defining the
+    /// scope boundary (mirroring the CLI's `--investments`/`--income`): money
+    /// leaving the investment accounts for income/external is a return, while a
+    /// transfer between two in-scope accounts is not. `currency` is the single
+    /// reporting currency every flow and the terminal valuation are converted
+    /// to; pass "" to fall back to the ledger's first `operating_currency`.
+    /// `end-date` (`YYYY-MM-DD`) is both the horizon (later flows are excluded)
+    /// and the terminal-valuation date; unlike the CLI it is required, since a
+    /// component has no reliable clock. Prices come from the held entries'
+    /// `price` directives and implicit transaction prices. Fallible: returns
+    /// `err(message)` on an empty/unparseable `end-date`, no resolvable
+    /// reporting currency, held load errors, or a boundary/terminal flow that
+    /// cannot be priced.
+    returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -394,9 +394,11 @@ interface ledger {
 
   /// Investment returns for one scope, as computed by `rledger report returns`
   /// (money-weighted XIRR + time-weighted TWR) — see `session.returns`
-  /// (WIT 3.9.0, #1847). The three amount fields are decimal strings (matching
-  /// `amount.number`) to preserve full precision; `cash-flows` is the number of
-  /// dated boundary flows the return was computed over. The two rates are
+  /// (WIT 3.9.0, #1847). The three amount fields are RAW, full-precision decimal
+  /// strings (matching `amount.number`) — NOT display-formatted: no thousands
+  /// separators and no display-precision padding, unlike the CLI's rendered
+  /// report. A host formats them for its own locale. `cash-flows` is the number
+  /// of dated boundary flows the return was computed over. The two rates are
   /// annualized fractions (0.1 = 10%) and `none` when undefined — money-weighted
   /// when there are fewer than two flows or no sign change; time-weighted when a
   /// sub-period cannot be priced.
@@ -557,10 +559,12 @@ interface ledger {
     /// `end-date` (`YYYY-MM-DD`) is both the horizon (later flows are excluded)
     /// and the terminal-valuation date; unlike the CLI it is required, since a
     /// component has no reliable clock. Prices come from the held entries'
-    /// `price` directives and implicit transaction prices. Fallible: returns
-    /// `err(message)` on an empty/unparseable `end-date`, no resolvable
-    /// reporting currency, held load errors, or a boundary/terminal flow that
-    /// cannot be priced.
+    /// `price` directives and implicit transaction prices. Like `format`, this
+    /// does NOT trap on recovered load errors (they surface via `info().errors`;
+    /// returns is computed over the held directives, as the CLI report renders
+    /// over them). Fallible: returns `err(message)` on an empty/unparseable
+    /// `end-date`, no resolvable reporting currency, or a boundary/terminal flow
+    /// that cannot be priced.
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -559,16 +559,15 @@ interface ledger {
     /// `end-date` (`YYYY-MM-DD`) is both the horizon (later flows are excluded)
     /// and the terminal-valuation date; unlike the CLI it is required, since a
     /// component has no reliable clock. Prices come from the held entries'
-    /// `price` directives and implicit transaction prices. This computes over the
-    /// held (possibly error-recovered) directives just as the CLI's `report
-    /// returns` renders over them — the beancount/fava model, where a report
-    /// renders over loaded-with-errors entries and errors surface separately (via
-    /// `info().errors`). It stays safe because the engine realizes through a
-    /// fallible path: an un-booked reduction in a VALUED account surfaces as
-    /// `err` (never a trap), and a booking error outside the returns scope is
-    /// skipped. Fallible: returns `err(message)` on an empty/unparseable
-    /// `end-date`, no resolvable reporting currency, or an in-scope
-    /// boundary/terminal flow that cannot be priced or is un-booked.
+    /// `price` directives and implicit transaction prices. A parse-recovered load
+    /// error does not block it — it computes over the held directives like the
+    /// CLI's `report returns` (errors surface via `info().errors`) — but a BOOKING
+    /// error (un-booked reduction) is fatal: the engine realizes through a
+    /// fallible path and returns a clean `err` rather than trap or report a figure
+    /// over a contract-violating stream (stricter than beangrow, deliberately —
+    /// run `rledger check`). Fallible: returns `err(message)` on an
+    /// empty/unparseable `end-date`, no resolvable reporting currency, a
+    /// boundary/terminal flow that cannot be priced, or a booking error.
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -559,12 +559,14 @@ interface ledger {
     /// `end-date` (`YYYY-MM-DD`) is both the horizon (later flows are excluded)
     /// and the terminal-valuation date; unlike the CLI it is required, since a
     /// component has no reliable clock. Prices come from the held entries'
-    /// `price` directives and implicit transaction prices. Like `format`, this
-    /// does NOT trap on recovered load errors (they surface via `info().errors`;
-    /// returns is computed over the held directives, as the CLI report renders
-    /// over them). Fallible: returns `err(message)` on an empty/unparseable
-    /// `end-date`, no resolvable reporting currency, or a boundary/terminal flow
-    /// that cannot be priced.
+    /// `price` directives and implicit transaction prices. Because returns
+    /// REALIZES inventory (unlike the text-only `format`), a load-errored ledger
+    /// can carry an un-booked, booking-failed transaction that would trap the
+    /// engine — so, like `query`, this refuses on load errors with a clean
+    /// `err` rather than risk the trap the contract forbids (inspect them via
+    /// `info().errors`). Fallible: returns `err(message)` on held load errors, an
+    /// empty/unparseable `end-date`, no resolvable reporting currency, or a
+    /// boundary/terminal flow that cannot be priced.
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -20,6 +20,7 @@ rustledger-core.workspace = true
 rustledger-booking.workspace = true
 rustledger-parser.workspace = true
 rustledger-loader.workspace = true
+rustledger-returns.workspace = true
 chumsky.workspace = true
 rust_decimal.workspace = true
 jiff.workspace = true

--- a/crates/rustledger-query/src/lib.rs
+++ b/crates/rustledger-query/src/lib.rs
@@ -32,6 +32,7 @@ pub mod error;
 pub mod executor;
 pub mod parser;
 pub mod price;
+pub mod returns;
 
 // AST types are accessed via `rustledger_query::ast::*` rather than re-exported
 // at the crate root. The previous `pub use ast::*;` glob exposed 22 names —
@@ -42,3 +43,4 @@ pub use error::{ParseError, QueryError};
 pub use executor::{Executor, Interval, IntervalUnit, QueryResult, Value};
 pub use parser::parse;
 pub use price::PriceDatabase;
+pub use returns::{scope_returns, scopes_returns};

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -79,6 +79,21 @@ struct RawPrice {
     rate: Decimal,
 }
 
+/// The [`PriceDatabase`] → [`PriceOracle`](rustledger_returns::PriceOracle)
+/// adapter returned by [`PriceDatabase::as_oracle`].
+///
+/// A pure pass-through to [`PriceDatabase::convert`] — the codebase's single
+/// such adapter (the CLI's `report returns`, the component's `session.returns`,
+/// and the shared `crate::returns` helpers all reach the returns engine through
+/// it).
+pub struct PriceDbOracle<'a>(&'a PriceDatabase);
+
+impl rustledger_returns::PriceOracle for PriceDbOracle<'_> {
+    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
+        self.0.convert(amount, to_currency, date)
+    }
+}
+
 impl PriceDatabase {
     /// Create a new empty price database.
     pub fn new() -> Self {
@@ -529,6 +544,19 @@ impl PriceDatabase {
 
         self.get_price(&amount.currency, to_currency, date)
             .map(|price| Amount::new(amount.number * price, to_currency))
+    }
+
+    /// Adapt this price index to the returns engine's
+    /// [`PriceOracle`](rustledger_returns::PriceOracle) trait.
+    ///
+    /// The single `PriceDatabase` → `PriceOracle` bridge in the codebase, so
+    /// `rustledger-returns` stays a leaf (it reaches prices only through the
+    /// trait) and no consumer re-derives the adapter. Used by
+    /// [`crate::returns::scope_returns`] / [`crate::returns::scopes_returns`] and
+    /// the CLI/component returns paths.
+    #[must_use]
+    pub const fn as_oracle(&self) -> PriceDbOracle<'_> {
+        PriceDbOracle(self)
     }
 
     /// Convert an amount using the latest available price.

--- a/crates/rustledger-query/src/returns.rs
+++ b/crates/rustledger-query/src/returns.rs
@@ -2,7 +2,7 @@
 //! engine.
 //!
 //! [`rustledger_returns::compute_returns`] is the canonical returns math, but it
-//! takes a [`PriceOracle`] rather than a
+//! takes a [`PriceOracle`](rustledger_returns::PriceOracle) rather than a
 //! concrete price index — so every consumer must still build a [`PriceDatabase`]
 //! from the ledger, adapt it to the trait, and construct the [`Scope`]. That
 //! wiring was duplicated at the CLI (`report returns`) and the component
@@ -16,24 +16,10 @@
 //! `rustledger-returns` deliberately stays a leaf (no dependency on the price
 //! index), reaching prices only through its `PriceOracle` trait.
 
-use rustledger_core::{Amount, Directive, NaiveDate};
-use rustledger_returns::{
-    ExtractError, PriceOracle, Returns, Scope, compute_returns, compute_returns_multi,
-};
+use rustledger_core::{Directive, NaiveDate};
+use rustledger_returns::{ExtractError, Returns, Scope, compute_returns, compute_returns_multi};
 
 use crate::PriceDatabase;
-
-/// Adapts the query engine's [`PriceDatabase`] to the returns engine's
-/// [`PriceOracle`] trait. A pure pass-through to [`PriceDatabase::convert`] —
-/// the single copy now that the CLI and component both route their returns
-/// through this module.
-struct PriceDbOracle<'a>(&'a PriceDatabase);
-
-impl PriceOracle for PriceDbOracle<'_> {
-    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
-        self.0.convert(amount, to_currency, date)
-    }
-}
 
 /// Compute one scope's investment returns from a booked, pad-expanded stream.
 ///
@@ -56,16 +42,25 @@ pub fn scope_returns(
     end_date: NaiveDate,
 ) -> Result<Returns, ExtractError> {
     let price_db = PriceDatabase::from_directives(directives);
-    let oracle = PriceDbOracle(&price_db);
-    compute_returns(directives, scope, reporting_currency, &oracle, end_date)
+    compute_returns(
+        directives,
+        scope,
+        reporting_currency,
+        &price_db.as_oracle(),
+        end_date,
+    )
 }
 
 /// Compute several scopes' returns in ONE shared realization.
 ///
 /// Via [`compute_returns_multi`]: the booking pass is scope-independent, so the
 /// price index and realization are paid once for all scopes rather than once per
-/// scope. Results come back per scope in the input order; each is independent
-/// (one scope's missing price degrades only that scope, never the rest).
+/// scope. Results come back per scope in the input order.
+///
+/// # Errors
+/// Each element is independent: a scope whose boundary flow or terminal
+/// valuation cannot be priced in `reporting_currency` fails with
+/// [`ExtractError::MissingPrice`] for that scope only, never failing the others.
 ///
 /// # Panics
 /// See [`compute_returns_multi`]: `directives` must be the booked, pad-expanded
@@ -78,6 +73,11 @@ pub fn scopes_returns(
     end_date: NaiveDate,
 ) -> Vec<Result<Returns, ExtractError>> {
     let price_db = PriceDatabase::from_directives(directives);
-    let oracle = PriceDbOracle(&price_db);
-    compute_returns_multi(directives, scopes, reporting_currency, &oracle, end_date)
+    compute_returns_multi(
+        directives,
+        scopes,
+        reporting_currency,
+        &price_db.as_oracle(),
+        end_date,
+    )
 }

--- a/crates/rustledger-query/src/returns.rs
+++ b/crates/rustledger-query/src/returns.rs
@@ -30,11 +30,11 @@ use crate::PriceDatabase;
 /// it here is what stops those two surfaces from drifting.
 ///
 /// # Errors
-/// Propagates [`ExtractError`] from the engine — e.g. a boundary flow, or the
-/// `end_date` terminal valuation, that cannot be priced in `reporting_currency`.
-///
-/// # Panics
-/// See [`compute_returns`]: `directives` must be the booked, pad-expanded stream.
+/// Propagates [`ExtractError`] from the engine: [`ExtractError::MissingPrice`]
+/// when a boundary flow or the `end_date` terminal valuation cannot be priced in
+/// `reporting_currency`, or [`ExtractError::UnbookedInput`] when `directives`
+/// violate the booked, pad-expanded contract (a re-merged booking-failed
+/// transaction) — the engine surfaces that as an `Err`, it does not panic.
 pub fn scope_returns(
     directives: &[Directive],
     scope: &Scope,
@@ -58,13 +58,12 @@ pub fn scope_returns(
 /// scope. Results come back per scope in the input order.
 ///
 /// # Errors
-/// Each element is independent: a scope whose boundary flow or terminal
-/// valuation cannot be priced in `reporting_currency` fails with
-/// [`ExtractError::MissingPrice`] for that scope only, never failing the others.
-///
-/// # Panics
-/// See [`compute_returns_multi`]: `directives` must be the booked, pad-expanded
-/// stream.
+/// [`ExtractError::MissingPrice`] is per-scope independent: a scope whose flow or
+/// terminal valuation cannot be priced fails alone, never the others. An
+/// [`ExtractError::UnbookedInput`] is different — the shared booking pass is
+/// contract-violating for the whole ledger, so it fails EVERY scope (a broken
+/// ledger yields no returns for any scope, not a partial report). The engine
+/// surfaces both as `Err`; neither panics.
 #[must_use]
 pub fn scopes_returns(
     directives: &[Directive],

--- a/crates/rustledger-query/src/returns.rs
+++ b/crates/rustledger-query/src/returns.rs
@@ -1,0 +1,83 @@
+//! Investment-returns composition shared by every embedding of the returns
+//! engine.
+//!
+//! [`rustledger_returns::compute_returns`] is the canonical returns math, but it
+//! takes a [`PriceOracle`] rather than a
+//! concrete price index — so every consumer must still build a [`PriceDatabase`]
+//! from the ledger, adapt it to the trait, and construct the [`Scope`]. That
+//! wiring was duplicated at the CLI (`report returns`) and the component
+//! (`session.returns`) composition roots, each carrying its own `PriceDbOracle`
+//! copy — exactly the re-derivation the canonical-function discipline warns
+//! against. This module is the single home for that composition: both surfaces
+//! call [`scope_returns`] / [`scopes_returns`], so they cannot compute different
+//! figures for the same ledger.
+//!
+//! It lives in `rustledger-query` because that crate owns [`PriceDatabase`];
+//! `rustledger-returns` deliberately stays a leaf (no dependency on the price
+//! index), reaching prices only through its `PriceOracle` trait.
+
+use rustledger_core::{Amount, Directive, NaiveDate};
+use rustledger_returns::{
+    ExtractError, PriceOracle, Returns, Scope, compute_returns, compute_returns_multi,
+};
+
+use crate::PriceDatabase;
+
+/// Adapts the query engine's [`PriceDatabase`] to the returns engine's
+/// [`PriceOracle`] trait. A pure pass-through to [`PriceDatabase::convert`] —
+/// the single copy now that the CLI and component both route their returns
+/// through this module.
+struct PriceDbOracle<'a>(&'a PriceDatabase);
+
+impl PriceOracle for PriceDbOracle<'_> {
+    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
+        self.0.convert(amount, to_currency, date)
+    }
+}
+
+/// Compute one scope's investment returns from a booked, pad-expanded stream.
+///
+/// Builds the price index from the same stream — so implicit transaction prices
+/// and explicit `price` directives both feed the valuation — adapts it to the
+/// engine's oracle, and calls [`compute_returns`]. This is the composition the
+/// CLI's `report returns` and the component's `session.returns` share; keeping
+/// it here is what stops those two surfaces from drifting.
+///
+/// # Errors
+/// Propagates [`ExtractError`] from the engine — e.g. a boundary flow, or the
+/// `end_date` terminal valuation, that cannot be priced in `reporting_currency`.
+///
+/// # Panics
+/// See [`compute_returns`]: `directives` must be the booked, pad-expanded stream.
+pub fn scope_returns(
+    directives: &[Directive],
+    scope: &Scope,
+    reporting_currency: &str,
+    end_date: NaiveDate,
+) -> Result<Returns, ExtractError> {
+    let price_db = PriceDatabase::from_directives(directives);
+    let oracle = PriceDbOracle(&price_db);
+    compute_returns(directives, scope, reporting_currency, &oracle, end_date)
+}
+
+/// Compute several scopes' returns in ONE shared realization.
+///
+/// Via [`compute_returns_multi`]: the booking pass is scope-independent, so the
+/// price index and realization are paid once for all scopes rather than once per
+/// scope. Results come back per scope in the input order; each is independent
+/// (one scope's missing price degrades only that scope, never the rest).
+///
+/// # Panics
+/// See [`compute_returns_multi`]: `directives` must be the booked, pad-expanded
+/// stream.
+#[must_use]
+pub fn scopes_returns(
+    directives: &[Directive],
+    scopes: &[Scope],
+    reporting_currency: &str,
+    end_date: NaiveDate,
+) -> Vec<Result<Returns, ExtractError>> {
+    let price_db = PriceDatabase::from_directives(directives);
+    let oracle = PriceDbOracle(&price_db);
+    compute_returns_multi(directives, scopes, reporting_currency, &oracle, end_date)
+}

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -475,14 +475,14 @@ fn apply_booked(
     engine: &mut rustledger_booking::BookingEngine,
     txn: &rustledger_core::Transaction,
 ) -> Result<(), ExtractError> {
-    if txn
+    if let Some(elided) = txn
         .postings
         .iter()
-        .any(|p| !matches!(p.units, Some(IncompleteAmount::Complete(_))))
+        .find(|p| !matches!(p.units, Some(IncompleteAmount::Complete(_))))
     {
         return Err(ExtractError::UnbookedInput(format!(
-            "transaction on {} has an un-booked (elided) posting",
-            txn.date
+            "posting to {} on {} has un-booked (elided) units",
+            elided.account, txn.date
         )));
     }
     engine

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -210,6 +210,14 @@ pub enum ExtractError {
         /// The date whose rate was missing.
         date: NaiveDate,
     },
+    /// A reduction posting referenced a lot that was never held — the input
+    /// stream is not booked. The loader re-merges booking-FAILED transactions
+    /// into `Ledger.directives` in their un-booked shape; realizing one would
+    /// over-sell inventory (and `debug_assert`-trap the booking engine in debug
+    /// builds), so extraction refuses with this error rather than return a wrong
+    /// valuation. Carries the underlying booking error's message.
+    #[error("cannot compute returns over an unbooked ledger ({0}); fix the booking error first")]
+    UnbookedInput(String),
 }
 
 /// Extract the full cash-flow series (external boundary-crossing flows plus the
@@ -239,13 +247,9 @@ pub enum ExtractError {
 /// # Errors
 ///
 /// Returns [`ExtractError::MissingPrice`] if any external flow or held position
-/// cannot be converted to `reporting_currency` on the date it is needed.
-///
-/// # Panics
-///
-/// See [`terminal_value`]: a stream that violates the booked input contract can
-/// make the booking engine `debug_assert` (debug builds) instead of returning
-/// `Err`.
+/// cannot be converted to `reporting_currency` on the date it is needed, or
+/// [`ExtractError::UnbookedInput`] if the stream violates the booked input
+/// contract (a re-merged booking-failed transaction) — see [`terminal_value`].
 pub fn extract_cash_flows(
     directives: &[Directive],
     scope: &Scope,
@@ -387,14 +391,11 @@ pub fn extract_flows(
 /// # Errors
 ///
 /// Returns [`ExtractError::MissingPrice`] if a held commodity has no price in
-/// `reporting_currency` on `end_date`.
-///
-/// # Panics
-///
-/// Requires the booked input stream of [`extract_cash_flows`]' contract. On a
-/// contract-violating (un-booked) stream, the booking engine may `debug_assert`
-/// in debug builds when a reduction has no matching lot; the leaf crate cannot
-/// detect this, so an un-booked stream can abort rather than return `Err`.
+/// `reporting_currency` on `end_date`, or [`ExtractError::UnbookedInput`] if the
+/// stream violates the booked input contract — a reduction with no matching lot
+/// (the loader re-merges booking-failed transactions in un-booked shape). The
+/// realization surfaces that as an `Err` via the booking engine's fallible
+/// `try_apply`, rather than over-selling inventory or trapping.
 pub fn terminal_value(
     directives: &[Directive],
     scope: &Scope,
@@ -447,7 +448,9 @@ fn investment_value_at(
         if let Directive::Transaction(txn) = directive
             && txn.date <= date
         {
-            engine.apply(txn);
+            engine
+                .try_apply(txn)
+                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
         }
     }
     value_investment_scope(
@@ -563,7 +566,16 @@ fn investment_values_at(
         // ascend, so the cursor only moves forward across the whole batch).
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                engine.apply(txn);
+                if let Err(e) = engine.try_apply(txn) {
+                    // Contract-violating (unbooked) stream: value every remaining
+                    // date as the same error rather than over-sell. Dates already
+                    // pushed (strictly before this transaction) stay correct.
+                    let err = ExtractError::UnbookedInput(e.to_string());
+                    while values.len() < dates.len() {
+                        values.push(Err(err.clone()));
+                    }
+                    return values;
+                }
                 txns.next();
             } else {
                 break;
@@ -633,7 +645,17 @@ fn investment_values_multi(
     for &date in &union {
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                engine.apply(txn);
+                if let Err(e) = engine.try_apply(txn) {
+                    // Contract-violating (unbooked) stream: fill every scope's
+                    // remaining dates with the same error rather than over-sell.
+                    let err = ExtractError::UnbookedInput(e.to_string());
+                    for (i, (_, dates)) in scoped_dates.iter().enumerate() {
+                        while values[i].len() < dates.len() {
+                            values[i].push(Err(err.clone()));
+                        }
+                    }
+                    return values;
+                }
                 txns.next();
             } else {
                 break;
@@ -720,9 +742,9 @@ fn investment_values_multi(
 /// [`PriceOracle`] resolves the most recent price on or before a date, so a
 /// dividend date with no same-day price still resolves from an earlier one.
 ///
-/// # Panics
-///
-/// Same booked, pad-expanded input requirement as [`extract_cash_flows`].
+/// The booked, pad-expanded input contract of [`extract_cash_flows`] applies: an
+/// un-booked reduction surfaces as [`ExtractError::UnbookedInput`] (not a panic),
+/// while an un-pad-expanded stream silently omits pad-seeded positions.
 pub fn twr(
     directives: &[Directive],
     scope: &Scope,
@@ -889,11 +911,10 @@ pub struct Returns {
 /// flow date degrades TWR to `None` rather than erroring — the summary itself is
 /// still well-defined.
 ///
-/// # Panics
-///
-/// Same booked, pad-expanded input requirement as [`twr`]. (Date-sorted input is
-/// a fast path, not a correctness requirement — an unsorted stream falls back to
-/// the order-independent per-date valuation.)
+/// The booked, pad-expanded input contract of [`twr`] applies: an un-booked
+/// reduction surfaces as [`ExtractError::UnbookedInput`] rather than panicking.
+/// (Date-sorted input is a fast path, not a correctness requirement — an unsorted
+/// stream falls back to the order-independent per-date valuation.)
 pub fn compute_returns(
     directives: &[Directive],
     scope: &Scope,
@@ -977,11 +998,11 @@ pub fn compute_returns(
 /// (an unpriceable boundary flow or `end_date` valuation) is reported in that
 /// scope's slot and does not affect the others. There is no whole-call error.
 ///
-/// # Panics
-///
-/// Same booked, pad-expanded input requirement as [`compute_returns`]/[`twr`]
-/// (date-sorted is a fast path, not a requirement — an unsorted stream falls back
-/// to per-scope valuation).
+/// The booked, pad-expanded input contract of [`compute_returns`]/[`twr`]
+/// applies: an un-booked reduction surfaces (per scope) as
+/// [`ExtractError::UnbookedInput`] rather than panicking. (Date-sorted is a fast
+/// path, not a requirement — an unsorted stream falls back to per-scope
+/// valuation.)
 #[must_use]
 pub fn compute_returns_multi(
     directives: &[Directive],
@@ -1136,6 +1157,48 @@ mod tests {
             vec!["Assets:Broker".to_string()],
             vec!["Income:Dividends".to_string()],
         )
+    }
+
+    /// The engine-level guard against realizing an un-booked stream. The loader
+    /// re-merges booking-FAILED transactions in their un-booked shape, so a
+    /// returns consumer can hand `compute_returns` a reduction of more units than
+    /// were ever held. That must surface as [`ExtractError::UnbookedInput`] (via
+    /// the booking engine's fallible `try_apply`), NOT `debug_assert`-trap — this
+    /// native test would abort — nor over-sell into a wrong figure. Closes the
+    /// #1849 third-review finding at the source, for every consumer.
+    #[test]
+    fn unbooked_oversell_errors_not_traps() {
+        use rustledger_core::{CostNumber, CostSpec};
+        // Buy 5 at a cost lot, then reduce 10 with an empty cost `{}` that forces
+        // a lot match — over-reducing a held lot. This is the shape the loader
+        // fails to book and re-merges un-booked; realizing it must NOT trap.
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(5), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number(CostNumber::PerUnit { value: dec!(100) })
+                            .with_currency("USD"),
+                    ),
+                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(-10), "AAPL"))
+                        .with_cost(CostSpec::empty()),
+                    Posting::new("Assets:Bank", amt(dec!(1000), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            "over-reducing an empty-cost lot must yield UnbookedInput, got {r:?}"
+        );
     }
 
     #[test]

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -85,7 +85,7 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
-use rustledger_core::{Amount, Directive, NaiveDate, is_subaccount_or_equal};
+use rustledger_core::{Amount, Directive, IncompleteAmount, NaiveDate, is_subaccount_or_equal};
 
 use crate::CashFlow;
 
@@ -479,6 +479,17 @@ fn apply_scoped(
 ) -> Result<(), ExtractError> {
     for posting in &txn.postings {
         if is_relevant(posting.account.as_str()) {
+            // A booked, pad-expanded stream fills every posting's units, so an
+            // in-scope posting with elided/uninterpolated units means the input
+            // is not booked. Surface it rather than let `try_apply_posting`
+            // silently skip the leg and understate the position (booking, which
+            // this leaf crate cannot run, would have filled it).
+            if !matches!(posting.units, Some(IncompleteAmount::Complete(_))) {
+                return Err(ExtractError::UnbookedInput(format!(
+                    "posting to {} has no complete units — un-booked input",
+                    posting.account
+                )));
+            }
             engine
                 .try_apply_posting(posting, txn.date)
                 .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
@@ -674,20 +685,31 @@ fn investment_values_multi(
                 // Relevant = valued by ANY scope; the shared pass books the union
                 // of every scope's investment accounts, so an over-sell outside
                 // all of them is skipped, not aborted.
-                if let Err(e) = apply_scoped(&mut engine, txn, |a| {
+                if apply_scoped(&mut engine, txn, |a| {
                     scoped_dates
                         .iter()
                         .any(|(scope, _)| scope.classify(a) == AccountRole::Investment)
-                }) {
-                    // An in-scope reduction is un-booked: the shared realization
-                    // can't produce any scope's values past here, so fill every
-                    // scope's remaining dates with the same error.
-                    for (i, (_, dates)) in scoped_dates.iter().enumerate() {
-                        while values[i].len() < dates.len() {
-                            values[i].push(Err(e.clone()));
-                        }
-                    }
-                    return values;
+                })
+                .is_err()
+                {
+                    // The union pass can't tell WHICH scope owns the failing
+                    // account, so it would wrongly error every scope. Recompute
+                    // each scope independently (exactly the unsorted fallback):
+                    // now only the scope whose own accounts contain the un-booked
+                    // reduction errors, and a clean, disjoint sub-portfolio still
+                    // values correctly — matching the single-scope path.
+                    return scoped_dates
+                        .iter()
+                        .map(|(scope, dates)| {
+                            investment_values_at(
+                                directives,
+                                scope,
+                                reporting_currency,
+                                prices,
+                                dates,
+                            )
+                        })
+                        .collect();
                 }
                 txns.next();
             } else {
@@ -1295,6 +1317,83 @@ mod tests {
         let returns = r.expect("out-of-scope over-sell must not abort the in-scope report");
         // In-scope figure is correct and unaffected: 10 AAPL @ 120 = 1200.
         assert_eq!(returns.current_value, dec!(1200));
+    }
+
+    /// `--by-group` isolation: an over-sell in one group's account must error
+    /// only THAT group, not a clean, disjoint group sharing the shared booking
+    /// pass. Input is date-sorted so it exercises the shared union pass (not the
+    /// unsorted per-scope fallback); the fix makes the union pass degrade to
+    /// per-scope on a booking error.
+    #[test]
+    fn multi_isolates_oversell_to_the_owning_scope() {
+        use rustledger_core::{CostNumber, CostSpec};
+        let cost_100 = CostSpec::empty()
+            .with_number(CostNumber::PerUnit { value: dec!(100) })
+            .with_currency("USD");
+        // Date-sorted: A buy, B buy (both Jan), then A's over-sell (Jun).
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:BrokerA:Stock", amt(dec!(5), "AAA")).with_cost(cost_100),
+                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:BrokerB:Stock", amt(dec!(10), "BBB")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:BrokerA:Stock", amt(dec!(-10), "AAA"))
+                        .with_cost(CostSpec::empty()),
+                    Posting::new("Assets:Bank", amt(dec!(1000), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default()
+            .with("AAA", "USD", d(2020, 12, 31), dec!(120))
+            .with("BBB", "USD", d(2020, 12, 31), dec!(150));
+        let scopes = [
+            Scope::new(vec!["Assets:BrokerA".to_string()], vec![]),
+            Scope::new(vec!["Assets:BrokerB".to_string()], vec![]),
+        ];
+        let results = compute_returns_multi(&dirs, &scopes, "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(results[0], Err(ExtractError::UnbookedInput(_))),
+            "group A (over-sell) must error, got {:?}",
+            results[0]
+        );
+        let b = results[1]
+            .as_ref()
+            .expect("group B (clean, disjoint) must still value despite A's over-sell");
+        assert_eq!(b.current_value, dec!(1500)); // 10 BBB @ 150
+    }
+
+    /// An in-scope posting with elided/uninterpolated units means un-booked input
+    /// (booking would fill it). It must surface as `UnbookedInput`, not be
+    /// silently dropped from the valuation (understating the position).
+    #[test]
+    fn elided_in_scope_posting_errors_not_understates() {
+        let dirs = vec![txn(
+            d(2020, 1, 1),
+            vec![
+                // In-scope investment leg with NO units (un-booked / to interpolate).
+                Posting::auto("Assets:Broker:Stock"),
+                Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+            ],
+        )];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
+        let r = compute_returns(&dirs, &scope, "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            "an elided in-scope posting must error, got {r:?}"
+        );
     }
 
     /// `twr`'s lazy short-circuit (an earlier `r <= 0` sub-period returns

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -795,6 +795,17 @@ fn twr_from_values(
     end_value: Result<Decimal, ExtractError>,
     end_date: NaiveDate,
 ) -> Result<Option<f64>, ExtractError> {
+    // A contract-violating (un-booked) stream is more severe than an undefined
+    // sub-period: surface `UnbookedInput` EAGERLY, before the lazy short-circuits
+    // below (`v_prev <= 0`, `r <= 0`) could return `Ok(None)` at an earlier flow
+    // and mask a later un-booked value. `MissingPrice` stays lazy — a later price
+    // gap is genuinely irrelevant once the chain is already undefined — but a
+    // broken ledger is never silently reported as "n/a".
+    for value in flow_values.iter().chain(std::iter::once(&end_value)) {
+        if let Err(e @ ExtractError::UnbookedInput(_)) = value {
+            return Err(e.clone());
+        }
+    }
     // `v_prev` is the portfolio value just after the previous valuation; on the
     // first flow date it is only established (that flow is the opening capital,
     // not a return).
@@ -994,15 +1005,16 @@ pub fn compute_returns(
 ///
 /// # Errors
 ///
-/// Each scope's result is independent: a scope's [`ExtractError::MissingPrice`]
-/// (an unpriceable boundary flow or `end_date` valuation) is reported in that
-/// scope's slot and does not affect the others. There is no whole-call error.
+/// A [`ExtractError::MissingPrice`] (an unpriceable boundary flow or `end_date`
+/// valuation) is per-scope independent: it is reported in that scope's slot and
+/// does not affect the others.
 ///
-/// The booked, pad-expanded input contract of [`compute_returns`]/[`twr`]
-/// applies: an un-booked reduction surfaces (per scope) as
-/// [`ExtractError::UnbookedInput`] rather than panicking. (Date-sorted is a fast
-/// path, not a requirement — an unsorted stream falls back to per-scope
-/// valuation.)
+/// An [`ExtractError::UnbookedInput`] is NOT per-scope: the booking forward pass
+/// is shared across every scope, so a reduction with no matching lot (an
+/// un-booked, re-merged booking-failure) fails EVERY scope's slot — a broken
+/// ledger yields no returns for any scope rather than a partial report, and
+/// surfaces as `Err` rather than panicking. (Date-sorted is a fast path, not a
+/// requirement — an unsorted stream falls back to per-scope valuation.)
 #[must_use]
 pub fn compute_returns_multi(
     directives: &[Directive],
@@ -1198,6 +1210,28 @@ mod tests {
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
             "over-reducing an empty-cost lot must yield UnbookedInput, got {r:?}"
+        );
+    }
+
+    /// `twr`'s lazy short-circuit (an earlier `r <= 0` sub-period returns
+    /// `Ok(None)`) must NOT mask a later `UnbookedInput`: a broken ledger is never
+    /// silently "n/a". Here the first sub-period wipes out (r = 0), which
+    /// pre-fix returned `Ok(None)` before the loop reached the un-booked
+    /// `end_value`; the eager scan surfaces it.
+    #[test]
+    fn twr_surfaces_unbooked_despite_earlier_short_circuit() {
+        let net: std::collections::BTreeMap<NaiveDate, Decimal> =
+            [(d(2020, 1, 1), dec!(100)), (d(2020, 6, 1), dec!(0))]
+                .into_iter()
+                .collect();
+        // Sub-period 0→1: r = (0 - 0) / 100 = 0 ⇒ the loop short-circuits to
+        // Ok(None) at flow 1, never reaching end_value below without the fix.
+        let flow_values = vec![Ok(dec!(100)), Ok(dec!(0))];
+        let end_value = Err(ExtractError::UnbookedInput("over-sell".into()));
+        let r = twr_from_values(&net, flow_values, end_value, d(2020, 12, 31));
+        assert!(
+            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            "must surface UnbookedInput, not swallow it to {r:?}"
         );
     }
 

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -448,9 +448,9 @@ fn investment_value_at(
         if let Directive::Transaction(txn) = directive
             && txn.date <= date
         {
-            engine
-                .try_apply(txn)
-                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
+            apply_scoped(&mut engine, txn, |a| {
+                scope.classify(a) == AccountRole::Investment
+            })?;
         }
     }
     value_investment_scope(
@@ -460,6 +460,31 @@ fn investment_value_at(
         prices,
         date,
     )
+}
+
+/// Apply the postings of `txn` whose account `is_relevant` accepts — the accounts
+/// a realization will actually value (`Investment`-scope) — surfacing an over-sell
+/// as [`ExtractError::UnbookedInput`].
+///
+/// Postings to accounts this realization never values (an unrelated account whose
+/// over-sell the loader re-merged un-booked) are skipped, so a booking error
+/// OUTSIDE the returns scope never aborts an in-scope report. This matches the
+/// beancount/fava model — reports render over loaded-with-errors entries, with
+/// errors surfaced separately (`rledger check`) — while an over-sell IN a valued
+/// account still surfaces (its valuation would otherwise be wrong).
+fn apply_scoped(
+    engine: &mut rustledger_booking::BookingEngine,
+    txn: &rustledger_core::Transaction,
+    is_relevant: impl Fn(&str) -> bool,
+) -> Result<(), ExtractError> {
+    for posting in &txn.postings {
+        if is_relevant(posting.account.as_str()) {
+            engine
+                .try_apply_posting(posting, txn.date)
+                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
+        }
+    }
+    Ok(())
 }
 
 /// Total market value (in `reporting_currency`, at `date`) of the
@@ -566,13 +591,14 @@ fn investment_values_at(
         // ascend, so the cursor only moves forward across the whole batch).
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(e) = engine.try_apply(txn) {
-                    // Contract-violating (unbooked) stream: value every remaining
+                if let Err(e) = apply_scoped(&mut engine, txn, |a| {
+                    scope.classify(a) == AccountRole::Investment
+                }) {
+                    // An in-scope reduction is un-booked: value every remaining
                     // date as the same error rather than over-sell. Dates already
                     // pushed (strictly before this transaction) stay correct.
-                    let err = ExtractError::UnbookedInput(e.to_string());
                     while values.len() < dates.len() {
-                        values.push(Err(err.clone()));
+                        values.push(Err(e.clone()));
                     }
                     return values;
                 }
@@ -645,13 +671,20 @@ fn investment_values_multi(
     for &date in &union {
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(e) = engine.try_apply(txn) {
-                    // Contract-violating (unbooked) stream: fill every scope's
-                    // remaining dates with the same error rather than over-sell.
-                    let err = ExtractError::UnbookedInput(e.to_string());
+                // Relevant = valued by ANY scope; the shared pass books the union
+                // of every scope's investment accounts, so an over-sell outside
+                // all of them is skipped, not aborted.
+                if let Err(e) = apply_scoped(&mut engine, txn, |a| {
+                    scoped_dates
+                        .iter()
+                        .any(|(scope, _)| scope.classify(a) == AccountRole::Investment)
+                }) {
+                    // An in-scope reduction is un-booked: the shared realization
+                    // can't produce any scope's values past here, so fill every
+                    // scope's remaining dates with the same error.
                     for (i, (_, dates)) in scoped_dates.iter().enumerate() {
                         while values[i].len() < dates.len() {
-                            values[i].push(Err(err.clone()));
+                            values[i].push(Err(e.clone()));
                         }
                     }
                     return values;
@@ -801,6 +834,11 @@ fn twr_from_values(
     // and mask a later un-booked value. `MissingPrice` stays lazy — a later price
     // gap is genuinely irrelevant once the chain is already undefined — but a
     // broken ledger is never silently reported as "n/a".
+    //
+    // This matters only for the STANDALONE public [`twr`]: [`compute_returns`]
+    // already surfaces `UnbookedInput` via its eager `end_value?` and discards
+    // this fn's `Err` with `unwrap_or(None)`. Kept so the public `twr` honors its
+    // documented contract regardless of that caller-side protection.
     for value in flow_values.iter().chain(std::iter::once(&end_value)) {
         if let Err(e @ ExtractError::UnbookedInput(_)) = value {
             return Err(e.clone());
@@ -1211,6 +1249,52 @@ mod tests {
             matches!(r, Err(ExtractError::UnbookedInput(_))),
             "over-reducing an empty-cost lot must yield UnbookedInput, got {r:?}"
         );
+    }
+
+    /// An over-sell OUTSIDE the returns scope must NOT abort the report — the
+    /// realization books only the accounts it values, matching beancount/fava
+    /// (reports render over loaded-with-errors entries). Here a clean in-scope
+    /// holding coexists with an un-booked over-sell in an unrelated broker.
+    #[test]
+    fn out_of_scope_oversell_does_not_abort_report() {
+        use rustledger_core::{CostNumber, CostSpec};
+        let dirs = vec![
+            // In-scope (Assets:Broker) — a clean buy, valued at end.
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            // OUT-of-scope (Assets:Other) — buy 5 then over-reduce 10 with empty
+            // cost: the loader would re-merge this un-booked, but it is never valued.
+            txn(
+                d(2020, 2, 1),
+                vec![
+                    Posting::new("Assets:Other:Stock", amt(dec!(5), "ZZZ")).with_cost(
+                        CostSpec::empty()
+                            .with_number(CostNumber::PerUnit { value: dec!(1) })
+                            .with_currency("USD"),
+                    ),
+                    Posting::new("Assets:Bank", amt(dec!(-5), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Other:Stock", amt(dec!(-10), "ZZZ"))
+                        .with_cost(CostSpec::empty()),
+                    Posting::new("Assets:Bank", amt(dec!(10), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
+        let r = compute_returns(&dirs, &scope, "USD", &prices, d(2020, 12, 31));
+        let returns = r.expect("out-of-scope over-sell must not abort the in-scope report");
+        // In-scope figure is correct and unaffected: 10 AAPL @ 120 = 1200.
+        assert_eq!(returns.current_value, dec!(1200));
     }
 
     /// `twr`'s lazy short-circuit (an earlier `r <= 0` sub-period returns

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -68,10 +68,12 @@
 //! expanded into their synthesized transactions (the loader's
 //! `Ledger::balance_view` output, the same stream the canonical
 //! `report_cmd::account_balances` consumes). This crate is a leaf and cannot
-//! book or pad-expand a raw stream itself; handing it un-booked directives lets
-//! the booking engine silently realize the wrong inventory (unmatched reductions and
-//! elided-units postings are dropped), and handing it un-expanded directives
-//! drops any position seeded by a pad.
+//! book or pad-expand a raw stream itself. It defends the booked half of the
+//! contract: an un-booked directive — an unmatched reduction, or a posting with
+//! elided/uninterpolated units — surfaces as [`ExtractError::UnbookedInput`]
+//! rather than a silently wrong figure. It cannot defend the pad half, though:
+//! handing it an un-expanded stream silently drops any position seeded by a pad,
+//! so callers must pad-expand first.
 //!
 //! Returns are computed **from ledger inception** — there is no analysis start
 //! date. An opening balance (a `pad`, or an explicit `Equity:Opening-Balances`
@@ -85,7 +87,7 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
-use rustledger_core::{Amount, Directive, NaiveDate, is_subaccount_or_equal};
+use rustledger_core::{Amount, Directive, IncompleteAmount, NaiveDate, is_subaccount_or_equal};
 
 use crate::CashFlow;
 
@@ -448,9 +450,7 @@ fn investment_value_at(
         if let Directive::Transaction(txn) = directive
             && txn.date <= date
         {
-            engine
-                .try_apply(txn)
-                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
+            apply_booked(&mut engine, txn)?;
         }
     }
     value_investment_scope(
@@ -460,6 +460,34 @@ fn investment_value_at(
         prices,
         date,
     )
+}
+
+/// Apply a whole transaction to `engine`, surfacing an un-booked stream as
+/// [`ExtractError::UnbookedInput`] instead of a wrong figure.
+///
+/// The realization requires the booked, pad-expanded input contract. Two ways a
+/// re-merged booking-failed transaction violates it, both caught here: an
+/// unmatched reduction (via the booking engine's fallible
+/// [`try_apply`](rustledger_booking::BookingEngine::try_apply)), and a posting
+/// with elided/uninterpolated units (booking fills these) — which `try_apply`
+/// would otherwise silently skip, understating the position.
+fn apply_booked(
+    engine: &mut rustledger_booking::BookingEngine,
+    txn: &rustledger_core::Transaction,
+) -> Result<(), ExtractError> {
+    if txn
+        .postings
+        .iter()
+        .any(|p| !matches!(p.units, Some(IncompleteAmount::Complete(_))))
+    {
+        return Err(ExtractError::UnbookedInput(format!(
+            "transaction on {} has an un-booked (elided) posting",
+            txn.date
+        )));
+    }
+    engine
+        .try_apply(txn)
+        .map_err(|e| ExtractError::UnbookedInput(e.to_string()))
 }
 
 /// Total market value (in `reporting_currency`, at `date`) of the
@@ -566,11 +594,10 @@ fn investment_values_at(
         // ascend, so the cursor only moves forward across the whole batch).
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(e) = engine.try_apply(txn) {
+                if let Err(err) = apply_booked(&mut engine, txn) {
                     // Contract-violating (un-booked) stream: value every remaining
                     // date as the same error rather than over-sell. Dates already
                     // pushed (strictly before this transaction) stay correct.
-                    let err = ExtractError::UnbookedInput(e.to_string());
                     while values.len() < dates.len() {
                         values.push(Err(err.clone()));
                     }
@@ -645,11 +672,10 @@ fn investment_values_multi(
     for &date in &union {
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(e) = engine.try_apply(txn) {
+                if let Err(err) = apply_booked(&mut engine, txn) {
                     // Contract-violating (un-booked) stream: the shared pass can't
                     // produce any scope's values past here, so fill every scope's
                     // remaining dates with the same error.
-                    let err = ExtractError::UnbookedInput(e.to_string());
                     for (i, (_, dates)) in scoped_dates.iter().enumerate() {
                         while values[i].len() < dates.len() {
                             values[i].push(Err(err.clone()));
@@ -777,6 +803,19 @@ pub fn twr(
     // Split off the `end_date` valuation; `values` then has exactly one entry per
     // flow date, in `net_by_date` order.
     let end_value = values.pop().expect("dates always includes end_date");
+    // A contract-violating (un-booked) stream is more severe than an undefined
+    // sub-period: surface `UnbookedInput` EAGERLY, before `twr_from_values`' lazy
+    // short-circuits (`v_prev <= 0`, `r <= 0`) could return `Ok(None)` at an
+    // earlier flow and mask a later un-booked value. `MissingPrice` stays lazy (a
+    // later price gap is irrelevant once the chain is undefined), but a broken
+    // ledger is never silently "n/a". `compute_returns` needs no such scan — it
+    // surfaces `UnbookedInput` via its eager `end_value?` — so this lives here, on
+    // the standalone public path, not in the shared `twr_from_values` hot path.
+    for value in values.iter().chain(std::iter::once(&end_value)) {
+        if let Err(e @ ExtractError::UnbookedInput(_)) = value {
+            return Err(e.clone());
+        }
+    }
     twr_from_values(&net_by_date, values, end_value, end_date)
 }
 
@@ -796,22 +835,6 @@ fn twr_from_values(
     end_value: Result<Decimal, ExtractError>,
     end_date: NaiveDate,
 ) -> Result<Option<f64>, ExtractError> {
-    // A contract-violating (un-booked) stream is more severe than an undefined
-    // sub-period: surface `UnbookedInput` EAGERLY, before the lazy short-circuits
-    // below (`v_prev <= 0`, `r <= 0`) could return `Ok(None)` at an earlier flow
-    // and mask a later un-booked value. `MissingPrice` stays lazy — a later price
-    // gap is genuinely irrelevant once the chain is already undefined — but a
-    // broken ledger is never silently reported as "n/a".
-    //
-    // This matters only for the STANDALONE public [`twr`]: [`compute_returns`]
-    // already surfaces `UnbookedInput` via its eager `end_value?` and discards
-    // this fn's `Err` with `unwrap_or(None)`. Kept so the public `twr` honors its
-    // documented contract regardless of that caller-side protection.
-    for value in flow_values.iter().chain(std::iter::once(&end_value)) {
-        if let Err(e @ ExtractError::UnbookedInput(_)) = value {
-            return Err(e.clone());
-        }
-    }
     // `v_prev` is the portfolio value just after the previous valuation; on the
     // first flow date it is only established (that flow is the opening capital,
     // not a return).
@@ -1219,25 +1242,62 @@ mod tests {
         );
     }
 
-    /// `twr`'s lazy short-circuit (an earlier `r <= 0` sub-period returns
-    /// `Ok(None)`) must NOT mask a later `UnbookedInput`: a broken ledger is never
-    /// silently "n/a". Here the first sub-period wipes out (r = 0), which
-    /// pre-fix returned `Ok(None)` before the loop reached the un-booked
-    /// `end_value`; the eager scan surfaces it.
+    /// The OTHER un-booked shape: a transaction with an elided/uninterpolated
+    /// posting (booking would have filled it). `try_apply` silently skips a
+    /// non-Complete leg, which would understate the position — strict-clean must
+    /// surface it as `UnbookedInput`, not report a wrong figure.
     #[test]
-    fn twr_surfaces_unbooked_despite_earlier_short_circuit() {
-        let net: std::collections::BTreeMap<NaiveDate, Decimal> =
-            [(d(2020, 1, 1), dec!(100)), (d(2020, 6, 1), dec!(0))]
-                .into_iter()
-                .collect();
-        // Sub-period 0→1: r = (0 - 0) / 100 = 0 ⇒ the loop short-circuits to
-        // Ok(None) at flow 1, never reaching end_value below without the fix.
-        let flow_values = vec![Ok(dec!(100)), Ok(dec!(0))];
-        let end_value = Err(ExtractError::UnbookedInput("over-sell".into()));
-        let r = twr_from_values(&net, flow_values, end_value, d(2020, 12, 31));
+    fn unbooked_elided_posting_errors_not_understates() {
+        let dirs = vec![txn(
+            d(2020, 1, 1),
+            vec![
+                // Elided in-scope investment leg (no units) — un-booked input.
+                Posting::auto("Assets:Broker:Stock"),
+                Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+            ],
+        )];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "must surface UnbookedInput, not swallow it to {r:?}"
+            "an elided posting must yield UnbookedInput, got {r:?}"
+        );
+    }
+
+    /// The public `twr` surfaces an un-booked reduction as `UnbookedInput` via
+    /// its eager scan, rather than masking it as `Ok(None)` through
+    /// `twr_from_values`' lazy short-circuits. (`compute_returns` is protected
+    /// separately by its eager terminal valuation.)
+    #[test]
+    fn twr_surfaces_unbooked_input() {
+        use rustledger_core::{CostNumber, CostSpec};
+        // Buy 5, then over-reduce 10 with an empty cost — an un-booked reduction.
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(5), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number(CostNumber::PerUnit { value: dec!(100) })
+                            .with_currency("USD"),
+                    ),
+                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(-10), "AAPL"))
+                        .with_cost(CostSpec::empty()),
+                    Posting::new("Assets:Bank", amt(dec!(1000), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let r = twr(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            "twr must surface UnbookedInput, not swallow it to {r:?}"
         );
     }
 

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -85,7 +85,7 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
-use rustledger_core::{Amount, Directive, IncompleteAmount, NaiveDate, is_subaccount_or_equal};
+use rustledger_core::{Amount, Directive, NaiveDate, is_subaccount_or_equal};
 
 use crate::CashFlow;
 
@@ -448,9 +448,9 @@ fn investment_value_at(
         if let Directive::Transaction(txn) = directive
             && txn.date <= date
         {
-            apply_scoped(&mut engine, txn, |a| {
-                scope.classify(a) == AccountRole::Investment
-            })?;
+            engine
+                .try_apply(txn)
+                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
         }
     }
     value_investment_scope(
@@ -460,42 +460,6 @@ fn investment_value_at(
         prices,
         date,
     )
-}
-
-/// Apply the postings of `txn` whose account `is_relevant` accepts — the accounts
-/// a realization will actually value (`Investment`-scope) — surfacing an over-sell
-/// as [`ExtractError::UnbookedInput`].
-///
-/// Postings to accounts this realization never values (an unrelated account whose
-/// over-sell the loader re-merged un-booked) are skipped, so a booking error
-/// OUTSIDE the returns scope never aborts an in-scope report. This matches the
-/// beancount/fava model — reports render over loaded-with-errors entries, with
-/// errors surfaced separately (`rledger check`) — while an over-sell IN a valued
-/// account still surfaces (its valuation would otherwise be wrong).
-fn apply_scoped(
-    engine: &mut rustledger_booking::BookingEngine,
-    txn: &rustledger_core::Transaction,
-    is_relevant: impl Fn(&str) -> bool,
-) -> Result<(), ExtractError> {
-    for posting in &txn.postings {
-        if is_relevant(posting.account.as_str()) {
-            // A booked, pad-expanded stream fills every posting's units, so an
-            // in-scope posting with elided/uninterpolated units means the input
-            // is not booked. Surface it rather than let `try_apply_posting`
-            // silently skip the leg and understate the position (booking, which
-            // this leaf crate cannot run, would have filled it).
-            if !matches!(posting.units, Some(IncompleteAmount::Complete(_))) {
-                return Err(ExtractError::UnbookedInput(format!(
-                    "posting to {} has no complete units — un-booked input",
-                    posting.account
-                )));
-            }
-            engine
-                .try_apply_posting(posting, txn.date)
-                .map_err(|e| ExtractError::UnbookedInput(e.to_string()))?;
-        }
-    }
-    Ok(())
 }
 
 /// Total market value (in `reporting_currency`, at `date`) of the
@@ -602,14 +566,13 @@ fn investment_values_at(
         // ascend, so the cursor only moves forward across the whole batch).
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(e) = apply_scoped(&mut engine, txn, |a| {
-                    scope.classify(a) == AccountRole::Investment
-                }) {
-                    // An in-scope reduction is un-booked: value every remaining
+                if let Err(e) = engine.try_apply(txn) {
+                    // Contract-violating (un-booked) stream: value every remaining
                     // date as the same error rather than over-sell. Dates already
                     // pushed (strictly before this transaction) stay correct.
+                    let err = ExtractError::UnbookedInput(e.to_string());
                     while values.len() < dates.len() {
-                        values.push(Err(e.clone()));
+                        values.push(Err(err.clone()));
                     }
                     return values;
                 }
@@ -682,34 +645,17 @@ fn investment_values_multi(
     for &date in &union {
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                // Relevant = valued by ANY scope; the shared pass books the union
-                // of every scope's investment accounts, so an over-sell outside
-                // all of them is skipped, not aborted.
-                if apply_scoped(&mut engine, txn, |a| {
-                    scoped_dates
-                        .iter()
-                        .any(|(scope, _)| scope.classify(a) == AccountRole::Investment)
-                })
-                .is_err()
-                {
-                    // The union pass can't tell WHICH scope owns the failing
-                    // account, so it would wrongly error every scope. Recompute
-                    // each scope independently (exactly the unsorted fallback):
-                    // now only the scope whose own accounts contain the un-booked
-                    // reduction errors, and a clean, disjoint sub-portfolio still
-                    // values correctly — matching the single-scope path.
-                    return scoped_dates
-                        .iter()
-                        .map(|(scope, dates)| {
-                            investment_values_at(
-                                directives,
-                                scope,
-                                reporting_currency,
-                                prices,
-                                dates,
-                            )
-                        })
-                        .collect();
+                if let Err(e) = engine.try_apply(txn) {
+                    // Contract-violating (un-booked) stream: the shared pass can't
+                    // produce any scope's values past here, so fill every scope's
+                    // remaining dates with the same error.
+                    let err = ExtractError::UnbookedInput(e.to_string());
+                    for (i, (_, dates)) in scoped_dates.iter().enumerate() {
+                        while values[i].len() < dates.len() {
+                            values[i].push(Err(err.clone()));
+                        }
+                    }
+                    return values;
                 }
                 txns.next();
             } else {
@@ -1270,129 +1216,6 @@ mod tests {
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
             "over-reducing an empty-cost lot must yield UnbookedInput, got {r:?}"
-        );
-    }
-
-    /// An over-sell OUTSIDE the returns scope must NOT abort the report — the
-    /// realization books only the accounts it values, matching beancount/fava
-    /// (reports render over loaded-with-errors entries). Here a clean in-scope
-    /// holding coexists with an un-booked over-sell in an unrelated broker.
-    #[test]
-    fn out_of_scope_oversell_does_not_abort_report() {
-        use rustledger_core::{CostNumber, CostSpec};
-        let dirs = vec![
-            // In-scope (Assets:Broker) — a clean buy, valued at end.
-            txn(
-                d(2020, 1, 1),
-                vec![
-                    Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
-                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
-                ],
-            ),
-            // OUT-of-scope (Assets:Other) — buy 5 then over-reduce 10 with empty
-            // cost: the loader would re-merge this un-booked, but it is never valued.
-            txn(
-                d(2020, 2, 1),
-                vec![
-                    Posting::new("Assets:Other:Stock", amt(dec!(5), "ZZZ")).with_cost(
-                        CostSpec::empty()
-                            .with_number(CostNumber::PerUnit { value: dec!(1) })
-                            .with_currency("USD"),
-                    ),
-                    Posting::new("Assets:Bank", amt(dec!(-5), "USD")),
-                ],
-            ),
-            txn(
-                d(2020, 6, 1),
-                vec![
-                    Posting::new("Assets:Other:Stock", amt(dec!(-10), "ZZZ"))
-                        .with_cost(CostSpec::empty()),
-                    Posting::new("Assets:Bank", amt(dec!(10), "USD")),
-                ],
-            ),
-        ];
-        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
-        let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
-        let r = compute_returns(&dirs, &scope, "USD", &prices, d(2020, 12, 31));
-        let returns = r.expect("out-of-scope over-sell must not abort the in-scope report");
-        // In-scope figure is correct and unaffected: 10 AAPL @ 120 = 1200.
-        assert_eq!(returns.current_value, dec!(1200));
-    }
-
-    /// `--by-group` isolation: an over-sell in one group's account must error
-    /// only THAT group, not a clean, disjoint group sharing the shared booking
-    /// pass. Input is date-sorted so it exercises the shared union pass (not the
-    /// unsorted per-scope fallback); the fix makes the union pass degrade to
-    /// per-scope on a booking error.
-    #[test]
-    fn multi_isolates_oversell_to_the_owning_scope() {
-        use rustledger_core::{CostNumber, CostSpec};
-        let cost_100 = CostSpec::empty()
-            .with_number(CostNumber::PerUnit { value: dec!(100) })
-            .with_currency("USD");
-        // Date-sorted: A buy, B buy (both Jan), then A's over-sell (Jun).
-        let dirs = vec![
-            txn(
-                d(2020, 1, 1),
-                vec![
-                    Posting::new("Assets:BrokerA:Stock", amt(dec!(5), "AAA")).with_cost(cost_100),
-                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
-                ],
-            ),
-            txn(
-                d(2020, 1, 1),
-                vec![
-                    Posting::new("Assets:BrokerB:Stock", amt(dec!(10), "BBB")),
-                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
-                ],
-            ),
-            txn(
-                d(2020, 6, 1),
-                vec![
-                    Posting::new("Assets:BrokerA:Stock", amt(dec!(-10), "AAA"))
-                        .with_cost(CostSpec::empty()),
-                    Posting::new("Assets:Bank", amt(dec!(1000), "USD")),
-                ],
-            ),
-        ];
-        let prices = MockPrices::default()
-            .with("AAA", "USD", d(2020, 12, 31), dec!(120))
-            .with("BBB", "USD", d(2020, 12, 31), dec!(150));
-        let scopes = [
-            Scope::new(vec!["Assets:BrokerA".to_string()], vec![]),
-            Scope::new(vec!["Assets:BrokerB".to_string()], vec![]),
-        ];
-        let results = compute_returns_multi(&dirs, &scopes, "USD", &prices, d(2020, 12, 31));
-        assert!(
-            matches!(results[0], Err(ExtractError::UnbookedInput(_))),
-            "group A (over-sell) must error, got {:?}",
-            results[0]
-        );
-        let b = results[1]
-            .as_ref()
-            .expect("group B (clean, disjoint) must still value despite A's over-sell");
-        assert_eq!(b.current_value, dec!(1500)); // 10 BBB @ 150
-    }
-
-    /// An in-scope posting with elided/uninterpolated units means un-booked input
-    /// (booking would fill it). It must surface as `UnbookedInput`, not be
-    /// silently dropped from the valuation (understating the position).
-    #[test]
-    fn elided_in_scope_posting_errors_not_understates() {
-        let dirs = vec![txn(
-            d(2020, 1, 1),
-            vec![
-                // In-scope investment leg with NO units (un-booked / to interpolate).
-                Posting::auto("Assets:Broker:Stock"),
-                Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
-            ],
-        )];
-        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
-        let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
-        let r = compute_returns(&dirs, &scope, "USD", &prices, d(2020, 12, 31));
-        assert!(
-            matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "an elided in-scope posting must error, got {r:?}"
         );
     }
 

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -843,7 +843,7 @@ mod tests {
         assert_eq!(canonical.len(), 3);
     }
 
-    /// The CLI `report returns` path (compute_group -> scope_returns) must
+    /// The CLI `report returns` path (`compute_group` -> `scope_returns`) must
     /// return a clean error, NOT trap, when the loaded ledger carries a
     /// booking-failed (un-booked, re-merged) transaction — the pre-existing CLI
     /// exposure the #1849 third review flagged, now closed by the returns

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -843,6 +843,46 @@ mod tests {
         assert_eq!(canonical.len(), 3);
     }
 
+    /// The CLI `report returns` path (compute_group -> scope_returns) must
+    /// return a clean error, NOT trap, when the loaded ledger carries a
+    /// booking-failed (un-booked, re-merged) transaction — the pre-existing CLI
+    /// exposure the #1849 third review flagged, now closed by the returns
+    /// engine's fallible `try_apply`. Over-reduce an empty-cost lot (sell 10 of a
+    /// 5-lot); without the fix this native test would abort.
+    #[test]
+    fn compute_group_errors_on_unbooked_oversell_not_traps() {
+        use rustledger_core::{CostNumber, CostSpec};
+        let dirs = vec![
+            Directive::Transaction(
+                Transaction::new(d(2020, 1, 1), "buy")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Broker:Stock", money(5, "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(CostNumber::PerUnit {
+                                    value: Decimal::from(100),
+                                })
+                                .with_currency("USD"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new("Assets:Bank", money(-500, "USD"))),
+            ),
+            Directive::Transaction(
+                Transaction::new(d(2020, 6, 1), "oversell")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Broker:Stock", money(-10, "AAPL"))
+                            .with_cost(CostSpec::empty()),
+                    )
+                    .with_synthesized_posting(Posting::new("Assets:Bank", money(1000, "USD"))),
+            ),
+        ];
+        let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
+        let r = compute_group(&dirs, &scope, "USD", d(2020, 12, 31), "TOTAL".to_string());
+        assert!(
+            r.is_err(),
+            "the CLI report path must error (not trap) on an un-booked over-sell"
+        );
+    }
+
     /// Drift guard (CLAUDE.md Canonical-Function Discipline): the batched
     /// `shared_inscope_accounts` (one pass over the transactions, used in
     /// production) must return, per group, exactly what the per-group

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -63,6 +63,12 @@ use std::io::Write;
 /// meet — deliberately: `rustledger-returns` stays a leaf (no dependency on the
 /// query engine that owns the price index), and `rustledger-query` stays free of
 /// a returns dependency.
+///
+/// A byte-identical twin exists at the component's composition root
+/// (`PriceDbOracle` in `rustledger-ffi-component/src/convert.rs`, for
+/// `session.returns`) for the same leaf-crate reason. Both are pure
+/// pass-throughs to [`PriceDatabase::convert`], so the compiler enforces
+/// agreement; if a third consumer appears, hoist the adapter into a shared home.
 pub(super) struct PriceDbOracle<'a>(pub(super) &'a PriceDatabase);
 
 impl PriceOracle for PriceDbOracle<'_> {

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -709,24 +709,13 @@ mod tests {
     use super::*;
     use rustledger_core::{Amount, Posting, Price, Transaction, naive_date};
     use rustledger_query::PriceDatabase;
-    // The drift guards below compare against the engine's individual primitives,
-    // which the production path no longer imports (it uses the shared
-    // `rustledger_query::scope_returns`). `PriceOracle` is needed in scope both
-    // to implement `TestOracle` and to call `.convert` on it directly.
+    // The drift guards below exercise the engine's individual primitives
+    // (`terminal_value` / `extract_flows` / `extract_cash_flows`), which the
+    // production path no longer imports (it uses the shared
+    // `rustledger_query::scope_returns`). They obtain a `PriceOracle` from the
+    // canonical `PriceDatabase::as_oracle()`; `PriceOracle` is in scope to call
+    // `.convert` on it directly.
     use rustledger_returns::{PriceOracle, extract_flows, terminal_value};
-
-    /// Test-only price oracle. Production returns now route through
-    /// `rustledger_query::scope_returns` (which owns the sole `PriceDatabase` →
-    /// `PriceOracle` adapter), but these lower-level drift guards exercise the
-    /// engine primitives (`terminal_value` / `extract_flows` /
-    /// `extract_cash_flows`) directly, which need a bare `PriceOracle` the helper
-    /// does not expose.
-    struct TestOracle<'a>(&'a PriceDatabase);
-    impl rustledger_returns::PriceOracle for TestOracle<'_> {
-        fn convert(&self, amount: &Amount, to: &str, date: NaiveDate) -> Option<Amount> {
-            self.0.convert(amount, to, date)
-        }
-    }
 
     fn d(y: i32, m: u32, day: u32) -> NaiveDate {
         naive_date(y, m, day).unwrap()
@@ -771,7 +760,7 @@ mod tests {
         ];
         let end = d(2020, 12, 31);
         let price_db = PriceDatabase::from_directives(&dirs);
-        let oracle = TestOracle(&price_db);
+        let oracle = price_db.as_oracle();
 
         // Independently value `account_balances`' inventories at market for the
         // same scope, then compare to `terminal_value`.
@@ -833,7 +822,7 @@ mod tests {
             vec!["Income:Dividends".to_string()],
         );
         let price_db = PriceDatabase::from_directives(&dirs);
-        let oracle = TestOracle(&price_db);
+        let oracle = price_db.as_oracle();
 
         // Reproduce report_returns' hand-built series.
         let flows = extract_flows(&dirs, &scope, "USD", &oracle, end).unwrap();

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -47,35 +47,11 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use rustledger_core::{
-    Amount, Directive, DisplayContext, MetaValue, NaiveDate, is_subaccount_or_equal,
-};
-use rustledger_query::PriceDatabase;
-use rustledger_returns::{AccountRole, PriceOracle, Scope, compute_returns, compute_returns_multi};
+use rustledger_core::{Directive, DisplayContext, MetaValue, NaiveDate, is_subaccount_or_equal};
+use rustledger_query::{scope_returns, scopes_returns};
+use rustledger_returns::{AccountRole, Scope};
 use std::collections::BTreeMap;
 use std::io::Write;
-
-/// Adapts the query engine's [`PriceDatabase`] to the returns engine's
-/// [`PriceOracle`] trait.
-///
-/// The `convert` signatures are identical, so this is a pass-through. It lives
-/// here at the composition root — where the CLI is the only place the two crates
-/// meet — deliberately: `rustledger-returns` stays a leaf (no dependency on the
-/// query engine that owns the price index), and `rustledger-query` stays free of
-/// a returns dependency.
-///
-/// A byte-identical twin exists at the component's composition root
-/// (`PriceDbOracle` in `rustledger-ffi-component/src/convert.rs`, for
-/// `session.returns`) for the same leaf-crate reason. Both are pure
-/// pass-throughs to [`PriceDatabase::convert`], so the compiler enforces
-/// agreement; if a third consumer appears, hoist the adapter into a shared home.
-pub(super) struct PriceDbOracle<'a>(pub(super) &'a PriceDatabase);
-
-impl PriceOracle for PriceDbOracle<'_> {
-    fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
-        self.0.convert(amount, to_currency, date)
-    }
-}
 
 /// The computed return figures for one scope (a group, or the whole portfolio).
 struct GroupResult {
@@ -92,20 +68,18 @@ struct GroupResult {
 
 /// Compute the return summary for one scope.
 ///
-/// Delegates to the engine's `compute_returns`, which extracts the boundary flows
-/// and realizes the portfolio ONCE. Previously this consumer composed
-/// `extract_flows` + `terminal_value` + `twr`, and `twr` itself re-ran
-/// `extract_flows` and a second realization — so each group did ~2 extractions and
-/// ~2 realizations. This adds only the row `label`.
+/// Delegates to [`rustledger_query::scope_returns`] — the composition shared with
+/// the component's `session.returns`, which builds the price index and calls the
+/// engine's `compute_returns` (one extraction + one realization per scope). This
+/// adds only the row `label`.
 fn compute_group(
     directives: &[Directive],
     scope: &Scope,
     reporting_currency: &str,
-    prices: &impl PriceOracle,
     end_date: NaiveDate,
     label: String,
 ) -> Result<GroupResult> {
-    let r = compute_returns(directives, scope, reporting_currency, prices, end_date)
+    let r = scope_returns(directives, scope, reporting_currency, end_date)
         .with_context(|| format!("computing investment returns for {label}"))?;
     Ok(GroupResult {
         label,
@@ -413,18 +387,12 @@ pub(super) fn report_returns<W: Write>(
     };
 
     let whole_scope = Scope::new(investments.to_vec(), income.to_vec());
-    // Price index built from the same stream, so implicit transaction prices and
-    // explicit `price` directives both feed the valuation.
-    let price_db = PriceDatabase::from_directives(directives);
-    let oracle = PriceDbOracle(&price_db);
-
     let currency = reporting_currency.as_str();
     if !by_group {
         let total = compute_group(
             directives,
             &whole_scope,
             &reporting_currency,
-            &oracle,
             end_date,
             "TOTAL".to_string(),
         )?;
@@ -447,7 +415,6 @@ pub(super) fn report_returns<W: Write>(
             directives,
             &whole_scope,
             &reporting_currency,
-            &oracle,
             end_date,
             "TOTAL".to_string(),
         )?;
@@ -466,8 +433,7 @@ pub(super) fn report_returns<W: Write>(
         labels.push(label);
         scopes.push(scope);
     }
-    let computed =
-        compute_returns_multi(directives, &scopes, &reporting_currency, &oracle, end_date);
+    let computed = scopes_returns(directives, &scopes, &reporting_currency, end_date);
 
     let mut rows: Vec<GroupResult> = Vec::with_capacity(computed.len());
     for (result, label) in computed.into_iter().zip(labels) {
@@ -741,10 +707,26 @@ fn truncate(s: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustledger_core::{Posting, Price, Transaction, naive_date};
+    use rustledger_core::{Amount, Posting, Price, Transaction, naive_date};
+    use rustledger_query::PriceDatabase;
     // The drift guards below compare against the engine's individual primitives,
-    // which the production path no longer imports (it uses `compute_returns`).
-    use rustledger_returns::{extract_flows, terminal_value};
+    // which the production path no longer imports (it uses the shared
+    // `rustledger_query::scope_returns`). `PriceOracle` is needed in scope both
+    // to implement `TestOracle` and to call `.convert` on it directly.
+    use rustledger_returns::{PriceOracle, extract_flows, terminal_value};
+
+    /// Test-only price oracle. Production returns now route through
+    /// `rustledger_query::scope_returns` (which owns the sole `PriceDatabase` →
+    /// `PriceOracle` adapter), but these lower-level drift guards exercise the
+    /// engine primitives (`terminal_value` / `extract_flows` /
+    /// `extract_cash_flows`) directly, which need a bare `PriceOracle` the helper
+    /// does not expose.
+    struct TestOracle<'a>(&'a PriceDatabase);
+    impl rustledger_returns::PriceOracle for TestOracle<'_> {
+        fn convert(&self, amount: &Amount, to: &str, date: NaiveDate) -> Option<Amount> {
+            self.0.convert(amount, to, date)
+        }
+    }
 
     fn d(y: i32, m: u32, day: u32) -> NaiveDate {
         naive_date(y, m, day).unwrap()
@@ -789,7 +771,7 @@ mod tests {
         ];
         let end = d(2020, 12, 31);
         let price_db = PriceDatabase::from_directives(&dirs);
-        let oracle = PriceDbOracle(&price_db);
+        let oracle = TestOracle(&price_db);
 
         // Independently value `account_balances`' inventories at market for the
         // same scope, then compare to `terminal_value`.
@@ -851,7 +833,7 @@ mod tests {
             vec!["Income:Dividends".to_string()],
         );
         let price_db = PriceDatabase::from_directives(&dirs);
-        let oracle = PriceDbOracle(&price_db);
+        let oracle = TestOracle(&price_db);
 
         // Reproduce report_returns' hand-built series.
         let flows = extract_flows(&dirs, &scope, "USD", &oracle, end).unwrap();


### PR DESCRIPTION
## What

Phase 3 of the investment-returns feature (#1814): expose the `rustledger-returns` engine to embedders via a new **`session.returns`** operation on the WIT component contract (`rustledger:ledger@3.9.0`). A host (rustfava) can now chart money-weighted (XIRR) and time-weighted (TWR) returns over a held ledger without re-deriving cash-flow extraction or the returns math.

This is the demand-driven first increment of Phase 3. The speculative BQL `#returns` virtual table (the issue's second bullet, explicitly "only if composable-query demand appears") is **not** included — it stays deferred until asked for. The rustfava chart itself is downstream (separate repo).

## The operation

```wit
returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string)
  -> result<returns-result, string>;

record returns-result {
  cash-flows: u32,
  invested: string,          // decimal strings, full precision (like amount.number)
  distributions: string,
  current-value: string,
  money-weighted: option<f64>, // annualized fractions; none when undefined
  time-weighted: option<f64>,
}
```

- `investments` / `income` are account-name prefixes defining the scope boundary (mirroring the CLI's `--investments` / `--income`).
- `currency` — empty falls back to the ledger's first `operating_currency`, matching the CLI's `--currency`-optional behavior.
- `end-date` (`YYYY-MM-DD`) is the horizon + terminal-valuation date. **Required**, unlike the CLI's today-default — a component has no reliable clock.
- Fallible: empty/unparseable `end-date`, no resolvable reporting currency, held load errors, or an unpriceable boundary/terminal flow → `err(message)`.

## How it shares the engine (no re-derivation)

`SessionState::returns` reuses the same booked, pad-expanded stream `session.query` already builds (the returns engine's documented input contract, via the `padded` OnceCell) and builds the `PriceDatabase` the same way the CLI's `report returns` does — so the boundary runs the exact `rustledger_returns::compute_returns` the CLI runs, over identical inputs.

The one duplicated piece is the trivial `PriceDbOracle` adapter (`PriceDatabase` → the returns crate's `PriceOracle` trait). It already exists at the CLI composition root; `rustledger-returns` is a leaf crate (no `rustledger-query` dep) so the adapter can't live beside the trait, and the CLI's is `pub(super)`. Per canonical-function discipline the deliberate duplicate is **documented at both sites** with cross-references; both are pure pass-throughs to `PriceDatabase::convert`, so the compiler enforces agreement.

## Tests

- **Native drift guard** (`convert.rs::returns_tests::returns_matches_direct_engine`): `session.returns` equals a direct `compute_returns` over the same booked+padded stream and price index — catches any wiring divergence (wrong stream, dropped scope arg, mis-mapped field). Plus fallback/bad-date/no-currency/load-error paths.
- **WASM parity drift guard** (`parity.rs::session_returns_matches_native_engine`): the component's returns across the wasm boundary equals the native engine. Decimal fields (rust_decimal → deterministic) match byte-for-byte; the two `f64` rates within tolerance (wasm vs native float ULP).

## Version

`package rustledger:ledger@3.8.0` → `@3.9.0`; `API_VERSION` `"3.8"` → `"3.9"` (kept in lockstep — the `version_matches_wit_package` parity test + CI `wit-version-gate` enforce this).

## How to test

```
cargo test -p rustledger-ffi-component returns_tests
cargo build -p rustledger-ffi-component --target wasm32-wasip2
cargo test -p rustledger-ffi-component-tests session_returns_matches_native_engine
```

Part of #1814. Advances #1847 (BQL table intentionally still open).
