### PR TITLE
ci: build, test and smoke the MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,68 @@ jobs:
       - name: Test rustledger-lsp on Windows
         run: cargo test -p rustledger-lsp
 
+  # Build + test the MCP server. Nothing did, until now.
+  #
+  # `packages/mcp-server` is published to npm as `@rustledger/mcp-server` and
+  # was covered by no PR job at all — only the release workflows touched it. An
+  # SDK MAJOR migration (#1879, monolithic `@modelcontextprotocol/sdk` v1 to the
+  # scoped v2 packages) went through with zero automated verification; it was
+  # checked by hand, which does not scale and does not repeat.
+  #
+  # No `should_build` gate: that filter is for Rust sources, and this package
+  # is TypeScript. Path-filtering on `packages/mcp-server/**` was tempting but
+  # would miss the case that actually bites — the server calls into
+  # `@rustledger/wasm`, so a Rust change can break it without touching a single
+  # file here.
+  mcp-server:
+    name: MCP Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: packages/mcp-server/package-lock.json
+      - name: Install
+        working-directory: packages/mcp-server
+        run: npm ci
+      - name: Typecheck and build
+        working-directory: packages/mcp-server
+        run: npm run build
+      - name: Test
+        working-directory: packages/mcp-server
+        run: npm test
+      - name: Smoke the stdio server
+        working-directory: packages/mcp-server
+        run: |
+          # A green build does not mean the server speaks the protocol. This
+          # drives the real binary over stdio in BOTH negotiation directions,
+          # which is what the SDK v2 migration had to be checked by hand for.
+          set -euo pipefail
+          probe() {
+            local label="$1"; shift
+            local out
+            out=$(printf '%s\n' "$@" | timeout 60 node dist/index.js 2>/dev/null || true)
+            node -e '
+              const lines = require("fs").readFileSync(0, "utf8").trim().split("\n").filter(Boolean);
+              const msgs = lines.map(l => JSON.parse(l));
+              const err = msgs.find(m => m.error);
+              if (err) { console.error("  '"$label"': JSON-RPC error " + JSON.stringify(err.error)); process.exit(1); }
+              const tools = msgs.find(m => m.result && m.result.tools);
+              if (!tools || tools.result.tools.length === 0) { console.error("  '"$label"': no tools listed"); process.exit(1); }
+              console.log("  '"$label"': ok, " + tools.result.tools.length + " tools");
+            ' <<< "$out"
+          }
+          # A pre-2026 client: full initialize handshake.
+          probe "legacy handshake" \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"1"}}}' \
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+          # A 2026-07-28 client: stateless, no handshake at all.
+          probe "stateless" \
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
   # Plugin-test policies (Phase 5 of plugin-testing-quality plan, see #992).
   # Catches weak count assertions and `(partial)` test ports that tend to
   # silently mask plugin bugs.
@@ -523,7 +585,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, uri-boundary, lsp-platform, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, uri-boundary, lsp-platform, mcp-server, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
     steps:
       - name: Check results
         run: |
@@ -554,6 +616,16 @@ jobs:
           echo "uri-boundary result: $uri_boundary"
           if [[ "$uri_boundary" != "success" ]]; then
             echo "uri-boundary must pass"
+            exit 1
+          fi
+
+          # mcp-server always runs (no should_build gate — it is a TypeScript
+          # package, and a Rust change can break it through @rustledger/wasm
+          # without touching it), so its result is always required.
+          mcp="${{ needs.mcp-server.result }}"
+          echo "mcp-server result: $mcp"
+          if [[ "$mcp" != "success" ]]; then
+            echo "mcp-server must pass"
             exit 1
           fi
 

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -283,7 +283,13 @@ describe('Tool Handlers', () => {
       expect(result.content[0].text).toContain('valid');
     });
 
