### PR TITLE
ci: confine file: URI conversion to the boundary module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
 
   # Ratchet keeping `file:` URI <-> path conversion inside
   # `rustledger-lsp/src/proto.rs` (#1868). Four hand-rolled converters coexisted
-  # in that crate, each wrong differently (no encoding / spaces only / no
-  # no decoding on the way back / a Windows separator escaped to %5C) and all four
+  # in that crate, each wrong differently: no encoding at all, spaces only, no
+  # decoding on the way back, a Windows separator escaped to %5C. All four
   # agreed on the ASCII paths anyone tests with. Same grep-ratchet, no-extra-
   # toolchain pattern as the unsafe and sync-primitive invariants.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,25 @@ jobs:
       - name: Forbid std::sync Mutex/RwLock in library code
         run: ./scripts/check-sync-primitives.sh
 
+  # Ratchet keeping `file:` URI <-> path conversion inside
+  # `rustledger-lsp/src/proto.rs` (#1868). Four hand-rolled converters coexisted
+  # in that crate, each wrong differently (no encoding / spaces only / no
+  # no decoding on the way back / a Windows separator escaped to %5C) and all four
+  # agreed on the ASCII paths anyone tests with. Same grep-ratchet, no-extra-
+  # toolchain pattern as the unsafe and sync-primitive invariants.
+  #
+  # No `should_build` gate: the scripts are what is being run, so a PR touching
+  # only them must still exercise them.
+  uri-boundary:
+    name: URI Boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Self-test the guard (a ratchet whose regex stopped matching says ok forever)
+        run: ./scripts/test-uri-boundary.sh
+      - name: "Confine file: URI conversion to the boundary module"
+        run: ./scripts/check-uri-boundary.sh
+
   # The ONLY job in this repo that runs `cargo test` off Linux.
   #
   # `rustledger-lsp` is where platform-specific path handling actually lives:
@@ -504,7 +523,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, lsp-platform, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, uri-boundary, lsp-platform, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
     steps:
       - name: Check results
         run: |
@@ -523,6 +542,18 @@ jobs:
           echo "wit-version-gate result: $wit_gate"
           if [[ "$wit_gate" != "success" ]]; then
             echo "wit-version-gate must pass"
+            exit 1
+          fi
+
+          # uri-boundary always runs (no should_build gate, because the
+          # scripts it runs are themselves what a PR may be changing), so its
+          # result is always required. It was advisory when first added, which
+          # meant the ratchet could report a violation and the PR would still
+          # be mergeable — a ratchet nobody has to satisfy is documentation.
+          uri_boundary="${{ needs.uri-boundary.result }}"
+          echo "uri-boundary result: $uri_boundary"
+          if [[ "$uri_boundary" != "success" ]]; then
+            echo "uri-boundary must pass"
             exit 1
           fi
 

