### PR TITLE
feat(returns): value net units at market, not lot-matched inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,7 +3662,6 @@ version = "0.21.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
- "rustledger-booking",
  "rustledger-core",
  "thiserror 2.0.19",
 ]

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -527,9 +527,9 @@ impl BookingEngine {
     /// Apply ONE posting to the running inventories, returning an error if it
     /// reduces a lot that is not held.
     ///
-    /// The per-posting core shared by [`Self::apply`] (which ignores a reduction
-    /// failure, per its booked-input contract) and [`Self::try_apply`] (which
-    /// surfaces it).
+    /// The per-posting core of [`Self::apply`], which ignores a reduction failure
+    /// per its booked-input contract; the fallible signature keeps the over-sell
+    /// detectable by the `debug_assert` there.
     ///
     /// # Errors
     /// Returns the reduce error when the posting reduces a lot that is not held
@@ -579,9 +579,10 @@ impl BookingEngine {
     /// matching lot yet is dropped (its `reduce` error is ignored, historical
     /// release behavior). The loader pipeline guarantees this ordering; the
     /// in-loop `debug_assert` below catches a violating caller in debug builds.
-    /// A caller that CANNOT guarantee booked input (e.g. valuing a returns scope
-    /// over a ledger whose loader re-merged a booking-failed transaction) must
-    /// use [`Self::try_apply`] instead, which surfaces the failure as an `Err`.
+    /// A caller that CANNOT guarantee booked input must not derive a figure from
+    /// this lot-matching realization — e.g. the returns engine values **net units
+    /// at market** (`rustledger-returns`), never `apply`, so a re-merged
+    /// booking-failed transaction cannot over-sell it.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
@@ -595,33 +596,6 @@ impl BookingEngine {
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;
         }
-    }
-
-    /// Fallible [`Self::apply`]: apply a transaction's postings, but return an
-    /// error the moment a reduction has no matching lot instead of
-    /// `debug_assert`-ing (debug) or silently over-selling (release).
-    ///
-    /// For consumers that realize inventory over a stream they cannot guarantee
-    /// is booked — the returns engine values a scope over `Ledger.directives`,
-    /// which the loader re-merges booking-FAILED transactions into in their
-    /// un-booked shape — so the failure becomes a clean `Err` at the boundary
-    /// rather than a wasm trap or a wrong figure.
-    ///
-    /// This catches the ONE un-booked shape the booking engine can detect: a
-    /// reduction with no matching lot. A posting with elided/uninterpolated units
-    /// is still SKIPPED (as in [`Self::apply`]) — interpolation is a separate
-    /// pass this engine does not run — so a caller that must also reject elided
-    /// input checks `units` for [`IncompleteAmount::Complete`] itself.
-    ///
-    /// # Errors
-    /// Returns [`BookingError::Inventory`] on the first posting that reduces a
-    /// lot not held. Postings before it have already been applied (the caller is
-    /// expected to discard the engine on error).
-    pub fn try_apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
-        for posting in &txn.postings {
-            self.try_apply_posting(posting, txn.date)?;
-        }
-        Ok(())
     }
 
     /// Book and interpolate a transaction.

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -590,8 +590,9 @@ impl BookingEngine {
                 reduced.is_ok(),
                 "apply() reduction failed — the transaction must be booked \
                  before apply() (postings filled, costs resolved); applying an \
-                 unbooked reduction silently over-sells inventory. Use \
-                 try_apply() if the input may be unbooked."
+                 unbooked reduction silently over-sells inventory. A caller that \
+                 cannot guarantee booked input must not derive a figure from this \
+                 realization (e.g. returns values net units at market instead)."
             );
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2939,13 +2939,16 @@ this line is not a valid directive @#$
     }
 
     #[test]