-    it('should report validation errors', () => {
+    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
+    // `validateSource` drops the loader's parse errors, so it answers
+    // `valid: true` for input `rledger check` rejects with P0012. These
+    // assertions are correct; the binding is not. `it.fails` keeps CI honest
+    // in both directions: red while the bug is here, and red again the moment
+    // it is fixed, so the marker cannot outlive the defect.
+    it.fails('should report validation errors', () => {
       const result = handleToolCall('validate', { source: '2024-01-01 invalid directive' });
       expect(result.content[0].text).toContain('error');
     });
@@ -389,7 +395,13 @@ describe('Tool Handlers', () => {
       expect(payload.transaction.date).toBe('2024-01-15');
     });
 
-    it('returns an error response when parsing fails', () => {
+    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
+    // `validateSource` drops the loader's parse errors, so it answers
+    // `valid: true` for input `rledger check` rejects with P0012. These
+    // assertions are correct; the binding is not. `it.fails` keeps CI honest
+    // in both directions: red while the bug is here, and red again the moment
+    // it is fixed, so the marker cannot outlive the defect.
+    it.fails('returns an error response when parsing fails', () => {
       // Pre-fix this would have silently produced a categorization
       // prompt with an empty accounts list; now it surfaces the parser
       // diagnostic, matching `handleParse`'s behavior.
@@ -427,7 +439,13 @@ describe('Tool Handlers', () => {
       expect(payload.low_confidence).toBe(0);
     });
 
-    it('returns an error response when parsing fails', () => {
+    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
+    // `validateSource` drops the loader's parse errors, so it answers
+    // `valid: true` for input `rledger check` rejects with P0012. These
+    // assertions are correct; the binding is not. `it.fails` keeps CI honest
+    // in both directions: red while the bug is here, and red again the moment
+    // it is fixed, so the marker cannot outlive the defect.
+    it.fails('returns an error response when parsing fails', () => {
       const result = handleToolCall('import_review', {
         source: '@@@ not beancount @@@',
       });

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -286,9 +286,13 @@ describe('Tool Handlers', () => {
     // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
     // `validateSource` drops the loader's parse errors, so it answers
     // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not. `it.fails` keeps CI honest
-    // in both directions: red while the bug is here, and red again the moment
-    // it is fixed, so the marker cannot outlive the defect.
+    // assertions are correct; the binding is not.
+    //
+    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
+    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
+    // test, which is the point — the marker cannot outlive the defect, and
+    // whoever fixes the binding is told to delete the `.fails` rather than
+    // discovering a stale skip years later.
     it.fails('should report validation errors', () => {
       const result = handleToolCall('validate', { source: '2024-01-01 invalid directive' });
       expect(result.content[0].text).toContain('error');
@@ -398,9 +402,13 @@ describe('Tool Handlers', () => {
     // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
     // `validateSource` drops the loader's parse errors, so it answers
     // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not. `it.fails` keeps CI honest
-    // in both directions: red while the bug is here, and red again the moment
-    // it is fixed, so the marker cannot outlive the defect.
+    // assertions are correct; the binding is not.
+    //
+    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
+    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
+    // test, which is the point — the marker cannot outlive the defect, and
+    // whoever fixes the binding is told to delete the `.fails` rather than
+    // discovering a stale skip years later.
     it.fails('returns an error response when parsing fails', () => {
       // Pre-fix this would have silently produced a categorization
       // prompt with an empty accounts list; now it surfaces the parser
@@ -442,9 +450,13 @@ describe('Tool Handlers', () => {
     // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
     // `validateSource` drops the loader's parse errors, so it answers
     // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not. `it.fails` keeps CI honest
-    // in both directions: red while the bug is here, and red again the moment
-    // it is fixed, so the marker cannot outlive the defect.
+    // assertions are correct; the binding is not.
+    //
+    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
+    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
+    // test, which is the point — the marker cannot outlive the defect, and
+    // whoever fixes the binding is told to delete the `.fails` rather than
+    // discovering a stale skip years later.
     it.fails('returns an error response when parsing fails', () => {
       const result = handleToolCall('import_review', {
         source: '@@@ not beancount @@@',

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Only the TypeScript sources. `dist/` holds the compiled copy of these
+    // same tests, so after a build vitest collected each one twice — 212
+    // "tests" for 106 real ones, and any failure reported twice. Harmless
+    // locally, actively confusing in CI, where build runs before test.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
`packages/mcp-server` is published to npm as `@rustledger/mcp-server` and **no PR job touched it**. Only the release workflows built it — so the check happened after the decision.

The concrete cost: an SDK **major** migration (#1879, monolithic `@modelcontextprotocol/sdk` v1 → the scoped v2 packages) went through with zero automated verification. I checked it by hand, which neither scales nor repeats.

## The job

`npm ci` → `npm run build` (tsc) → `npm test` → stdio smoke.

The smoke is there because a green build doesn't mean the server speaks the protocol. It drives the real binary in **both** negotiation directions — a pre-2026 client doing the full `initialize` handshake, and a 2026-07-28 stateless client with no handshake — which is precisely what the v2 migration had to be hand-verified for.

Sabotage-checked three ways, all caught:

| broken server | probe |
|---|---|
| dies on start | caught |
| answers with 0 tools | caught |
| returns a JSON-RPC error | caught |

**No `should_build` gate.** That filter matches Rust sources and this package is TypeScript. Path-filtering on `packages/mcp-server/**` was tempting but would miss the case that actually bites: the server calls into `@rustledger/wasm`, so a Rust change can break it without touching a file here. The job is in the `build` gate, so a failure blocks merge.

## Two fixes needed to make the job meaningful

**`vitest.config.ts` now collects only `src/`.** `dist/` holds the compiled copy of the same tests, so after a build vitest ran each one twice — 212 "tests" for 106 real ones, every failure reported twice. Harmless locally; actively misleading in CI, where build runs before test.

**Three tests marked `it.fails()` against #1884.** While writing this I found that the wasm's `validateSource` drops the loader's parse errors, so it answers `valid: true` for input `rledger check` rejects with `P0012`:

```
"2024-01-01 invalid directive"  -> valid=true  errors=0
"@@@ not beancount @@@"         -> valid=true  errors=0
```

Reproduced against a wasm built from **current main**, not just the published artifact — so every wasm consumer is affected, including rustfava. Root cause and suggested fix are in #1884.

Those three assertions are correct and the binding is not, so they're **pinned, not skipped**. `it.fails` inverts the verdict: the suite is **green while the assertion fails**, and turns **red if it ever passes** — so fixing #1884 breaks these tests by design, and the marker can't outlive the defect.

*(An earlier version of this description and the first commit had this backwards — claiming it was red while the bug exists. Copilot caught it; corrected in `docs(mcp)`.)*

## Verification

- `npm ci` from a clean tree (as CI runs it): builds, 103 pass + 3 expected-fail.
- Smoke script extracted from the YAML and executed for real, not just `bash -n`.