--- a/scripts/check-uri-boundary.sh
+++ b/scripts/check-uri-boundary.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Keep `file:` URI <-> path conversion inside `rustledger-lsp/src/proto.rs`.
+#
+# Four separate hand-rolled converters existed at once in this crate, and each
+# was wrong in its own way: one escaped nothing, one escaped only spaces, one
+# stripped the `file://` prefix without decoding it (so the URI for a path
+# with a space kept the literal `%20`, naming a file that does not exist), and
+# one escaped a Windows
+# path separator into `%5C`. They agreed on every ASCII-only path a developer
+# tests with, which is why all four survived review. `proto.rs` is now the one
+# place that knows the encoding, and this is the ratchet that keeps a fifth
+# copy from appearing the next time a call site needs a URI in a hurry.
+#
+# This is the same lightweight, named-CI-status pattern as
+# `check-sync-primitives.sh` — deliberately a grep ratchet rather than a
+# `dylint` lint so it needs no extra (nightly) toolchain.
+#
+# Scope: `crates/*/src/` only, and within those files only non-test code —
+# a trailing `#[cfg(test)] mod ...` block is skipped, because a test that
+# simulates what an EDITOR sends must build the URI by hand; using our own
+# encoder there would only test the encoder against itself. Integration tests
+# live outside `src/` and aren't scanned. `proto.rs` itself is exempt: it is
+# the implementation.
+#
+# Escape hatch: append `// ratchet-allow: uri-boundary <reason>` to the line.
+#
+# Exit codes
+# ----------
+#   0  no URI assembly or parsing outside the boundary module
+#   1  one or more violations found
+#
+# Usage
+# -----
+#   ./scripts/check-uri-boundary.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+boundary="crates/rustledger-lsp/src/proto.rs"
+
+# Two families:
+#   * assembling a URI from a string ("file://" appearing in a format!, a
+#     literal conversion, or a push onto a buffer), and
+#   * taking one apart by hand (prefix strip/test).
+# Plus `url`'s own path conversions, so `proto` stays their only caller —
+# they are correct primitives, but calling them elsewhere re-creates the
+# WHATWG-vs-RFC-3986 encoding gap that `proto::path_to_uri` closes.
+forbidden='format!\("file://|"file://"\.to_|push_str\("file://|(strip_prefix|starts_with|trim_start_matches)\("file://|(from_file_path|to_file_path)\('
+
+# Print a file's non-test code: every `#[cfg(test)]`-attributed `mod` BODY is
+# skipped, and everything else is printed.
+#
+# `check-sync-primitives.sh` exits at the first such module, on the assumption
+# that test modules come last. Rust does not require that, and
+# `document_links.rs` alone has three — so everything after the first was
+# unscanned, and appending a hand-rolled `file://` converter below it made this
+# script report "ok". A ratchet with a hole where the ninth copy would go is
+# worse than none, because it is believed.
+#
+# Braces are counted to find the end of each module rather than assuming one.
+strip_test_module() {
+    awk '
+        # Remember a `#[cfg(test)]` so the `mod` on a following line is caught.
+        /#\[cfg\(test\)\]/ { pending = 1; print; next }
+        pending && /^[[:space:]]*$/ { print; next }
+        pending && /^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]]/ {
+            pending = 0
+            # A `mod foo;` declaration has no body to skip.
+            if ($0 ~ /;[[:space:]]*$/) { print; next }
+            depth = 0
+            for (i = 1; i <= length($0); i++) {
+                c = substr($0, i, 1)
+                if (c == "{") depth++
+                else if (c == "}") depth--
+            }
+            # Consume until the body closes. Blank the lines rather than
+            # dropping them so grep -n line numbers stay true to the file.
+            while (depth > 0 && (getline line) > 0) {
+                for (i = 1; i <= length(line); i++) {
+                    c = substr(line, i, 1)
+                    if (c == "{") depth++
+                    else if (c == "}") depth--
+                }
+                print ""
+            }
+            print ""
+            next
+        }
+        { pending = 0; print }
+    ' "$1"
+}
+
+violations=""
+while IFS= read -r f; do
+    [ "$f" = "$boundary" ] && continue
+    hits="$(strip_test_module "$f" | grep -nE "$forbidden" | grep -v 'ratchet-allow: uri-boundary' || true)"
+    if [ -n "$hits" ]; then
+        violations+="$f:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/    /')"$'\n'
+    fi
+done < <(grep -rlE "$forbidden" crates/*/src --include='*.rs' 2>/dev/null | sort)
+
+# A SECOND rule, over `src/` AND `tests/`: never compare URIs as strings.
+#
+# One file has many URI spellings, so a string comparison answers "did these two
+# producers happen to spell it the same way", not "are these the same file". It
+# is the defect the diagnostics cache had (a `didClose` in the client's spelling
+# could not evict an entry stored in ours), and eleven more instances were then
+# found in the protocol tests, where the server's URI comes from the loader's
+# canonicalized path and the test's from the temp dir it made. On Linux those
+# are the same string; on Windows they are not, so every one of those
+# assertions silently never matched.
+#
+# `tests/` is in scope here, unlike the rule above: building a URI by hand is
+# legitimate in a test simulating an editor, but comparing two of them as
+# strings is wrong wherever it appears. Convert both sides with `uri_to_path`
+# and compare paths.
+#
+# KNOWN GAP, stated rather than papered over: this matches on the NAME, so it
+# needs one side to be called `uri`/`*_uri` or to be a `.uri` field. It caught
+# all twelve real instances and every realistic variant, but
+# `let a = some_uri(); a.as_str() == b` slips through. Banning every
+# `.as_str() ==` in the crate would close it at the cost of one unrelated line
+# today and a tax on every string comparison later; that trade is available if
+# this ever misses something real.
+uri_eq='\.as_str\(\) *[=!]= *[&]?[a-z_]*uri|uri\.as_str\(\) *[=!]='
+
+uri_eq_violations=""
+while IFS= read -r f; do
+    # Comment-only lines are skipped: the doc comments explaining this rule
+    # necessarily quote the pattern it bans.
+    hits="$(grep -nE "$uri_eq" "$f" \
+        | grep -vE '^[0-9]+:[[:space:]]*(//|/\*|\*)' \
+        | grep -v 'ratchet-allow: uri-string-eq' || true)"
+    if [ -n "$hits" ]; then
+        uri_eq_violations+="$f:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/    /')"$'\n'
+    fi
+done < <(grep -rlE "$uri_eq" crates/*/src crates/*/tests --include='*.rs' 2>/dev/null | sort)
+
+if [ -n "$uri_eq_violations" ]; then
+    echo "error: URIs compared as strings." >&2
+    echo "       A Uri is a string and a string is not a file identity: %2E vs ., a" >&2
+    echo "       dot segment, C: vs c:, and a canonicalized vs an uncanonicalized" >&2
+    echo "       parent all spell one file differently." >&2
+    echo "       Convert both sides with uri_to_path and compare the paths." >&2
+    echo "       Tests can use the harness's \`same_file\`." >&2
+    echo "       If a literal string comparison is genuinely what you mean, append" >&2
+    echo "         // ratchet-allow: uri-string-eq <reason>" >&2
+    echo "       to the line." >&2
+    echo >&2
+    printf '%s' "$uri_eq_violations" >&2
+    exit 1
+fi
+
+if [ -n "$violations" ]; then
+    echo "error: file: URI assembled or parsed outside the boundary module." >&2
+    echo "       Use rustledger_lsp::{path_to_uri, uri_to_path} (crates/rustledger-lsp/src/proto.rs)." >&2
+    echo "       Hand-rolled conversions have been wrong four times: percent-encoding," >&2
+    echo "       percent-decoding, and the Windows path separator each got missed." >&2
+    echo "       If a raw conversion is genuinely required, append" >&2
+    echo "         // ratchet-allow: uri-boundary <reason>" >&2
+    echo "       to the line." >&2
+    echo >&2
+    printf '%s' "$violations" >&2
+    exit 1
+fi
+
+echo "ok: file: URI conversion confined to $boundary, and no URI compared as a string."

--- a/scripts/check-uri-boundary.sh
+++ b/scripts/check-uri-boundary.sh
@@ -16,12 +16,16 @@
 # `check-sync-primitives.sh` — deliberately a grep ratchet rather than a
 # `dylint` lint so it needs no extra (nightly) toolchain.
 #
-# Scope: `crates/*/src/` only, and within those files only non-test code —
-# a trailing `#[cfg(test)] mod ...` block is skipped, because a test that
-# simulates what an EDITOR sends must build the URI by hand; using our own
-# encoder there would only test the encoder against itself. Integration tests
-# live outside `src/` and aren't scanned. `proto.rs` itself is exempt: it is
-# the implementation.
+# Scope: `crates/*/src/`, and within those files only non-test code — the BODY
+# of every `#[cfg(test)] mod`, wherever it appears, is skipped, and scanning
+# resumes after it. Test modules are exempt because a test simulating what an
+# EDITOR sends must build the URI by hand; using our own encoder there would
+# only test the encoder against itself. Integration tests live outside `src/`
+# and aren't scanned by this rule. `proto.rs` itself is exempt: it is the
+# implementation.
+#
+# (The second rule below has a WIDER scope — it also scans `crates/*/tests`
+# and does not exempt test modules. See its own comment.)
 #
 # Escape hatch: append `// ratchet-allow: uri-boundary <reason>` to the line.
 #
@@ -145,7 +149,8 @@ if [ -n "$uri_eq_violations" ]; then
     echo "       dot segment, C: vs c:, and a canonicalized vs an uncanonicalized" >&2
     echo "       parent all spell one file differently." >&2
     echo "       Convert both sides with uri_to_path and compare the paths." >&2
-    echo "       Tests can use the harness's \`same_file\`." >&2
+    echo "       In rustledger-lsp's protocol tests, the harness's \`same_file\`" >&2
+    echo "       already does this." >&2
     echo "       If a literal string comparison is genuinely what you mean, append" >&2
     echo "         // ratchet-allow: uri-string-eq <reason>" >&2
     echo "       to the line." >&2

--- a/scripts/test-uri-boundary.sh
+++ b/scripts/test-uri-boundary.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Self-test for `check-uri-boundary.sh`.
+#
+# A grep ratchet whose regex has quietly stopped matching is worse than no
+# ratchet: it reports "ok" forever and everyone believes it. This plants each
+# violation the guard claims to catch and asserts it actually fails, then
+# asserts the escape hatch and the test-module exemption still work.
+#
+# The fixture is a scratch file created and removed under
+# `crates/rustledger-lsp/src/`; it is never compiled (no `mod` declares it).
+#
+# Usage
+# -----
+#   ./scripts/test-uri-boundary.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fixture="crates/rustledger-lsp/src/zz_uri_boundary_fixture.rs"
+trap 'rm -f "$fixture" "crates/rustledger-lsp/tests/zz_uri_eq_fixture.rs"' EXIT
+
+fail=0
+
+# A clean tree must pass, or every result below is meaningless.
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: the guard does not pass on an unmodified tree" >&2
+    ./scripts/check-uri-boundary.sh || true
+    exit 1
+fi
+
+# Each of these must be caught. They are the exact shapes that existed in the
+# crate before `proto.rs`: assembly by format!, by literal, by push; parsing by
+# prefix strip or test; and `url`'s own conversions called outside the boundary.
+must_catch=(
+    'fn f(p: &std::path::Path) -> String { format!("file://{}", p.display()) }'
+    'fn f() -> String { "file://".to_string() }'
+    'fn f(s: &mut String) { s.push_str("file://"); }'
+    'fn f(u: &str) -> Option<&str> { u.strip_prefix("file://") }'
+    'fn f(u: &str) -> bool { u.starts_with("file://") }'
+    'fn f(u: &str) -> &str { u.trim_start_matches("file://") }'
+    'fn f(p: &std::path::Path) { let _ = url::Url::from_file_path(p); }'
+    'fn f(u: &url::Url) { let _ = u.to_file_path(); }'
+)
+for line in "${must_catch[@]}"; do
+    printf '%s\n' "$line" > "$fixture"
+    if ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+        echo "FAIL: not caught: $line" >&2
+        fail=1
+    fi
+done
+
+# The second rule: URIs compared as strings. These are the shapes that actually
+# occurred — in the server's diagnostics cache and in eleven protocol tests.
+uri_eq_catch=(
+    'fn f(p: &P, b: &str) -> bool { p.uri.as_str() == b_uri }'
+    'fn f(l: &L) -> bool { l.uri.as_str() == main_uri }'
+    'fn f(u: &U) -> bool { u.as_str() == main_uri }'
+    'fn f(uri: &U, o: &str) -> bool { uri.as_str() == o }'
+    'fn f(a: &A) -> bool { a.uri.as_str() != b_uri }'
+)
+for line in "${uri_eq_catch[@]}"; do
+    printf '%s\n' "$line" > "$fixture"
+    if ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+        echo "FAIL: URI string comparison not caught: $line" >&2
+        fail=1
+    fi
+done
+
+# It must apply to tests/ too, which is where eleven of the twelve were.
+test_fixture="crates/rustledger-lsp/tests/zz_uri_eq_fixture.rs"
+printf '%s\n' 'fn f(p: &P) -> bool { p.uri.as_str() == bad_uri }' > "$test_fixture"
+if ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: URI string comparison in tests/ not caught" >&2
+    fail=1
+fi
+rm -f "$test_fixture"
+
+# A comment quoting the pattern must NOT trip it — the docs for this very rule
+# have to be able to name what they ban.
+printf '%s\n' '/// Never write `p.uri.as_str() == other_uri`; compare paths.' > "$fixture"
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: a comment quoting the banned pattern was flagged" >&2
+    fail=1
+fi
+
+# Its own escape hatch.
+printf '%s\n' 'fn f(p: &P) -> bool { p.uri.as_str() == b_uri } // ratchet-allow: uri-string-eq self-test' > "$fixture"
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: ratchet-allow: uri-string-eq did not suppress" >&2
+    fail=1
+fi
+
+# The escape hatch must suppress a real violation.
+printf '%s\n' 'fn f(u: &url::Url) { let _ = u.to_file_path(); } // ratchet-allow: uri-boundary self-test' > "$fixture"
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: ratchet-allow did not suppress a violation" >&2
+    fail=1
+fi
+
+# A trailing `#[cfg(test)] mod` is exempt: a test that simulates an editor's
+# URI must build it by hand.
+cat > "$fixture" <<'EOF'
+fn ordinary() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        let _ = format!("file://{}", "/tmp/x");
+    }
+}
+EOF
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: a violation inside a trailing #[cfg(test)] mod was flagged" >&2
+    fail=1
+fi
+
+# ...but code BEFORE that module is still scanned, or the exemption would be a
+# hole big enough to hide the whole crate in.
+cat > "$fixture" <<'EOF'
+fn ordinary(p: &std::path::Path) -> String { format!("file://{}", p.display()) }
+
+#[cfg(test)]
+mod tests {}
+EOF
+if ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: non-test code before a #[cfg(test)] mod was not scanned" >&2
+    fail=1
+fi
+
+# Production code AFTER a test module must still be scanned. The original awk
+# exited at the first `#[cfg(test)] mod`, and real files have several, so the
+# ratchet reported "ok" on a hand-rolled converter appended below one.
+cat > "$fixture" <<'EOF'
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        let _ = format!("file://{}", "/tmp/x");
+    }
+}
+
+pub fn sneaky(p: &std::path::Path) -> String { format!("file://{}", p.display()) }
+EOF
+if ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: code after a #[cfg(test)] mod was not scanned" >&2
+    fail=1
+fi
+
+# Two test modules, and clean code between and after them, must stay clean.
+cat > "$fixture" <<'EOF'
+#[cfg(test)]
+mod a {
+    fn x() { let _ = format!("file://{}", "/tmp/x"); }
+}
+
+pub fn between() {}
+
+#[cfg(test)]
+mod b {
+    fn y() { let _ = "file:///x".strip_prefix("file://"); }
+}
+
+pub fn after() {}
+EOF
+if ! ./scripts/check-uri-boundary.sh >/dev/null 2>&1; then
+    echo "FAIL: clean code around two test modules was flagged" >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "self-test FAILED" >&2
+    exit 1
+fi
+
+echo "ok: check-uri-boundary.sh catches all 8 conversion shapes and 6 URI-string comparisons, honors both escape hatches, and scopes the test-module exemption to the module BODY."