-    fn returns_errors_on_in_scope_booking_error() {
+    fn returns_tolerates_in_scope_booking_error() {
         // A booking-FAILED transaction (selling 10 units when only 5 were bought,
         // empty cost forcing a lot match) is re-merged into the held directives
-        // UN-booked. Realizing it would `debug_assert`-trap the booking engine
-        // (over-sell) — this native test would ABORT without the engine's fallible
-        // `try_apply`. With it, an IN-SCOPE over-sell surfaces as a clean Err (no
-        // guard involved). Regression guard for the #1849 second-review finding.
+        // UN-booked — the common state of imported brokerage data. Returns value
+        // NET UNITS at market (never cost-basis lots), so this must NOT trap and
+        // must NOT refuse the report: the over-sell nets to −5 ACME, valued at the
+        // terminal price (−5 × 120 = −600). The booking error still surfaces via
+        // info().errors; `rledger check` remains the validator (see #1850). Without
+        // the net-units rewrite this native test would ABORT in the lot-matching
+        // booking engine.
         const OVERSELL: &str = "\
 option \"operating_currency\" \"USD\"
 2020-01-01 open Assets:Invest:Broker
@@ -2956,6 +2959,7 @@ option \"operating_currency\" \"USD\"
 2020-06-01 * \"Sell 10 — more than held\"
   Assets:Invest:Broker  -10 ACME {}
   Assets:Cash  1000 USD
+2021-01-01 price ACME  120 USD
 ";
         let state = SessionState::from_source(OVERSELL);
         assert!(
@@ -2963,21 +2967,22 @@ option \"operating_currency\" \"USD\"
             "over-sell must surface as a booking load error"
         );
         let (inv, inc) = scope_args();
-        assert!(
-            state.returns(&inv, &inc, "USD", "2021-01-01").is_err(),
-            "an in-scope over-sell must surface as a clean Err, not trap"
-        );
+        let r = state
+            .returns(&inv, &inc, "USD", "2021-01-01")
+            .expect("net-units returns tolerate an in-scope over-sell");
+        assert_eq!(r.current_value, "-600", "net −5 ACME × 120");
     }
 
     #[test]
-    fn returns_from_entries_oversell_errors_not_traps() {
+    fn returns_from_entries_oversell_tolerated_not_traps() {
         // A `from_entries` session holds directives UN-booked with `errors:
-        // vec![]`, so the load-error guard is bypassed (the #1849 third-review
-        // gap). The engine-level `try_apply` fix is what closes this path: an
-        // over-sell (reduce 10 of an empty-cost lot only 5 were bought into)
-        // makes compute_returns — hence returns() — return a clean Err instead of
-        // trapping. This native test would abort without that fix.
-        use rustledger_core::{Amount, CostNumber, CostSpec, Decimal, Posting, Transaction};
+        // vec![]`, so no load-error guard is involved at all. Returns value net
+        // units at market, so an over-sell (reduce 10 of an empty-cost lot only 5
+        // were bought into) nets to −5 ACME and is valued at the terminal price
+        // (−5 × 120 = −600) — compute_returns, hence returns(), yields a clean Ok,
+        // never a trap or refusal. This native test would abort without the
+        // net-units rewrite (see #1850).
+        use rustledger_core::{Amount, CostNumber, CostSpec, Decimal, Posting, Price, Transaction};
         let dt = |m, day| rustledger_core::naive_date(2020, m, day).unwrap();
         let buy = Transaction::new(dt(1, 1), "buy")
             .with_synthesized_posting(
@@ -3009,21 +3014,23 @@ option \"operating_currency\" \"USD\"
                 "Assets:Cash",
                 Amount::new(Decimal::from(1000), "USD"),
             ));
+        let price = Price::new(dt(12, 31), "ACME", Amount::new(Decimal::from(120), "USD"));
         let core = [
             rustledger_core::Directive::Transaction(buy),
             rustledger_core::Directive::Transaction(sell),
+            rustledger_core::Directive::Price(price),
         ];
         let wit: Vec<_> = core
             .iter()
             .map(|d| super::directive_from_core(d, 0, "<test>"))
             .collect();
         let state = SessionState::from_entries(&wit);
-        // The guard cannot help here — from_entries carries no load errors.
+        // from_entries carries no load errors; net-units tolerance is what matters.
         assert!(state.info().errors.is_empty());
         let (inv, inc) = scope_args();
-        assert!(
-            state.returns(&inv, &inc, "USD", "2020-12-31").is_err(),
-            "engine fix must make an un-booked from_entries session err, not trap"
-        );
+        let r = state
+            .returns(&inv, &inc, "USD", "2020-12-31")
+            .expect("net-units returns tolerate an un-booked from_entries over-sell");
+        assert_eq!(r.current_value, "-600", "net −5 ACME × 120");
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1827,9 +1827,10 @@ impl SessionState {
     /// `rledger report returns` engine over the boundary, so a host charts
     /// returns without re-deriving the cash-flow extraction or the XIRR/TWR
     /// math. Delegates to [`rustledger_query::scope_returns`] — the *same*
-    /// composition the CLI's `report returns` calls — over the same booked,
-    /// pad-expanded stream `query` builds (reused via the `padded` cell), so the
-    /// two surfaces cannot compute different figures for one ledger.
+    /// composition the CLI's `report returns` calls — over the same interpolated,
+    /// pad-expanded stream `query` builds (reused via the `padded` cell; booking is
+    /// not required — net units are valued at market), so the two surfaces cannot
+    /// compute different figures for one ledger.
     ///
     /// A parse-recovered load error does not block it — it computes over the held
     /// directives just as the CLI's `report returns` renders over them (errors
@@ -1848,9 +1849,10 @@ impl SessionState {
     /// # Errors
     /// `Err(message)` when `end` is empty/unparseable, no reporting currency
     /// resolves (empty `currency` and no `operating_currency`), a boundary or
-    /// terminal flow cannot be priced, or an in-scope account carries an
-    /// elided/uninterpolated posting (its units are unknown — the one shape
-    /// net-units cannot value). A cost-basis/lot error is NOT an error here.
+    /// terminal flow cannot be priced, or an elided/uninterpolated posting leaves a
+    /// scope-relevant quantity unknown — an in-scope holding, or an external
+    /// boundary leg whose cash flow is unknown (the one shape net-units cannot
+    /// value). A cost-basis/lot error is NOT an error here.
     pub fn returns(
         &self,
         investments: &[String],
@@ -2822,7 +2824,7 @@ option \"operating_currency\" \"USD\"
     }
 
     /// Drift guard (canonical-function discipline): `session.returns` must equal
-    /// [`rustledger_query::scope_returns`] over the same booked, pad-expanded
+    /// [`rustledger_query::scope_returns`] over the same interpolated, pad-expanded
     /// stream. That helper is the SAME composition the CLI's `report returns`
     /// calls, so equality here pins the component against the CLI's returns path
     /// — not merely against a private copy of the engine wiring.

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1833,13 +1833,13 @@ impl SessionState {
     ///
     /// A parse-recovered load error does not block it — it computes over the held
     /// directives just as the CLI's `report returns` renders over them (errors
-    /// surface separately, here via `info().errors`). But a BOOKING error (an
-    /// un-booked reduction the loader re-merged) is fatal: the returns engine
-    /// realizes through the booking engine's fallible path, so it returns a clean
-    /// `err` rather than trap or emit a figure computed over a contract-violating
-    /// stream. This is stricter than beangrow (which discards errors and reports
-    /// a number regardless) — deliberately: run `rledger check` to find the
-    /// booking error, then re-run. The CLI and this op agree on every ledger.
+    /// surface separately, here via `info().errors`). It values **net units at
+    /// market**, so a cost-basis / lot error (an over-sell, an empty-cost `{}` sale
+    /// with no matching lot — the common state of imported brokerage data) does NOT
+    /// block the report: the units net (possibly negative) and value at market,
+    /// like beancount + beangrow. `rledger check` remains the validator. The only
+    /// genuinely-unvaluable inputs error (see below). The CLI and this op agree on
+    /// every ledger.
     ///
     /// `investments`/`income` are the scope's account-name prefixes; `currency`
     /// is the single reporting currency (empty → the ledger's first
@@ -1847,9 +1847,10 @@ impl SessionState {
     ///
     /// # Errors
     /// `Err(message)` when `end` is empty/unparseable, no reporting currency
-    /// resolves (empty `currency` and no `operating_currency`), a boundary/
-    /// terminal flow cannot be priced, or the ledger has a booking error
-    /// (un-booked reduction).
+    /// resolves (empty `currency` and no `operating_currency`), a boundary or
+    /// terminal flow cannot be priced, or an in-scope account carries an
+    /// elided/uninterpolated posting (its units are unknown — the one shape
+    /// net-units cannot value). A cost-basis/lot error is NOT an error here.
     pub fn returns(
         &self,
         investments: &[String],

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -561,13 +561,16 @@ interface ledger {
     /// component has no reliable clock. Prices come from the held entries'
     /// `price` directives and implicit transaction prices. A parse-recovered load
     /// error does not block it — it computes over the held directives like the
-    /// CLI's `report returns` (errors surface via `info().errors`) — but a BOOKING
-    /// error (un-booked reduction) is fatal: the engine realizes through a
-    /// fallible path and returns a clean `err` rather than trap or report a figure
-    /// over a contract-violating stream (stricter than beangrow, deliberately —
-    /// run `rledger check`). Fallible: returns `err(message)` on an
-    /// empty/unparseable `end-date`, no resolvable reporting currency, a
-    /// boundary/terminal flow that cannot be priced, or a booking error.
+    /// CLI's `report returns` (errors surface via `info().errors`). It values NET
+    /// UNITS at market, so a cost-basis / lot error (an over-sell, an empty-cost
+    /// `{}` sale with no matching lot — the common state of imported brokerage
+    /// data) does NOT block the report: units net (possibly negative) and value at
+    /// market, like beancount + beangrow; `rledger check` remains the validator.
+    /// Fallible: returns `err(message)` on an empty/unparseable `end-date`, no
+    /// resolvable reporting currency, a boundary or terminal flow that cannot be
+    /// priced, or an in-scope account with an elided/uninterpolated posting (its
+    /// units are unknown — the one shape net-units cannot value; a cost-basis/lot
+    /// error is not fatal).
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -568,8 +568,9 @@ interface ledger {
     /// market, like beancount + beangrow; `rledger check` remains the validator.
     /// Fallible: returns `err(message)` on an empty/unparseable `end-date`, no
     /// resolvable reporting currency, a boundary or terminal flow that cannot be
-    /// priced, or an in-scope account with an elided/uninterpolated posting (its
-    /// units are unknown — the one shape net-units cannot value; a cost-basis/lot
+    /// priced, or an elided/uninterpolated posting that leaves a scope-relevant
+    /// quantity unknown — an in-scope holding, or an external boundary leg whose
+    /// cash flow is unknown (the one shape net-units cannot value; a cost-basis/lot
     /// error is not fatal).
     returns: func(investments: list<string>, income: list<string>, currency: string, end-date: string) -> result<returns-result, string>;
   }

--- a/crates/rustledger-returns/Cargo.toml
+++ b/crates/rustledger-returns/Cargo.toml
@@ -17,7 +17,6 @@ bench = false
 
 [dependencies]
 rustledger-core.workspace = true
-rustledger-booking.workspace = true
 rust_decimal.workspace = true
 thiserror.workspace = true
 

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -1,9 +1,10 @@
-//! Cash-flow extraction: turn a booked ledger into the [`CashFlow`] series that
+//! Cash-flow extraction: turn a ledger into the [`CashFlow`] series that
 //! [`xirr`](crate::xirr) consumes.
 //!
-//! This is the correctness core of returns reporting. Given a booked directive
-//! stream and a [`Scope`] that classifies accounts, it produces the dated,
-//! single-currency cash-flow series an investor's money-weighted return is
+//! This is the correctness core of returns reporting. Given an interpolated,
+//! pad-expanded directive stream (see the input contract below — it does *not*
+//! require booking) and a [`Scope`] that classifies accounts, it produces the
+//! dated, single-currency cash-flow series an investor's money-weighted return is
 //! computed from.
 //!
 //! # The boundary-crossing model
@@ -221,12 +222,16 @@ pub enum ExtractError {
         /// The date whose rate was missing.
         date: NaiveDate,
     },
-    /// An in-scope account carried an elided/uninterpolated posting, so its net
-    /// units are unknown and cannot be valued. This is the ONE input the net-units
-    /// method genuinely cannot handle — unlike a cost-basis/lot error (an
-    /// over-sell, an empty-cost `{}` sale with no matching lot), which nets the
-    /// units and values at market. Extraction refuses with this error rather than
-    /// silently understate the position. Carries a human-readable description.
+    /// A posting with elided/uninterpolated units left a scope-relevant quantity
+    /// unknown, so the figure cannot be computed. Two shapes: an **in-scope
+    /// holding** whose net units are unknown (valuation side), and an
+    /// **external/boundary leg of a portfolio-touching transaction** whose cash
+    /// flow is unknown (flows side — [`extract_flows`]). This is the ONE class of
+    /// input net-units genuinely
+    /// cannot handle — unlike a cost-basis/lot error (an over-sell, an empty-cost
+    /// `{}` sale with no matching lot), which nets the units and values at market.
+    /// Extraction refuses rather than silently understate the position or drop the
+    /// flow. Carries a human-readable description.
     #[error("cannot compute returns: {0}")]
     UnbookedInput(String),
 }
@@ -260,8 +265,9 @@ pub enum ExtractError {
 ///
 /// Returns [`ExtractError::MissingPrice`] if any external flow or held position
 /// cannot be converted to `reporting_currency` on the date it is needed, or
-/// [`ExtractError::UnbookedInput`] if an in-scope account carries an
-/// elided/uninterpolated posting — see [`terminal_value`].
+/// [`ExtractError::UnbookedInput`] if an elided/uninterpolated posting leaves a
+/// scope-relevant quantity unknown — an in-scope holding (see [`terminal_value`])
+/// or an external boundary leg (see [`extract_flows`]).
 pub fn extract_cash_flows(
     directives: &[Directive],
     scope: &Scope,
@@ -286,8 +292,9 @@ pub fn extract_cash_flows(
 /// external postings, converted to `reporting_currency` at the transaction's
 /// date. Transactions that touch no investment or income account, and those
 /// whose external postings net to zero (internal transfers), contribute
-/// nothing. Flows dated after `end_date` are excluded. Expects the booked,
-/// pad-expanded stream described in the module-level docs.
+/// nothing. Flows dated after `end_date` are excluded. Expects the interpolated,
+/// pad-expanded stream described in the module-level docs (booking is not
+/// required — a cost-basis/lot error does not affect the flows).
 ///
 /// External postings are valued by their **units** (the money that moved
 /// through the outside account). A boundary-crossing external posting that

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -63,17 +63,26 @@
 //!
 //! # Input contract
 //!
-//! Both entry points take the **booked, pad-expanded** directive stream — costs
-//! resolved, amounts interpolated, and `pad`/`balance` directives already
-//! expanded into their synthesized transactions (the loader's
-//! `Ledger::balance_view` output, the same stream the canonical
-//! `report_cmd::account_balances` consumes). This crate is a leaf and cannot
-//! book or pad-expand a raw stream itself. It defends the booked half of the
-//! contract: an un-booked directive — an unmatched reduction, or a posting with
-//! elided/uninterpolated units — surfaces as [`ExtractError::UnbookedInput`]
-//! rather than a silently wrong figure. It cannot defend the pad half, though:
-//! handing it an un-expanded stream silently drops any position seeded by a pad,
-//! so callers must pad-expand first.
+//! Both entry points take the **interpolated, pad-expanded** directive stream —
+//! amounts interpolated and `pad`/`balance` directives already expanded into their
+//! synthesized transactions (the loader's `Ledger::balance_view` output, the same
+//! stream the canonical `report_cmd::account_balances` consumes). This crate is a
+//! leaf and cannot interpolate or pad-expand a raw stream itself.
+//!
+//! It does **not** require a *booked* stream. Money-weighted (XIRR) and
+//! time-weighted returns depend on cash flows and terminal **market** value
+//! (`net units × price`), never on cost-basis lots, so this crate values **net
+//! units** — the running sum of each account's complete posting units — without
+//! lot-matching. A cost-basis/lot error therefore does not affect the report: an
+//! over-sell or an empty-cost `{}` sale with no matching lot (the common state of
+//! imported brokerage data) simply nets the units, possibly negative, and is
+//! valued at market — like beancount + beangrow. `rledger check` remains the
+//! validator (see #1850). The one shape it genuinely cannot value is an in-scope
+//! account with an elided/uninterpolated posting — its net units are unknown —
+//! which surfaces as [`ExtractError::UnbookedInput`] rather than a silently
+//! understated figure. It cannot defend the pad half either: handing it an
+//! un-expanded stream silently drops any position seeded by a pad, so callers must
+//! pad-expand first.
 //!
 //! Returns are computed **from ledger inception** — there is no analysis start
 //! date. An opening balance (a `pad`, or an explicit `Equity:Opening-Balances`
@@ -212,13 +221,13 @@ pub enum ExtractError {
         /// The date whose rate was missing.
         date: NaiveDate,
     },
-    /// A reduction posting referenced a lot that was never held — the input
-    /// stream is not booked. The loader re-merges booking-FAILED transactions
-    /// into `Ledger.directives` in their un-booked shape; realizing one would
-    /// over-sell inventory (and `debug_assert`-trap the booking engine in debug
-    /// builds), so extraction refuses with this error rather than return a wrong
-    /// valuation. Carries the underlying booking error's message.
-    #[error("cannot compute returns over an unbooked ledger ({0}); fix the booking error first")]
+    /// An in-scope account carried an elided/uninterpolated posting, so its net
+    /// units are unknown and cannot be valued. This is the ONE input the net-units
+    /// method genuinely cannot handle — unlike a cost-basis/lot error (an
+    /// over-sell, an empty-cost `{}` sale with no matching lot), which nets the
+    /// units and values at market. Extraction refuses with this error rather than
+    /// silently understate the position. Carries a human-readable description.
+    #[error("cannot compute returns: {0}")]
     UnbookedInput(String),
 }
 
@@ -232,13 +241,14 @@ pub enum ExtractError {
 ///
 /// # Input contract
 ///
-/// `directives` must be the **booked, pad-expanded** stream — costs resolved,
-/// amounts interpolated, and `pad`/`balance` directives already expanded into
-/// their synthesized transactions (the loader's `Ledger::balance_view` output,
-/// the same stream `report_cmd::account_balances` consumes). This crate is a
-/// leaf and cannot book or pad-expand a raw stream: an un-booked stream lets the
-/// booking engine silently realize the wrong inventory, and an un-expanded stream
-/// drops pad-seeded positions.
+/// `directives` must be the **interpolated, pad-expanded** stream — amounts
+/// interpolated and `pad`/`balance` directives already expanded into their
+/// synthesized transactions (the loader's `Ledger::balance_view` output, the same
+/// stream `report_cmd::account_balances` consumes). This crate is a leaf and
+/// cannot interpolate or pad-expand a raw stream. It does **not** require a booked
+/// stream: it values net units at market, so a cost-basis/lot error nets the units
+/// rather than realizing a wrong inventory (see the module docs). An un-expanded
+/// stream still drops pad-seeded positions, though.
 ///
 /// Returns are computed **from ledger inception** — an opening balance (a `pad`,
 /// or an `Equity:Opening-Balances` posting) is a genuine flow, the capital
@@ -250,8 +260,8 @@ pub enum ExtractError {
 ///
 /// Returns [`ExtractError::MissingPrice`] if any external flow or held position
 /// cannot be converted to `reporting_currency` on the date it is needed, or
-/// [`ExtractError::UnbookedInput`] if the stream violates the booked input
-/// contract (a re-merged booking-failed transaction) — see [`terminal_value`].
+/// [`ExtractError::UnbookedInput`] if an in-scope account carries an
+/// elided/uninterpolated posting — see [`terminal_value`].
 pub fn extract_cash_flows(
     directives: &[Directive],
     scope: &Scope,
@@ -336,11 +346,11 @@ pub fn extract_flows(
             if scope.classify(posting.account.as_str()) != AccountRole::External {
                 continue;
             }
-            // The input-contract booked stream (module docs) fills units on every
-            // posting, so a None here is unreachable in practice; skipping is
-            // defensive, not a silent drop of a real flow (an un-booked stream is
-            // a contract violation the leaf crate cannot detect, exactly as
-            // `apply`/`account_balances` also require pre-booked input).
+            // The input-contract interpolated stream (module docs) fills units on
+            // every posting, so a None here is unreachable in practice; skipping is
+            // defensive, not a silent drop of a real flow (an un-interpolated
+            // stream is a contract violation the leaf crate cannot detect, exactly
+            // as `account_balances` also requires interpolated input).
             let Some(amount) = posting.amount() else {
                 continue;
             };
@@ -373,17 +383,16 @@ pub fn extract_flows(
 /// fabricated return. A consumer that needs to distinguish "still holding,
 /// net-flat" from "fully liquidated" must not learn it from a zero cash flow.
 ///
-/// Holdings are realized through the booking engine — lots keep their cost and
-/// reductions match the account's booking method — over every transaction dated
-/// on or before `end_date`, then each position's units are valued at **market**
-/// (`position.units`, not cost basis) via `prices`. Because market value is
-/// `units × price` and every lot of a commodity shares one market price, the
-/// terminal value depends only on total held units, not on which lots a
-/// reduction matched; the booking method affects realized-gain reporting (a
-/// later concern), not this figure. Only accounts the `scope` classifies as
-/// [`Investment`](AccountRole::Investment) are counted. Positions seeded by a
-/// `pad` are realized only if the input stream is pad-expanded, as
-/// [`extract_cash_flows`]' input contract requires.
+/// Holdings are the **net units** per `(account, commodity)` — the running sum of
+/// each account's complete posting units over every transaction dated on or before
+/// `end_date`, **without lot-matching** — valued at **market** via `prices`. Market
+/// value is `units × price` and every lot of a commodity shares one market price,
+/// so the terminal value depends only on total held units, never on which lots a
+/// reduction matched or on cost basis; a cost-basis/lot error (an over-sell, an
+/// empty-cost `{}` sale with no matching lot) simply nets the units. Only accounts
+/// the `scope` classifies as [`Investment`](AccountRole::Investment) are counted.
+/// Positions seeded by a `pad` are counted only if the input stream is pad-expanded,
+/// as [`extract_cash_flows`]' input contract requires.
 ///
 /// A net-short position (negative units) values negatively, correctly reducing
 /// the terminal flow (see the [`PriceOracle`] linearity requirement). A position
@@ -393,11 +402,9 @@ pub fn extract_flows(
 /// # Errors
 ///
 /// Returns [`ExtractError::MissingPrice`] if a held commodity has no price in
-/// `reporting_currency` on `end_date`, or [`ExtractError::UnbookedInput`] if the
-/// stream violates the booked input contract — a reduction with no matching lot
-/// (the loader re-merges booking-failed transactions in un-booked shape). The
-/// realization surfaces that as an `Err` via the booking engine's fallible
-/// `try_apply`, rather than over-selling inventory or trapping.
+/// `reporting_currency` on `end_date`, or [`ExtractError::UnbookedInput`] if an
+/// in-scope account carries an elided/uninterpolated posting (its net units are
+/// unknown — the one shape net-units cannot value).
 pub fn terminal_value(
     directives: &[Directive],
     scope: &Scope,
@@ -420,21 +427,19 @@ pub fn terminal_value(
 }
 
 /// Market value (in `reporting_currency`) of the investment-scope holdings as of
-/// `date`: the inventory realized from every transaction dated on or before
-/// `date`, with each held position valued at **market** at `date`.
+/// `date`: the **net units** accumulated from every transaction dated on or before
+/// `date`, each commodity valued at **market** at `date`.
 ///
-/// This is the shared realization primitive behind [`terminal_value`] (the
-/// value at the report end date) and [`twr`] (the value at each cash-flow date).
-/// It mirrors `report_cmd::account_balances`
-/// (`crates/rustledger/src/cmd/report_cmd/mod.rs`) plus the `<= date` filter — the
-/// leaf crate cannot call that CLI-side helper. Kept aligned by hand; the returns
-/// CLI's `terminal_value_matches_account_balances_realization` test guards it (it
-/// values `account_balances`' inventories and compares to [`terminal_value`],
-/// which delegates here — so this realization is covered end to end).
-/// Like that helper, inventories are collected into a `BTreeMap` so iteration
-/// order is stable across runs (an `FxHashMap` would make which currency a
-/// `MissingPrice` names depend on hash order, and differ between 32- and 64-bit
-/// targets).
+/// This is the shared valuation primitive behind [`terminal_value`] (the value at
+/// the report end date) and [`twr`] (the value at each cash-flow date). On a
+/// booked stream the net units per commodity equal the total units
+/// `report_cmd::account_balances` (`crates/rustledger/src/cmd/report_cmd/mod.rs`)
+/// realizes, so the market value agrees; the returns CLI's
+/// `terminal_value_matches_account_balances_realization` test guards that
+/// agreement (it values `account_balances`' inventories and compares to
+/// [`terminal_value`], which delegates here). Net units are held in a `BTreeMap`
+/// so iteration order — hence which currency a `MissingPrice` names — is stable
+/// across runs and between 32- and 64-bit targets (an `FxHashMap` would not be).
 fn investment_value_at(
     directives: &[Directive],
     scope: &Scope,
@@ -442,87 +447,107 @@ fn investment_value_at(
     prices: &impl PriceOracle,
     date: NaiveDate,
 ) -> Result<Decimal, ExtractError> {
-    // Opens carry booking methods regardless of date, so register with the full
-    // stream but apply only transactions up to the valuation date.
-    let mut engine = rustledger_booking::BookingEngine::new();
-    engine.register_account_methods(directives.iter());
+    let mut holdings = NetUnits::default();
     for directive in directives {
         if let Directive::Transaction(txn) = directive
             && txn.date <= date
         {
-            apply_booked(&mut engine, txn)?;
+            holdings.apply(txn);
         }
     }
-    value_investment_scope(
-        engine.inventories(),
-        scope,
-        reporting_currency,
-        prices,
-        date,
-    )
+    value_investment_scope(&holdings, scope, reporting_currency, prices, date)
 }
 
-/// Apply a whole transaction to `engine`, surfacing an un-booked stream as
-/// [`ExtractError::UnbookedInput`] instead of a wrong figure.
+/// Net units held per `(account, commodity)`, accumulated by summing complete
+/// posting units — **without lot-matching**.
 ///
-/// The realization requires the booked, pad-expanded input contract. Two ways a
-/// re-merged booking-failed transaction violates it, both caught here: an
-/// unmatched reduction (via the booking engine's fallible
-/// [`try_apply`](rustledger_booking::BookingEngine::try_apply)), and a posting
-/// with elided/uninterpolated units (booking fills these) — which `try_apply`
-/// would otherwise silently skip, understating the position.
-fn apply_booked(
-    engine: &mut rustledger_booking::BookingEngine,
-    txn: &rustledger_core::Transaction,
-) -> Result<(), ExtractError> {
-    if let Some(elided) = txn
-        .postings
-        .iter()
-        .find(|p| !matches!(p.units, Some(IncompleteAmount::Complete(_))))
-    {
-        return Err(ExtractError::UnbookedInput(format!(
-            "posting to {} on {} has un-booked (elided) units",
-            elided.account, txn.date
-        )));
+/// Market valuation for returns (XIRR/TWR) is `net units × price`; it never needs
+/// cost-basis lots. So a lot-matching/cost-basis error — an over-sell with no
+/// matching lot, an empty-cost `{}` sale (the common state of imported brokerage
+/// data) — simply nets the units (possibly negative) and is valued at market,
+/// rather than trapping or refusing the report. `rledger check` remains the
+/// validator; the returns report computes over what loaded, like beancount +
+/// beangrow (see #1850). `BTreeMap`s keep `MissingPrice` selection deterministic
+/// across runs and target word sizes.
+#[derive(Default)]
+struct NetUnits {
+    per_account: std::collections::BTreeMap<
+        rustledger_core::Account,
+        std::collections::BTreeMap<rustledger_core::Currency, Decimal>,
+    >,
+    /// Accounts with an elided/uninterpolated posting: a leg's units are unknown,
+    /// so the account's net units are incomplete. This is the ONE input the
+    /// net-units method genuinely cannot value — valuing such an in-scope account
+    /// errors rather than silently understating it.
+    unvaluable: std::collections::BTreeSet<rustledger_core::Account>,
+}
+
+impl NetUnits {
+    fn apply(&mut self, txn: &rustledger_core::Transaction) {
+        for posting in &txn.postings {
+            if let Some(IncompleteAmount::Complete(amount)) = &posting.units {
+                *self
+                    .per_account
+                    .entry(posting.account.clone())
+                    .or_default()
+                    .entry(amount.currency.clone())
+                    .or_default() += amount.number;
+            } else {
+                self.unvaluable.insert(posting.account.clone());
+            }
+        }
     }
-    engine
-        .try_apply(txn)
-        .map_err(|e| ExtractError::UnbookedInput(e.to_string()))
 }
 
 /// Total market value (in `reporting_currency`, at `date`) of the
-/// `Investment`-scope positions among `inventories`.
+/// `Investment`-scope net holdings.
 ///
-/// The single valuation implementation shared by [`investment_value_at`] (one
-/// date, a fresh realization) and [`investment_values_at`] (a batch of dates over
-/// one realization pass), so the two cannot drift. Collects into a `BTreeMap`
-/// first so iteration — and hence which currency a [`ExtractError::MissingPrice`]
-/// names — is deterministic across runs and target word sizes (the engine's
-/// `FxHashMap` order is neither).
-fn value_investment_scope<'a>(
-    inventories: impl Iterator<Item = (&'a rustledger_core::Account, &'a rustledger_core::Inventory)>,
+/// The single valuation shared by [`investment_value_at`] and the batch
+/// [`investment_values_at`] / [`investment_values_multi`], so they cannot drift.
+/// Iterates the deterministic `BTreeMap` so which currency a
+/// [`ExtractError::MissingPrice`] names is stable.
+///
+/// # Errors
+/// [`ExtractError::MissingPrice`] when an in-scope commodity has no price in
+/// `reporting_currency` on `date`, or [`ExtractError::UnbookedInput`] when an
+/// in-scope account carried an elided/uninterpolated posting (its net units are
+/// incomplete — the one shape net-units cannot value).
+fn value_investment_scope(
+    holdings: &NetUnits,
     scope: &Scope,
     reporting_currency: &str,
     prices: &impl PriceOracle,
     date: NaiveDate,
 ) -> Result<Decimal, ExtractError> {
-    // Classify every realized account, but collect only the Investment-scope ones
-    // into the `BTreeMap` (kept for deterministic `MissingPrice` selection) — so
-    // the sort and the price conversions scale with the in-scope positions, while
-    // the classify scan is still over the whole chart.
-    let ordered: std::collections::BTreeMap<_, _> = inventories
-        .filter(|(account, _)| scope.classify(account.as_str()) == AccountRole::Investment)
-        .collect();
+    // An in-scope account carrying an elided/uninterpolated posting has incomplete
+    // net units — the one shape net-units cannot value — so error rather than
+    // understate it. Scanned over the whole `unvaluable` set (a `BTreeSet`, so the
+    // choice of named account is deterministic), including accounts that appear
+    // ONLY with an elided leg and so never entered `per_account`.
+    for account in &holdings.unvaluable {
+        if scope.classify(account.as_str()) == AccountRole::Investment {
+            return Err(ExtractError::UnbookedInput(format!(
+                "account {account} has an un-booked (elided) posting; cannot value returns"
+            )));
+        }
+    }
     let mut total = Decimal::ZERO;
-    for inventory in ordered.values() {
-        for position in inventory.positions() {
-            if position.units.number.is_zero() {
+    for (account, commodities) in &holdings.per_account {
+        if scope.classify(account.as_str()) != AccountRole::Investment {
+            continue;
+        }
+        for (commodity, units) in commodities {
+            if units.is_zero() {
                 continue;
             }
             let converted = prices
-                .convert(&position.units, reporting_currency, date)
+                .convert(
+                    &Amount::new(*units, commodity.clone()),
+                    reporting_currency,
+                    date,
+                )
                 .ok_or_else(|| ExtractError::MissingPrice {
-                    currency: position.units.currency.to_string(),
+                    currency: commodity.to_string(),
                     date,
                 })?;
             total += converted.number;
@@ -541,18 +566,18 @@ fn value_investment_scope<'a>(
 ///
 /// # Fast path vs. fallback
 ///
-/// When `directives` is **date-sorted** (the report's booked stream is), a single
-/// forward pass suffices — `O(directives + dates × accounts)`, each date classifying
-/// the realized accounts and pricing the in-scope positions, versus the
-/// `O(dates × directives)` of a per-date rescan — because the per-date realization
-/// applies transactions in directive order, which *is* date order, so a cursor
-/// that snapshots as it crosses each target date agrees exactly (all same-date
-/// transactions applied before that date's snapshot).
+/// When `directives` is **date-sorted** (the report's stream is), a single
+/// forward pass suffices — `O(directives + dates × accounts)`, each date pricing
+/// the in-scope net units, versus the `O(dates × directives)` of a per-date
+/// rescan — because the per-date accumulation applies transactions in directive
+/// order, which *is* date order, so a cursor that snapshots as it crosses each
+/// target date agrees exactly (all same-date transactions applied before that
+/// date's snapshot).
 ///
 /// When it is **not** date-sorted, the single pass would skip a later-appearing
 /// in-range transaction, so this falls back to the order-independent per-date
 /// [`investment_value_at`] — the result then matches `investment_value_at` for
-/// *any* booked input, never silently wrong. The
+/// *any* input, never silently wrong. The
 /// `investment_values_at_matches_per_date` and
 /// `investment_values_at_matches_per_date_when_unsorted` tests pin both paths.
 fn investment_values_at(
@@ -567,10 +592,10 @@ fn investment_values_at(
         "investment_values_at requires ascending dates"
     );
 
-    // The single-pass cursor is only equivalent to the per-date realization when
+    // The single-pass cursor is only equivalent to the per-date accumulation when
     // transactions are in date order; otherwise fall back to the (order-independent)
-    // per-date path so the result is correct for any booked stream. The check is a
-    // cheap O(transactions) date-comparison scan, dominated by the booking pass it
+    // per-date path so the result is correct for any stream. The check is a cheap
+    // O(transactions) date-comparison scan, dominated by the accumulation pass it
     // guards; the report's input is always sorted, so the fast path is the norm.
     let transactions = || {
         directives.iter().filter_map(|directive| match directive {
@@ -585,31 +610,22 @@ fn investment_values_at(
             .collect();
     }
 
-    let mut engine = rustledger_booking::BookingEngine::new();
-    engine.register_account_methods(directives.iter());
+    let mut holdings = NetUnits::default();
     let mut txns = transactions().peekable();
     let mut values = Vec::with_capacity(dates.len());
     for &date in dates {
-        // Apply every transaction on or before this date (dates and txns both
+        // Accumulate every transaction on or before this date (dates and txns both
         // ascend, so the cursor only moves forward across the whole batch).
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(err) = apply_booked(&mut engine, txn) {
-                    // Contract-violating (un-booked) stream: value every remaining
-                    // date as the same error rather than over-sell. Dates already
-                    // pushed (strictly before this transaction) stay correct.
-                    while values.len() < dates.len() {
-                        values.push(Err(err.clone()));
-                    }
-                    return values;
-                }
+                holdings.apply(txn);
                 txns.next();
             } else {
                 break;
             }
         }
         values.push(value_investment_scope(
-            engine.inventories(),
+            &holdings,
             scope,
             reporting_currency,
             prices,
@@ -619,19 +635,19 @@ fn investment_values_at(
     values
 }
 
-/// Value SEVERAL scopes at their (each ascending) dates in ONE booking pass over
-/// the whole ledger.
+/// Value SEVERAL scopes at their (each ascending) dates in ONE accumulation pass
+/// over the whole ledger.
 ///
-/// The booking forward pass is **scope-independent** — it applies every
-/// transaction once and realizes every account — so N scopes share a single
-/// realization; only the per-date valuation ([`value_investment_scope`]) filters
-/// by scope. The engine state at any date is exactly `transactions ≤ date`,
+/// The net-units forward pass is **scope-independent** — it sums every
+/// transaction's units once for every account — so N scopes share a single
+/// accumulation; only the per-date valuation ([`value_investment_scope`]) filters
+/// by scope. The net-units state at any date is exactly `transactions ≤ date`,
 /// identical to what per-scope [`investment_values_at`] would build, so each
-/// scope's values match `investment_values_at` for that scope — but the O(N)
-/// booking is paid once instead of once per scope. Returns, per scope (in input
-/// order), its value at each of its dates. Falls back to per-scope
-/// `investment_values_at` on an unsorted stream, matching that function's own
-/// fallback. Pinned by `investment_values_multi_matches_per_scope`.
+/// scope's values match `investment_values_at` for that scope — but the O(N) pass
+/// is paid once instead of once per scope. Returns, per scope (in input order),
+/// its value at each of its dates. Falls back to per-scope `investment_values_at`
+/// on an unsorted stream, matching that function's own fallback. Pinned by
+/// `investment_values_multi_matches_per_scope`.
 fn investment_values_multi(
     directives: &[Directive],
     scoped_dates: &[(&Scope, &[NaiveDate])],
@@ -660,8 +676,7 @@ fn investment_values_multi(
         .flat_map(|(_, dates)| dates.iter().copied())
         .collect();
 
-    let mut engine = rustledger_booking::BookingEngine::new();
-    engine.register_account_methods(directives.iter());
+    let mut holdings = NetUnits::default();
     let mut txns = transactions().peekable();
     let mut values: Vec<Vec<Result<Decimal, ExtractError>>> = scoped_dates
         .iter()
@@ -672,17 +687,7 @@ fn investment_values_multi(
     for &date in &union {
         while let Some(txn) = txns.peek() {
             if txn.date <= date {
-                if let Err(err) = apply_booked(&mut engine, txn) {
-                    // Contract-violating (un-booked) stream: the shared pass can't
-                    // produce any scope's values past here, so fill every scope's
-                    // remaining dates with the same error.
-                    for (i, (_, dates)) in scoped_dates.iter().enumerate() {
-                        while values[i].len() < dates.len() {
-                            values[i].push(Err(err.clone()));
-                        }
-                    }
-                    return values;
-                }
+                holdings.apply(txn);
                 txns.next();
             } else {
                 break;
@@ -694,7 +699,7 @@ fn investment_values_multi(
             // flow date), then leave the cursor at the next, later date.
             while cursors[i] < dates.len() && dates[cursors[i]] == date {
                 values[i].push(value_investment_scope(
-                    engine.inventories(),
+                    &holdings,
                     scope,
                     reporting_currency,
                     prices,
@@ -753,13 +758,13 @@ fn investment_values_multi(
 ///
 /// # Performance
 ///
-/// When the booked stream is date-sorted (the report's input is), the portfolio
-/// is valued at every flow date and at `end_date` in a **single forward
-/// realization pass** (`investment_values_at`): one booking walk of the stream,
-/// snapshotting value as it crosses each date, so cost is
-/// `O(directives + flow_dates × accounts)` — linear in the ledger. An unsorted
-/// stream falls back to a per-date realization (`O(flow_dates × directives)`),
-/// still correct; see `investment_values_at`.
+/// When the stream is date-sorted (the report's input is), the portfolio is
+/// valued at every flow date and at `end_date` in a **single forward accumulation
+/// pass** (`investment_values_at`): one net-units walk of the stream, snapshotting
+/// value as it crosses each date, so cost is `O(directives + flow_dates ×
+/// accounts)` — linear in the ledger. An unsorted stream falls back to a per-date
+/// accumulation (`O(flow_dates × directives)`), still correct; see
+/// `investment_values_at`.
 ///
 /// # Errors
 ///
@@ -769,9 +774,11 @@ fn investment_values_multi(
 /// [`PriceOracle`] resolves the most recent price on or before a date, so a
 /// dividend date with no same-day price still resolves from an earlier one.
 ///
-/// The booked, pad-expanded input contract of [`extract_cash_flows`] applies: an
-/// un-booked reduction surfaces as [`ExtractError::UnbookedInput`] (not a panic),
-/// while an un-pad-expanded stream silently omits pad-seeded positions.
+/// The interpolated, pad-expanded input contract of [`extract_cash_flows`] applies:
+/// an in-scope account with an elided/uninterpolated posting surfaces as
+/// [`ExtractError::UnbookedInput`] (not a panic), while an un-pad-expanded stream
+/// silently omits pad-seeded positions. A cost-basis/lot error is tolerated (net
+/// units valued at market).
 pub fn twr(
     directives: &[Directive],
     scope: &Scope,
@@ -794,7 +801,7 @@ pub fn twr(
     }
 
     // Value the portfolio at every flow date and at `end_date` in ONE forward
-    // realization pass (rather than a fresh booking pass per date). Flows are all
+    // accumulation pass (rather than a fresh pass per date). Flows are all
     // `<= end_date`, so appending `end_date` keeps the date list ascending; the
     // trailing entry is the end valuation.
     let mut dates: Vec<NaiveDate> = net_by_date.keys().copied().collect();
@@ -803,11 +810,11 @@ pub fn twr(
     // Split off the `end_date` valuation; `values` then has exactly one entry per
     // flow date, in `net_by_date` order.
     let end_value = values.pop().expect("dates always includes end_date");
-    // A contract-violating (un-booked) stream is more severe than an undefined
+    // An unvaluable (elided-in-scope) stream is more severe than an undefined
     // sub-period: surface `UnbookedInput` EAGERLY, before `twr_from_values`' lazy
     // short-circuits (`v_prev <= 0`, `r <= 0`) could return `Ok(None)` at an
-    // earlier flow and mask a later un-booked value. `MissingPrice` stays lazy (a
-    // later price gap is irrelevant once the chain is undefined), but a broken
+    // earlier flow and mask a later unvaluable value. `MissingPrice` stays lazy (a
+    // later price gap is irrelevant once the chain is undefined), but an unvaluable
     // ledger is never silently "n/a". `compute_returns` needs no such scan — it
     // surfaces `UnbookedInput` via its eager `end_value?` — so this lives here, on
     // the standalone public path, not in the shared `twr_from_values` hot path.
@@ -819,11 +826,11 @@ pub fn twr(
     twr_from_values(&net_by_date, values, end_value, end_date)
 }
 
-/// Chain the sub-period returns from portfolio valuations already realized.
+/// Chain the sub-period returns from portfolio valuations already computed.
 ///
 /// The unit-value core of [`twr`], factored out so it can run over values
 /// snapshotted in a SINGLE forward pass — shared with [`compute_returns`], which
-/// derives MWR and the terminal value from the same realization. `flow_values[i]`
+/// derives MWR and the terminal value from the same valuations. `flow_values[i]`
 /// is the portfolio value at the i-th flow date (in `net_by_date` order);
 /// `end_value` is the value at `end_date`. Each value is a `Result` so a
 /// `MissingPrice` at a later date is propagated only if the chain actually reaches
@@ -927,18 +934,18 @@ pub struct Returns {
 }
 
 /// Compute a scope's full return summary from a single flow extraction and a
-/// single portfolio realization.
+/// single portfolio valuation.
 ///
 /// Folds [`extract_flows`], [`terminal_value`], [`xirr`](crate::xirr), and
 /// [`twr`] into one computation: the boundary flows are extracted once, and the
 /// portfolio is valued at every flow date and at `end_date` in one forward
-/// realization pass (on the date-sorted fast path — the report's stream is; an
+/// accumulation pass (on the date-sorted fast path — the report's stream is; an
 /// unsorted stream falls back to per-date valuation, see `investment_values_at`),
 /// then reused for the terminal value, the money-weighted series, and the
 /// time-weighted chaining. A caller needing every figure (the `report returns`
-/// breakdown, one call per group) thus avoids the ~2× extraction and ~2×
-/// realization of invoking those functions separately. The result is identical to
-/// composing them by hand — pinned by `compute_returns_matches_manual_composition`.
+/// breakdown, one call per group) thus avoids the ~2× extraction and ~2× valuation
+/// of invoking those functions separately. The result is identical to composing
+/// them by hand — pinned by `compute_returns_matches_manual_composition`.
 ///
 /// TWR is `None` for a scope that never held investment capital (an income-only
 /// group, or a holding opened but never bought): with no capital there is no
@@ -951,10 +958,12 @@ pub struct Returns {
 /// flow date degrades TWR to `None` rather than erroring — the summary itself is
 /// still well-defined.
 ///
-/// The booked, pad-expanded input contract of [`twr`] applies: an un-booked
-/// reduction surfaces as [`ExtractError::UnbookedInput`] rather than panicking.
-/// (Date-sorted input is a fast path, not a correctness requirement — an unsorted
-/// stream falls back to the order-independent per-date valuation.)
+/// The interpolated, pad-expanded input contract of [`twr`] applies: an in-scope
+/// account with an elided/uninterpolated posting surfaces as
+/// [`ExtractError::UnbookedInput`] rather than panicking; a cost-basis/lot error is
+/// tolerated (net units valued at market). (Date-sorted input is a fast path, not a
+/// correctness requirement — an unsorted stream falls back to the order-independent
+/// per-date valuation.)
 pub fn compute_returns(
     directives: &[Directive],
     scope: &Scope,
@@ -980,7 +989,7 @@ pub fn compute_returns(
         *net_by_date.entry(flow.date).or_default() += -flow.amount;
     }
 
-    // One forward realization pass: value at every flow date and at `end_date`.
+    // One forward accumulation pass: value at every flow date and at `end_date`.
     let mut dates: Vec<NaiveDate> = net_by_date.keys().copied().collect();
     dates.push(end_date);
     let mut values = investment_values_at(directives, scope, reporting_currency, prices, &dates);
@@ -1019,31 +1028,30 @@ pub fn compute_returns(
     })
 }
 
-/// Compute [`compute_returns`] for SEVERAL scopes while realizing the portfolio
+/// Compute [`compute_returns`] for SEVERAL scopes while accumulating the portfolio
 /// only ONCE.
 ///
 /// `report returns --by-group` computes one summary for the whole scope plus one
-/// per group; calling [`compute_returns`] for each re-runs the booking pass every
-/// time even though the booking is scope-independent. This shares a single
-/// realization across all scopes (see `investment_values_multi`), turning the
-/// per-group booking cost from `O(scopes × directives)` into `O(directives)`.
-/// Flow extraction and valuation are still per scope (they must be), so the
-/// result for each scope is **identical** to `compute_returns(that scope)` —
-/// pinned by `compute_returns_multi_matches_per_scope`. Returns one result per
-/// input scope, in order.
+/// per group; calling [`compute_returns`] for each re-runs the accumulation pass
+/// every time even though it is scope-independent. This shares a single net-units
+/// accumulation across all scopes (see `investment_values_multi`), turning the
+/// per-group cost from `O(scopes × directives)` into `O(directives)`. Flow
+/// extraction and valuation are still per scope (they must be), so the result for
+/// each scope is **identical** to `compute_returns(that scope)` — pinned by
+/// `compute_returns_multi_matches_per_scope`. Returns one result per input scope,
+/// in order.
 ///
 /// # Errors
 ///
-/// A [`ExtractError::MissingPrice`] (an unpriceable boundary flow or `end_date`
-/// valuation) is per-scope independent: it is reported in that scope's slot and
-/// does not affect the others.
-///
-/// An [`ExtractError::UnbookedInput`] is NOT per-scope: the booking forward pass
-/// is shared across every scope, so a reduction with no matching lot (an
-/// un-booked, re-merged booking-failure) fails EVERY scope's slot — a broken
-/// ledger yields no returns for any scope rather than a partial report, and
-/// surfaces as `Err` rather than panicking. (Date-sorted is a fast path, not a
-/// requirement — an unsorted stream falls back to per-scope valuation.)
+/// Both error kinds are **per-scope independent** — reported in the offending
+/// scope's slot without affecting the others — because valuation runs per scope
+/// over the shared accumulation. A [`ExtractError::MissingPrice`] names an
+/// unpriceable boundary flow or `end_date` valuation. An
+/// [`ExtractError::UnbookedInput`] names a scope whose Investment accounts include
+/// one with an elided/uninterpolated posting; a scope that does not classify that
+/// account as Investment is unaffected. A cost-basis/lot error affects no scope
+/// (net units valued at market). (Date-sorted is a fast path, not a requirement —
+/// an unsorted stream falls back to per-scope valuation.)
 #[must_use]
 pub fn compute_returns_multi(
     directives: &[Directive],
@@ -1052,7 +1060,7 @@ pub fn compute_returns_multi(
     prices: &impl PriceOracle,
     end_date: NaiveDate,
 ) -> Vec<Result<Returns, ExtractError>> {
-    /// Per-scope work computed before the shared realization.
+    /// Per-scope work computed before the shared accumulation.
     struct Prep {
         flows: Vec<CashFlow>,
         invested: Decimal,
@@ -1092,7 +1100,7 @@ pub fn compute_returns_multi(
         })
         .collect();
 
-    // ONE realization pass over the union of the ready scopes' dates.
+    // ONE accumulation pass over the union of the ready scopes' dates.
     let scoped_dates: Vec<(&Scope, &[NaiveDate])> = preps
         .iter()
         .zip(scopes)
@@ -1200,19 +1208,18 @@ mod tests {
         )
     }
 
-    /// The engine-level guard against realizing an un-booked stream. The loader
-    /// re-merges booking-FAILED transactions in their un-booked shape, so a
-    /// returns consumer can hand `compute_returns` a reduction of more units than
-    /// were ever held. That must surface as [`ExtractError::UnbookedInput`] (via
-    /// the booking engine's fallible `try_apply`), NOT `debug_assert`-trap — this
-    /// native test would abort — nor over-sell into a wrong figure. Closes the
-    /// #1849 third-review finding at the source, for every consumer.
+    /// Net-units valuation tolerates a cost-basis/lot error. The loader re-merges
+    /// booking-FAILED transactions in their un-booked shape, so a returns consumer
+    /// can hand `compute_returns` a reduction of more units than were ever held —
+    /// the common state of imported brokerage data (empty-cost `{}` sales, no
+    /// matching lot). Because returns value **net units at market** (never
+    /// cost-basis lots), this must NOT trap, refuse the report, nor understate:
+    /// buying 5 then reducing 10 nets to −5 units, valued at the terminal price.
+    /// `rledger check` remains the validator; the returns report computes over
+    /// what loaded (like beancount + beangrow). See #1850.
     #[test]
-    fn unbooked_oversell_errors_not_traps() {
+    fn oversell_nets_negative_valued_at_market() {
         use rustledger_core::{CostNumber, CostSpec};
-        // Buy 5 at a cost lot, then reduce 10 with an empty cost `{}` that forces
-        // a lot match — over-reducing a held lot. This is the shape the loader
-        // fails to book and re-merges un-booked; realizing it must NOT trap.
         let dirs = vec![
             txn(
                 d(2020, 1, 1),
@@ -1235,23 +1242,24 @@ mod tests {
             ),
         ];
         let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
-        let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
-        assert!(
-            matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "over-reducing an empty-cost lot must yield UnbookedInput, got {r:?}"
-        );
+        let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31))
+            .expect("net-units valuation tolerates an over-sell");
+        // Net −5 AAPL × 120 = −600; not a trap, not an UnbookedInput refusal.
+        assert_eq!(r.current_value, dec!(-600));
     }
 
-    /// The OTHER un-booked shape: a transaction with an elided/uninterpolated
-    /// posting (booking would have filled it). `try_apply` silently skips a
-    /// non-Complete leg, which would understate the position — strict-clean must
-    /// surface it as `UnbookedInput`, not report a wrong figure.
+    /// The one shape net-units genuinely cannot value: an in-scope account with an
+    /// elided/uninterpolated posting (booking would have filled it). Its net units
+    /// are incomplete, so valuing it must surface as [`ExtractError::UnbookedInput`]
+    /// rather than silently understate the position. This is distinct from a
+    /// cost-basis error (tolerated, see `oversell_nets_negative_valued_at_market`) —
+    /// here the units themselves are unknown.
     #[test]
-    fn unbooked_elided_posting_errors_not_understates() {
+    fn elided_in_scope_posting_errors_not_understates() {
         let dirs = vec![txn(
             d(2020, 1, 1),
             vec![
-                // Elided in-scope investment leg (no units) — un-booked input.
+                // Elided in-scope investment leg (no units) — its net units are unknown.
                 Posting::auto("Assets:Broker:Stock"),
                 Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
             ],
@@ -1260,18 +1268,18 @@ mod tests {
         let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "an elided posting must yield UnbookedInput, got {r:?}"
+            "an elided in-scope posting must yield UnbookedInput, got {r:?}"
         );
     }
 
-    /// The public `twr` surfaces an un-booked reduction as `UnbookedInput` via
+    /// The public `twr` surfaces an elided-in-scope posting as `UnbookedInput` via
     /// its eager scan, rather than masking it as `Ok(None)` through
-    /// `twr_from_values`' lazy short-circuits. (`compute_returns` is protected
-    /// separately by its eager terminal valuation.)
+    /// `twr_from_values`' lazy short-circuits. The first flow date values cleanly
+    /// (net 5 AAPL priced), so only the eager scan reaches the later elided date.
+    /// (`compute_returns` is protected separately by its eager terminal valuation.)
     #[test]
     fn twr_surfaces_unbooked_input() {
         use rustledger_core::{CostNumber, CostSpec};
-        // Buy 5, then over-reduce 10 with an empty cost — an un-booked reduction.
         let dirs = vec![
             txn(
                 d(2020, 1, 1),
@@ -1287,13 +1295,15 @@ mod tests {
             txn(
                 d(2020, 6, 1),
                 vec![
-                    Posting::new("Assets:Broker:Stock", amt(dec!(-10), "AAPL"))
-                        .with_cost(CostSpec::empty()),
-                    Posting::new("Assets:Bank", amt(dec!(1000), "USD")),
+                    // Elided in-scope leg — net units become unknown from here.
+                    Posting::auto("Assets:Broker:Stock"),
+                    Posting::new("Assets:Bank", amt(dec!(-100), "USD")),
                 ],
             ),
         ];
-        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(120));
         let r = twr(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -227,9 +227,9 @@ pub enum ExtractError {
     /// holding** whose net units are unknown (valuation side), and an
     /// **external/boundary leg of a portfolio-touching transaction** whose cash
     /// flow is unknown (flows side — [`extract_flows`]). This is the ONE class of
-    /// input net-units genuinely
-    /// cannot handle — unlike a cost-basis/lot error (an over-sell, an empty-cost
-    /// `{}` sale with no matching lot), which nets the units and values at market.
+    /// input that net-units genuinely cannot handle — unlike a cost-basis/lot error
+    /// (an over-sell, an empty-cost `{}` sale with no matching lot), which nets the
+    /// units and values at market.
     /// Extraction refuses rather than silently understate the position or drop the
     /// flow. Carries a human-readable description.
     #[error("cannot compute returns: {0}")]
@@ -365,7 +365,7 @@ pub fn extract_flows(
             // never hits this; a re-merged booking-failed transaction can.
             let Some(amount) = posting.amount() else {
                 return Err(ExtractError::UnbookedInput(format!(
-                    "posting to {} on {} has un-booked (elided) units; cannot compute its cash flow",
+                    "posting to {} on {} has elided/uninterpolated units; cannot compute its cash flow",
                     posting.account, txn.date
                 )));
             };
@@ -542,7 +542,7 @@ fn value_investment_scope(
     for account in &holdings.unvaluable {
         if scope.classify(account.as_str()) == AccountRole::Investment {
             return Err(ExtractError::UnbookedInput(format!(
-                "account {account} has an un-booked (elided) posting; cannot value returns"
+                "account {account} has an elided/uninterpolated posting; cannot value returns"
             )));
         }
     }
@@ -1316,6 +1316,48 @@ mod tests {
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
             "compute_returns must not report a figure over a dropped flow, got {r:?}"
+        );
+    }
+
+    /// Per-scope isolation — what `--by-group` partial rendering relies on. Over
+    /// ONE shared accumulation, [`compute_returns_multi`] returns
+    /// [`ExtractError::UnbookedInput`] for a scope whose Investment accounts include
+    /// an elided posting, while a DISJOINT scope that excludes that account still
+    /// computes `Ok`. (The elided account is marked unvaluable globally, but a scope
+    /// errors only if it classifies that account as `Investment`.)
+    #[test]
+    fn compute_returns_multi_isolates_an_unvaluable_scope() {
+        let dirs = vec![
+            // Clean group: a complete, priceable buy.
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Clean", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            // Broken group: an elided in-scope leg → net units unknown.
+            txn(
+                d(2020, 3, 1),
+                vec![
+                    Posting::auto("Assets:Broker:Broken"),
+                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(130));
+        let clean = Scope::new(vec!["Assets:Broker:Clean".to_string()], vec![]);
+        let broken = Scope::new(vec!["Assets:Broker:Broken".to_string()], vec![]);
+        let out = compute_returns_multi(&dirs, &[clean, broken], "USD", &prices, d(2020, 12, 31));
+        assert_eq!(
+            out[0].as_ref().expect("clean scope computes").current_value,
+            dec!(1300),
+            "net 10 AAPL × 130",
+        );
+        assert!(
+            matches!(out[1], Err(ExtractError::UnbookedInput(_))),
+            "the elided scope fails alone: {:?}",
+            out[1]
         );
     }
 

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -300,7 +300,9 @@ pub fn extract_cash_flows(
 /// # Errors
 ///
 /// Returns [`ExtractError::MissingPrice`] if an external posting of a relevant
-/// transaction cannot be converted to `reporting_currency` on its date.
+/// transaction cannot be converted to `reporting_currency` on its date, or
+/// [`ExtractError::UnbookedInput`] if such a posting has elided/uninterpolated
+/// units (its cash flow is unknown — the flows counterpart of an elided holding).
 pub fn extract_flows(
     directives: &[Directive],
     scope: &Scope,
@@ -346,13 +348,19 @@ pub fn extract_flows(
             if scope.classify(posting.account.as_str()) != AccountRole::External {
                 continue;
             }
-            // The input-contract interpolated stream (module docs) fills units on
-            // every posting, so a None here is unreachable in practice; skipping is
-            // defensive, not a silent drop of a real flow (an un-interpolated
-            // stream is a contract violation the leaf crate cannot detect, exactly
-            // as `account_balances` also requires interpolated input).
+            // An elided/uninterpolated external leg of a portfolio-touching
+            // transaction is a boundary cash flow of UNKNOWN magnitude — the flows
+            // counterpart of an elided in-scope holding (see `value_investment_scope`).
+            // Net-units tolerates a cost-basis/lot error, but it cannot invent a
+            // flow it can't see, so surface it as `UnbookedInput` rather than
+            // silently drop the contribution (which would understate `invested` and
+            // report a wrong money-weighted return). A fully interpolated stream
+            // never hits this; a re-merged booking-failed transaction can.
             let Some(amount) = posting.amount() else {
-                continue;
+                return Err(ExtractError::UnbookedInput(format!(
+                    "posting to {} on {} has un-booked (elided) units; cannot compute its cash flow",
+                    posting.account, txn.date
+                )));
             };
             let converted = prices
                 .convert(amount, reporting_currency, txn.date)
@@ -1269,6 +1277,38 @@ mod tests {
         assert!(
             matches!(r, Err(ExtractError::UnbookedInput(_))),
             "an elided in-scope posting must yield UnbookedInput, got {r:?}"
+        );
+    }
+
+    /// The FLOWS counterpart: an elided **external** (boundary cash) leg of a
+    /// portfolio-touching transaction is a contribution of unknown magnitude. It
+    /// must surface as [`ExtractError::UnbookedInput`], NOT be silently dropped —
+    /// dropping it would value the (complete) investment leg at market with no
+    /// matching outflow, understating `invested` and reporting a wrong
+    /// money-weighted return while exiting `Ok`. The investment leg here is
+    /// complete, so only the elided external leg triggers the error.
+    #[test]
+    fn elided_external_leg_errors_not_dropped() {
+        let dirs = vec![txn(
+            d(2020, 1, 1),
+            vec![
+                // Complete in-scope buy...
+                Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                // ...but the boundary cash leg is elided (interpolation failed).
+                Posting::auto("Assets:Bank"),
+            ],
+        )];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
+        let flows = extract_flows(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(flows, Err(ExtractError::UnbookedInput(_))),
+            "an elided external leg must yield UnbookedInput, got {flows:?}"
+        );
+        // And the whole summary errors rather than reporting a wrong figure.
+        let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
+        assert!(
+            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            "compute_returns must not report a figure over a dropped flow, got {r:?}"
         );
     }
 

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -735,26 +735,48 @@ mod tests {
     }
 
     /// Drift guard (CLAUDE.md Canonical-Function Discipline): `terminal_value`
-    /// deliberately re-derives `report_cmd::account_balances`' realization loop
-    /// (a leaf crate cannot call this CLI-side helper). Pin that the two still
-    /// agree — the returns terminal value must equal the market valuation of
-    /// `account_balances`' inventories for the same scope and date. If the
-    /// realization in either place changes, this trips.
+    /// (net units) deliberately re-derives `report_cmd::account_balances`'
+    /// lot-matching realization (a leaf crate cannot call this CLI-side helper).
+    /// Pin that the two still agree — the returns terminal value must equal the
+    /// market valuation of `account_balances`' inventories for the same scope and
+    /// date. Includes a **reduction** (an empty-cost `{}` sell that lot-matches):
+    /// that is the exact shape where net-units and the lot-matching engine keep
+    /// different intermediate state, so a buy-only fixture could not catch a
+    /// divergence on the reduction path. If either realization changes, this trips.
     #[test]
     fn terminal_value_matches_account_balances_realization() {
+        use rustledger_core::{CostNumber, CostSpec};
+        let cost = |n: i64| {
+            CostSpec::empty()
+                .with_number(CostNumber::PerUnit {
+                    value: Decimal::from(n),
+                })
+                .with_currency("USD")
+        };
         let dirs = vec![
             Directive::Transaction(
                 Transaction::new(d(2020, 1, 1), "buy lot 1")
-                    .with_synthesized_posting(Posting::new(
-                        "Assets:Broker:Stock",
-                        money(10, "AAPL"),
-                    ))
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Broker:Stock", money(10, "AAPL")).with_cost(cost(100)),
+                    )
                     .with_synthesized_posting(Posting::new("Assets:Bank", money(-1000, "USD"))),
             ),
             Directive::Transaction(
                 Transaction::new(d(2020, 3, 1), "buy lot 2")
-                    .with_synthesized_posting(Posting::new("Assets:Broker:Stock", money(5, "AAPL")))
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Broker:Stock", money(5, "AAPL")).with_cost(cost(120)),
+                    )
                     .with_synthesized_posting(Posting::new("Assets:Bank", money(-600, "USD"))),
+            ),
+            // Reduction: sell 4 with an empty cost that lot-matches lot 1 (FIFO).
+            // Net units and the lot-matching engine must agree the residual is 11.
+            Directive::Transaction(
+                Transaction::new(d(2020, 6, 1), "sell 4")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Broker:Stock", money(-4, "AAPL"))
+                            .with_cost(CostSpec::empty()),
+                    )
+                    .with_synthesized_posting(Posting::new("Assets:Bank", money(600, "USD"))),
             ),
             Directive::Price(Price::new(d(2020, 12, 31), "AAPL", money(150, "USD"))),
         ];
@@ -785,8 +807,8 @@ mod tests {
             tv.amount, ab_total,
             "terminal_value drifted from account_balances realization",
         );
-        // Sanity: 15 AAPL @ 150 = 2250 USD.
-        assert_eq!(tv.amount, Decimal::from(2250));
+        // Sanity: net 10 + 5 − 4 = 11 AAPL @ 150 = 1650 USD.
+        assert_eq!(tv.amount, Decimal::from(1650));
     }
 
     /// Drift guard for the money-weighted series assembly `flows + terminal + sort`.

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -843,14 +843,15 @@ mod tests {
         assert_eq!(canonical.len(), 3);
     }
 
-    /// The CLI `report returns` path (`compute_group` -> `scope_returns`) must
-    /// return a clean error, NOT trap, when the loaded ledger carries a
-    /// booking-failed (un-booked, re-merged) transaction — the pre-existing CLI
-    /// exposure the #1849 third review flagged, now closed by the returns
-    /// engine's fallible `try_apply`. Over-reduce an empty-cost lot (sell 10 of a
-    /// 5-lot); without the fix this native test would abort.
+    /// The CLI `report returns` path (`compute_group` -> `scope_returns`) values
+    /// **net units at market**, so a booking-failed (un-booked, re-merged)
+    /// transaction — the common state of imported brokerage data — must NOT trap
+    /// and must NOT refuse the report. Over-reducing an empty-cost lot (sell 10 of
+    /// a 5-lot) nets to −5 units, valued at the terminal price. `rledger check`
+    /// remains the validator (see #1850); without the net-units rewrite this native
+    /// test would abort in the lot-matching booking engine.
     #[test]
-    fn compute_group_errors_on_unbooked_oversell_not_traps() {
+    fn compute_group_tolerates_unbooked_oversell_not_traps() {
         use rustledger_core::{CostNumber, CostSpec};
         let dirs = vec![
             Directive::Transaction(
@@ -874,13 +875,13 @@ mod tests {
                     )
                     .with_synthesized_posting(Posting::new("Assets:Bank", money(1000, "USD"))),
             ),
+            Directive::Price(Price::new(d(2020, 12, 31), "AAPL", money(120, "USD"))),
         ];
         let scope = Scope::new(vec!["Assets:Broker".to_string()], vec![]);
-        let r = compute_group(&dirs, &scope, "USD", d(2020, 12, 31), "TOTAL".to_string());
-        assert!(
-            r.is_err(),
-            "the CLI report path must error (not trap) on an un-booked over-sell"
-        );
+        let r = compute_group(&dirs, &scope, "USD", d(2020, 12, 31), "TOTAL".to_string())
+            .expect("the CLI report path values net units, tolerating an over-sell");
+        // Net −5 AAPL × 120 = −600; not a trap, not a refusal.
+        assert_eq!(r.current_value, Decimal::from(-600));
     }
 
     /// Drift guard (CLAUDE.md Canonical-Function Discipline): the batched


### PR DESCRIPTION
## Summary

Re-architects the returns engine to **value net units at market** instead of realizing holdings through the lot-matching `BookingEngine`. This is the core of the reframed #1850 (§1), and it reverses the strict-clean broken-ledger behavior shipped in #1849.

Money-weighted (XIRR) and time-weighted returns depend only on cash flows and terminal **market** value (`net units × price`) — never on cost-basis lots. So the engine now sums each account's complete posting units per commodity **without lot-matching** and values the net at market.

### Why (the research reversal)

#1849 shipped strict-clean: any booking error → clean `Err`. Research (reading beangrow's `returns.py` + beancount mailing-list threads) showed that was wrong — the leniency it blocked is a genuinely useful, common capability. An over-sell, or an empty-cost `{}` sale with no matching lot, is the **normal state of imported brokerage data**; beangrow sums `Inventory.add_position` (no lot-matching) and values at market, so it never crashes. rledger's fragility was self-inflicted: it valued net units at market but *sourced* them from the full lot-matching engine, which traps on unmatched reductions — lot-matching that market valuation never needed.

### Behavior

- **Cost-basis/lot errors are now a non-event for the report** — an over-sell or empty-cost `{}` sale simply nets the units (possibly negative) and values at market, like beancount + beangrow. `rledger check` remains the validator.
- **Only genuinely-unvaluable input errors** — an in-scope account with an elided/uninterpolated posting (net units unknown) → `ExtractError::UnbookedInput`.
- **Clean-ledger output is byte-identical** — the existing per-date / per-scope drift guards stay green.

## Changes

- **`rustledger-returns/src/extract.rs`**: a `NetUnits` accumulator (`BTreeMap<Account, BTreeMap<Currency, Decimal>>` + an `unvaluable` set) replaces the `BookingEngine` in `investment_value_at` / `investment_values_at` / `investment_values_multi`. The accumulation pass can no longer error; valuation errors move per-date / per-scope — so `UnbookedInput` is now **per-scope** in the `--by-group` path (unblocks §4 partial render).
- **Dependency cleanup**: drop `rustledger-booking` from `rustledger-returns`; remove the now-dead `BookingEngine::try_apply` from `rustledger-booking` (§3).
- **Tests**: rewrite the three #1849 strict-clean tests (returns, CLI, FFI component) to assert the tolerant net-units behavior — an over-sell nets negative and values at market; only an elided in-scope posting errors.
- **Docs**: module + function docs updated from the booking-realization framing to net-units.

## Verification

- `rustledger-returns` 62 · `rustledger-booking` 110+ · `rustledger-ffi-component` 30 · `rustledger` CLI 424 — all pass
- `cargo check --workspace --all-features --all-targets`, `clippy` @1.97.0, `rustdoc -D warnings` — all clean
- pre-push hooks (rustfmt, typos, gitleaks, workspace check, unsafe-invariant, plugin-test-quality) — all pass

## Follow-ups (remaining #1850 increments)

§2 report-vs-validator separation · §4 `--by-group` CLI partial-render (now unblocked) · §5 edge cases (falling-price / negative-return tests, missing-price policy) · §6 messy-imported-ledger + beangrow cross-check suite · §7 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
