### PR TITLE
docs(returns): net-units model in report.md (#1850 §7)

### DIFF
--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -193,15 +193,16 @@ What this means in practice:
 - **Losing portfolios** produce a real **negative** rate (e.g. `-42.10%`), never a
   crash or a silent `n/a`.
 - Because returns ignore cost basis, they can **disagree with `report balances` /
-  `report holdings`** (which lot-match) on an *un-booked* ledger — e.g. an over-sell
-  shows as a negative net position here but is ignored there. That is a signal the
-  ledger's bookkeeping is broken; run [`rledger check`](check.md) to find and fix
-  the booking error.
-- **Only two things** actually stop a figure: no **price** for a commodity at the
-  date it's needed (a held position, or an unconvertible boundary flow), and a
-  posting whose **units are elided** and could not be interpolated — either a held
-  quantity (unknown holding) or a boundary cash leg (unknown flow). Both errors name
-  exactly what is missing.
+  `report holdings`** (which lot-match) on a ledger with **booking / lot errors**
+  (e.g. an over-sell that does not book cleanly) — the over-sell shows as a negative
+  net position here but is ignored there. That is a signal the ledger's bookkeeping
+  is broken; run [`rledger check`](check.md) to find and fix it.
+- **Only two things** actually stop a figure. First, a missing **price** for a
+  *held position at `--end`* or an *unconvertible boundary flow* — note a missing
+  price at an intermediate cash-flow date is **not** fatal (it degrades only TWR to
+  `n/a`, per the callout above). Second, a posting whose **units are elided** and
+  could not be interpolated — either a held quantity (unknown holding) or a boundary
+  cash leg (unknown flow). Both errors name exactly what is missing.
 
 #### Per-group breakdown
 
@@ -274,7 +275,7 @@ Notes on grouping:
 
   **Exit status.** When any row is unvaluable, `rledger` **exits non-zero** even
   though it still prints the partial report — an incomplete report is not a full
-  success, so a script gating on the exit code (`rledger ... && …`) stops rather
+  success, so a script gating on the exit code (`rledger ... && ...`) stops rather
   than consuming a report with silent `n/a` holes. For CSV and text (which have no
   error column) the exit code is the only machine-readable "incomplete" signal.
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -192,10 +192,16 @@ What this means in practice:
   treated as errors.
 - **Losing portfolios** produce a real **negative** rate (e.g. `-42.10%`), never a
   crash or a silent `n/a`.
-- **Only two things** actually stop a figure: no **price** for a held commodity at
-  the date it's needed (or an unconvertible boundary flow), and a posting whose
-  **units are elided** and could not be interpolated (so the held quantity is
-  unknown). Both errors name exactly what is missing.
+- Because returns ignore cost basis, they can **disagree with `report balances` /
+  `report holdings`** (which lot-match) on an *un-booked* ledger — e.g. an over-sell
+  shows as a negative net position here but is ignored there. That is a signal the
+  ledger's bookkeeping is broken; run [`rledger check`](check.md) to find and fix
+  the booking error.
+- **Only two things** actually stop a figure: no **price** for a commodity at the
+  date it's needed (a held position, or an unconvertible boundary flow), and a
+  posting whose **units are elided** and could not be interpolated — either a held
+  quantity (unknown holding) or a boundary cash leg (unknown flow). Both errors name
+  exactly what is missing.
 
 #### Per-group breakdown
 
@@ -260,11 +266,17 @@ Notes on grouping:
     only the TOTAL row).
 - **Partial reports.** Because each group is valued independently, a group (or the
   `TOTAL`) that hits one of the two blockers above — an unpriced commodity or an
-  elided in-scope posting — shows `n/a` across its row, with a `warning:` naming the
-  reason, while the other groups still report their figures. The report fails
-  outright only when *every* row is unvaluable. In `--format json` an unvaluable row
-  carries an `"error"` field (with `null` figures); a computed row's `"error"` is
-  `null`, so the schema is the same for both.
+  elided posting — shows `n/a` across its row, with a `warning:` naming the reason,
+  while the other groups still report their figures. The rows are always rendered;
+  only when *every* row is unvaluable is nothing shown. In `--format json` an
+  unvaluable row carries an `"error"` field (with `null` figures); a computed row's
+  `"error"` is `null`, so the schema is the same for both.
+
+  **Exit status.** When any row is unvaluable, `rledger` **exits non-zero** even
+  though it still prints the partial report — an incomplete report is not a full
+  success, so a script gating on the exit code (`rledger ... && …`) stops rather
+  than consuming a report with silent `n/a` holes. For CSV and text (which have no
+  error column) the exit code is the only machine-readable "incomplete" signal.
 
 See [`returns-group:` metadata](../reference/syntax.md#returns-group-metadata) for
 the tagging syntax.

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -169,6 +169,34 @@ Time-weighted return    6.24%
 > return to `n/a` while the rest of the summary is still reported.) Provide
 > `price` directives to cover your holdings at the report date.
 