### PR DESCRIPTION
Split out of #1869, which had grown into a bug fix plus an invariant overhaul. This is the speculative-infrastructure half, so it can be judged on its own merits or rejected without touching correctness code.

**Stacked on #1869** — the hand-rolled converters this bans are exactly the ones that PR removes, so against `main` it fails immediately. Merge #1869 first, and this retargets to `main` automatically.

## What it does

Two grep ratchets over `rustledger-lsp`, in the repo's existing no-extra-toolchain style (`check-sync-primitives.sh`, `check-hot-path-collections.sh`):

1. **`file:` URIs are assembled and parsed only in `proto.rs`.** Four hand-rolled converters coexisted in that crate, each wrong differently — one escaped nothing, one escaped only spaces, one stripped `file://` without decoding, one escaped a Windows separator to `%5C`. They agreed on every ASCII path anyone tests with, which is why all four passed review. `url`'s own `from_file_path`/`to_file_path` are covered too, so `proto` stays their only caller.

2. **URIs are never compared as strings**, in `src/` *and* `tests/`. A string comparison answers "did these two producers spell it the same way", not "are these the same file". Twelve instances existed: one in the diagnostics cache, eleven in protocol tests where the server's URI comes from the loader's canonicalized path and the test's from its temp dir — identical on Linux, different on Windows, so those assertions silently never matched.

