### PR TITLE
feat(report): realized IRR for capgains (--irr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ______________________________________________________________________
 | **31 built-in plugins** | Plus Python plugin compatibility via WASI sandbox |
 | **Bank import** | CSV/OFX import with auto-detection, dedup, and categorization |
 | **Investment returns** | Money-weighted (XIRR) and time-weighted returns, robust over imperfect ledgers: a built-in beangrow replacement |
-| **Capital gains** | Realized gains per tax lot, short vs long term, with exact `@@` proceeds and calendar-correct holding periods |
+| **Capital gains** | Realized gains per tax lot, short vs long term, with exact `@@` proceeds, calendar-correct holding periods, and optional per-lot annualized return (`--irr`) |
 
 <details>
 <summary><strong>Comparison with other tools</strong></summary>

--- a/crates/rustledger/src/cmd/report_cmd/capgains.rs
+++ b/crates/rustledger/src/cmd/report_cmd/capgains.rs
@@ -39,7 +39,7 @@
 //! rules beyond the long-term threshold are out of scope (run `rledger check` to
 //! validate the ledger first).
 
-use super::returns::fmt_rate_pct;
+use super::returns::{fmt_rate, fmt_rate_pct, json_rate};
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
@@ -104,17 +104,25 @@ struct Disposal {
 /// The cash flows of one closed round trip: the basis paid out at acquisition and
 /// the proceeds received at sale — the input to this lot's IRR.
 ///
-/// `None` when a round-trip rate is undefined, so the lot renders `n/a` and is
-/// excluded from the pooled aggregate:
+/// `None` when a round-trip rate is undefined, so the lot renders `n/a` **and** is
+/// excluded from the pooled aggregate. Eligibility is decided here, once, so the
+/// per-lot cell and the pooled rate always agree about which lots count:
 /// - **short sales** — the money-in-then-out shape makes an IRR unconventional and
 ///   misleading, so it is deliberately not reported;
 /// - **no acquisition date** (an `AVERAGE`-cost lot merges lots and drops dates),
 ///   so the outflow cannot be dated;
 /// - **same-day round trips** (zero-day holding), where annualizing divides by a
 ///   zero time span;
-/// - **non-positive cost basis**, which has no rate of return.
+/// - **non-positive cost basis**, which has no rate of return;
+/// - **negative proceeds** (a disposal that cost more to close than it returned),
+///   which is outside the domain of a simple round-trip rate.
+///
+/// A **total loss** (`proceeds == 0`) is NOT excluded: its rate is exactly -100%
+/// (you cannot lose more than the whole basis, at any horizon), handled by
+/// [`lot_irr`]. Dropping it would silently flatter every pooled rate by hiding
+/// capital that never came back.
 fn lot_flows(d: &Disposal) -> Option<[CashFlow; 2]> {
-    if d.short_sale || d.cost_basis <= Decimal::ZERO {
+    if d.short_sale || d.cost_basis <= Decimal::ZERO || d.proceeds < Decimal::ZERO {
         return None;
     }
     let acquired = d.acquired?;
@@ -127,25 +135,91 @@ fn lot_flows(d: &Disposal) -> Option<[CashFlow; 2]> {
     ])
 }
 
+/// One lot's own annualized round-trip rate.
+///
+/// A **total loss** is the exact pole `-100%`: with `proceeds == 0` the series
+/// `[-basis, 0]` has no root the solver can bracket (NPV never crosses zero), yet
+/// the answer is not unknown — losing the entire basis is `-100%`/yr at any
+/// horizon. Returning it directly keeps the per-lot cell consistent with the
+/// pooled rate, which does include the lot's flows.
+fn lot_irr(d: &Disposal) -> Option<f64> {
+    let flows = lot_flows(d)?;
+    if d.proceeds.is_zero() {
+        return Some(-1.0);
+    }
+    xirr(&flows)
+}
+
+/// Solve each row's own round-trip rate (the `--irr` pass). Rows whose rate is
+/// undefined keep `None` and render `n/a`.
+fn fill_lot_irr(rows: &mut [Disposal]) {
+    for d in rows {
+        d.irr = lot_irr(d);
+    }
+}
+
+/// A pooled rate and the denominator it was actually computed over.
+///
+/// The two are reported together because they differ: the gain/proceeds totals on
+/// the same summary line count EVERY disposal, while the rate can only include
+/// lots with a defined round trip (see [`lot_flows`]). Printing a rate beside a
+/// count it was not computed from is how "why doesn't this reconcile?" starts.
+struct PooledIrr {
+    rate: Option<f64>,
+    /// Lots that contributed flows.
+    eligible: usize,
+    /// Lots in the bucket, eligible or not.
+    total: usize,
+}
+
+impl PooledIrr {
+    /// `10.00%`, or `10.00% (2 of 5 lots)` when some lots had no defined rate, so
+    /// the reader can see the rate's denominator is not the line's disposal count.
+    fn render(&self) -> String {
+        let rate = fmt_rate_cell(self.rate);
+        if self.eligible == self.total {
+            rate
+        } else {
+            format!("{rate} ({} of {} lots)", self.eligible, self.total)
+        }
+    }
+}
+
 /// Pooled realized IRR over the eligible closed lots in `currency`, optionally
 /// restricted to one `term` bucket.
 ///
 /// Pooling every lot's flows into one series and solving once is the
 /// beangrow-shaped aggregate: a money-weighted return over all the capital that
-/// actually cycled through, not an average of per-lot rates. Returns `None` when
-/// no lot is eligible or the series has no computable root (e.g. no sign change).
-fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Option<f64> {
-    let mut flows: Vec<CashFlow> = rows
+/// actually cycled through, not an average of per-lot rates. The rate is `None`
+/// when no lot is eligible or the series has no computable root (e.g. no sign
+/// change); the returned counts say how much of the bucket it covers.
+fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> PooledIrr {
+    let mut total = 0usize;
+    let mut eligible = 0usize;
+    let mut flows: Vec<CashFlow> = Vec::new();
+    for d in rows
         .iter()
         .filter(|d| d.currency == currency && term.is_none_or(|t| d.term == t))
-        .filter_map(lot_flows)
-        .flatten()
-        .collect();
+    {
+        total += 1;
+        if let Some(f) = lot_flows(d) {
+            eligible += 1;
+            flows.extend(f);
+        }
+    }
     if flows.is_empty() {
-        return None;
+        return PooledIrr {
+            rate: None,
+            eligible,
+            total,
+        };
     }
     flows.sort_by_key(|f| f.date);
-    xirr(&flows)
+    PooledIrr {
+        rate: xirr(&flows),
+        eligible,
+        total,
+    }
 }
 
 /// Transform the loader's canonical [`CapitalGain`]s into report [`Disposal`]s,
@@ -163,13 +237,9 @@ fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Optio
 /// `cross_currency` total so the caller can surface it (rather than silently
 /// omitting it). `long_term_days = Some(n)` means held strictly more than `n` days;
 /// `None` uses the leap-year-safe calendar rule.
-fn to_disposals(
-    gains: &[CapitalGain],
-    long_term_days: Option<i64>,
-    with_irr: bool,
-) -> (Vec<Disposal>, usize) {
+fn to_disposals(gains: &[CapitalGain], long_term_days: Option<i64>) -> (Vec<Disposal>, usize) {
     let mut cross_currency = 0usize;
-    let mut rows: Vec<Disposal> = gains
+    let rows: Vec<Disposal> = gains
         .iter()
         .filter_map(|g| {
             // Cross-currency: proceeds and basis are in different currencies, so
@@ -216,12 +286,6 @@ fn to_disposals(
             })
         })
         .collect();
-    // Per-lot IRR is opt-in: the solver runs only when the caller asked for it.
-    if with_irr {
-        for d in &mut rows {
-            d.irr = lot_flows(d).and_then(|f| xirr(&f));
-        }
-    }
     (rows, cross_currency)
 }
 
@@ -276,7 +340,7 @@ pub(super) fn report_capgains<W: Write>(
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let (disposals, cross_currency) = to_disposals(gains, long_term_days, with_irr);
+    let (disposals, cross_currency) = to_disposals(gains, long_term_days);
     // A cross-currency disposal (sale price in a different currency than the lot's
     // cost basis) has no gain without an FX rate, so it is dropped from the rows.
     // Surface the count on stderr rather than silently omitting it.
@@ -303,6 +367,11 @@ pub(super) fn report_capgains<W: Write>(
     rows.sort_by(|a, b| {
         (a.sold, &a.account, &a.commodity).cmp(&(b.sold, &b.account, &b.commodity))
     });
+    // Solve per-lot rates AFTER filtering: only rows that will actually be printed
+    // cost a solver run.
+    if with_irr {
+        fill_lot_irr(&mut rows);
+    }
     render(&rows, with_irr, ctx, format, writer)
 }
 
@@ -361,7 +430,7 @@ fn render<W: Write>(
             writeln!(
                 writer,
                 "sold,account,commodity,units,acquired,held_days,term,currency,proceeds,cost_basis,gain{}",
-                if with_irr { ",irr" } else { "" }
+                if with_irr { ",irr_pct" } else { "" }
             )?;
             for d in rows {
                 // Raw `Decimal` (no separators, no rounding) for machine parsing.
@@ -409,7 +478,7 @@ fn render<W: Write>(
                     // Numeric rate, or `null` when undefined; present only under
                     // `--irr` so the default schema is unchanged.
                     if with_irr {
-                        format!(r#", "irr": {}"#, fmt_rate_json(d.irr))
+                        format!(r#", "irr_pct": {}"#, json_rate(d.irr))
                     } else {
                         String::new()
                     },
@@ -429,10 +498,15 @@ fn render<W: Write>(
                             t.cost_basis,
                             t.gain,
                             if with_irr {
-                                format!(
-                                    r#", "irr": {}"#,
-                                    fmt_rate_json(aggregate_irr(rows, c, Some(term)))
-                                )
+                                {
+                                    let p = aggregate_irr(rows, c, Some(term));
+                                    format!(
+                                        r#", "irr_pct": {}, "irr_lots": {}, "irr_lots_total": {}"#,
+                                        json_rate(p.rate),
+                                        p.eligible,
+                                        p.total
+                                    )
+                                }
                             } else {
                                 String::new()
                             },
@@ -453,14 +527,19 @@ fn render<W: Write>(
                 let parts: Vec<String> = currencies
                     .iter()
                     .map(|c| {
-                        format!(
-                            r#"{{"currency": "{}", "irr": {}}}"#,
-                            json_escape(c),
-                            fmt_rate_json(aggregate_irr(rows, c, None))
-                        )
+                        {
+                            let p = aggregate_irr(rows, c, None);
+                            format!(
+                                r#"{{"currency": "{}", "irr_pct": {}, "irr_lots": {}, "irr_lots_total": {}}}"#,
+                                json_escape(c),
+                                json_rate(p.rate),
+                                p.eligible,
+                                p.total
+                            )
+                        }
                     })
                     .collect();
-                format!(r#", "total_irr": [{}]"#, parts.join(", "))
+                format!(r#", "total_irr_pct": [{}]"#, parts.join(", "))
             } else {
                 String::new()
             };
@@ -482,7 +561,7 @@ fn render<W: Write>(
             // The trailing IRR cell, empty when the column is off.
             let irr_cell = |r: Option<f64>| {
                 if with_irr {
-                    format!("{:>10}", fmt_rate_pct(r))
+                    format!("{:>10}", fmt_rate_cell(r))
                 } else {
                     String::new()
                 }
@@ -553,11 +632,11 @@ fn render<W: Write>(
                             t.count,
                             money(t.proceeds, c),
                             money(t.gain, c),
-                            if with_irr {
-                                format!(
-                                    "   IRR {}",
-                                    fmt_rate_pct(aggregate_irr(rows, c, Some(term)))
-                                )
+                            // The Unknown bucket is dateless by definition, so its
+                            // pooled rate can never be defined — a permanent `n/a`
+                            // there would be noise.
+                            if with_irr && term != Term::Unknown {
+                                format!("   IRR {}", aggregate_irr(rows, c, Some(term)).render())
                             } else {
                                 String::new()
                             },
@@ -573,7 +652,7 @@ fn render<W: Write>(
                     "TOTAL",
                     money(net, c),
                     if with_irr {
-                        format!("   IRR {}", fmt_rate_pct(aggregate_irr(rows, c, None)))
+                        format!("   IRR {}", aggregate_irr(rows, c, None).render())
                     } else {
                         String::new()
                     },
@@ -584,17 +663,31 @@ fn render<W: Write>(
     Ok(())
 }
 
-/// A rate for CSV: the raw fractional rate (e.g. `0.1042`), empty when undefined.
+/// A rate for CSV: a 2-decimal **percent**, empty when undefined.
 ///
-/// Machine output stays unformatted — no percent sign, no rounding to a display
-/// precision — matching the exact-value policy the other CSV/JSON columns follow.
+/// Deliberately the same unit and precision as the sibling `returns` report's
+/// `money_weighted_return_pct` (it shares [`fmt_rate`]): two reports emitting the
+/// same conceptual metric 100x apart would be a scripting trap. The `_pct` column
+/// name says the unit out loud.
 fn fmt_rate_machine(rate: Option<f64>) -> String {
-    rate.map_or_else(String::new, |r| r.to_string())
+    rate.map_or_else(String::new, |r| fmt_rate(Some(r)))
 }
 
-/// A rate for JSON: a bare number, or `null` when undefined.
-fn fmt_rate_json(rate: Option<f64>) -> String {
-    rate.map_or_else(|| "null".to_string(), |r| r.to_string())
+/// Rate columns are capped in the fixed-width **text** table at this magnitude
+/// (percent). An annualized rate is unbounded — a one-day round trip compounds its
+/// gain 365 times, reaching `1e30`% — which would overflow the column and shift
+/// every later field out of alignment. Past this the cell shows `>9999%` /
+/// `<-9999%`; CSV and JSON still carry the exact value.
+const RATE_DISPLAY_CAP_PCT: f64 = 9999.0;
+
+/// A rate for the fixed-width text column: [`fmt_rate_pct`], but clamped so an
+/// astronomically annualized short hold cannot break the table layout.
+fn fmt_rate_cell(rate: Option<f64>) -> String {
+    match rate {
+        Some(r) if r * 100.0 > RATE_DISPLAY_CAP_PCT => format!(">{RATE_DISPLAY_CAP_PCT:.0}%"),
+        Some(r) if r * 100.0 < -RATE_DISPLAY_CAP_PCT => format!("<-{RATE_DISPLAY_CAP_PCT:.0}%"),
+        other => fmt_rate_pct(other),
+    }
 }
 
 /// The leaf of an account path (`Assets:Broker:AAPL` -> `AAPL`), for the compact
@@ -699,7 +792,7 @@ mod tests {
                 true,
             ),
         ];
-        let (ds, cross) = to_disposals(&gains, None, false);
+        let (ds, cross) = to_disposals(&gains, None);
         assert_eq!(cross, 0);
         assert_eq!(ds[0].term.as_str(), "long"); // held ~4 years
         assert_eq!(ds[1].term.as_str(), "short"); // held ~1 month
@@ -723,18 +816,149 @@ mod tests {
             500,
             false,
         );
-        let (ds, _) = to_disposals(&[g], None, false);
+        let (ds, _) = to_disposals(&[g], None);
         assert_eq!(ds[0].term.as_str(), "unknown");
         assert_eq!(ds[0].held_days, None, "negative span dropped");
     }
 
-    /// A one-year round trip 1000 -> 1100 annualizes to exactly 10%; a two-year
-    /// 500 -> 605 also annualizes to 10% (the rate compounds, so it is NOT the
-    /// 21% total). Pinning both shapes proves the flows are dated, not just divided.
+    /// Per-lot rates annualize the round trip, and the pooled rate is a genuine
+    /// money-weighted solve over both lots' flows.
+    ///
+    /// The fixture deliberately avoids a 10% rate: `xirr` seeds Newton at exactly
+    /// 0.10, so a 10% fixture can be satisfied by the seed at iteration 0 and would
+    /// not prove the solver searched. The two lots also carry DIFFERENT rates so an
+    /// assertion cannot pass by matching the wrong lot. Expected values are from an
+    /// independent bisection XIRR over the same flows.
     #[test]
     fn per_lot_irr_annualizes_the_round_trip() {
         let gains = vec![
-            // 2020-01-01 -> 2020-12-31 (365 days): 1000 -> 1100.
+            // 365 days: 1000 -> 1250 = 25%/yr.
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 12, 31),
+                Some(d(2020, 1, 1)),
+                10,
+                1000,
+                1250,
+                false,
+            ),
+            // 730 days: 1000 -> 1440 = 1.44x over 2y = 20%/yr compounded.
+            gain(
+                "Assets:Broker:Stock",
+                d(2021, 12, 31),
+                Some(d(2020, 1, 1)),
+                10,
+                1000,
+                1440,
+                false,
+            ),
+        ];
+        let (mut ds, _) = to_disposals(&gains, None);
+        fill_lot_irr(&mut ds);
+        let near = |r: Option<f64>, want: f64| (r.expect("defined rate") - want).abs() < 1e-4;
+        assert!(near(ds[0].irr, 0.25), "one-year 25% gain: {:?}", ds[0].irr);
+        assert!(
+            near(ds[1].irr, 0.20),
+            "two-year 44% gain -> 20%/yr compounded: {:?}",
+            ds[1].irr
+        );
+        // Pooled: a single money-weighted solve over all four flows — NOT the mean
+        // of 25% and 20% (which would be 22.5%).
+        let pooled = aggregate_irr(&ds, "USD", None);
+        assert!(
+            near(pooled.rate, 0.216_743),
+            "pooled money-weighted rate: {:?}",
+            pooled.rate
+        );
+        assert_eq!(
+            (pooled.eligible, pooled.total),
+            (2, 2),
+            "both lots eligible"
+        );
+    }
+
+    /// Hermetic coverage of the `--irr` RENDER paths (CSV header + cell, JSON
+    /// fields, text column + pooled line). The end-to-end tests exercise the real
+    /// binary but skip when it is absent, so these run everywhere.
+    #[test]
+    fn irr_render_paths_are_covered_in_process() {
+        let gains = vec![
+            // 365 days, 1000 -> 1250 = 25%/yr.
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 12, 31),
+                Some(d(2020, 1, 1)),
+                10,
+                1000,
+                1250,
+                false,
+            ),
+            // A short sale: no defined rate, so it renders empty/null/n-a.
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 12, 31),
+                Some(d(2020, 1, 1)),
+                5,
+                400,
+                500,
+                true,
+            ),
+        ];
+        let ctx = DisplayContext::new();
+        let filter = CapgainsFilter {
+            account: None,
+            year: None,
+            end: None,
+        };
+        let render_as = |f: &OutputFormat| {
+            let mut buf = Vec::new();
+            report_capgains(&gains, &filter, None, true, &ctx, f, &mut buf).unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+
+        let csv = render_as(&OutputFormat::Csv);
+        assert!(csv.lines().next().unwrap().ends_with(",irr_pct"));
+        // The priced lot carries a percent rate; the short sale's cell is empty.
+        // (Both are term=short here: a 365-day hold across the 2020 leap day is not
+        // yet more than one calendar year.)
+        let rows: Vec<&str> = csv.lines().skip(1).collect();
+        assert_eq!(rows.len(), 2, "two disposal rows: {csv}");
+        assert!(
+            rows.iter().any(|l| l.ends_with(",25.00")),
+            "priced lot's percent rate: {csv}"
+        );
+        assert!(
+            rows.iter().any(|l| l.ends_with(',')),
+            "short sale has an empty rate: {csv}"
+        );
+
+        let json = render_as(&OutputFormat::Json);
+        assert!(json.contains(r#""irr_pct": 25.00"#), "{json}");
+        assert!(
+            json.contains(r#""irr_pct": null"#),
+            "short sale is null: {json}"
+        );
+        assert!(json.contains(r#""total_irr_pct""#), "{json}");
+        assert!(
+            json.contains(r#""irr_lots": 1"#),
+            "coverage in JSON: {json}"
+        );
+
+        let txt = render_as(&OutputFormat::Text);
+        assert!(txt.contains("IRR"), "column header: {txt}");
+        assert!(txt.contains("25.00%"), "rate cell: {txt}");
+        assert!(txt.contains("n/a"), "undefined cell: {txt}");
+        assert!(
+            txt.contains("(1 of 2 lots)"),
+            "pooled coverage annotated: {txt}"
+        );
+    }
+
+    /// A total loss is the exact -100% pole, not `n/a` — and it stays in the pool,
+    /// so the pooled rate cannot be flattered by hiding capital that never returned.
+    #[test]
+    fn total_loss_is_minus_one_hundred_percent_and_stays_pooled() {
+        let gains = vec![
             gain(
                 "Assets:Broker:Stock",
                 d(2020, 12, 31),
@@ -744,36 +968,36 @@ mod tests {
                 1100,
                 false,
             ),
-            // 2020-01-01 -> 2021-12-31 (730 days): 500 -> 605 = 1.21x over 2y.
+            // Worthless: proceeds 0.
             gain(
                 "Assets:Broker:Stock",
-                d(2021, 12, 31),
+                d(2020, 12, 31),
                 Some(d(2020, 1, 1)),
-                5,
-                500,
-                605,
+                10,
+                1000,
+                0,
                 false,
             ),
         ];
-        let (ds, _) = to_disposals(&gains, None, true);
-        // Compare the rate to within a hundredth of a percent (the solver returns
-        // a converged float, not an exact decimal).
-        let is_10pct = |r: Option<f64>| (r.expect("defined rate") - 0.10).abs() < 1e-4;
-        assert!(
-            is_10pct(ds[0].irr),
-            "one-year 10% gain -> 10%/yr: {:?}",
-            ds[0].irr
+        let (mut ds, _) = to_disposals(&gains, None);
+        fill_lot_irr(&mut ds);
+        let writeoff = ds.iter().find(|d| d.proceeds.is_zero()).expect("writeoff");
+        assert_eq!(writeoff.irr, Some(-1.0), "total loss is exactly -100%");
+        let pooled = aggregate_irr(&ds, "USD", None);
+        assert_eq!(
+            (pooled.eligible, pooled.total),
+            (2, 2),
+            "the write-off is pooled, not silently dropped"
         );
+        // Independently: -1000 and -1000 out, +1100 back over one year => -45%.
         assert!(
-            is_10pct(ds[1].irr),
-            "two-year 21% gain -> 10%/yr compounded: {:?}",
-            ds[1].irr
+            (pooled.rate.expect("rate") + 0.45).abs() < 1e-4,
+            "pooled: {:?}",
+            pooled.rate
         );
-        // Pooled over both lots (same rate) -> the same 10%.
-        assert!(is_10pct(aggregate_irr(&ds, "USD", None)));
     }
 
-    /// IRR is opt-in: with `with_irr = false` no rate is computed at all.
+    /// IRR is opt-in: `to_disposals` alone never computes a rate.
     #[test]
     fn per_lot_irr_is_not_computed_unless_requested() {
         let gains = vec![gain(
@@ -782,11 +1006,11 @@ mod tests {
             Some(d(2020, 1, 1)),
             10,
             1000,
-            1100,
+            1250,
             false,
         )];
-        let (ds, _) = to_disposals(&gains, None, false);
-        assert_eq!(ds[0].irr, None, "no IRR unless --irr");
+        let (ds, _) = to_disposals(&gains, None);
+        assert_eq!(ds[0].irr, None, "no IRR unless the --irr pass runs");
     }
 
     /// The undefined cases render `n/a` and are excluded from the pooled aggregate:
@@ -825,16 +1049,19 @@ mod tests {
                 true,
             ),
         ];
-        let (ds, _) = to_disposals(&gains, None, true);
+        let (mut ds, _) = to_disposals(&gains, None);
+        fill_lot_irr(&mut ds);
         assert!(ds.iter().all(|d| d.irr.is_none()), "all three undefined");
         assert!(
             ds.iter().all(|d| lot_flows(d).is_none()),
             "none contribute flows"
         );
+        let pooled = aggregate_irr(&ds, "USD", None);
+        assert_eq!(pooled.rate, None, "no eligible lot -> no pooled rate");
         assert_eq!(
-            aggregate_irr(&ds, "USD", None),
-            None,
-            "no eligible lot -> no pooled rate"
+            (pooled.eligible, pooled.total),
+            (0, 3),
+            "coverage is reported so the rate is never read as covering all 3"
         );
     }
 
@@ -861,7 +1088,7 @@ mod tests {
             acquired_date: Some(d(2020, 1, 1)),
             short_sale: false,
         };
-        let (ds, cross_count) = to_disposals(&[same, cross], None, false);
+        let (ds, cross_count) = to_disposals(&[same, cross], None);
         assert_eq!(ds.len(), 1, "only the same-currency disposal is kept");
         assert_eq!(cross_count, 1, "the cross-currency disposal is counted");
         assert_eq!(ds[0].gain, Decimal::from(250));

--- a/crates/rustledger/src/cmd/report_cmd/capgains.rs
+++ b/crates/rustledger/src/cmd/report_cmd/capgains.rs
@@ -25,17 +25,27 @@
 //! no acquisition date — e.g. under `AVERAGE` booking, which merges lots and drops
 //! their dates — is classified `unknown`, not silently `short`.
 //!
+//! **Realized IRR** (`--irr`): the annualized money-weighted return of each closed
+//! round trip — `−cost_basis` at acquisition, `+proceeds` at sale — solved with the
+//! canonical [`rustledger_returns::xirr`], plus a pooled rate per term and per
+//! currency. This is a **realized-only** return: it can only see lots you actually
+//! closed, so it is NOT the portfolio's total return. For that (including what you
+//! still hold, valued at market) use `report returns`, which is the beangrow-shaped
+//! total-return report; this column is the per-lot view `returns` cannot give.
+//!
 //! Gains are reported in each lot's **cost currency**; a multi-currency ledger is
 //! summarized per currency. Not a tax filing: wash-sale adjustment, currency-gain
 //! separation, lots seeded by `pad` (no well-defined cost basis), and jurisdiction
 //! rules beyond the long-term threshold are out of scope (run `rledger check` to
 //! validate the ledger first).
 
+use super::returns::fmt_rate_pct;
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
 use rustledger_booking::CapitalGain;
 use rustledger_core::{DisplayContext, NaiveDate};
+use rustledger_returns::{CashFlow, xirr};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -84,6 +94,58 @@ struct Disposal {
     gain: Decimal,
     /// The cost currency the figures are denominated in.
     currency: String,
+    /// Closing a short position — excluded from IRR (see [`lot_flows`]).
+    short_sale: bool,
+    /// Annualized money-weighted return of this lot's round trip, when defined
+    /// and requested (`--irr`). `None` = not requested, or undefined for this lot.
+    irr: Option<f64>,
+}
+
+/// The cash flows of one closed round trip: the basis paid out at acquisition and
+/// the proceeds received at sale — the input to this lot's IRR.
+///
+/// `None` when a round-trip rate is undefined, so the lot renders `n/a` and is
+/// excluded from the pooled aggregate:
+/// - **short sales** — the money-in-then-out shape makes an IRR unconventional and
+///   misleading, so it is deliberately not reported;
+/// - **no acquisition date** (an `AVERAGE`-cost lot merges lots and drops dates),
+///   so the outflow cannot be dated;
+/// - **same-day round trips** (zero-day holding), where annualizing divides by a
+///   zero time span;
+/// - **non-positive cost basis**, which has no rate of return.
+fn lot_flows(d: &Disposal) -> Option<[CashFlow; 2]> {
+    if d.short_sale || d.cost_basis <= Decimal::ZERO {
+        return None;
+    }
+    let acquired = d.acquired?;
+    if d.held_days? <= 0 {
+        return None;
+    }
+    Some([
+        CashFlow::new(acquired, -d.cost_basis),
+        CashFlow::new(d.sold, d.proceeds),
+    ])
+}
+
+/// Pooled realized IRR over the eligible closed lots in `currency`, optionally
+/// restricted to one `term` bucket.
+///
+/// Pooling every lot's flows into one series and solving once is the
+/// beangrow-shaped aggregate: a money-weighted return over all the capital that
+/// actually cycled through, not an average of per-lot rates. Returns `None` when
+/// no lot is eligible or the series has no computable root (e.g. no sign change).
+fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Option<f64> {
+    let mut flows: Vec<CashFlow> = rows
+        .iter()
+        .filter(|d| d.currency == currency && term.is_none_or(|t| d.term == t))
+        .filter_map(lot_flows)
+        .flatten()
+        .collect();
+    if flows.is_empty() {
+        return None;
+    }
+    flows.sort_by_key(|f| f.date);
+    xirr(&flows)
 }
 
 /// Transform the loader's canonical [`CapitalGain`]s into report [`Disposal`]s,
@@ -101,9 +163,13 @@ struct Disposal {
 /// `cross_currency` total so the caller can surface it (rather than silently
 /// omitting it). `long_term_days = Some(n)` means held strictly more than `n` days;
 /// `None` uses the leap-year-safe calendar rule.
-fn to_disposals(gains: &[CapitalGain], long_term_days: Option<i64>) -> (Vec<Disposal>, usize) {
+fn to_disposals(
+    gains: &[CapitalGain],
+    long_term_days: Option<i64>,
+    with_irr: bool,
+) -> (Vec<Disposal>, usize) {
     let mut cross_currency = 0usize;
-    let rows = gains
+    let mut rows: Vec<Disposal> = gains
         .iter()
         .filter_map(|g| {
             // Cross-currency: proceeds and basis are in different currencies, so
@@ -145,9 +211,17 @@ fn to_disposals(gains: &[CapitalGain], long_term_days: Option<i64>) -> (Vec<Disp
                 cost_basis: g.cost_basis.number,
                 gain: g.proceeds.number - g.cost_basis.number,
                 currency: g.cost_basis.currency.to_string(),
+                short_sale: g.short_sale,
+                irr: None,
             })
         })
         .collect();
+    // Per-lot IRR is opt-in: the solver runs only when the caller asked for it.
+    if with_irr {
+        for d in &mut rows {
+            d.irr = lot_flows(d).and_then(|f| xirr(&f));
+        }
+    }
     (rows, cross_currency)
 }
 
@@ -188,7 +262,8 @@ pub(super) struct CapgainsFilter<'a> {
 ///
 /// `gains` are the loader's canonical realized gains (`Ledger::capital_gains`).
 /// `long_term_days` is the holding-period threshold: `None` uses the calendar
-/// "> 1 year" rule (leap-year correct), `Some(n)` a fixed day count.
+/// "> 1 year" rule (leap-year correct), `Some(n)` a fixed day count. `with_irr`
+/// adds the annualized realized-return columns (see the module docs).
 ///
 /// # Errors
 /// Propagates writer I/O errors.
@@ -196,11 +271,12 @@ pub(super) fn report_capgains<W: Write>(
     gains: &[CapitalGain],
     filter: &CapgainsFilter,
     long_term_days: Option<i64>,
+    with_irr: bool,
     ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let (disposals, cross_currency) = to_disposals(gains, long_term_days);
+    let (disposals, cross_currency) = to_disposals(gains, long_term_days, with_irr);
     // A cross-currency disposal (sale price in a different currency than the lot's
     // cost basis) has no gain without an FX rate, so it is dropped from the rows.
     // Surface the count on stderr rather than silently omitting it.
@@ -227,7 +303,7 @@ pub(super) fn report_capgains<W: Write>(
     rows.sort_by(|a, b| {
         (a.sold, &a.account, &a.commodity).cmp(&(b.sold, &b.account, &b.commodity))
     });
-    render(&rows, ctx, format, writer)
+    render(&rows, with_irr, ctx, format, writer)
 }
 
 /// Per-(currency, term) running totals for the summary.
@@ -250,6 +326,7 @@ impl Totals {
 
 fn render<W: Write>(
     rows: &[Disposal],
+    with_irr: bool,
     ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
@@ -279,15 +356,18 @@ fn render<W: Write>(
 
     match format {
         OutputFormat::Csv => {
+            // The `irr` column appears only under `--irr`, so the default schema is
+            // unchanged for existing consumers.
             writeln!(
                 writer,
-                "sold,account,commodity,units,acquired,held_days,term,currency,proceeds,cost_basis,gain"
+                "sold,account,commodity,units,acquired,held_days,term,currency,proceeds,cost_basis,gain{}",
+                if with_irr { ",irr" } else { "" }
             )?;
             for d in rows {
                 // Raw `Decimal` (no separators, no rounding) for machine parsing.
                 writeln!(
                     writer,
-                    "{},{},{},{},{},{},{},{},{},{},{}",
+                    "{},{},{},{},{},{},{},{},{},{},{}{}",
                     d.sold,
                     csv_escape(&d.account),
                     csv_escape(&d.commodity),
@@ -299,13 +379,20 @@ fn render<W: Write>(
                     d.proceeds,
                     d.cost_basis,
                     d.gain,
+                    // Raw rate (e.g. `0.1042`), empty when undefined — the text
+                    // report owns percent formatting.
+                    if with_irr {
+                        format!(",{}", fmt_rate_machine(d.irr))
+                    } else {
+                        String::new()
+                    },
                 )?;
             }
         }
         OutputFormat::Json => {
             let obj = |d: &Disposal| {
                 format!(
-                    r#"{{"sold": "{}", "account": "{}", "commodity": "{}", "units": "{}", "acquired": {}, "held_days": {}, "term": "{}", "currency": "{}", "proceeds": "{}", "cost_basis": "{}", "gain": "{}"}}"#,
+                    r#"{{"sold": "{}", "account": "{}", "commodity": "{}", "units": "{}", "acquired": {}, "held_days": {}, "term": "{}", "currency": "{}", "proceeds": "{}", "cost_basis": "{}", "gain": "{}"{}}}"#,
                     d.sold,
                     json_escape(&d.account),
                     json_escape(&d.commodity),
@@ -319,40 +406,89 @@ fn render<W: Write>(
                     d.proceeds,
                     d.cost_basis,
                     d.gain,
+                    // Numeric rate, or `null` when undefined; present only under
+                    // `--irr` so the default schema is unchanged.
+                    if with_irr {
+                        format!(r#", "irr": {}"#, fmt_rate_json(d.irr))
+                    } else {
+                        String::new()
+                    },
                 )
             };
             let disposals: Vec<String> = rows.iter().map(obj).collect();
-            let summ = |b: &BTreeMap<String, Totals>| -> String {
+            // Each term bucket carries the pooled IRR of that bucket's lots.
+            let summ = |b: &BTreeMap<String, Totals>, term: Term| -> String {
                 let parts: Vec<String> = b
                     .iter()
                     .map(|(c, t)| {
                         format!(
-                            r#"{{"currency": "{}", "disposals": {}, "proceeds": "{}", "cost_basis": "{}", "gain": "{}"}}"#,
+                            r#"{{"currency": "{}", "disposals": {}, "proceeds": "{}", "cost_basis": "{}", "gain": "{}"{}}}"#,
                             json_escape(c),
                             t.count,
                             t.proceeds,
                             t.cost_basis,
                             t.gain,
+                            if with_irr {
+                                format!(
+                                    r#", "irr": {}"#,
+                                    fmt_rate_json(aggregate_irr(rows, c, Some(term)))
+                                )
+                            } else {
+                                String::new()
+                            },
                         )
                     })
                     .collect();
                 format!("[{}]", parts.join(", "))
             };
+            // Whole-report realized IRR per currency (all terms pooled).
+            let totals_irr = if with_irr {
+                let mut currencies: Vec<&String> = short
+                    .keys()
+                    .chain(long.keys())
+                    .chain(unknown.keys())
+                    .collect();
+                currencies.sort_unstable();
+                currencies.dedup();
+                let parts: Vec<String> = currencies
+                    .iter()
+                    .map(|c| {
+                        format!(
+                            r#"{{"currency": "{}", "irr": {}}}"#,
+                            json_escape(c),
+                            fmt_rate_json(aggregate_irr(rows, c, None))
+                        )
+                    })
+                    .collect();
+                format!(r#", "total_irr": [{}]"#, parts.join(", "))
+            } else {
+                String::new()
+            };
             writeln!(
                 writer,
-                r#"{{"disposals": [{}], "short_term": {}, "long_term": {}, "unknown_term": {}}}"#,
+                r#"{{"disposals": [{}], "short_term": {}, "long_term": {}, "unknown_term": {}{}}}"#,
                 disposals.join(", "),
-                summ(&short),
-                summ(&long),
-                summ(&unknown),
+                summ(&short, Term::Short),
+                summ(&long, Term::Long),
+                summ(&unknown, Term::Unknown),
+                totals_irr,
             )?;
         }
         OutputFormat::Text => {
             // Wide enough for millions with thousands separators (e.g.
-            // `1,500,000.00`) without the amount columns overflowing.
-            const RULE: usize = 91;
+            // `1,500,000.00`) without the amount columns overflowing; the IRR
+            // column adds its own width when shown.
+            let rule: usize = if with_irr { 101 } else { 91 };
+            // The trailing IRR cell, empty when the column is off.
+            let irr_cell = |r: Option<f64>| {
+                if with_irr {
+                    format!("{:>10}", fmt_rate_pct(r))
+                } else {
+                    String::new()
+                }
+            };
             writeln!(writer, "Realized capital gains")?;
-            writeln!(writer, "{}", "=".repeat(RULE))?;
+            writeln!(writer, "{}", "=".repeat(rule))?;
             writeln!(writer)?;
             if rows.is_empty() {
                 writeln!(writer, "No realized disposals in range.")?;
@@ -360,14 +496,25 @@ fn render<W: Write>(
             }
             writeln!(
                 writer,
-                "{:<11}{:<22}{:>10}{:<12}{:>6}{:>15}{:>15}",
-                "Sold", "Commodity / account", "Units", "  Acquired", "Term", "Proceeds", "Gain"
+                "{:<11}{:<22}{:>10}{:<12}{:>6}{:>15}{:>15}{}",
+                "Sold",
+                "Commodity / account",
+                "Units",
+                "  Acquired",
+                "Term",
+                "Proceeds",
+                "Gain",
+                if with_irr {
+                    format!("{:>10}", "IRR")
+                } else {
+                    String::new()
+                },
             )?;
-            writeln!(writer, "{}", "-".repeat(RULE))?;
+            writeln!(writer, "{}", "-".repeat(rule))?;
             for d in rows {
                 writeln!(
                     writer,
-                    "{:<11}{:<22}{:>10}{:<12}{:>6}{:>15}{:>15}",
+                    "{:<11}{:<22}{:>10}{:<12}{:>6}{:>15}{:>15}{}",
                     // `Date` `Display` ignores fmt width flags, so stringify first
                     // to keep the columns aligned.
                     d.sold.to_string(),
@@ -381,9 +528,10 @@ fn render<W: Write>(
                     d.term.abbr(),
                     money(d.proceeds, &d.currency),
                     money(d.gain, &d.currency),
+                    irr_cell(d.irr),
                 )?;
             }
-            writeln!(writer, "{}", "-".repeat(RULE))?;
+            writeln!(writer, "{}", "-".repeat(rule))?;
             // Per-currency short-term / long-term / unknown totals, then net.
             let mut currencies: Vec<&String> = short
                 .keys()
@@ -393,18 +541,26 @@ fn render<W: Write>(
             currencies.sort_unstable();
             currencies.dedup();
             for c in currencies {
-                for (label, bucket) in [
-                    ("Short-term", &short),
-                    ("Long-term", &long),
-                    ("Unknown-term", &unknown),
+                for (label, bucket, term) in [
+                    ("Short-term", &short, Term::Short),
+                    ("Long-term", &long, Term::Long),
+                    ("Unknown-term", &unknown, Term::Unknown),
                 ] {
                     if let Some(t) = bucket.get(c) {
                         writeln!(
                             writer,
-                            "{label:<12}{:>3} disposals   proceeds {:>15}   gain {:>15} {c}",
+                            "{label:<12}{:>3} disposals   proceeds {:>15}   gain {:>15} {c}{}",
                             t.count,
                             money(t.proceeds, c),
                             money(t.gain, c),
+                            if with_irr {
+                                format!(
+                                    "   IRR {}",
+                                    fmt_rate_pct(aggregate_irr(rows, c, Some(term)))
+                                )
+                            } else {
+                                String::new()
+                            },
                         )?;
                     }
                 }
@@ -413,14 +569,32 @@ fn render<W: Write>(
                     + unknown.get(c).map(|t| t.gain).unwrap_or_default();
                 writeln!(
                     writer,
-                    "{:<12}net realized gain {:>15} {c}",
+                    "{:<12}net realized gain {:>15} {c}{}",
                     "TOTAL",
-                    money(net, c)
+                    money(net, c),
+                    if with_irr {
+                        format!("   IRR {}", fmt_rate_pct(aggregate_irr(rows, c, None)))
+                    } else {
+                        String::new()
+                    },
                 )?;
             }
         }
     }
     Ok(())
+}
+
+/// A rate for CSV: the raw fractional rate (e.g. `0.1042`), empty when undefined.
+///
+/// Machine output stays unformatted — no percent sign, no rounding to a display
+/// precision — matching the exact-value policy the other CSV/JSON columns follow.
+fn fmt_rate_machine(rate: Option<f64>) -> String {
+    rate.map_or_else(String::new, |r| r.to_string())
+}
+
+/// A rate for JSON: a bare number, or `null` when undefined.
+fn fmt_rate_json(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "null".to_string(), |r| r.to_string())
 }
 
 /// The leaf of an account path (`Assets:Broker:AAPL` -> `AAPL`), for the compact
@@ -525,7 +699,7 @@ mod tests {
                 true,
             ),
         ];
-        let (ds, cross) = to_disposals(&gains, None);
+        let (ds, cross) = to_disposals(&gains, None, false);
         assert_eq!(cross, 0);
         assert_eq!(ds[0].term.as_str(), "long"); // held ~4 years
         assert_eq!(ds[1].term.as_str(), "short"); // held ~1 month
@@ -549,9 +723,119 @@ mod tests {
             500,
             false,
         );
-        let (ds, _) = to_disposals(&[g], None);
+        let (ds, _) = to_disposals(&[g], None, false);
         assert_eq!(ds[0].term.as_str(), "unknown");
         assert_eq!(ds[0].held_days, None, "negative span dropped");
+    }
+
+    /// A one-year round trip 1000 -> 1100 annualizes to exactly 10%; a two-year
+    /// 500 -> 605 also annualizes to 10% (the rate compounds, so it is NOT the
+    /// 21% total). Pinning both shapes proves the flows are dated, not just divided.
+    #[test]
+    fn per_lot_irr_annualizes_the_round_trip() {
+        let gains = vec![
+            // 2020-01-01 -> 2020-12-31 (365 days): 1000 -> 1100.
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 12, 31),
+                Some(d(2020, 1, 1)),
+                10,
+                1000,
+                1100,
+                false,
+            ),
+            // 2020-01-01 -> 2021-12-31 (730 days): 500 -> 605 = 1.21x over 2y.
+            gain(
+                "Assets:Broker:Stock",
+                d(2021, 12, 31),
+                Some(d(2020, 1, 1)),
+                5,
+                500,
+                605,
+                false,
+            ),
+        ];
+        let (ds, _) = to_disposals(&gains, None, true);
+        // Compare the rate to within a hundredth of a percent (the solver returns
+        // a converged float, not an exact decimal).
+        let is_10pct = |r: Option<f64>| (r.expect("defined rate") - 0.10).abs() < 1e-4;
+        assert!(
+            is_10pct(ds[0].irr),
+            "one-year 10% gain -> 10%/yr: {:?}",
+            ds[0].irr
+        );
+        assert!(
+            is_10pct(ds[1].irr),
+            "two-year 21% gain -> 10%/yr compounded: {:?}",
+            ds[1].irr
+        );
+        // Pooled over both lots (same rate) -> the same 10%.
+        assert!(is_10pct(aggregate_irr(&ds, "USD", None)));
+    }
+
+    /// IRR is opt-in: with `with_irr = false` no rate is computed at all.
+    #[test]
+    fn per_lot_irr_is_not_computed_unless_requested() {
+        let gains = vec![gain(
+            "Assets:Broker:Stock",
+            d(2020, 12, 31),
+            Some(d(2020, 1, 1)),
+            10,
+            1000,
+            1100,
+            false,
+        )];
+        let (ds, _) = to_disposals(&gains, None, false);
+        assert_eq!(ds[0].irr, None, "no IRR unless --irr");
+    }
+
+    /// The undefined cases render `n/a` and are excluded from the pooled aggregate:
+    /// a same-day round trip, a dateless (AVERAGE-cost) lot, and a short sale.
+    #[test]
+    fn irr_is_undefined_for_same_day_dateless_and_short_lots() {
+        let gains = vec![
+            // Same-day: zero-day span.
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 1, 1),
+                Some(d(2020, 1, 1)),
+                10,
+                100,
+                120,
+                false,
+            ),
+            // Dateless (AVERAGE cost).
+            gain(
+                "Assets:Broker:Stock",
+                d(2020, 6, 1),
+                None,
+                6,
+                690,
+                900,
+                false,
+            ),
+            // Short sale.
+            gain(
+                "Assets:Broker:Stock",
+                d(2021, 6, 1),
+                Some(d(2020, 1, 1)),
+                5,
+                400,
+                500,
+                true,
+            ),
+        ];
+        let (ds, _) = to_disposals(&gains, None, true);
+        assert!(ds.iter().all(|d| d.irr.is_none()), "all three undefined");
+        assert!(
+            ds.iter().all(|d| lot_flows(d).is_none()),
+            "none contribute flows"
+        );
+        assert_eq!(
+            aggregate_irr(&ds, "USD", None),
+            None,
+            "no eligible lot -> no pooled rate"
+        );
     }
 
     /// A cross-currency disposal (proceeds and basis in different currencies) is
@@ -577,7 +861,7 @@ mod tests {
             acquired_date: Some(d(2020, 1, 1)),
             short_sale: false,
         };
-        let (ds, cross_count) = to_disposals(&[same, cross], None);
+        let (ds, cross_count) = to_disposals(&[same, cross], None, false);
         assert_eq!(ds.len(), 1, "only the same-currency disposal is kept");
         assert_eq!(cross_count, 1, "the cross-currency disposal is counted");
         assert_eq!(ds[0].gain, Decimal::from(250));
@@ -655,7 +939,16 @@ mod tests {
     fn csv(gains: &[CapitalGain], filter: &CapgainsFilter) -> String {
         let ctx = DisplayContext::new();
         let mut buf = Vec::new();
-        report_capgains(gains, filter, None, &ctx, &OutputFormat::Csv, &mut buf).unwrap();
+        report_capgains(
+            gains,
+            filter,
+            None,
+            false,
+            &ctx,
+            &OutputFormat::Csv,
+            &mut buf,
+        )
+        .unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -725,7 +1018,16 @@ mod tests {
             end: None,
         };
         let mut buf = Vec::new();
-        report_capgains(&gains, &filter, None, &ctx, &OutputFormat::Text, &mut buf).unwrap();
+        report_capgains(
+            &gains,
+            &filter,
+            None,
+            false,
+            &ctx,
+            &OutputFormat::Text,
+            &mut buf,
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("Realized capital gains"));
         assert!(out.contains("AAPL"));
@@ -780,7 +1082,16 @@ mod tests {
             end: None,
         };
         let mut buf = Vec::new();
-        report_capgains(&gains, &filter, None, &ctx, &OutputFormat::Text, &mut buf).unwrap();
+        report_capgains(
+            &gains,
+            &filter,
+            None,
+            false,
+            &ctx,
+            &OutputFormat::Text,
+            &mut buf,
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("Short-term") && out.contains("Long-term") && out.contains("Unknown-term")

--- a/crates/rustledger/src/cmd/report_cmd/capgains.rs
+++ b/crates/rustledger/src/cmd/report_cmd/capgains.rs
@@ -205,6 +205,11 @@ impl PooledIrr {
 /// Pooled realized IRR over the eligible closed lots in `currency`, optionally
 /// restricted to one `term` bucket.
 ///
+/// **Precondition:** [`fill_lot_irr`] has run over `rows` — eligibility keys off
+/// each row's solved `irr`, so an unfilled slice pools nothing. The render path
+/// guarantees this (rates are filled before `render`), and it is what keeps a
+/// summary rate consistent with the cells above it.
+///
 /// Pooling every lot's flows into one series and solving once is the
 /// beangrow-shaped aggregate: a money-weighted return over all the capital that
 /// actually cycled through, not an average of per-lot rates. The rate is `None`
@@ -219,10 +224,12 @@ fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Poole
         .filter(|d| d.currency == currency && term.is_none_or(|t| d.term == t))
     {
         total += 1;
-        // Pool a lot ONLY if its own rate solved — the same predicate the per-lot
-        // cell uses. Pooling on flow-availability instead would let a lot that
-        // renders `n/a` silently drive the aggregate (and be counted as covered).
-        if lot_irr(d).is_some()
+        // Pool a lot ONLY if its own rate solved, reusing the ALREADY-SOLVED
+        // `d.irr` — the literal value in its cell, so the cell and the aggregate
+        // cannot disagree about which lots count, and no lot is re-solved once per
+        // summary cell. (Pooling on flow-availability instead would let a lot that
+        // renders `n/a` silently drive the aggregate and be counted as covered.)
+        if d.irr.is_some()
             && let Some(f) = lot_flows(d)
         {
             eligible += 1;

--- a/crates/rustledger/src/cmd/report_cmd/capgains.rs
+++ b/crates/rustledger/src/cmd/report_cmd/capgains.rs
@@ -119,7 +119,7 @@ struct Disposal {
 ///
 /// A **total loss** (`proceeds == 0`) is NOT excluded: its rate is exactly -100%
 /// (you cannot lose more than the whole basis, at any horizon), handled by
-/// [`lot_irr`]. Dropping it would silently flatter every pooled rate by hiding
+/// [`solve_irr`]. Dropping it would silently flatter every pooled rate by hiding
 /// capital that never came back.
 fn lot_flows(d: &Disposal) -> Option<[CashFlow; 2]> {
     if d.short_sale || d.cost_basis <= Decimal::ZERO || d.proceeds < Decimal::ZERO {
@@ -135,19 +135,36 @@ fn lot_flows(d: &Disposal) -> Option<[CashFlow; 2]> {
     ])
 }
 
-/// One lot's own annualized round-trip rate.
+/// Solve an annualized rate for one series of CLOSED round-trip flows.
 ///
-/// A **total loss** is the exact pole `-100%`: with `proceeds == 0` the series
-/// `[-basis, 0]` has no root the solver can bracket (NPV never crosses zero), yet
-/// the answer is not unknown — losing the entire basis is `-100%`/yr at any
-/// horizon. Returning it directly keeps the per-lot cell consistent with the
-/// pooled rate, which does include the lot's flows.
-fn lot_irr(d: &Disposal) -> Option<f64> {
-    let flows = lot_flows(d)?;
-    if d.proceeds.is_zero() {
+/// The single entry point for both the per-lot cell and the pooled aggregate, so
+/// the two can never answer differently for the same flows.
+///
+/// **Total loss** (`-100%`) is handled here rather than in the canonical
+/// [`xirr`], and deliberately so: `xirr` returns `None` for any series without a
+/// sign change, which is correct for its other caller — in `report returns` an
+/// all-negative series means "bought and still holding", NOT a loss, and reporting
+/// -100% there would be flatly wrong. Only THIS caller knows its series is a
+/// *closed* round trip, where nothing coming back really does mean the whole basis
+/// was lost, at any horizon. The knowledge is the caller's, so the special case
+/// belongs to the caller. (`rustledger-returns` pins the `None` contract in
+/// `no_sign_change_is_none` / `zero_flows_do_not_count_as_a_sign_change`; if that
+/// ever changes, revisit this.)
+fn solve_irr(flows: &[CashFlow]) -> Option<f64> {
+    if flows.is_empty() {
+        return None;
+    }
+    // Nothing came back from a closed round trip: the whole outlay was lost.
+    if flows.iter().all(|f| f.amount <= Decimal::ZERO) {
         return Some(-1.0);
     }
-    xirr(&flows)
+    xirr(flows)
+}
+
+/// One lot's own annualized round-trip rate (`None` when the lot has no defined
+/// round trip — see [`lot_flows`] — or when the rate is not solvable).
+fn lot_irr(d: &Disposal) -> Option<f64> {
+    solve_irr(&lot_flows(d)?)
 }
 
 /// Solve each row's own round-trip rate (the `--irr` pass). Rows whose rate is
@@ -202,7 +219,12 @@ fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Poole
         .filter(|d| d.currency == currency && term.is_none_or(|t| d.term == t))
     {
         total += 1;
-        if let Some(f) = lot_flows(d) {
+        // Pool a lot ONLY if its own rate solved — the same predicate the per-lot
+        // cell uses. Pooling on flow-availability instead would let a lot that
+        // renders `n/a` silently drive the aggregate (and be counted as covered).
+        if lot_irr(d).is_some()
+            && let Some(f) = lot_flows(d)
+        {
             eligible += 1;
             flows.extend(f);
         }
@@ -216,7 +238,9 @@ fn aggregate_irr(rows: &[Disposal], currency: &str, term: Option<Term>) -> Poole
     }
     flows.sort_by_key(|f| f.date);
     PooledIrr {
-        rate: xirr(&flows),
+        // Same solver as the per-lot cell, so a bucket of one lot reports that
+        // lot's rate rather than contradicting it.
+        rate: solve_irr(&flows),
         eligible,
         total,
     }
@@ -448,8 +472,8 @@ fn render<W: Write>(
                     d.proceeds,
                     d.cost_basis,
                     d.gain,
-                    // Raw rate (e.g. `0.1042`), empty when undefined — the text
-                    // report owns percent formatting.
+                    // 2-decimal percent (e.g. `10.42`), empty when undefined or
+                    // beyond the reporting cap.
                     if with_irr {
                         format!(",{}", fmt_rate_machine(d.irr))
                     } else {
@@ -478,7 +502,7 @@ fn render<W: Write>(
                     // Numeric rate, or `null` when undefined; present only under
                     // `--irr` so the default schema is unchanged.
                     if with_irr {
-                        format!(r#", "irr_pct": {}"#, json_rate(d.irr))
+                        format!(r#", "irr_pct": {}"#, rate_json(d.irr))
                     } else {
                         String::new()
                     },
@@ -502,7 +526,7 @@ fn render<W: Write>(
                                     let p = aggregate_irr(rows, c, Some(term));
                                     format!(
                                         r#", "irr_pct": {}, "irr_lots": {}, "irr_lots_total": {}"#,
-                                        json_rate(p.rate),
+                                        rate_json(p.rate),
                                         p.eligible,
                                         p.total
                                     )
@@ -532,7 +556,7 @@ fn render<W: Write>(
                             format!(
                                 r#"{{"currency": "{}", "irr_pct": {}, "irr_lots": {}, "irr_lots_total": {}}}"#,
                                 json_escape(c),
-                                json_rate(p.rate),
+                                rate_json(p.rate),
                                 p.eligible,
                                 p.total
                             )
@@ -663,29 +687,53 @@ fn render<W: Write>(
     Ok(())
 }
 
-/// A rate for CSV: a 2-decimal **percent**, empty when undefined.
+/// A rate for CSV: a 2-decimal **percent**, empty when undefined or beyond
+/// [`RATE_REPORTING_CAP_PCT`].
 ///
 /// Deliberately the same unit and precision as the sibling `returns` report's
 /// `money_weighted_return_pct` (it shares [`fmt_rate`]): two reports emitting the
 /// same conceptual metric 100x apart would be a scripting trap. The `_pct` column
 /// name says the unit out loud.
 fn fmt_rate_machine(rate: Option<f64>) -> String {
-    rate.map_or_else(String::new, |r| fmt_rate(Some(r)))
+    match rate {
+        Some(r) if rate_is_reportable(r) => fmt_rate(Some(r)),
+        _ => String::new(),
+    }
 }
 
-/// Rate columns are capped in the fixed-width **text** table at this magnitude
-/// (percent). An annualized rate is unbounded — a one-day round trip compounds its
-/// gain 365 times, reaching `1e30`% — which would overflow the column and shift
-/// every later field out of alignment. Past this the cell shows `>9999%` /
-/// `<-9999%`; CSV and JSON still carry the exact value.
-const RATE_DISPLAY_CAP_PCT: f64 = 9999.0;
+/// A rate for JSON: a 2-decimal percent number, or `null` when undefined or beyond
+/// [`RATE_REPORTING_CAP_PCT`].
+fn rate_json(rate: Option<f64>) -> String {
+    match rate {
+        Some(r) if rate_is_reportable(r) => json_rate(Some(r)),
+        _ => "null".to_string(),
+    }
+}
 
-/// A rate for the fixed-width text column: [`fmt_rate_pct`], but clamped so an
-/// astronomically annualized short hold cannot break the table layout.
+/// Rates above this magnitude (percent) are not reported as a number.
+///
+/// An annualized rate is unbounded above: a one-day round trip compounds its gain
+/// 365 times, so a +20% day reaches ~8e30 %/yr. Such a figure is arithmetically
+/// true but financially meaningless, and printing it breaks both surfaces — it
+/// overflows the fixed-width text column, and at ~31 significant digits it exceeds
+/// what `rust_decimal` (this project's own numeric type, ~28-29 digits) can parse
+/// back. So past this cap the text cell shows `>9999%` and machine output is empty
+/// / `null`: no fabricated precision, and nothing a consumer cannot read.
+///
+/// There is no lower cap: a round trip cannot lose more than its basis, so no rate
+/// is below -100%.
+const RATE_REPORTING_CAP_PCT: f64 = 9999.0;
+
+/// Whether a rate is small enough to report as a number.
+fn rate_is_reportable(r: f64) -> bool {
+    r * 100.0 <= RATE_REPORTING_CAP_PCT
+}
+
+/// A rate for the fixed-width text column: [`fmt_rate_pct`], but an
+/// unreportably-large rate becomes `>9999%` so it cannot break the table layout.
 fn fmt_rate_cell(rate: Option<f64>) -> String {
     match rate {
-        Some(r) if r * 100.0 > RATE_DISPLAY_CAP_PCT => format!(">{RATE_DISPLAY_CAP_PCT:.0}%"),
-        Some(r) if r * 100.0 < -RATE_DISPLAY_CAP_PCT => format!("<-{RATE_DISPLAY_CAP_PCT:.0}%"),
+        Some(r) if !rate_is_reportable(r) => format!(">{RATE_REPORTING_CAP_PCT:.0}%"),
         other => fmt_rate_pct(other),
     }
 }
@@ -927,10 +975,13 @@ mod tests {
             rows.iter().any(|l| l.ends_with(",25.00")),
             "priced lot's percent rate: {csv}"
         );
-        assert!(
-            rows.iter().any(|l| l.ends_with(',')),
-            "short sale has an empty rate: {csv}"
-        );
+        let short_row = rows
+            .iter()
+            .find(|l| l.contains(",Assets:Broker:Stock,AAPL,5,"))
+            .expect("the short-sale row");
+        let cols: Vec<&str> = short_row.split(',').collect();
+        assert_eq!(cols.len(), 12, "all columns present: {short_row}");
+        assert_eq!(cols[11], "", "short sale's rate cell is empty: {short_row}");
 
         let json = render_as(&OutputFormat::Json);
         assert!(json.contains(r#""irr_pct": 25.00"#), "{json}");
@@ -952,6 +1003,61 @@ mod tests {
             txt.contains("(1 of 2 lots)"),
             "pooled coverage annotated: {txt}"
         );
+    }
+
+    /// A rate too large to report (a one-day round trip annualizes past the cap)
+    /// shows `>9999%` in text and is EMPTY/`null` in machine output — never a
+    /// 31-digit number that this project's own `Decimal` could not parse back.
+    #[test]
+    fn unreportably_large_rate_is_capped_in_text_and_omitted_in_machine_output() {
+        // 1 day, 1000 -> 1200: annualizes to ~8e30.
+        let huge = gain(
+            "Assets:Broker:Stock",
+            d(2020, 1, 2),
+            Some(d(2020, 1, 1)),
+            10,
+            1000,
+            1200,
+            false,
+        );
+        let (mut ds, _) = to_disposals(&[huge], None);
+        fill_lot_irr(&mut ds);
+        let r = ds[0].irr.expect("a (huge) rate is solved");
+        assert!(r > 1e20, "sanity: the rate really is astronomic: {r}");
+        assert!(!rate_is_reportable(r));
+        assert_eq!(fmt_rate_cell(Some(r)), ">9999%");
+        assert_eq!(fmt_rate_machine(Some(r)), "", "CSV cell is empty");
+        assert_eq!(rate_json(Some(r)), "null", "JSON is null");
+        // A normal rate is unaffected by the cap.
+        assert_eq!(fmt_rate_machine(Some(0.25)), "25.00");
+        assert_eq!(rate_json(Some(0.25)), "25.00");
+        assert_eq!(fmt_rate_cell(Some(0.25)), "25.00%");
+    }
+
+    /// A bucket whose lots are ALL total losses reports -100%, not `n/a`: the
+    /// pooled series has no inflow to bracket, but the answer is not unknown, and a
+    /// summary line must never contradict the single row it summarizes.
+    #[test]
+    fn all_total_loss_bucket_agrees_with_its_rows() {
+        let gains = vec![gain(
+            "Assets:Broker:Stock",
+            d(2020, 6, 1),
+            Some(d(2020, 1, 1)),
+            10,
+            1000,
+            0,
+            false,
+        )];
+        let (mut ds, _) = to_disposals(&gains, None);
+        fill_lot_irr(&mut ds);
+        assert_eq!(ds[0].irr, Some(-1.0), "the row is -100%");
+        let pooled = aggregate_irr(&ds, "USD", None);
+        assert_eq!(
+            pooled.rate,
+            Some(-1.0),
+            "the bucket must not read n/a while its only row reads -100%"
+        );
+        assert_eq!((pooled.eligible, pooled.total), (1, 1));
     }
 
     /// A total loss is the exact -100% pole, not `n/a` — and it stays in the pool,

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -204,6 +204,13 @@ pub enum Report {
         /// unlike any fixed day count.
         #[arg(long)]
         long_term_days: Option<i64>,
+        /// Add the annualized realized return (IRR) of each closed lot, plus a
+        /// pooled IRR per term and currency. This is a **realized-only**
+        /// money-weighted return over lots you actually closed; for the
+        /// total-portfolio return including what you still hold, use
+        /// `report returns`.
+        #[arg(long)]
+        irr: bool,
     },
 }
 
@@ -543,6 +550,7 @@ fn render<W: io::Write>(
             year,
             end,
             long_term_days,
+            irr,
         } => {
             if let Some(n) = long_term_days
                 && *n < 0
@@ -565,6 +573,7 @@ fn render<W: io::Write>(
                 &loaded.capital_gains,
                 &filter,
                 *long_term_days,
+                *irr,
                 &loaded.display_context,
                 format,
                 writer,

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -563,7 +563,10 @@ pub(super) fn report_returns<W: Write>(
 
 /// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.
 /// A rate rounding to zero renders a clean `"0.00"` (not `"-0.00"`).
-fn fmt_rate(rate: Option<f64>) -> String {
+///
+/// Shared with the capgains report's realized-IRR columns so every rate this CLI
+/// prints uses one unit (percent) and one precision.
+pub(super) fn fmt_rate(rate: Option<f64>) -> String {
     rate.map_or_else(
         || "n/a".to_string(),
         |r| {
@@ -682,7 +685,7 @@ fn render_single<W: Write>(
 }
 
 /// A JSON rate field: a bare 2-decimal number, or `null` when undefined.
-fn json_rate(rate: Option<f64>) -> String {
+pub(super) fn json_rate(rate: Option<f64>) -> String {
     rate.map_or_else(|| "null".to_string(), |r| fmt_rate(Some(r)))
 }
 

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -574,10 +574,13 @@ fn fmt_rate(rate: Option<f64>) -> String {
     )
 }
 
-/// A rate for the grouped **text** table: the numeric rate carries its own `%`,
-/// but an undefined rate is `n/a` (not `n/a%`). Matches `render_single`'s
-/// single-scope text output, where the `%` hangs off the value, not the column.
-fn fmt_rate_pct(rate: Option<f64>) -> String {
+/// A rate for a **text** table: the numeric rate carries its own `%`, but an
+/// undefined rate is `n/a` (not `n/a%`). Matches `render_single`'s single-scope
+/// text output, where the `%` hangs off the value, not the column.
+///
+/// Shared with the capgains report's realized-IRR column so the two rate columns
+/// cannot drift in formatting.
+pub(super) fn fmt_rate_pct(rate: Option<f64>) -> String {
     match rate {
         Some(_) => format!("{}%", fmt_rate(rate)),
         None => "n/a".to_string(),

--- a/crates/rustledger/tests/report_capgains_test.rs
+++ b/crates/rustledger/tests/report_capgains_test.rs
@@ -106,6 +106,34 @@ const LEDGER_AVERAGE: &str = r#"option "booking_method" "AVERAGE"
   Income:Gains
 "#;
 
+/// Two closed round trips that each annualize to exactly 10%: a one-year
+/// 1000 -> 1100, and a two-year 500 -> 605 (1.21x compounded). The pooled
+/// realized IRR is therefore also 10%.
+const LEDGER_IRR: &str = r#"option "booking_method" "FIFO"
+
+2019-01-01 open Assets:Broker:Stock
+2019-01-01 open Assets:Bank
+2019-01-01 open Income:Gains
+
+2020-01-01 * "buy A"
+  Assets:Broker:Stock  10 AAA {100 USD}
+  Assets:Bank       -1000 USD
+
+2020-12-31 * "sell A"
+  Assets:Broker:Stock  -10 AAA {} @ 110 USD
+  Assets:Bank        1100 USD
+  Income:Gains
+
+2020-01-01 * "buy B"
+  Assets:Broker:Stock  5 BBB {100 USD}
+  Assets:Bank        -500 USD
+
+2021-12-31 * "sell B"
+  Assets:Broker:Stock  -5 BBB {} @ 121 USD
+  Assets:Bank         605 USD
+  Income:Gains
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-capgains-")
@@ -345,6 +373,104 @@ fn average_cost_disposal_has_unknown_term() {
     assert!(
         txt.contains("net realized gain") && txt.contains("210 USD"),
         "net includes the unknown-term gain: {txt}"
+    );
+}
+
+#[test]
+fn irr_annualizes_each_lot_and_pools_the_aggregate() {
+    let bin = require_rledger!();
+    let f = write_fixture(LEDGER_IRR);
+    let path = f.path().to_str().unwrap();
+
+    // CSV gains a raw-rate `irr` column: both lots annualize to 0.1 (10%/yr).
+    let csv = run(
+        &bin,
+        &["report", path, "capgains", "--irr", "--format", "csv"],
+    );
+    let rows: Vec<&str> = csv.lines().collect();
+    assert!(rows[0].ends_with(",irr"), "header gains irr: {}", rows[0]);
+    assert!(
+        rows[1].ends_with(",0.1"),
+        "one-year lot = 10%/yr: {}",
+        rows[1]
+    );
+    assert!(
+        rows[2].ends_with(",0.1"),
+        "two-year lot = 10%/yr: {}",
+        rows[2]
+    );
+
+    // Text shows the percent column and the pooled per-term / total rates.
+    let txt = run(&bin, &["report", path, "capgains", "--irr", "--no-pager"]);
+    assert!(txt.contains("IRR"), "IRR column header: {txt}");
+    assert!(txt.contains("10.00%"), "annualized rate: {txt}");
+    assert!(
+        txt.lines()
+            .any(|l| l.starts_with("TOTAL") && l.contains("IRR 10.00%")),
+        "pooled total IRR: {txt}"
+    );
+
+    // JSON carries numeric rates plus the per-currency total_irr block.
+    let json = run(
+        &bin,
+        &["report", path, "capgains", "--irr", "--format", "json"],
+    );
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(v["disposals"][0]["irr"], 0.1);
+    assert_eq!(v["total_irr"][0]["currency"], "USD");
+    assert_eq!(v["total_irr"][0]["irr"], 0.1);
+}
+
+#[test]
+fn irr_is_absent_without_the_flag() {
+    let bin = require_rledger!();
+    let f = write_fixture(LEDGER_IRR);
+    let path = f.path().to_str().unwrap();
+    // Default output schema is unchanged — no irr column/field anywhere.
+    let csv = run(&bin, &["report", path, "capgains", "--format", "csv"]);
+    assert!(!csv.contains("irr"), "no irr column by default: {csv}");
+    let json = run(&bin, &["report", path, "capgains", "--format", "json"]);
+    assert!(!json.contains("irr"), "no irr field by default: {json}");
+    let txt = run(&bin, &["report", path, "capgains", "--no-pager"]);
+    assert!(!txt.contains("IRR"), "no IRR column by default: {txt}");
+}
+
+#[test]
+fn irr_is_na_for_short_sales_and_dateless_lots() {
+    let bin = require_rledger!();
+    // A short cover: money-in-then-out, so no conventional IRR.
+    let fs = write_fixture(LEDGER_SHORT);
+    let short = run(
+        &bin,
+        &[
+            "report",
+            fs.path().to_str().unwrap(),
+            "capgains",
+            "--irr",
+            "--format",
+            "csv",
+        ],
+    );
+    assert!(
+        short.lines().nth(1).is_some_and(|l| l.ends_with(',')),
+        "short sale has an empty irr cell: {short}"
+    );
+    // An AVERAGE-cost lot has no acquisition date to run the clock from.
+    let fa = write_fixture(LEDGER_AVERAGE);
+    let avg = run(
+        &bin,
+        &[
+            "report",
+            fa.path().to_str().unwrap(),
+            "capgains",
+            "--irr",
+            "--format",
+            "csv",
+        ],
+    );
+    assert!(
+        avg.lines().nth(1).is_some_and(|l| l.ends_with(',')),
+        "dateless lot has an empty irr cell: {avg}"
     );
 }
 

--- a/crates/rustledger/tests/report_capgains_test.rs
+++ b/crates/rustledger/tests/report_capgains_test.rs
@@ -439,12 +439,32 @@ fn irr_is_absent_without_the_flag() {
     let f = write_fixture(LEDGER_IRR);
     let path = f.path().to_str().unwrap();
     // Default output schema is unchanged — no irr column/field anywhere.
+    // Assert on the SCHEMA lines, not a substring of the whole output: a commodity
+    // or payee containing "irr" must not be able to fail (or pass) these.
     let csv = run(&bin, &["report", path, "capgains", "--format", "csv"]);
-    assert!(!csv.contains("irr"), "no irr column by default: {csv}");
+    let header = csv.lines().next().expect("a header");
+    assert!(
+        !header.contains("irr"),
+        "no irr column by default: {header}"
+    );
+    assert_eq!(
+        header.split(',').count(),
+        11,
+        "pre-IRR column count: {header}"
+    );
     let json = run(&bin, &["report", path, "capgains", "--format", "json"]);
-    assert!(!json.contains("irr"), "no irr field by default: {json}");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert!(
+        v["disposals"][0].get("irr_pct").is_none(),
+        "no irr field: {json}"
+    );
+    assert!(v.get("total_irr_pct").is_none(), "no total block: {json}");
     let txt = run(&bin, &["report", path, "capgains", "--no-pager"]);
-    assert!(!txt.contains("IRR"), "no IRR column by default: {txt}");
+    let thead = txt
+        .lines()
+        .find(|l| l.starts_with("Sold"))
+        .expect("a table header");
+    assert!(!thead.contains("IRR"), "no IRR column by default: {thead}");
 }
 
 #[test]

--- a/crates/rustledger/tests/report_capgains_test.rs
+++ b/crates/rustledger/tests/report_capgains_test.rs
@@ -106,9 +106,14 @@ const LEDGER_AVERAGE: &str = r#"option "booking_method" "AVERAGE"
   Income:Gains
 "#;
 
-/// Two closed round trips that each annualize to exactly 10%: a one-year
-/// 1000 -> 1100, and a two-year 500 -> 605 (1.21x compounded). The pooled
-/// realized IRR is therefore also 10%.
+/// Two closed round trips with DIFFERENT annualized rates, neither of which is
+/// 10% — `xirr` seeds Newton at exactly 0.10, so a 10% fixture could be satisfied
+/// by the seed at iteration 0 and would not prove the solver searched.
+///
+/// - A: 365 days, 1000 -> 1250 = 25%/yr.
+/// - B: 730 days, 1000 -> 1440 = 1.44x over 2y = 20%/yr compounded.
+///
+/// Pooled over all four flows: 21.67%/yr (independently computed by bisection).
 const LEDGER_IRR: &str = r#"option "booking_method" "FIFO"
 
 2019-01-01 open Assets:Broker:Stock
@@ -120,17 +125,17 @@ const LEDGER_IRR: &str = r#"option "booking_method" "FIFO"
   Assets:Bank       -1000 USD
 
 2020-12-31 * "sell A"
-  Assets:Broker:Stock  -10 AAA {} @ 110 USD
-  Assets:Bank        1100 USD
+  Assets:Broker:Stock  -10 AAA {} @ 125 USD
+  Assets:Bank        1250 USD
   Income:Gains
 
 2020-01-01 * "buy B"
-  Assets:Broker:Stock  5 BBB {100 USD}
-  Assets:Bank        -500 USD
+  Assets:Broker:Stock  10 BBB {100 USD}
+  Assets:Bank       -1000 USD
 
 2021-12-31 * "sell B"
-  Assets:Broker:Stock  -5 BBB {} @ 121 USD
-  Assets:Bank         605 USD
+  Assets:Broker:Stock  -10 BBB {} @ 144 USD
+  Assets:Bank        1440 USD
   Income:Gains
 "#;
 
@@ -382,43 +387,50 @@ fn irr_annualizes_each_lot_and_pools_the_aggregate() {
     let f = write_fixture(LEDGER_IRR);
     let path = f.path().to_str().unwrap();
 
-    // CSV gains a raw-rate `irr` column: both lots annualize to 0.1 (10%/yr).
+    // CSV: the rate is a 2-decimal PERCENT in an `irr_pct` column — the same unit
+    // and name shape as `report returns`' money_weighted_return_pct.
     let csv = run(
         &bin,
         &["report", path, "capgains", "--irr", "--format", "csv"],
     );
     let rows: Vec<&str> = csv.lines().collect();
-    assert!(rows[0].ends_with(",irr"), "header gains irr: {}", rows[0]);
-    assert!(
-        rows[1].ends_with(",0.1"),
-        "one-year lot = 10%/yr: {}",
-        rows[1]
+    assert_eq!(
+        rows[0],
+        "sold,account,commodity,units,acquired,held_days,term,currency,proceeds,cost_basis,gain,irr_pct"
     );
-    assert!(
-        rows[2].ends_with(",0.1"),
-        "two-year lot = 10%/yr: {}",
-        rows[2]
+    // Assert the whole row, so the rate is pinned to its column and the two lots'
+    // DIFFERENT rates cannot satisfy each other's assertion.
+    assert_eq!(
+        rows[1],
+        "2020-12-31,Assets:Broker:Stock,AAA,10,2020-01-01,365,short,USD,1250,1000,250,25.00"
+    );
+    assert_eq!(
+        rows[2],
+        "2021-12-31,Assets:Broker:Stock,BBB,10,2020-01-01,730,long,USD,1440,1000,440,20.00"
     );
 
-    // Text shows the percent column and the pooled per-term / total rates.
+    // Text: per-row percent column plus pooled per-term and TOTAL rates.
     let txt = run(&bin, &["report", path, "capgains", "--irr", "--no-pager"]);
-    assert!(txt.contains("IRR"), "IRR column header: {txt}");
-    assert!(txt.contains("10.00%"), "annualized rate: {txt}");
+    assert!(txt.contains("25.00%"), "one-year lot: {txt}");
+    assert!(txt.contains("20.00%"), "two-year lot: {txt}");
     assert!(
         txt.lines()
-            .any(|l| l.starts_with("TOTAL") && l.contains("IRR 10.00%")),
-        "pooled total IRR: {txt}"
+            .any(|l| l.starts_with("TOTAL") && l.contains("IRR 21.67%")),
+        "pooled money-weighted TOTAL (not the 22.50% mean of 25 and 20): {txt}"
     );
 
-    // JSON carries numeric rates plus the per-currency total_irr block.
+    // JSON: numeric percent, plus the per-currency total block with coverage.
     let json = run(
         &bin,
         &["report", path, "capgains", "--irr", "--format", "json"],
     );
     let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
-    assert_eq!(v["disposals"][0]["irr"], 0.1);
-    assert_eq!(v["total_irr"][0]["currency"], "USD");
-    assert_eq!(v["total_irr"][0]["irr"], 0.1);
+    assert_eq!(v["disposals"][0]["irr_pct"], 25.00);
+    assert_eq!(v["disposals"][1]["irr_pct"], 20.00);
+    assert_eq!(v["total_irr_pct"][0]["currency"], "USD");
+    assert_eq!(v["total_irr_pct"][0]["irr_pct"], 21.67);
+    assert_eq!(v["total_irr_pct"][0]["irr_lots"], 2);
+    assert_eq!(v["total_irr_pct"][0]["irr_lots_total"], 2);
 }
 
 #[test]
@@ -440,38 +452,47 @@ fn irr_is_na_for_short_sales_and_dateless_lots() {
     let bin = require_rledger!();
     // A short cover: money-in-then-out, so no conventional IRR.
     let fs = write_fixture(LEDGER_SHORT);
-    let short = run(
+    let sp = fs.path().to_str().unwrap();
+    // CSV: the irr_pct field is empty — asserted as the exact final field, not a
+    // bare `ends_with(',')` which would also pass if a later column were dropped.
+    let csv = run(
         &bin,
-        &[
-            "report",
-            fs.path().to_str().unwrap(),
-            "capgains",
-            "--irr",
-            "--format",
-            "csv",
-        ],
+        &["report", sp, "capgains", "--irr", "--format", "csv"],
     );
-    assert!(
-        short.lines().nth(1).is_some_and(|l| l.ends_with(',')),
-        "short sale has an empty irr cell: {short}"
+    let cols: Vec<&str> = csv
+        .lines()
+        .nth(1)
+        .expect("a disposal row")
+        .split(',')
+        .collect();
+    assert_eq!(cols.len(), 12, "all columns present: {csv}");
+    assert_eq!(cols[11], "", "short sale has no rate: {csv}");
+    // Text renders `n/a`, and the pooled line reports 0-of-1 coverage.
+    let txt = run(&bin, &["report", sp, "capgains", "--irr", "--no-pager"]);
+    assert!(txt.contains("n/a"), "short sale renders n/a: {txt}");
+    assert!(txt.contains("(0 of 1 lots)"), "coverage annotated: {txt}");
+    // JSON renders null.
+    let json = run(
+        &bin,
+        &["report", sp, "capgains", "--irr", "--format", "json"],
     );
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(v["disposals"][0]["irr_pct"], serde_json::Value::Null);
+
     // An AVERAGE-cost lot has no acquisition date to run the clock from.
     let fa = write_fixture(LEDGER_AVERAGE);
+    let ap = fa.path().to_str().unwrap();
     let avg = run(
         &bin,
-        &[
-            "report",
-            fa.path().to_str().unwrap(),
-            "capgains",
-            "--irr",
-            "--format",
-            "csv",
-        ],
+        &["report", ap, "capgains", "--irr", "--format", "csv"],
     );
-    assert!(
-        avg.lines().nth(1).is_some_and(|l| l.ends_with(',')),
-        "dateless lot has an empty irr cell: {avg}"
-    );
+    let acols: Vec<&str> = avg
+        .lines()
+        .nth(1)
+        .expect("a disposal row")
+        .split(',')
+        .collect();
+    assert_eq!(acols[11], "", "dateless lot has no rate: {avg}");
 }
 
 #[test]

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -319,6 +319,48 @@ TOTAL       net realized gain          660 USD
 | `--year <YYYY>` | Only disposals in this calendar/tax year. |
 | `--end <YYYY-MM-DD>` | Exclude disposals after this date. |
 | `--long-term-days <N>` | Override the long-term threshold with a fixed day count (held strictly more than `N` days is long-term). |
+| `--irr` | Add the annualized realized return of each closed lot, plus a pooled rate per term and currency (see below). |
+
+**Realized IRR (`--irr`).**
+
+Each closed lot is a round trip — money out at acquisition, money back at sale — so
+it has an annualized money-weighted return:
+
+```bash
+rledger report ledger.beancount capgains --irr
+```
+
+```text
+Sold       Commodity / account        Units  Acquired    Term       Proceeds           Gain       IRR
+-----------------------------------------------------------------------------------------------------
+2020-12-31 AAA Stock                     10  2020-01-01    ST           1100            100    10.00%
+2021-12-31 BBB Stock                      5  2020-01-01    LT            605            105    10.00%
+-----------------------------------------------------------------------------------------------------
+Short-term    1 disposals   proceeds            1100   gain             100 USD   IRR 10.00%
+Long-term     1 disposals   proceeds             605   gain             105 USD   IRR 10.00%
+TOTAL       net realized gain             205 USD   IRR 10.00%
+```
+
+Note both lots read 10% even though the second gained 21% in total — the rate is
+*annualized*, so a 1.21× return over two years is 10%/year compounded. The summary
+rates pool every eligible lot's flows into one series and solve once (a
+money-weighted return over all the capital that cycled through), rather than
+averaging per-lot rates.
+
+> **This is a realized-only return.** It can only see lots you actually closed, so
+> it is **not** your portfolio's total return — a position you still hold
+> contributes nothing, however it has performed. For the total return including
+> unrealized holdings valued at market, use [`report returns`](#investment-returns)
+> (money-weighted **and** time-weighted). The two answer different questions:
+> `returns` is the portfolio-level view; this is the per-lot view.
+
+A lot shows `n/a` (and is excluded from the pooled rates) when the rate is
+undefined: **short sales** (money-in-then-out makes an IRR unconventional and
+misleading), lots with **no acquisition date** (e.g. under `AVERAGE` booking, which
+merges lots and drops their dates), **same-day round trips** (a zero-day holding
+cannot be annualized), and a non-positive cost basis. In CSV/JSON the rate is the
+raw fraction (`0.1`, or empty/`null` when undefined); the percent formatting is
+text-only.
 
 **How it works.**
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -370,11 +370,14 @@ never came back.
 In CSV and JSON the rate is a 2-decimal **percent** in an `irr_pct` field (empty /
 `null` when undefined) — the same unit as `report returns`' `money_weighted_return_pct`,
 so the two reports' rates are directly comparable. The JSON summaries also carry
-`irr_lots` / `irr_lots_total` (the rate's coverage). In the text table a rate beyond
-±9999% is shown as `>9999%` / `<-9999%` to keep the columns aligned; the exact value
-is always in CSV/JSON. (A very short hold can annualize to an enormous number — a
-one-day 20% gain compounds to about 8×10³⁰ %/yr — which is arithmetically true but
-rarely meaningful.)
+`irr_lots` / `irr_lots_total` (the rate's coverage).
+
+A very short hold annualizes to an enormous number — a one-day 20% gain compounds to
+about 8×10³⁰ %/yr, arithmetically true but meaningless, and far more digits than a
+consumer (or this project's own decimal type) can read back. Rates **above 9999%**
+are therefore shown as `>9999%` in the text table and reported as empty / `null` in
+CSV/JSON, rather than as a fabricated figure. There is no lower cap: a round trip
+cannot lose more than its basis, so no rate falls below -100%.
 
 With `--year` or `--end`, the rate is computed from the flows of the lots that
 *closed* in the window; a lot bought in 2019 and sold in 2024 contributes its full

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -333,19 +333,23 @@ rledger report ledger.beancount capgains --irr
 ```text
 Sold       Commodity / account        Units  Acquired    Term       Proceeds           Gain       IRR
 -----------------------------------------------------------------------------------------------------
-2020-12-31 AAA Stock                     10  2020-01-01    ST           1100            100    10.00%
-2021-12-31 BBB Stock                      5  2020-01-01    LT            605            105    10.00%
+2020-12-31 AAA Stock                     10  2020-01-01    ST           1250            250    25.00%
+2021-12-31 BBB Stock                     10  2020-01-01    LT           1440            440    20.00%
 -----------------------------------------------------------------------------------------------------
-Short-term    1 disposals   proceeds            1100   gain             100 USD   IRR 10.00%
-Long-term     1 disposals   proceeds             605   gain             105 USD   IRR 10.00%
-TOTAL       net realized gain             205 USD   IRR 10.00%
+Short-term    1 disposals   proceeds            1250   gain             250 USD   IRR 25.00%
+Long-term     1 disposals   proceeds            1440   gain             440 USD   IRR 20.00%
+TOTAL       net realized gain             690 USD   IRR 21.67%
 ```
 
-Note both lots read 10% even though the second gained 21% in total — the rate is
-*annualized*, so a 1.21× return over two years is 10%/year compounded. The summary
-rates pool every eligible lot's flows into one series and solve once (a
-money-weighted return over all the capital that cycled through), rather than
-averaging per-lot rates.
+The second lot gained 44% in total but reads 20% — the rate is *annualized*, so a
+1.44× return over two years is 20%/year compounded. The summary rates pool every
+eligible lot's flows into one series and solve once (a money-weighted return over
+all the capital that cycled through), which is why the TOTAL is 21.67% and not the
+22.50% average of the two rates.
+
+When some lots in a bucket have no defined rate, the summary says so explicitly —
+`IRR 25.00% (1 of 3 lots)` — because the disposal count, proceeds and gain on that
+line cover *every* lot while the rate can only cover the eligible ones.
 
 > **This is a realized-only return.** It can only see lots you actually closed, so
 > it is **not** your portfolio's total return — a position you still hold
@@ -358,9 +362,24 @@ A lot shows `n/a` (and is excluded from the pooled rates) when the rate is
 undefined: **short sales** (money-in-then-out makes an IRR unconventional and
 misleading), lots with **no acquisition date** (e.g. under `AVERAGE` booking, which
 merges lots and drops their dates), **same-day round trips** (a zero-day holding
-cannot be annualized), and a non-positive cost basis. In CSV/JSON the rate is the
-raw fraction (`0.1`, or empty/`null` when undefined); the percent formatting is
-text-only.
+cannot be annualized), a non-positive cost basis, and negative proceeds. A **total
+loss** is *not* undefined — it is exactly `-100.00%` at any horizon, and it stays in
+the pooled rate, since dropping it would flatter the result by hiding capital that
+never came back.
+
+In CSV and JSON the rate is a 2-decimal **percent** in an `irr_pct` field (empty /
+`null` when undefined) — the same unit as `report returns`' `money_weighted_return_pct`,
+so the two reports' rates are directly comparable. The JSON summaries also carry
+`irr_lots` / `irr_lots_total` (the rate's coverage). In the text table a rate beyond
+±9999% is shown as `>9999%` / `<-9999%` to keep the columns aligned; the exact value
+is always in CSV/JSON. (A very short hold can annualize to an enormous number — a
+one-day 20% gain compounds to about 8×10³⁰ %/yr — which is arithmetically true but
+rarely meaningful.)
+
+With `--year` or `--end`, the rate is computed from the flows of the lots that
+*closed* in the window; a lot bought in 2019 and sold in 2024 contributes its full
+five-year span to a `--year 2024` rate. The rate answers "what did the round trips
+I closed in this window earn, annualized", not "what did this window earn".
 
 **How it works.**
 


### PR DESCRIPTION
## Realized IRR for `report capgains`

Adds `--irr`: the annualized money-weighted return of each **closed** tax lot,
plus a pooled rate per term and per currency.

```text
Sold       Commodity / account        Units  Acquired    Term       Proceeds           Gain       IRR
-----------------------------------------------------------------------------------------------------
2020-12-31 AAA Stock                     10  2020-01-01    ST           1100            100    10.00%
2021-12-31 BBB Stock                      5  2020-01-01    LT            605            105    10.00%
-----------------------------------------------------------------------------------------------------
Short-term    1 disposals   proceeds            1100   gain             100 USD   IRR 10.00%
Long-term     1 disposals   proceeds             605   gain             105 USD   IRR 10.00%
TOTAL       net realized gain             205 USD   IRR 10.00%
```

Both lots read 10% although the second gained 21% in total — the rate is
*annualized*, so 1.21× over two years compounds to 10%/year. That is the thing the
raw gain column cannot tell you.

### Design

- **Per-lot**: each closed lot is a round trip (`-cost_basis` at acquisition,
  `+proceeds` at sale), so it has a well-defined IRR.
- **Aggregate**: the summary rates pool every eligible lot's flows into one series
  and solve once — a money-weighted return over all the capital that actually
  cycled through — rather than averaging per-lot rates.
- **Reuses the canonical solver**: `rustledger_returns::xirr` (365-day basis,
  beangrow-compatible). No IRR solver is re-derived. The text column reuses
  `returns`' `fmt_rate_pct` so the two rate columns cannot drift in formatting.
- **Opt-in**: keeps the default a lean tax report, and leaves the CSV/JSON schema
  unchanged unless `--irr` is passed. Machine output is a **2-decimal percent** in
  an `irr_pct` field (empty / `null` when undefined) — the same unit as `report
  returns`' `money_weighted_return_pct`, so the two reports' rates are directly
  comparable rather than 100x apart. JSON summaries also carry `irr_lots` /
  `irr_lots_total`, the rate's coverage.
- **Bounded reporting**: a very short hold annualizes to an enormous number (a
  one-day 20% gain compounds to ~8e30 %/yr) — too wide for the text column and more
  digits than this project's own decimal type can parse back. Rates above 9999% show
  as `>9999%` in text and are omitted (empty/`null`) in machine output rather than
  emitting a fabricated figure.

### Positioning vs `report returns`

This is a **realized-only** return — it sees only lots you actually closed, so it
is *not* the portfolio's total return (a position you still hold contributes
nothing, however it has performed). `report returns` remains the beangrow-shaped
total-return report (money- **and** time-weighted, including still-held positions
valued at market). This adds the **per-lot** view that `returns` cannot give. The
docs state the distinction and cross-reference both ways.

### Undefined cases

`n/a`, and excluded from the pooled rates: **short sales** (money-in-then-out makes
an IRR unconventional and misleading), lots with **no acquisition date** (AVERAGE
booking merges lots and drops dates), **same-day round trips** (a zero-day span
cannot be annualized), a non-positive cost basis, negative proceeds, and any lot
whose rate does not solve. A **total loss** is *not* excluded — it is exactly
`-100%` at any horizon and stays in the pool, since dropping it would flatter the
aggregate by hiding capital that never came back.

When a bucket's rate covers fewer lots than the line's disposal count, the summary
says so: `IRR 25.00% (1 of 2 lots)`. The rate and the per-lot cells use one
predicate, so a summary can never contradict the rows above it.

### Testing

Verified against an independent bisection XIRR — per-lot and pooled rates agree to
6 decimals (a 1-year 1000→1100 and a 2-year 500→605 both annualize to
10.000000%). Tests cover annualization/compounding, the opt-in default (schema
unchanged), and every undefined case, at both unit and end-to-end CLI level.
Full `rustledger` suite green; clippy + docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
