### PR TITLE
feat(returns): --by-group partial report on unvaluable scopes (#1850 §4)

### DIFF
--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -1068,19 +1068,47 @@ mod tests {
         )
         .unwrap();
         let json = String::from_utf8(json).unwrap();
-        assert!(json.contains(r#""group": "Tech""#));
+        // Parse structurally so the assertions pin the `error` FIELD, not a
+        // substring floating anywhere in the blob (CLAUDE.md: assert the exact
+        // observable, not a proxy).
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("render_grouped must emit valid JSON");
+        let rows = parsed["groups"].as_array().expect("groups array");
+        let tech = &rows[0];
+        let broken = &rows[1];
+        let reason = "cannot compute returns: account Assets:Broker:Broken has an un-booked (elided) posting";
+
+        // Computed row: figures present, `error` explicitly null.
+        assert_eq!(tech["group"], "Tech");
         assert!(
-            json.contains(r#""error": null"#),
-            "computed row error is null:\n{json}"
+            tech["current_value"].is_string(),
+            "computed figure present: {tech}"
         );
         assert!(
-            json.contains(r#""current_value": null"#),
-            "unvaluable figures null:\n{json}"
+            tech["error"].is_null(),
+            "computed row error must be null: {tech}"
+        );
+
+        // Unvaluable row: the reason is on the `error` FIELD, and every figure is
+        // null — the stable schema a consumer branches on.
+        assert_eq!(broken["group"], "Broken");
+        assert_eq!(
+            broken["error"].as_str(),
+            Some(reason),
+            "reason on the error field: {broken}"
         );
         assert!(
-            json.contains(r#""error": "cannot compute returns"#) || json.contains("un-booked"),
-            "unvaluable row carries the reason:\n{json}"
+            broken["current_value"].is_null(),
+            "unvaluable figures null: {broken}"
         );
+        assert!(
+            broken["cash_flows"].is_null(),
+            "unvaluable figures null: {broken}"
+        );
+
+        // The TOTAL row is likewise unvaluable, same schema.
+        assert_eq!(parsed["total"]["error"].as_str(), Some(reason));
+        assert!(parsed["total"]["current_value"].is_null());
     }
 
     /// #1850 §4 end-to-end: a `--by-group` report with one valuable group and one

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -481,7 +481,15 @@ pub(super) fn report_returns<W: Write>(
                 twr: r.time_weighted,
             })),
             Err(e) => {
-                eprintln!("warning: returns for {label} are unavailable: {e}");
+                // `label` is a user-controlled `returns-group` value; sanitize it
+                // for this stderr warning so it cannot inject control chars / extra
+                // lines (same guard the grouping warnings use). The error text is
+                // grammar-constrained (account names / currencies), so it needs no
+                // sanitizing.
+                eprintln!(
+                    "warning: returns for {} are unavailable: {e}",
+                    sanitize_display(&label)
+                );
                 rows.push(GroupRow::Unvaluable {
                     label,
                     reason: e.to_string(),

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -489,10 +489,11 @@ pub(super) fn report_returns<W: Write>(
             }
         }
     }
-    if rows
+    let unvaluable = rows
         .iter()
-        .all(|r| matches!(r, GroupRow::Unvaluable { .. }))
-    {
+        .filter(|r| matches!(r, GroupRow::Unvaluable { .. }))
+        .count();
+    if unvaluable == rows.len() {
         // Nothing is computable — surface the TOTAL's reason as the failure.
         let reason = match rows.first() {
             Some(GroupRow::Unvaluable { reason, .. }) => reason.clone(),
@@ -504,7 +505,22 @@ pub(super) fn report_returns<W: Write>(
         .split_first()
         .expect("scopes always contains the whole-portfolio TOTAL");
 
-    render_grouped(groups, total, currency, end_date, ctx, format, writer)
+    render_grouped(groups, total, currency, end_date, ctx, format, writer)?;
+
+    // The partial report was emitted above (computable rows + `n/a` markers). Exit
+    // NON-ZERO so a pipeline gating on exit status does not treat an incomplete
+    // report as a full success — the CSV/text formats carry no error column, so the
+    // exit code is their only machine-readable "incomplete" signal (JSON also has a
+    // per-row `error` field). Mirrors the single-scope path, which errors outright.
+    if unvaluable > 0 {
+        anyhow::bail!(
+            "returns report is incomplete: {unvaluable} of {} {} could not be valued \
+             (see the n/a rows and the warnings above)",
+            rows.len(),
+            if rows.len() == 1 { "scope" } else { "scopes" },
+        );
+    }
+    Ok(())
 }
 
 /// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.
@@ -1115,7 +1131,9 @@ mod tests {
     /// unvaluable group (an elided in-scope posting) renders the valuable group's
     /// figures and marks the unvaluable one — and the whole-portfolio TOTAL, which
     /// includes the elided account — `n/a`, instead of aborting on the first error
-    /// (the pre-fix `?`). The report still succeeds because a group computed.
+    /// (the pre-fix `?`). The partial report IS still written to the writer, but the
+    /// call returns `Err` so the CLI exits non-zero to signal it is incomplete
+    /// (review pass 2, finding [0]).
     #[test]
     fn report_returns_by_group_partial_renders() {
         use rustledger_core::{Metadata, Open};
@@ -1162,11 +1180,16 @@ mod tests {
             &OutputFormat::Text,
             &mut out,
         );
-        assert!(r.is_ok(), "partial report must not abort: {r:?}");
+        // Incomplete report → non-zero exit (Err), but the partial output is still
+        // written (render happens before the bail).
+        assert!(
+            r.is_err(),
+            "a partial report must signal incompleteness via Err: {r:?}"
+        );
         let out = String::from_utf8(out).unwrap();
         assert!(
             out.contains("1300"),
-            "valuable Tech group renders its figures:\n{out}"
+            "the valuable Tech group is still rendered despite the Err:\n{out}"
         );
         let broken = out
             .lines()

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -66,6 +66,24 @@ struct GroupResult {
     twr: Option<f64>,
 }
 
+/// One row of the `--by-group` report: either computed figures, or a marker that
+/// the scope hit an unvaluable input.
+///
+/// Net-units valuation isolates scopes — each sums only its own accounts — so one
+/// group hitting an unvaluable input (an in-scope account with an elided posting,
+/// or a commodity with no price) leaves the others computable. The report renders
+/// the computable rows and marks the unvaluable ones with `n/a`, rather than
+/// aborting the whole report on the first error (#1850 §4).
+enum GroupRow {
+    Ok(GroupResult),
+    /// The scope could not be valued; carries its label and the reason (shown as a
+    /// stderr warning, and — in JSON — on the row itself).
+    Unvaluable {
+        label: String,
+        reason: String,
+    },
+}
+
 /// Compute the return summary for one scope.
 ///
 /// Delegates to [`rustledger_query::scope_returns`] — the composition shared with
@@ -411,6 +429,8 @@ pub(super) fn report_returns<W: Write>(
         eprintln!(
             "warning: --by-group but no in-scope `returns-group:` metadata found; reporting only the whole-portfolio total"
         );
+        // No groups to partially render, so an unvaluable TOTAL still fails loudly
+        // (via `?`), matching the all-unvaluable rule below.
         let total = compute_group(
             directives,
             &whole_scope,
@@ -418,7 +438,15 @@ pub(super) fn report_returns<W: Write>(
             end_date,
             "TOTAL".to_string(),
         )?;
-        return render_grouped(&[], &total, currency, end_date, ctx, format, writer);
+        return render_grouped(
+            &[],
+            &GroupRow::Ok(total),
+            currency,
+            end_date,
+            ctx,
+            format,
+            writer,
+        );
     }
 
     // Compute the whole-portfolio TOTAL and every group in ONE shared realization:
@@ -435,18 +463,42 @@ pub(super) fn report_returns<W: Write>(
     }
     let computed = scopes_returns(directives, &scopes, &reporting_currency, end_date);
 
-    let mut rows: Vec<GroupResult> = Vec::with_capacity(computed.len());
+    // Each scope is valued independently (net-units isolates them), so a scope that
+    // hits an unvaluable input becomes an `n/a` row with a stderr warning rather
+    // than aborting the whole report — figures for the computable groups still
+    // render (#1850 §4). Only if EVERY row (TOTAL included) is unvaluable is there
+    // nothing to show, and the report fails loudly.
+    let mut rows: Vec<GroupRow> = Vec::with_capacity(computed.len());
     for (result, label) in computed.into_iter().zip(labels) {
-        let r = result.with_context(|| format!("computing investment returns for {label}"))?;
-        rows.push(GroupResult {
-            label,
-            flow_count: r.cash_flows,
-            invested: r.invested,
-            distributions: r.distributions,
-            current_value: r.current_value,
-            mwr: r.money_weighted,
-            twr: r.time_weighted,
-        });
+        match result {
+            Ok(r) => rows.push(GroupRow::Ok(GroupResult {
+                label,
+                flow_count: r.cash_flows,
+                invested: r.invested,
+                distributions: r.distributions,
+                current_value: r.current_value,
+                mwr: r.money_weighted,
+                twr: r.time_weighted,
+            })),
+            Err(e) => {
+                eprintln!("warning: returns for {label} are unavailable: {e}");
+                rows.push(GroupRow::Unvaluable {
+                    label,
+                    reason: e.to_string(),
+                });
+            }
+        }
+    }
+    if rows
+        .iter()
+        .all(|r| matches!(r, GroupRow::Unvaluable { .. }))
+    {
+        // Nothing is computable — surface the TOTAL's reason as the failure.
+        let reason = match rows.first() {
+            Some(GroupRow::Unvaluable { reason, .. }) => reason.clone(),
+            _ => "no valuable scope".to_string(),
+        };
+        anyhow::bail!("no returns could be computed: {reason}");
     }
     let (total, groups) = rows
         .split_first()
@@ -578,9 +630,13 @@ fn json_rate(rate: Option<f64>) -> String {
 }
 
 /// Per-group rows plus a TOTAL, when grouping is active.
+///
+/// A row that hit an unvaluable input renders `n/a` figures rather than aborting
+/// the report (#1850 §4); in JSON it also carries an `error` field (`null` on a
+/// computed row) so the failure is machine-distinguishable.
 fn render_grouped<W: Write>(
-    groups: &[GroupResult],
-    total: &GroupResult,
+    groups: &[GroupRow],
+    total: &GroupRow,
     currency: &str,
     end_date: NaiveDate,
     ctx: &DisplayContext,
@@ -595,26 +651,37 @@ fn render_grouped<W: Write>(
                 writer,
                 "group,as_of,reporting_currency,cash_flows,invested,distributions,current_value,money_weighted_return_pct,time_weighted_return_pct"
             )?;
-            for r in rows {
-                writeln!(
-                    writer,
-                    "{},{},{},{},{},{},{},{},{}",
-                    csv_escape(&sanitize_display(&r.label)),
-                    end_date,
-                    currency,
-                    r.flow_count,
-                    csv_escape(&money(r.invested)),
-                    csv_escape(&money(r.distributions)),
-                    csv_escape(&money(r.current_value)),
-                    fmt_rate(r.mwr),
-                    fmt_rate(r.twr),
-                )?;
+            for row in rows {
+                match row {
+                    GroupRow::Ok(r) => writeln!(
+                        writer,
+                        "{},{},{},{},{},{},{},{},{}",
+                        csv_escape(&sanitize_display(&r.label)),
+                        end_date,
+                        currency,
+                        r.flow_count,
+                        csv_escape(&money(r.invested)),
+                        csv_escape(&money(r.distributions)),
+                        csv_escape(&money(r.current_value)),
+                        fmt_rate(r.mwr),
+                        fmt_rate(r.twr),
+                    )?,
+                    // An unvaluable row keeps the column count stable with `n/a` in
+                    // every figure column; the reason is on stderr.
+                    GroupRow::Unvaluable { label, .. } => writeln!(
+                        writer,
+                        "{},{},{},n/a,n/a,n/a,n/a,n/a,n/a",
+                        csv_escape(&sanitize_display(label)),
+                        end_date,
+                        currency,
+                    )?,
+                }
             }
         }
         OutputFormat::Json => {
-            let obj = |r: &GroupResult| {
-                format!(
-                    r#"{{"group": "{}", "cash_flows": {}, "invested": "{}", "distributions": "{}", "current_value": "{}", "money_weighted_return_pct": {}, "time_weighted_return_pct": {}}}"#,
+            let obj = |row: &GroupRow| match row {
+                GroupRow::Ok(r) => format!(
+                    r#"{{"group": "{}", "cash_flows": {}, "invested": "{}", "distributions": "{}", "current_value": "{}", "money_weighted_return_pct": {}, "time_weighted_return_pct": {}, "error": null}}"#,
                     json_escape(&r.label),
                     r.flow_count,
                     money(r.invested),
@@ -622,7 +689,13 @@ fn render_grouped<W: Write>(
                     money(r.current_value),
                     json_rate(r.mwr),
                     json_rate(r.twr),
-                )
+                ),
+                // Stable schema: same keys, figures `null`, plus the reason string.
+                GroupRow::Unvaluable { label, reason } => format!(
+                    r#"{{"group": "{}", "cash_flows": null, "invested": null, "distributions": null, "current_value": null, "money_weighted_return_pct": null, "time_weighted_return_pct": null, "error": "{}"}}"#,
+                    json_escape(label),
+                    json_escape(reason),
+                ),
             };
             let group_objs: Vec<String> = groups.iter().map(obj).collect();
             writeln!(
@@ -647,17 +720,30 @@ fn render_grouped<W: Write>(
                 "Group", "MWR", "TWR", "Invested", "Distributions", "Current"
             )?;
             writeln!(writer, "{}", "-".repeat(RULE))?;
-            let row = |w: &mut W, r: &GroupResult| -> Result<()> {
-                writeln!(
-                    w,
-                    "{:23}{:>9}{:>9}{:>12}{:>14}{:>12}",
-                    truncate(&r.label, 23),
-                    fmt_rate_pct(r.mwr),
-                    fmt_rate_pct(r.twr),
-                    money(r.invested),
-                    money(r.distributions),
-                    money(r.current_value),
-                )?;
+            let row = |w: &mut W, row: &GroupRow| -> Result<()> {
+                match row {
+                    GroupRow::Ok(r) => writeln!(
+                        w,
+                        "{:23}{:>9}{:>9}{:>12}{:>14}{:>12}",
+                        truncate(&r.label, 23),
+                        fmt_rate_pct(r.mwr),
+                        fmt_rate_pct(r.twr),
+                        money(r.invested),
+                        money(r.distributions),
+                        money(r.current_value),
+                    )?,
+                    // `n/a` in every figure column; the reason is on stderr.
+                    GroupRow::Unvaluable { label, .. } => writeln!(
+                        w,
+                        "{:23}{:>9}{:>9}{:>12}{:>14}{:>12}",
+                        truncate(label, 23),
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                    )?,
+                }
                 Ok(())
             };
             for r in groups {
@@ -904,6 +990,172 @@ mod tests {
             .expect("the CLI report path values net units, tolerating an over-sell");
         // Net −5 AAPL × 120 = −600; not a trap, not a refusal.
         assert_eq!(r.current_value, Decimal::from(-600));
+    }
+
+    /// #1850 §4: `render_grouped` marks an unvaluable row `n/a` (never aborts) and,
+    /// in JSON, carries a machine-readable `error` on that row while a computed
+    /// row's `error` is `null` — the schema stays stable across both shapes.
+    #[test]
+    fn render_grouped_marks_unvaluable_rows() {
+        let ctx = DisplayContext::new();
+        let end = d(2020, 12, 31);
+        let groups = vec![
+            GroupRow::Ok(GroupResult {
+                label: "Tech".to_string(),
+                flow_count: 2,
+                invested: Decimal::from(1000),
+                distributions: Decimal::ZERO,
+                current_value: Decimal::from(1300),
+                mwr: Some(0.30),
+                twr: Some(0.30),
+            }),
+            GroupRow::Unvaluable {
+                label: "Broken".to_string(),
+                reason: "cannot compute returns: account Assets:Broker:Broken has an un-booked (elided) posting".to_string(),
+            },
+        ];
+        let total = GroupRow::Unvaluable {
+            label: "TOTAL".to_string(),
+            reason: "cannot compute returns: account Assets:Broker:Broken has an un-booked (elided) posting".to_string(),
+        };
+
+        // Text: Tech's figures render; the Broken and TOTAL rows are `n/a`.
+        let mut text = Vec::new();
+        render_grouped(
+            &groups,
+            &total,
+            "USD",
+            end,
+            &ctx,
+            &OutputFormat::Text,
+            &mut text,
+        )
+        .unwrap();
+        let text = String::from_utf8(text).unwrap();
+        assert!(
+            text.contains("1300"),
+            "computed group renders its figures:\n{text}"
+        );
+        let broken = text
+            .lines()
+            .find(|l| l.starts_with("Broken"))
+            .expect("Broken row");
+        assert!(
+            broken.contains("n/a"),
+            "unvaluable group is n/a: {broken:?}"
+        );
+        assert!(!broken.contains("1300"));
+        let total_line = text
+            .lines()
+            .find(|l| l.starts_with("TOTAL"))
+            .expect("TOTAL row");
+        assert!(
+            total_line.contains("n/a"),
+            "unvaluable TOTAL is n/a: {total_line:?}"
+        );
+
+        // JSON: stable schema — computed row `error: null`, unvaluable row carries
+        // the reason with `null` figures.
+        let mut json = Vec::new();
+        render_grouped(
+            &groups,
+            &total,
+            "USD",
+            end,
+            &ctx,
+            &OutputFormat::Json,
+            &mut json,
+        )
+        .unwrap();
+        let json = String::from_utf8(json).unwrap();
+        assert!(json.contains(r#""group": "Tech""#));
+        assert!(
+            json.contains(r#""error": null"#),
+            "computed row error is null:\n{json}"
+        );
+        assert!(
+            json.contains(r#""current_value": null"#),
+            "unvaluable figures null:\n{json}"
+        );
+        assert!(
+            json.contains(r#""error": "cannot compute returns"#) || json.contains("un-booked"),
+            "unvaluable row carries the reason:\n{json}"
+        );
+    }
+
+    /// #1850 §4 end-to-end: a `--by-group` report with one valuable group and one
+    /// unvaluable group (an elided in-scope posting) renders the valuable group's
+    /// figures and marks the unvaluable one — and the whole-portfolio TOTAL, which
+    /// includes the elided account — `n/a`, instead of aborting on the first error
+    /// (the pre-fix `?`). The report still succeeds because a group computed.
+    #[test]
+    fn report_returns_by_group_partial_renders() {
+        use rustledger_core::{Metadata, Open};
+        let group_meta = |name: &str| {
+            let mut m = Metadata::default();
+            m.insert(
+                "returns-group".to_string(),
+                MetaValue::String(name.to_string()),
+            );
+            m
+        };
+        let dirs = vec![
+            Directive::Open(
+                Open::new(d(2020, 1, 1), "Assets:Broker:Tech").with_meta(group_meta("Tech")),
+            ),
+            Directive::Open(
+                Open::new(d(2020, 1, 1), "Assets:Broker:Broken").with_meta(group_meta("Broken")),
+            ),
+            Directive::Transaction(
+                Transaction::new(d(2020, 1, 2), "buy")
+                    .with_synthesized_posting(Posting::new("Assets:Broker:Tech", money(10, "AAPL")))
+                    .with_synthesized_posting(Posting::new("Assets:Bank", money(-1000, "USD"))),
+            ),
+            // Elided in-scope leg → net units unknown → this group (and TOTAL) can't
+            // be valued, but the Tech group is untouched.
+            Directive::Transaction(
+                Transaction::new(d(2020, 3, 1), "elided")
+                    .with_synthesized_posting(Posting::auto("Assets:Broker:Broken"))
+                    .with_synthesized_posting(Posting::new("Assets:Bank", money(-500, "USD"))),
+            ),
+            Directive::Price(Price::new(d(2020, 12, 31), "AAPL", money(130, "USD"))),
+        ];
+        let ctx = DisplayContext::new();
+        let mut out = Vec::new();
+        let r = report_returns(
+            &dirs,
+            &["USD".to_string()],
+            &["Assets:Broker".to_string()],
+            &[],
+            None,
+            Some("2020-12-31"),
+            true,
+            &ctx,
+            &OutputFormat::Text,
+            &mut out,
+        );
+        assert!(r.is_ok(), "partial report must not abort: {r:?}");
+        let out = String::from_utf8(out).unwrap();
+        assert!(
+            out.contains("1300"),
+            "valuable Tech group renders its figures:\n{out}"
+        );
+        let broken = out
+            .lines()
+            .find(|l| l.starts_with("Broken"))
+            .expect("Broken row");
+        assert!(
+            broken.contains("n/a"),
+            "unvaluable group is n/a: {broken:?}"
+        );
+        let total_line = out
+            .lines()
+            .find(|l| l.starts_with("TOTAL"))
+            .expect("TOTAL row");
+        assert!(
+            total_line.contains("n/a"),
+            "unvaluable TOTAL is n/a: {total_line:?}"
+        );
     }
 
     /// Drift guard (CLAUDE.md Canonical-Function Discipline): the batched

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -599,6 +599,73 @@ fn returns_group_metadata_breaks_down_dividend_inclusive() {
     );
 }
 
+/// #1850 §4 + review pass 2, finding [0]: a `--by-group` report where one group
+/// cannot be valued (here Bonds holds BND priced only in EUR, with no EUR→USD
+/// rate, so its boundary flow is unpriceable) must (a) still RENDER the computable
+/// groups + `n/a` rows, and (b) exit NON-ZERO so a pipeline gating on exit status
+/// does not treat the incomplete report as a full success. The Tech group is
+/// fully priced and unaffected.
+#[test]
+fn by_group_partial_report_renders_but_exits_nonzero() {
+    const LEDGER: &str = r#"option "operating_currency" "USD"
+2020-01-01 open Assets:Bank
+2020-01-01 open Assets:Broker:Tech
+  returns-group: "Tech"
+2020-01-01 open Assets:Broker:Bonds
+  returns-group: "Bonds"
+2020-01-02 * "buy tech"
+  Assets:Broker:Tech  10 AAPL {100 USD}
+  Assets:Bank
+2020-01-03 * "buy bonds, priced only in EUR"
+  Assets:Broker:Bonds  5 BND {100 EUR}
+  Assets:Bank  -500 EUR
+2020-12-31 price AAPL 130 USD
+"#;
+    let bin = require_rledger!();
+    let f = write_fixture(LEDGER);
+    let path = f.path().to_str().unwrap();
+    let out = Command::new(&bin)
+        .args([
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--no-pager",
+        ])
+        .output()
+        .expect("run rledger");
+
+    // (b) Non-zero exit — the incomplete-report signal for pipelines.
+    assert!(
+        !out.status.success(),
+        "a partial by-group report must exit non-zero; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // (a) The partial report is still written to stdout: Tech's figures render,
+    // and the unvaluable Bonds + TOTAL rows are `n/a`.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Tech"),
+        "computable group rendered:\n{stdout}"
+    );
+    assert!(
+        stdout
+            .lines()
+            .any(|l| l.starts_with("Bonds") && l.contains("n/a")),
+        "unvaluable Bonds row is n/a:\n{stdout}"
+    );
+    // The reason and the incompleteness are on stderr.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("incomplete") || stderr.contains("unavailable"),
+        "stderr explains the incompleteness:\n{stderr}"
+    );
+}
+
 #[test]
 fn by_group_omits_untagged_holdings_no_residual() {
     let bin = require_rledger!();


### PR DESCRIPTION
## Summary

`report returns --by-group` now renders a **partial report** when a scope hits an unvaluable input, instead of aborting the whole report on the first error (#1850 §4). Stacked work; base is now `main` (#1851 merged).

## Behavior

- Each scope is valued independently (net-units isolates them), so a group that hits an unvaluable input — an unpriced commodity, or an elided posting — becomes an **`n/a` row** with a stderr `warning:` naming the reason, while the computable groups still report their figures.
- **Exit status (updated in review):** when *any* row is unvaluable the report is still **rendered**, but `rledger` **exits non-zero** — an incomplete report is not a full success, so a script gating on the exit code (`rledger … && …`) stops rather than consuming a report with silent `n/a` holes. The partial output is written to stdout *before* the non-zero exit (pinned by the `by_group_partial_report_renders_but_exits_nonzero` subprocess test). Only when *every* row is unvaluable is nothing rendered.
- **JSON** keeps a stable schema: every row gains an `error` field (`null` when computed, the reason string when not) with `null` figures on an unvaluable row — machine-distinguishable in all formats (CSV/text signal via the exit code + `n/a`).

## Changes

- `report_returns`: build `Vec<GroupRow>` (`Ok` | `Unvaluable { label, reason }`) instead of `?`-aborting; warn per unavailable scope (label routed through `sanitize_display` — it is user-controlled `returns-group` metadata); return `Err` (non-zero exit) when the report is partial; bail before rendering only when *all* rows are unvaluable.
- `render_grouped`: `n/a` in every figure column (text/CSV); JSON gains the stable `error` field.
- Tests: `render_grouped` (text + structural JSON `error`-field assertion), an end-to-end `report_returns` unit test (partial output written **and** `Err`), and a subprocess test pinning the non-zero exit + partial stdout + stderr reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