+#### What the report computes over
+
+Both returns are derived from two things: your **cash flows** — money crossing the
+portfolio boundary, i.e. contributions in and withdrawals/dividends out — and the
+**market value** of the position still held at `--end` (`net units × price`). They
+do **not** depend on cost basis or lot matching. Cost lots matter for *realized
+capital gains*, which these figures don't use.
+
+A practical consequence: an **imperfect or freshly-imported ledger still reports.**
+Brokerage imports routinely leave cost-basis gaps — an empty-cost `{}` sale with no
+matching lot, a sale of more units than the ledger records buying, or a holding
+whose opening purchase predates the import. `report returns` sums the *net* units
+(a net-short position simply values **negative** at market) and reports the return;
+it does not refuse. Validate the bookkeeping itself — unmatched lots, unbalanced
+transactions — separately with [`rledger check`](check.md) (the equivalent of
+`bean-check`). **`report returns` is a reporting tool, not a validator.**
+
+What this means in practice:
+
+- **Short / negative positions** value at market (negatively) and are reported, not
+  treated as errors.
+- **Losing portfolios** produce a real **negative** rate (e.g. `-42.10%`), never a
+  crash or a silent `n/a`.
+- **Only two things** actually stop a figure: no **price** for a held commodity at
+  the date it's needed (or an unconvertible boundary flow), and a posting whose
+  **units are elided** and could not be interpolated (so the held quantity is
+  unknown). Both errors name exactly what is missing.
+
 #### Per-group breakdown
 
 To see the return of each part of your portfolio with `--by-group`, tag the relevant `open`
@@ -230,6 +258,13 @@ Notes on grouping:
   - a group named `TOTAL` (it collides with the total row in text/CSV output);
   - `--by-group` with no in-scope `returns-group:` tags (the report then shows
     only the TOTAL row).
+- **Partial reports.** Because each group is valued independently, a group (or the
+  `TOTAL`) that hits one of the two blockers above — an unpriced commodity or an
+  elided in-scope posting — shows `n/a` across its row, with a `warning:` naming the
+  reason, while the other groups still report their figures. The report fails
+  outright only when *every* row is unvaluable. In `--format json` an unvaluable row
+  carries an `"error"` field (with `null` figures); a computed row's `"error"` is
+  `null`, so the schema is the same for both.
 
 See [`returns-group:` metadata](../reference/syntax.md#returns-group-metadata) for
 the tagging syntax.


### PR DESCRIPTION
## Summary

Adds **#1850 §7** — documents the net-units returns model in `docs/commands/report.md`. This is the **last** increment of #1850.

> ⚠️ **Stacked on #1853 → #1852 → #1851** (docs-only). Base branch is `feat/returns-messy-ledger-tests`; review the parents first. Retarget down the stack as each merges.

## What it documents

A new **"What the report computes over"** subsection, plus behavior notes:

- Returns are derived from **cash flows + terminal market value** (`net units × price`), **not** cost basis or lot matching — cost lots only matter for realized capital gains, which these figures don't use.
- So an **imperfect / freshly-imported ledger still reports**: empty-cost `{}` sales, over-sells, a holding whose opening buy predates the import → net units (possibly negative) valued at market. **`rledger check` is the validator; `report returns` is a reporting tool.**
- Observable behavior spelled out: short/negative positions and losing portfolios (real **negative** rates) are reported, not errored; only a **missing price** or an **elided-units** posting stops a figure, and both name what's missing.
- The **`--by-group` partial render** (from #1852): an unvaluable group/`TOTAL` shows `n/a` with a stderr warning while the others report; in JSON an unvaluable row carries an `"error"` field on a stable schema.

Docs-only — no code change.

## This completes #1850

The reframed net-units re-architecture ships across four stacked PRs:

| PR | Increment |
|----|-----------|
| #1851 | §1 net-units core (+§3) |
| #1852 | §4 `--by-group` partial render |
| #1853 | §6 messy-ledger suite (+§5, +§2 docs) |
| **this** | §7 report.md model docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
