### PR TITLE
refactor(returns): rename UnvaluableInput; typed partial-report outcome; README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ______________________________________________________________________
 | **Better errors** | Detailed error messages with source locations |
 | **31 built-in plugins** | Plus Python plugin compatibility via WASI sandbox |
 | **Bank import** | CSV/OFX import with auto-detection, dedup, and categorization |
+| **Investment returns** | Money-weighted (XIRR) and time-weighted returns, robust over imperfect ledgers: a built-in beangrow replacement |
 
 <details>
 <summary><strong>Comparison with other tools</strong></summary>
@@ -140,6 +141,7 @@ Python beancount users can install `bean-check`, `bean-query`, etc. wrapper scri
 | `income` | `is` | Income statement |
 | `journal` | `register` | Transaction register |
 | `holdings` | | Investment holdings |
+| `returns` | | Investment returns: money-weighted (XIRR) + time-weighted, with `--by-group` breakdown (a built-in beangrow replacement) |
 | `networth` | | Net worth over time |
 | `accounts` | | List all accounts |
 | `commodities` | | List all commodities |

--- a/crates/rustledger-query/src/returns.rs
+++ b/crates/rustledger-query/src/returns.rs
@@ -38,7 +38,7 @@ use crate::PriceDatabase;
 /// # Errors
 /// Propagates [`ExtractError`] from the engine: [`ExtractError::MissingPrice`]
 /// when a boundary flow or the `end_date` terminal valuation cannot be priced in
-/// `reporting_currency`, or [`ExtractError::UnbookedInput`] when an
+/// `reporting_currency`, or [`ExtractError::UnvaluableInput`] when an
 /// elided/uninterpolated posting leaves a scope-relevant quantity unknown — an
 /// in-scope holding, or an external boundary leg whose cash flow is unknown (the
 /// one shape net-units cannot value). The engine surfaces both as an `Err`, it
