### PR TITLE
chore(deps): patch vscode dev-tooling deps for Dependabot security alerts

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -2406,9 +2406,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2934,9 +2934,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3066,9 +3066,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -102,6 +102,9 @@
     "typescript": "^7.0.2"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "fast-uri": "^3.1.4",
+    "linkify-it": "^5.0.2",
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
Clears **4 of 5** open Dependabot alerts (the VS Code extension ones). All three packages are **transitive, dev-only** dependencies — they live in the `@vscode/vsce` / `markdown-it` / `textlint` build toolchains and never ship in the published `.vsix` (esbuild bundles only `vscode-languageclient`). Real-world exposure is nil, but this clears the HIGH alerts.

Adds npm `overrides` forcing patched versions and regenerates the lockfile:

| Alert | Package | → patched |
|-------|---------|-----------|
| #96, #94 (HIGH) | `fast-uri` (via ajv) | 3.1.2 → **3.1.4** |
| #95 (HIGH) | `linkify-it` (via markdown-it) | 5.0.1 → **5.0.2** |
| #87 (HIGH) | `js-yaml` (via textlint / rc-config-loader) | 4.2.0 → **4.3.0** |

**Verification:** `npm audit` → **0 vulnerabilities**; `npm run build` (esbuild) clean, bundle unchanged at 437 kb.

The 5th alert (#88 `@hono/node-server` in `packages/mcp-server`) is a *runtime* transitive dep needing a major bump — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
