### PR TITLE
chore(deps): override @hono/node-server to 2.0.5+ for Dependabot #88

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -59,12 +59,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -239,9 +239,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -259,9 +256,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,9 +273,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -299,9 +290,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -319,9 +307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,9 +324,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1795,9 +1777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1819,9 +1798,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1843,9 +1819,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1867,9 +1840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -48,5 +48,8 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
+  }
 }


### PR DESCRIPTION
Clears the **last open Dependabot alert**, #88 (MEDIUM, `GHSA-frvp-7c67-39w9`: `serve-static` path traversal on Windows via encoded backslash).

`@hono/node-server` is a transitive runtime dep via `@modelcontextprotocol/sdk`, which pins `^1.19.9`. The fix only landed in the **2.0.x** line (all `1.x` are flagged), so the SDK's caret can't reach it. This adds an npm `override` forcing the patched line (resolves **2.0.11**).

**Not actually reachable here:** the MCP server uses `StdioServerTransport` only (`src/index.ts`), never the HTTP adapter that `serve-static` lives in. The override clears the alert and pins the patched version regardless.

**Verification:** tsc build clean with the override; `npm audit` -> **0 vulnerabilities**.

The 3 pre-existing `vitest` failures (validation-output tests) are unrelated to this change: they fail identically without it, caused by a stale published `@rustledger/wasm` in local installs (CI builds the wasm from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