@@ -69,7 +69,7 @@ pub fn scope_returns(
 /// Both error kinds are **per-scope independent** — reported in the offending
 /// scope's slot without affecting the others, because valuation runs per scope
 /// over the shared accumulation. [`ExtractError::MissingPrice`] names a scope whose
-/// flow or terminal valuation cannot be priced; [`ExtractError::UnbookedInput`]
+/// flow or terminal valuation cannot be priced; [`ExtractError::UnvaluableInput`]
 /// names a scope with an elided/uninterpolated posting leaving a scope-relevant
 /// quantity unknown (an in-scope holding, or an external boundary leg of one of
 /// its transactions). A cost-basis/lot error affects no scope (net units valued at

--- a/crates/rustledger-query/tests/messy_returns_test.rs
+++ b/crates/rustledger-query/tests/messy_returns_test.rs
@@ -230,7 +230,7 @@ fn missing_intermediate_price_degrades_twr_not_mwr() {
 
 /// Per-scope isolation at the shared-composition level (what `--by-group` relies
 /// on, #1850 §4): one scope with an elided in-scope posting fails alone
-/// (`UnbookedInput`), while a clean scope computes — over ONE shared accumulation.
+/// (`UnvaluableInput`), while a clean scope computes — over ONE shared accumulation.
 /// A cost-basis/lot error in one scope never touches another.
 #[test]
 fn scopes_are_isolated_one_unvaluable_others_compute() {
@@ -265,7 +265,7 @@ fn scopes_are_isolated_one_unvaluable_others_compute() {
         dec!(1300),
     );
     assert!(
-        matches!(results[1], Err(ExtractError::UnbookedInput(_))),
+        matches!(results[1], Err(ExtractError::UnvaluableInput(_))),
         "the elided scope fails alone: {:?}",
         results[1]
     );

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -80,7 +80,7 @@
 //! valued at market — like beancount + beangrow. `rledger check` remains the
 //! validator (see #1850). The one shape it genuinely cannot value is an in-scope
 //! account with an elided/uninterpolated posting — its net units are unknown —
-//! which surfaces as [`ExtractError::UnbookedInput`] rather than a silently
+//! which surfaces as [`ExtractError::UnvaluableInput`] rather than a silently
 //! understated figure. It cannot defend the pad half either: handing it an
 //! un-expanded stream silently drops any position seeded by a pad, so callers must
 //! pad-expand first.
@@ -233,7 +233,7 @@ pub enum ExtractError {
     /// Extraction refuses rather than silently understate the position or drop the
     /// flow. Carries a human-readable description.
     #[error("cannot compute returns: {0}")]
-    UnbookedInput(String),
+    UnvaluableInput(String),
 }
 
 /// Extract the full cash-flow series (external boundary-crossing flows plus the
@@ -265,7 +265,7 @@ pub enum ExtractError {
 ///
 /// Returns [`ExtractError::MissingPrice`] if any external flow or held position
 /// cannot be converted to `reporting_currency` on the date it is needed, or
-/// [`ExtractError::UnbookedInput`] if an elided/uninterpolated posting leaves a
+/// [`ExtractError::UnvaluableInput`] if an elided/uninterpolated posting leaves a
 /// scope-relevant quantity unknown — an in-scope holding (see [`terminal_value`])
 /// or an external boundary leg (see [`extract_flows`]).
 pub fn extract_cash_flows(
@@ -308,7 +308,7 @@ pub fn extract_cash_flows(
 ///
 /// Returns [`ExtractError::MissingPrice`] if an external posting of a relevant
 /// transaction cannot be converted to `reporting_currency` on its date, or
-/// [`ExtractError::UnbookedInput`] if such a posting has elided/uninterpolated
+/// [`ExtractError::UnvaluableInput`] if such a posting has elided/uninterpolated
 /// units (its cash flow is unknown — the flows counterpart of an elided holding).
 pub fn extract_flows(
     directives: &[Directive],
@@ -359,12 +359,12 @@ pub fn extract_flows(
             // transaction is a boundary cash flow of UNKNOWN magnitude — the flows
             // counterpart of an elided in-scope holding (see `value_investment_scope`).
             // Net-units tolerates a cost-basis/lot error, but it cannot invent a
-            // flow it can't see, so surface it as `UnbookedInput` rather than
+            // flow it can't see, so surface it as `UnvaluableInput` rather than
             // silently drop the contribution (which would understate `invested` and
             // report a wrong money-weighted return). A fully interpolated stream
             // never hits this; a re-merged booking-failed transaction can.
             let Some(amount) = posting.amount() else {
-                return Err(ExtractError::UnbookedInput(format!(
+                return Err(ExtractError::UnvaluableInput(format!(
                     "posting to {} on {} has elided/uninterpolated units; cannot compute its cash flow",
                     posting.account, txn.date
                 )));
@@ -417,7 +417,7 @@ pub fn extract_flows(
 /// # Errors
 ///
 /// Returns [`ExtractError::MissingPrice`] if a held commodity has no price in
-/// `reporting_currency` on `end_date`, or [`ExtractError::UnbookedInput`] if an
+/// `reporting_currency` on `end_date`, or [`ExtractError::UnvaluableInput`] if an
 /// in-scope account carries an elided/uninterpolated posting (its net units are
 /// unknown — the one shape net-units cannot value).
 pub fn terminal_value(
@@ -524,7 +524,7 @@ impl NetUnits {
 ///
 /// # Errors
 /// [`ExtractError::MissingPrice`] when an in-scope commodity has no price in
-/// `reporting_currency` on `date`, or [`ExtractError::UnbookedInput`] when an
+/// `reporting_currency` on `date`, or [`ExtractError::UnvaluableInput`] when an
 /// in-scope account carried an elided/uninterpolated posting (its net units are
 /// incomplete — the one shape net-units cannot value).
 fn value_investment_scope(
@@ -541,7 +541,7 @@ fn value_investment_scope(
     // ONLY with an elided leg and so never entered `per_account`.
     for account in &holdings.unvaluable {
         if scope.classify(account.as_str()) == AccountRole::Investment {
-            return Err(ExtractError::UnbookedInput(format!(
+            return Err(ExtractError::UnvaluableInput(format!(
                 "account {account} has an elided/uninterpolated posting; cannot value returns"
             )));
         }
@@ -791,7 +791,7 @@ fn investment_values_multi(
 ///
 /// The interpolated, pad-expanded input contract of [`extract_cash_flows`] applies:
 /// an in-scope account with an elided/uninterpolated posting surfaces as
-/// [`ExtractError::UnbookedInput`] (not a panic), while an un-pad-expanded stream
+/// [`ExtractError::UnvaluableInput`] (not a panic), while an un-pad-expanded stream
 /// silently omits pad-seeded positions. A cost-basis/lot error is tolerated (net
 /// units valued at market).
 pub fn twr(
@@ -826,15 +826,15 @@ pub fn twr(
     // flow date, in `net_by_date` order.
     let end_value = values.pop().expect("dates always includes end_date");
     // An unvaluable (elided-in-scope) stream is more severe than an undefined
-    // sub-period: surface `UnbookedInput` EAGERLY, before `twr_from_values`' lazy
+    // sub-period: surface `UnvaluableInput` EAGERLY, before `twr_from_values`' lazy
     // short-circuits (`v_prev <= 0`, `r <= 0`) could return `Ok(None)` at an
     // earlier flow and mask a later unvaluable value. `MissingPrice` stays lazy (a
     // later price gap is irrelevant once the chain is undefined), but an unvaluable
     // ledger is never silently "n/a". `compute_returns` needs no such scan — it
-    // surfaces `UnbookedInput` via its eager `end_value?` — so this lives here, on
+    // surfaces `UnvaluableInput` via its eager `end_value?` — so this lives here, on
     // the standalone public path, not in the shared `twr_from_values` hot path.
     for value in values.iter().chain(std::iter::once(&end_value)) {
-        if let Err(e @ ExtractError::UnbookedInput(_)) = value {
+        if let Err(e @ ExtractError::UnvaluableInput(_)) = value {
             return Err(e.clone());
         }
     }
@@ -975,7 +975,7 @@ pub struct Returns {
 ///
 /// The interpolated, pad-expanded input contract of [`twr`] applies: an in-scope
 /// account with an elided/uninterpolated posting surfaces as
-/// [`ExtractError::UnbookedInput`] rather than panicking; a cost-basis/lot error is
+/// [`ExtractError::UnvaluableInput`] rather than panicking; a cost-basis/lot error is
 /// tolerated (net units valued at market). (Date-sorted input is a fast path, not a
 /// correctness requirement — an unsorted stream falls back to the order-independent
 /// per-date valuation.)
@@ -1062,7 +1062,7 @@ pub fn compute_returns(
 /// scope's slot without affecting the others — because valuation runs per scope
 /// over the shared accumulation. A [`ExtractError::MissingPrice`] names an
 /// unpriceable boundary flow or `end_date` valuation. An
-/// [`ExtractError::UnbookedInput`] names a scope whose Investment accounts include
+/// [`ExtractError::UnvaluableInput`] names a scope whose Investment accounts include
 /// one with an elided/uninterpolated posting; a scope that does not classify that
 /// account as Investment is unaffected. A cost-basis/lot error affects no scope
 /// (net units valued at market). (Date-sorted is a fast path, not a requirement —
@@ -1259,13 +1259,13 @@ mod tests {
         let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
         let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31))
             .expect("net-units valuation tolerates an over-sell");
-        // Net −5 AAPL × 120 = −600; not a trap, not an UnbookedInput refusal.
+        // Net −5 AAPL × 120 = −600; not a trap, not an UnvaluableInput refusal.
         assert_eq!(r.current_value, dec!(-600));
     }
 
     /// The one shape net-units genuinely cannot value: an in-scope account with an
     /// elided/uninterpolated posting (booking would have filled it). Its net units
-    /// are incomplete, so valuing it must surface as [`ExtractError::UnbookedInput`]
+    /// are incomplete, so valuing it must surface as [`ExtractError::UnvaluableInput`]
     /// rather than silently understate the position. This is distinct from a
     /// cost-basis error (tolerated, see `oversell_nets_negative_valued_at_market`) —
     /// here the units themselves are unknown.
@@ -1282,14 +1282,14 @@ mod tests {
         let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
         let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
-            matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "an elided in-scope posting must yield UnbookedInput, got {r:?}"
+            matches!(r, Err(ExtractError::UnvaluableInput(_))),
+            "an elided in-scope posting must yield UnvaluableInput, got {r:?}"
         );
     }
 
     /// The FLOWS counterpart: an elided **external** (boundary cash) leg of a
     /// portfolio-touching transaction is a contribution of unknown magnitude. It
-    /// must surface as [`ExtractError::UnbookedInput`], NOT be silently dropped —
+    /// must surface as [`ExtractError::UnvaluableInput`], NOT be silently dropped —
     /// dropping it would value the (complete) investment leg at market with no
     /// matching outflow, understating `invested` and reporting a wrong
     /// money-weighted return while exiting `Ok`. The investment leg here is
@@ -1308,20 +1308,20 @@ mod tests {
         let prices = MockPrices::default().with("AAPL", "USD", d(2020, 12, 31), dec!(120));
         let flows = extract_flows(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
-            matches!(flows, Err(ExtractError::UnbookedInput(_))),
-            "an elided external leg must yield UnbookedInput, got {flows:?}"
+            matches!(flows, Err(ExtractError::UnvaluableInput(_))),
+            "an elided external leg must yield UnvaluableInput, got {flows:?}"
         );
         // And the whole summary errors rather than reporting a wrong figure.
         let r = compute_returns(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
-            matches!(r, Err(ExtractError::UnbookedInput(_))),
+            matches!(r, Err(ExtractError::UnvaluableInput(_))),
             "compute_returns must not report a figure over a dropped flow, got {r:?}"
         );
     }
 
     /// Per-scope isolation — what `--by-group` partial rendering relies on. Over
     /// ONE shared accumulation, [`compute_returns_multi`] returns
-    /// [`ExtractError::UnbookedInput`] for a scope whose Investment accounts include
+    /// [`ExtractError::UnvaluableInput`] for a scope whose Investment accounts include
     /// an elided posting, while a DISJOINT scope that excludes that account still
     /// computes `Ok`. (The elided account is marked unvaluable globally, but a scope
     /// errors only if it classifies that account as `Investment`.)
@@ -1355,13 +1355,13 @@ mod tests {
             "net 10 AAPL × 130",
         );
         assert!(
-            matches!(out[1], Err(ExtractError::UnbookedInput(_))),
+            matches!(out[1], Err(ExtractError::UnvaluableInput(_))),
             "the elided scope fails alone: {:?}",
             out[1]
         );
     }
 
-    /// The public `twr` surfaces an elided-in-scope posting as `UnbookedInput` via
+    /// The public `twr` surfaces an elided-in-scope posting as `UnvaluableInput` via
     /// its eager scan, rather than masking it as `Ok(None)` through
     /// `twr_from_values`' lazy short-circuits. The first flow date values cleanly
     /// (net 5 AAPL priced), so only the eager scan reaches the later elided date.
@@ -1395,8 +1395,8 @@ mod tests {
             .with("AAPL", "USD", d(2020, 12, 31), dec!(120));
         let r = twr(&dirs, &invest_scope(), "USD", &prices, d(2020, 12, 31));
         assert!(
-            matches!(r, Err(ExtractError::UnbookedInput(_))),
-            "twr must surface UnbookedInput, not swallow it to {r:?}"
+            matches!(r, Err(ExtractError::UnvaluableInput(_))),
+            "twr must surface UnvaluableInput, not swallow it to {r:?}"
         );
     }
 

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -486,7 +486,7 @@ fn render<W: io::Write>(
             end,
             by_group,
         } => {
-            returns::report_returns(
+            let outcome = returns::report_returns(
                 balance_input,
                 &loaded.operating_currency,
                 investments,
@@ -498,6 +498,17 @@ fn render<W: io::Write>(
                 format,
                 writer,
             )?;
+            // The report is already written. A partial `--by-group` report exits
+            // non-zero so a pipeline gating on exit status does not treat an
+            // incomplete report as a success. The exit-code policy lives here, at
+            // the CLI boundary, not inside the report producer.
+            if let returns::ReturnsOutcome::Partial { unvaluable, total } = outcome {
+                anyhow::bail!(
+                    "returns report is incomplete: {unvaluable} of {total} {} could not be valued \
+                     (see the n/a rows and the warnings above)",
+                    if total == 1 { "scope" } else { "scopes" },
+                );
+            }
         }
     }
 

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -358,19 +358,22 @@ fn first_shared_inscope_account(
     None
 }
 
-/// Whether a rendered returns report covered every scope, or left some as `n/a`.
+/// Whether a rendered returns report covered every scope, or left some unvaluable.
 ///
-/// The report is written to the `writer` regardless; this only reports the
-/// *completeness* of what was written, so the CLI boundary can decide the process
-/// exit code. Keeping the exit-code policy at the call site (rather than having
-/// `report_returns` return `Err` after it has already produced output) separates
-/// "produce the report" from "decide the exit status".
+/// Returned only on `Ok(_)` (the report is written to the `writer` in that case);
+/// this reports the *completeness* of what was written, so the CLI boundary can
+/// decide the process exit code. Keeping the exit-code policy at the call site
+/// (rather than having `report_returns` return `Err` after it has already produced
+/// output) separates "produce the report" from "decide the exit status". An
+/// unvaluable scope renders as an `n/a` row in text/CSV, and as a row with `null`
+/// figures plus a populated `error` field in JSON.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ReturnsOutcome {
     /// Every scope was valued.
     Complete,
-    /// `unvaluable` of `total` scopes could not be valued and rendered as `n/a`.
-    /// The report was still written; the caller should exit non-zero.
+    /// `unvaluable` of `total` scopes could not be valued (rendered `n/a` in
+    /// text/CSV, or `null` figures with an `error` field in JSON). The report was
+    /// still written; the caller should exit non-zero.
     Partial { unvaluable: usize, total: usize },
 }
 
@@ -387,7 +390,8 @@ pub(super) enum ReturnsOutcome {
 /// # Returns
 ///
 /// [`ReturnsOutcome`], reporting whether the written report covered every scope
-/// or left some `--by-group` rows as `n/a`. The report is written to `writer`
+/// or left some `--by-group` rows unvaluable (`n/a` in text/CSV, or `null` figures
+/// with an `error` field in JSON). On `Ok(_)` the report is written to `writer`
 /// either way; the caller maps [`ReturnsOutcome::Partial`] to a non-zero exit.
 ///
 /// # Errors

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -358,21 +358,45 @@ fn first_shared_inscope_account(
     None
 }
 
+/// Whether a rendered returns report covered every scope, or left some as `n/a`.
+///
+/// The report is written to the `writer` regardless; this only reports the
+/// *completeness* of what was written, so the CLI boundary can decide the process
+/// exit code. Keeping the exit-code policy at the call site (rather than having
+/// `report_returns` return `Err` after it has already produced output) separates
+/// "produce the report" from "decide the exit status".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReturnsOutcome {
+    /// Every scope was valued.
+    Complete,
+    /// `unvaluable` of `total` scopes could not be valued and rendered as `n/a`.
+    /// The report was still written; the caller should exit non-zero.
+    Partial { unvaluable: usize, total: usize },
+}
+
 /// Generate the returns report.
 ///
-/// `directives` must be the booked, pad-expanded stream (the returns engine's
-/// input contract); the dispatcher passes `balance_input` for exactly this
-/// reason. With `by_group`, the report adds one independent-sub-portfolio row per
+/// `directives` must be the interpolated, pad-expanded stream (the returns
+/// engine's input contract; booking is not required, net units are valued at
+/// market); the dispatcher passes `balance_input` for exactly this reason. With
+/// `by_group`, the report adds one independent-sub-portfolio row per
 /// `returns-group:` group (constrained to `--investments`/`--income`) alongside
 /// the whole-portfolio TOTAL; otherwise it is the single whole-scope summary.
 /// Grouping is opt-in, so the default output shape never changes.
+///
+/// # Returns
+///
+/// [`ReturnsOutcome`], reporting whether the written report covered every scope
+/// or left some `--by-group` rows as `n/a`. The report is written to `writer`
+/// either way; the caller maps [`ReturnsOutcome::Partial`] to a non-zero exit.
 ///
 /// # Errors
 ///
 /// Returns an error if no reporting currency can be determined (neither
 /// `--currency` nor an `operating_currency` option), if `--end` is not a valid
 /// `YYYY-MM-DD` date, or if a cash flow or held position cannot be priced in the
-/// reporting currency (a [`rustledger_returns::ExtractError`]).
+/// reporting currency (a [`rustledger_returns::ExtractError`]). Also errors if
+/// *every* scope is unvaluable (there is nothing to render).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn report_returns<W: Write>(
     directives: &[Directive],
@@ -385,7 +409,7 @@ pub(super) fn report_returns<W: Write>(
     ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
-) -> Result<()> {
+) -> Result<ReturnsOutcome> {
     // Reporting currency: --currency, else the ledger's first operating currency,
     // else an actionable error (the return is single-currency by construction).
     let reporting_currency: String = match currency_arg {
@@ -414,7 +438,8 @@ pub(super) fn report_returns<W: Write>(
             end_date,
             "TOTAL".to_string(),
         )?;
-        return render_single(&total, currency, end_date, ctx, format, writer);
+        render_single(&total, currency, end_date, ctx, format, writer)?;
+        return Ok(ReturnsOutcome::Complete);
     }
 
     // Grouping is opt-in; warnings (bad tags, overlaps, non-self-contained
@@ -438,7 +463,7 @@ pub(super) fn report_returns<W: Write>(
             end_date,
             "TOTAL".to_string(),
         )?;
-        return render_grouped(
+        render_grouped(
             &[],
             &GroupRow::Ok(total),
             currency,
@@ -446,7 +471,8 @@ pub(super) fn report_returns<W: Write>(
             ctx,
             format,
             writer,
-        );
+        )?;
+        return Ok(ReturnsOutcome::Complete);
     }
 
     // Compute the whole-portfolio TOTAL and every group in ONE shared realization:
@@ -515,20 +541,20 @@ pub(super) fn report_returns<W: Write>(
 
     render_grouped(groups, total, currency, end_date, ctx, format, writer)?;
 
-    // The partial report was emitted above (computable rows + `n/a` markers). Exit
-    // NON-ZERO so a pipeline gating on exit status does not treat an incomplete
-    // report as a full success — the CSV/text formats carry no error column, so the
-    // exit code is their only machine-readable "incomplete" signal (JSON also has a
-    // per-row `error` field). Mirrors the single-scope path, which errors outright.
+    // The report is written (computable rows + `n/a` markers). Report completeness
+    // to the caller as data rather than erroring after producing output; the CLI
+    // boundary maps `Partial` to a non-zero exit so a pipeline gating on exit
+    // status does not treat an incomplete report as a full success (the CSV/text
+    // formats carry no error column, so the exit code is their only machine-readable
+    // "incomplete" signal; JSON also has a per-row `error` field).
     if unvaluable > 0 {
-        anyhow::bail!(
-            "returns report is incomplete: {unvaluable} of {} {} could not be valued \
-             (see the n/a rows and the warnings above)",
-            rows.len(),
-            if rows.len() == 1 { "scope" } else { "scopes" },
-        );
+        Ok(ReturnsOutcome::Partial {
+            unvaluable,
+            total: rows.len(),
+        })
+    } else {
+        Ok(ReturnsOutcome::Complete)
     }
-    Ok(())
 }
 
 /// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.
@@ -1139,9 +1165,9 @@ mod tests {
     /// unvaluable group (an elided in-scope posting) renders the valuable group's
     /// figures and marks the unvaluable one — and the whole-portfolio TOTAL, which
     /// includes the elided account — `n/a`, instead of aborting on the first error
-    /// (the pre-fix `?`). The partial report IS still written to the writer, but the
-    /// call returns `Err` so the CLI exits non-zero to signal it is incomplete
-    /// (review pass 2, finding [0]).
+    /// (the pre-fix `?`). The partial report IS still written to the writer, and the
+    /// call returns `Ok(ReturnsOutcome::Partial)`; the CLI boundary maps that to a
+    /// non-zero exit (review pass 2, finding [0]).
     #[test]
     fn report_returns_by_group_partial_renders() {
         use rustledger_core::{Metadata, Open};
@@ -1188,16 +1214,21 @@ mod tests {
             &OutputFormat::Text,
             &mut out,
         );
-        // Incomplete report → non-zero exit (Err), but the partial output is still
-        // written (render happens before the bail).
-        assert!(
-            r.is_err(),
-            "a partial report must signal incompleteness via Err: {r:?}"
+        // The report is written AND the outcome reports it is partial (2 of 3
+        // scopes unvaluable: Broken and TOTAL). The non-zero exit is the CLI
+        // boundary's job, mapped from this outcome; here we assert the producer's
+        // contract directly, without an Err-after-write.
+        assert_eq!(
+            r.expect("a partial report is Ok(Partial), not Err"),
+            ReturnsOutcome::Partial {
+                unvaluable: 2,
+                total: 3
+            },
         );
         let out = String::from_utf8(out).unwrap();
         assert!(
             out.contains("1300"),
-            "the valuable Tech group is still rendered despite the Err:\n{out}"
+            "the valuable Tech group is still rendered:\n{out}"
         );
         let broken = out
             .lines()


### PR DESCRIPTION
Fixes the architectural debt identified in the post-ship review of the #1850 net-units returns work, plus a README update.

## What changed

**1. Rename `ExtractError::UnbookedInput` -> `UnvaluableInput`.** After the net-units reframe the variant means "an elided/uninterpolated posting left a scope-relevant quantity unknown" (an in-scope holding, or an external boundary leg). That has nothing to do with booking; the old name misled. Mechanical rename across `rustledger-returns` and `rustledger-query`. No output change (the `Display` string was never the variant name).

**2. Partial `--by-group` report: typed outcome instead of write-then-`Err`.** `report_returns` now returns `Result<ReturnsOutcome>` (`Complete` | `Partial { unvaluable, total }`) and no longer returns `Err` after producing output. The CLI boundary (the `Returns` arm of `render`) maps `Partial` to the non-zero exit. This separates "produce the report" from "decide the exit status", and lets the producer be unit-tested on the outcome directly. The exit-code contract is unchanged end to end (the subprocess test still asserts a non-zero exit on a partial report). The outcome stays local to the returns arm rather than threading through the generic report dispatcher, which would spread a returns-specific concern into the shared layer.

Also swept a stale "booked" wording in `report_returns`' doc comment.

**3. README.** Adds `report returns` to the Report subcommands table and an "Investment returns" capability highlight (a built-in beangrow replacement).

## Deliberately excluded (from the same review)

These were named in the review but the fix would cost more than the smell:
- **Modified-Dietz TWR fallback** is a *feature* (new financial-math algorithm), not debt, and deserves its own design + validation.
- **Moving `scope_returns` out of `rustledger-query`** would require relocating `PriceDatabase` or minting a new crate; the layering (query is the data + composition layer) is defensible.
- **Collapsing `NetUnits` into a shared core primitive** is not viable: `report balances` genuinely needs the lot-matching engine, not a net-units accumulator; a drift guard already pins their agreement on clean input.

## Verification
- `rustledger-returns` 64, `rustledger-query` messy 7, `rustledger` report unit 7 + integration 20 (incl. the subprocess exit-code test) all pass.
- `clippy` @1.97.0 and `rustdoc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
