### PR TITLE
fix(ci): make the Scoop dispatch wait for the Windows binaries

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -333,7 +333,15 @@ jobs:
   # Gate: release-publish (trigger: release published) runs in parallel with
   # release-build (trigger: tag push), so binary-consuming jobs can race the
   # binary upload and fail with "no assets to download". Block them until the
-  # platform tarballs actually exist on the release.
+  # platform archives actually exist on the release.
+  #
+  # This waits for EVERY platform, not only the ones a given consumer reads.
+  # That costs the Linux-only consumers (docker, rustfava, aur) the extra few
+  # minutes the Windows builds take, which is worth it on a release path where
+  # nothing is latency-sensitive: the alternative is a per-consumer wait list
+  # that has to be kept in sync with what each downstream repo fetches, and the
+  # last time that drifted the scoop bucket quietly stopped tracking releases
+  # for a fortnight. Please don't narrow this back down per consumer.
   wait-for-assets:
     name: Wait for release binaries
     runs-on: ubuntu-latest
@@ -344,18 +352,32 @@ jobs:
           GH_REPO: ${{ github.repository }} # gh resolves the repo from this (no checkout)
           TAG: ${{ env.RELEASE_TAG }}
         run: |
-          # Wait for both the tarballs AND their .sha256 sidecars:
-          # update-aur-bin curls the .sha256 files (`curl -f`), and those
-          # can lag the tarball uploads.
-          targets=(
+          # Wait for both the archives AND their .sha256 sidecars: consumers
+          # curl the .sha256 files (`curl -f`), and those can lag the archive
+          # uploads.
+          #
+          # Windows is here because `update-scoop` depends on this job: the
+          # scoop bucket reads `<zip>.sha256` to fill in the manifest hash.
+          # Waiting only for Linux would let scoop dispatch while the zips are
+          # still building — which is exactly how v0.21.0's bucket update
+          # failed (scoop-rustledger#4): dispatch at 02:25:53, Windows assets
+          # at 02:39:38, and the bucket's 10-minute poll gave up 3m45s short.
+          linux_targets=(
             x86_64-unknown-linux-gnu
             x86_64-unknown-linux-musl
             aarch64-unknown-linux-gnu
             aarch64-unknown-linux-musl
           )
+          windows_targets=(
+            x86_64-pc-windows-msvc
+            aarch64-pc-windows-msvc
+          )
           expected=()
-          for t in "${targets[@]}"; do
+          for t in "${linux_targets[@]}"; do
             expected+=("rustledger-${TAG}-${t}.tar.gz" "rustledger-${TAG}-${t}.tar.gz.sha256")
+          done
+          for t in "${windows_targets[@]}"; do
+            expected+=("rustledger-${TAG}-${t}.zip" "rustledger-${TAG}-${t}.zip.sha256")
           done
           deadline=$(( $(date +%s) + 1800 ))   # 30 min
           while :; do
@@ -364,7 +386,7 @@ jobs:
             for a in "${expected[@]}"; do
               grep -qxF "$a" <<<"$assets" || missing+=("$a")
             done
-            if [ ${#missing[@]} -eq 0 ]; then echo "✓ all platform tarballs present"; exit 0; fi
+            if [ ${#missing[@]} -eq 0 ]; then echo "✓ all platform archives present"; exit 0; fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "::error::timed out waiting for release binaries:"
               printf '  - %s\n' "${missing[@]}"; exit 1
@@ -438,6 +460,12 @@ jobs:
   # Update Scoop bucket
   update-scoop:
     name: Update Scoop bucket
+    # The bucket polls `<zip>.sha256` for 10 minutes and then errors, so
+    # dispatching before the Windows zips exist just burns that budget. The
+    # dispatch itself always succeeds, so this workflow stayed green while the
+    # bucket run failed and the manifest silently stopped tracking releases —
+    # it took a user report (scoop-rustledger#4) to notice, two days later.
+    needs: wait-for-assets
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -341,7 +341,7 @@ jobs:
   # nothing is latency-sensitive: the alternative is a per-consumer wait list
   # that has to be kept in sync with what each downstream repo fetches, and the
   # last time that drifted the scoop bucket quietly stopped tracking releases
-  # for a fortnight. Please don't narrow this back down per consumer.
+  # for 17 days. Please don't narrow this back down per consumer.
   wait-for-assets:
     name: Wait for release binaries
     runs-on: ubuntu-latest
@@ -362,21 +362,28 @@ jobs:
           # still building — which is exactly how v0.21.0's bucket update
           # failed (scoop-rustledger#4): dispatch at 02:25:53, Windows assets
           # at 02:39:38, and the bucket's 10-minute poll gave up 3m45s short.
-          linux_targets=(
+          # macOS is here because the list should match what release-build
+          # produces, not what today's consumers happen to read.
+          # Every target release-build produces. Keep this list complete: a
+          # missing platform is a consumer that can still race, which is the
+          # whole defect being fixed.
+          tarball_targets=(
             x86_64-unknown-linux-gnu
             x86_64-unknown-linux-musl
             aarch64-unknown-linux-gnu
             aarch64-unknown-linux-musl
+            x86_64-apple-darwin
+            aarch64-apple-darwin
           )
-          windows_targets=(
+          zip_targets=(
             x86_64-pc-windows-msvc
             aarch64-pc-windows-msvc
           )
           expected=()
-          for t in "${linux_targets[@]}"; do
+          for t in "${tarball_targets[@]}"; do
             expected+=("rustledger-${TAG}-${t}.tar.gz" "rustledger-${TAG}-${t}.tar.gz.sha256")
           done
-          for t in "${windows_targets[@]}"; do
+          for t in "${zip_targets[@]}"; do
             expected+=("rustledger-${TAG}-${t}.zip" "rustledger-${TAG}-${t}.zip.sha256")
           done
           deadline=$(( $(date +%s) + 1800 ))   # 30 min
@@ -463,8 +470,10 @@ jobs:
     # The bucket polls `<zip>.sha256` for 10 minutes and then errors, so
     # dispatching before the Windows zips exist just burns that budget. The
     # dispatch itself always succeeds, so this workflow stayed green while the
-    # bucket run failed and the manifest silently stopped tracking releases —
-    # it took a user report (scoop-rustledger#4) to notice, two days later.
+    # bucket run failed and the manifest silently stopped tracking releases.
+    # Nothing here noticed: it took a user report two days after the release
+    # (scoop-rustledger#4), and another fortnight before that report carried
+    # the error text that identified the cause.
     needs: wait-for-assets
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Scoop bucket stopped tracking releases at 0.20.2. Reported by a user on [scoop-rustledger#4](https://github.com/rustledger/scoop-rustledger/issues/4), two weeks after it broke.

## Root cause, measured

`update-scoop` had **no `needs:`**, so it fired its `repository_dispatch` the moment `release-publish` started. The bucket's workflow then polls `<zip>.sha256` every 20s and errors after 10 minutes.

On v0.21.0:

```
02:25:51  release published
02:25:53  release-publish starts -> scoop dispatched immediately
02:39:38  Windows assets uploaded
          bucket gave up at ~02:35:53 — 3m45s short
```

**v0.20.2 won the same race by luck** — its Windows `.sha256` was already up when the release was published (gap 0.0 min), so the first poll succeeded. Same code, different build timing, different outcome. Nothing regressed; the race was always there.

The `.sha256` file itself is fine — I downloaded it and verified the hash against the actual artifact.

## Two fixes, because one isn't enough

1. `update-scoop` now `needs: wait-for-assets`.
2. **`wait-for-assets` now waits for the Windows zips.** It only listed the four Linux tarballs, having been written for `update-aur-bin` — so adding the dependency alone would not have helped scoop at all. This is the part that makes it a real fix rather than a reordering.

## Tradeoff, stated deliberately

The wait now covers every platform rather than a per-consumer list. That costs the Linux-only consumers (docker, rustfava, aur) the few extra minutes the Windows builds take, on a release path where nothing is latency-sensitive.

The alternative — a wait list per downstream repo, kept in sync with what each one fetches — is exactly the drift that caused this. There's a comment in the file asking not to narrow it back down.

## Verification

- YAML parses; the `run` block is valid bash (`bash -n`).
- The 12 expected asset names all exist on the real v0.21.0 release.
- Can't be end-to-end tested without cutting a release, which is the nature of release-path changes.

## Not fixed here

**The dispatch cannot fail.** `update-scoop` only sends an event and never checks the outcome, so `release-publish` went green while the bucket run failed — which is why this took a user report to surface. Making that visible is a separate change worth doing.

The 0.21.0 manifest has been [updated by hand](https://github.com/rustledger/scoop-rustledger/commit/03f3a13) in the bucket meanwhile, so users are unblocked regardless of when this merges.