### PR TITLE
docs(returns): sweep stale booked wording in session.returns parity test

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -715,7 +715,7 @@ fn session_format_honors_display_precision() -> Result<()> {
 
 /// `session.returns` (WIT 3.9.0, #1847): the component's returns over the held
 /// ledger must equal the NATIVE `rustledger_query::scope_returns` over the same
-/// booked, pad-expanded stream — the SAME composition the CLI's `report returns`
+/// interpolated, pad-expanded stream — the SAME composition the CLI's `report returns`
 /// calls, so this pins the wasm surface against the CLI's returns path, not a
 /// private re-implementation. Drift guard across the wasm boundary: the decimal
 /// fields (rust_decimal, pure integer arithmetic) must match byte-for-byte; the


### PR DESCRIPTION
Sweeps a stale doc comment the #1850 wording pass missed (this test file was outside that diff).

The `session_returns_matches_native_engine` parity test's doc comment said the composition runs "over the same **booked**, pad-expanded stream". Since #1850 the returns engine values **net units at market** and does not require a booked stream — it takes the **interpolated**, pad-expanded stream. Comment-only, no behavior change.

Found while testing the shipped returns feature end-to-end as a user (the parity harness itself passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