## Known gap, stated rather than glossed

Rule 2 matches on the *name*, so it needs one side called `uri`/`*_uri` or a `.uri` field. It caught all twelve real instances and every realistic variant, but `let a = some_uri(); a.as_str() == b` slips through. Banning every `.as_str() ==` in the crate would close it, at the cost of one unrelated line today and a tax on every string comparison later. The trade is written next to the rule.

## The self-test is the point

A ratchet whose regex has quietly stopped matching reports `ok` forever and is worse than none, because it is believed. `test-uri-boundary.sh` plants all 8 conversion shapes and 6 comparison shapes, checks both escape hatches, checks that comments quoting the banned patterns aren't flagged, and checks the test-module exemption covers only the module *body*.

That last case is not hypothetical. The first version exited at the first `#[cfg(test)] mod`; real files have several — `document_links.rs` has three — so everything after the first went unscanned, and a hand-rolled converter appended below one made the script report `ok`. It counts braces now, and the self-test fails against the old form.

## Review notes

- The job is in the `build` gate, not advisory — a ratchet nobody has to satisfy is documentation.
- Escape hatches: `// ratchet-allow: uri-boundary <reason>` and `// ratchet-allow: uri-string-eq <reason>`. Neither is used today.
- Reasonable to reject: this is ~350 lines of shell guarding a class of bug that the type system and the platform CI matrix (both in #1869) already make harder to reintroduce.