### PR TITLE
fix(parser): EOF terminates a line, so a malformed last line is reported

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -335,6 +335,13 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     pre-/post-hash NUMBER tokens like red (#1713); inputs with garbage
 ///     around `{a # b}` parse to different `CostNumber` values than v13
 ///     cached them as.
+/// v15: EOF now terminates a line in the parser's error-recovery walkers, so a
+///     malformed FINAL line without a trailing newline emits its diagnostic
+///     (#1884). Previously such a file parsed to zero errors and `rledger
+///     check` exited 0 on it. The cached `errors` differ, and a cache written
+///     by a pre-fix binary would serve the silent-pass result to a fixed one —
+///     resurrecting exactly the bug for every ledger already in the cache,
+///     which is the worst case since the symptom is "no error reported".
 /// v9: `CachedOptions` gained a `set_options: Vec<String>` field
 ///     (#1340). It was previously dropped, so a cache hit lost the
 ///     record of which options the file explicitly set — making
@@ -353,7 +360,7 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     silently ignored `option "display_precision" "USD:0.0001"` (formatting
 ///     fell back to inferred precision) and the other two settings. New fields
 ///     change the archived layout, so old bytes must be regenerated.
-const CACHE_VERSION: u32 = 14;
+const CACHE_VERSION: u32 = 15;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1056,7 +1063,11 @@ mod tests {
         // existing discriminants and payload encodings are unchanged (the
         // arrays below still pin them), and a fixture for the new variant
         // joins them.
-        const FIXTURE_VERSION: u32 = 14;
+        // v15 (#1884) changes WHICH parse errors are emitted, not how anything
+        // is archived, so the byte arrays below still pin the same encoding —
+        // only the fixture version moves. The assertions after this one prove
+        // that rather than assume it.
+        const FIXTURE_VERSION: u32 = 15;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
@@ -1143,7 +1154,9 @@ mod tests {
         // v13 (#1700) added a CostNumber variant; MetaValue's archived
         // layout is untouched, so per the tripwire contract only the
         // fixture version moves.
-        const FIXTURE_VERSION: u32 = 14;
+        // v15 (#1884) is a parser-diagnostics change with no layout impact —
+        // same reasoning, and the hash assertion below is what verifies it.
+        const FIXTURE_VERSION: u32 = 15;
         const META_VALUE_LAYOUT_HASH: &str =
             "43e3c258fe376cede6a6c2c975100bcf67ddda0ab84b21566b123c01e0a54b25";
         assert_eq!(

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -2093,6 +2093,20 @@ fn custom_value_check(
 /// Matches the legacy parser, which fails its inner posting
 /// parser on such lines and recovers by skipping to the next
 /// NEWLINE while emitting a `SyntaxError`.
+/// The `unexpected input` diagnostic for one catch-all transaction-body line.
+///
+/// Mirrors `green::unexpected_body_input`; shared by the newline- and
+/// EOF-terminated sites so the span rule cannot drift between them.
+fn unexpected_body_input(line_start: u32, end: u32, bom_offset: u32) -> crate::ParseError {
+    crate::ParseError::new(
+        crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
+        Span::new(
+            (line_start + bom_offset) as usize,
+            (end + bom_offset) as usize,
+        ),
+    )
+}
+
 fn transaction_body_check(
     child: &crate::SyntaxNode,
     bom_offset: u32,
@@ -2134,15 +2148,7 @@ fn transaction_body_check(
                     }
                     if t.kind() == crate::SyntaxKind::NEWLINE {
                         if line_has_content && let Some(ls) = line_start {
-                            // Skip leading WHITESPACE in the span.
-                            let span =
-                                Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
-                            // Find first non-whitespace position
-                            // for a tighter span matching legacy.
-                            out.push(crate::ParseError::new(
-                                crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
-                                span,
-                            ));
+                            out.push(unexpected_body_input(ls, end, bom_offset));
                         }
                         line_start = None;
                         line_has_content = false;
@@ -2175,10 +2181,7 @@ fn transaction_body_check(
             && let Some(ls) = line_start
         {
             let end: u32 = child.text_range().end().into();
-            out.push(crate::ParseError::new(
-                crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
-                Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize),
-            ));
+            out.push(unexpected_body_input(ls, end, bom_offset));
         }
     }
 }
@@ -2192,6 +2195,46 @@ fn transaction_body_check(
 /// `InvalidAccount`; otherwise → `SyntaxError("unexpected
 /// input")`. `stripped` is the post-BOM-strip source so token
 /// `text_range` indices into it correctly.
+/// Emit the recovery diagnostics for one `ERROR_NODE` line.
+///
+/// Mirrors `green::emit_error_node_line`, and exists for the same reason:
+/// this runs from BOTH the newline-terminated and the EOF-terminated site, and
+/// two inline copies is how the span rule or the secondary BOM diagnostic
+/// drifts between them.
+fn emit_error_node_line(
+    first_non_trivia: Option<crate::SyntaxKind>,
+    line_start: Option<u32>,
+    end: u32,
+    bom_offset: u32,
+    stripped: &str,
+    out: &mut Vec<crate::ParseError>,
+) {
+    let is_section = matches!(first_non_trivia, Some(crate::SyntaxKind::STAR));
+    let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
+    if is_section || is_comment || first_non_trivia.is_none() {
+        return;
+    }
+    let Some(ls) = line_start else { return };
+    // Legacy span INCLUDES the terminator NEWLINE (skip_to_newline consumes it
+    // before span_from is called); at EOF the terminator is the node end.
+    let span = Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
+    let line_text = stripped.get(ls as usize..end as usize).unwrap_or("");
+    let primary = classify_recovery_error(line_text, span);
+    let primary_is_bom = matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
+    out.push(primary);
+    // Additive secondary `BomInDirectiveBody` when a different primary
+    // diagnostic already fired AND the line ALSO contains a BOM byte. Matches
+    // legacy `parser.rs:2258-2263`: without it, a Windows-exported line with
+    // both problems surfaces only the actionable root cause and the user has no
+    // clue the invisible BOM byte is also corrupting the line.
+    if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
+        out.push(
+            crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
+                .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
+        );
+    }
+}
+
 fn error_node_check(
     child: &crate::SyntaxNode,
     stripped: &str,
@@ -2213,39 +2256,7 @@ fn error_node_check(
                 line_start = Some(start);
             }
             if t.kind() == crate::SyntaxKind::NEWLINE {
-                // Decide the line's classification.
-                let is_section = matches!(first_non_trivia, Some(crate::SyntaxKind::STAR));
-                let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
-                if !is_section
-                    && !is_comment
-                    && first_non_trivia.is_some()
-                    && let Some(ls) = line_start
-                {
-                    // Legacy span INCLUDES the terminator NEWLINE
-                    // (skip_to_newline consumes it before
-                    // span_from is called).
-                    let span = Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
-                    let line_text = stripped.get(ls as usize..end as usize).unwrap_or("");
-                    let primary = classify_recovery_error(line_text, span);
-                    let primary_is_bom =
-                        matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
-                    out.push(primary);
-                    // Additive secondary `BomInDirectiveBody` when
-                    // a different primary diagnostic (Unicode
-                    // account / generic syntax) already fired AND
-                    // the line ALSO contains a BOM byte. Matches
-                    // legacy `parser.rs:2258-2263`: without this,
-                    // a Windows-exported line with both problems
-                    // surfaces only the actionable root cause and
-                    // the user has no clue the invisible BOM byte
-                    // is also corrupting the line.
-                    if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
-                        out.push(
-                            crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
-                                .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
-                        );
-                    }
-                }
+                emit_error_node_line(first_non_trivia, line_start, end, bom_offset, stripped, out);
                 line_start = None;
                 first_non_trivia = None;
                 continue;
@@ -2258,26 +2269,8 @@ fn error_node_check(
         // `green::tl_error_node_check`; without it the two paths disagree on
         // any input lacking a trailing newline, and a malformed last line
         // produced no diagnostic at all (#1884).
-        let is_section = matches!(first_non_trivia, Some(crate::SyntaxKind::STAR));
-        let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
-        if !is_section
-            && !is_comment
-            && first_non_trivia.is_some()
-            && let Some(ls) = line_start
-        {
-            let end: u32 = child.text_range().end().into();
-            let span = Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
-            let line_text = stripped.get(ls as usize..end as usize).unwrap_or("");
-            let primary = classify_recovery_error(line_text, span);
-            let primary_is_bom = matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
-            out.push(primary);
-            if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
-                out.push(
-                    crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
-                        .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
-                );
-            }
-        }
+        let end: u32 = child.text_range().end().into();
+        emit_error_node_line(first_non_trivia, line_start, end, bom_offset, stripped, out);
     }
 }
 

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -2168,6 +2168,18 @@ fn transaction_body_check(
                 }
             }
         }
+        // EOF terminates the final body line, same as a NEWLINE. Mirrors
+        // `green::tl_transaction_body_check` (#1884).
+        if past_header
+            && line_has_content
+            && let Some(ls) = line_start
+        {
+            let end: u32 = child.text_range().end().into();
+            out.push(crate::ParseError::new(
+                crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
+                Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize),
+            ));
+        }
     }
 }
 
@@ -2240,6 +2252,30 @@ fn error_node_check(
             }
             if first_non_trivia.is_none() && !is_trivia_kind(t.kind()) {
                 first_non_trivia = Some(t.kind());
+            }
+        }
+        // EOF terminates the final line exactly as a NEWLINE would. Mirrors
+        // `green::tl_error_node_check`; without it the two paths disagree on
+        // any input lacking a trailing newline, and a malformed last line
+        // produced no diagnostic at all (#1884).
+        let is_section = matches!(first_non_trivia, Some(crate::SyntaxKind::STAR));
+        let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
+        if !is_section
+            && !is_comment
+            && first_non_trivia.is_some()
+            && let Some(ls) = line_start
+        {
+            let end: u32 = child.text_range().end().into();
+            let span = Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
+            let line_text = stripped.get(ls as usize..end as usize).unwrap_or("");
+            let primary = classify_recovery_error(line_text, span);
+            let primary_is_bom = matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
+            out.push(primary);
+            if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
+                out.push(
+                    crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
+                        .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
+                );
             }
         }
     }
@@ -2481,6 +2517,14 @@ fn section_marker_check(
         if first_non_trivia.is_none() && !is_trivia_kind(t.kind()) {
             first_non_trivia = Some(t.kind());
         }
+    }
+    // EOF terminates the final line. Mirrors `green::tl_section_marker_check`.
+    if first_non_trivia == Some(crate::SyntaxKind::STAR)
+        && let Some(ls) = line_start
+    {
+        let end: u32 = child.text_range().end().into();
+        let span = Span::new((ls + bom_offset) as usize, (end + bom_offset) as usize);
+        out.push(Spanned::new(String::new(), span));
     }
 }
 

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -735,6 +735,17 @@ fn tl_custom_check(
     }
 }
 
+/// The `unexpected input` diagnostic for one catch-all transaction-body line.
+///
+/// Shared by the newline-terminated and EOF-terminated paths in
+/// [`tl_transaction_body_check`] so the two cannot drift.
+fn unexpected_body_input(line_start: usize, end: usize, bom_offset: u32) -> crate::ParseError {
+    crate::ParseError::new(
+        crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
+        Span::new(line_start + bom_offset as usize, end + bom_offset as usize),
+    )
+}
+
 /// `transaction_body_check` on green: a body line with catch-all tokens (outside
 /// `POSTING` / `META_ENTRY` nodes) is "unexpected input".
 fn tl_transaction_body_check(
@@ -761,12 +772,7 @@ fn tl_transaction_body_check(
                     }
                     if kind == K::NEWLINE {
                         if line_has_content && let Some(ls) = line_start {
-                            let span =
-                                Span::new(ls + bom_offset as usize, end + bom_offset as usize);
-                            out.push(crate::ParseError::new(
-                                crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
-                                span,
-                            ));
+                            out.push(unexpected_body_input(ls, end, bom_offset));
                         }
                         line_start = None;
                         line_has_content = false;
@@ -793,11 +799,60 @@ fn tl_transaction_body_check(
         }
         offset += len;
     }
+    // EOF terminates the final body line just as a newline would. Without this,
+    // a transaction whose last body line is junk AND whose file has no trailing
+    // newline reported one fewer error than the same file with one (#1884).
+    if past_header
+        && line_has_content
+        && let Some(ls) = line_start
+    {
+        out.push(unexpected_body_input(ls, offset, bom_offset));
+    }
+}
+
+/// Emit the recovery diagnostics for one `ERROR_NODE` line.
+///
+/// Split out of [`tl_error_node_check`] so the newline-terminated and the
+/// EOF-terminated line go through the SAME code. Inlining it at both call
+/// sites is how the two would drift.
+fn emit_error_node_line(
+    first_non_trivia: Option<crate::SyntaxKind>,
+    line_start: Option<usize>,
+    end: usize,
+    bom_offset: u32,
+    stripped: &str,
+    out: &mut Vec<crate::ParseError>,
+) {
+    use crate::SyntaxKind as K;
+    let is_section = first_non_trivia == Some(K::STAR);
+    let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
+    if is_section || is_comment || first_non_trivia.is_none() {
+        return;
+    }
+    let Some(ls) = line_start else { return };
+    let span = Span::new(ls + bom_offset as usize, end + bom_offset as usize);
+    let line_text = stripped.get(ls..end).unwrap_or("");
+    let primary = classify_recovery_error(line_text, span);
+    let primary_is_bom = matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
+    out.push(primary);
+    if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
+        out.push(
+            crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
+                .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
+        );
+    }
 }
 
 /// `error_node_check` on green: each `ERROR_NODE` line that is neither a section
 /// marker nor a column-0 comment emits a classified recovery error (+ a
 /// secondary BOM diagnostic when the line also contains a BOM byte).
+///
+/// A line is terminated by a NEWLINE **or by the end of input** — the trailing
+/// newline is optional, and beancount treats EOF as a terminator (its lexer
+/// does, so `bean-check` reports the same error with or without it). Without
+/// the EOF flush below, a malformed LAST line produced no diagnostic at all and
+/// `rledger check` exited 0 on a ledger it had not understood (#1884): two
+/// files differing by one `0a` byte gave opposite verdicts.
 fn tl_error_node_check(
     node: &rowan::GreenNodeData,
     base: usize,
@@ -818,26 +873,7 @@ fn tl_error_node_check(
                 line_start = Some(start);
             }
             if kind == K::NEWLINE {
-                let is_section = first_non_trivia == Some(K::STAR);
-                let is_comment = matches!(first_non_trivia, Some(k) if is_comment_kind(k));
-                if !is_section
-                    && !is_comment
-                    && first_non_trivia.is_some()
-                    && let Some(ls) = line_start
-                {
-                    let span = Span::new(ls + bom_offset as usize, end + bom_offset as usize);
-                    let line_text = stripped.get(ls..end).unwrap_or("");
-                    let primary = classify_recovery_error(line_text, span);
-                    let primary_is_bom =
-                        matches!(primary.kind, crate::ParseErrorKind::BomInDirectiveBody);
-                    out.push(primary);
-                    if !primary_is_bom && line_text.contains(crate::bom::BOM_CHAR) {
-                        out.push(
-                            crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
-                                .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
-                        );
-                    }
-                }
+                emit_error_node_line(first_non_trivia, line_start, end, bom_offset, stripped, out);
                 line_start = None;
                 first_non_trivia = None;
             } else if first_non_trivia.is_none() && !is_trivia_kind(kind) {
@@ -846,10 +882,24 @@ fn tl_error_node_check(
         }
         offset += len;
     }
+    // EOF terminates the final line just as a newline would.
+    emit_error_node_line(
+        first_non_trivia,
+        line_start,
+        offset,
+        bom_offset,
+        stripped,
+        out,
+    );
 }
 
 /// `section_marker_check` on green: emit an empty-string comment for each
 /// `*`-starting (org-mode section) line inside an `ERROR_NODE`.
+///
+/// EOF terminates the final line, same as [`tl_error_node_check`] — a file
+/// ending `* Section` with no trailing newline used to yield no comment at all.
+/// Cosmetic next to the error case, but the same defect, and leaving one of the
+/// three line-walkers newline-only is how the rule gets forgotten.
 fn tl_section_marker_check(
     node: &rowan::GreenNodeData,
     base: usize,
@@ -860,6 +910,19 @@ fn tl_section_marker_check(
     let mut line_start: Option<usize> = None;
     let mut first_non_trivia: Option<crate::SyntaxKind> = None;
     let mut offset = base;
+    let emit = |first_non_trivia: Option<crate::SyntaxKind>,
+                line_start: Option<usize>,
+                end: usize,
+                out: &mut Vec<Spanned<String>>| {
+        if first_non_trivia == Some(K::STAR)
+            && let Some(ls) = line_start
+        {
+            out.push(Spanned::new(
+                String::new(),
+                Span::new(ls + bom_offset as usize, end + bom_offset as usize),
+            ));
+        }
+    };
     for child in node.children() {
         let len = child_len(child);
         if let NodeOrToken::Token(t) = &child {
@@ -869,14 +932,7 @@ fn tl_section_marker_check(
                 line_start = Some(start);
             }
             if kind == K::NEWLINE {
-                if first_non_trivia == Some(K::STAR)
-                    && let Some(ls) = line_start
-                {
-                    out.push(Spanned::new(
-                        String::new(),
-                        Span::new(ls + bom_offset as usize, end + bom_offset as usize),
-                    ));
-                }
+                emit(first_non_trivia, line_start, end, out);
                 line_start = None;
                 first_non_trivia = None;
             } else if first_non_trivia.is_none() && !is_trivia_kind(kind) {
@@ -885,6 +941,7 @@ fn tl_section_marker_check(
         }
         offset += len;
     }
+    emit(first_non_trivia, line_start, offset, out);
 }
 
 #[cfg(test)]

--- a/crates/rustledger-parser/tests/eof_terminates_line.rs
+++ b/crates/rustledger-parser/tests/eof_terminates_line.rs
@@ -1,0 +1,145 @@
+//! A malformed FINAL line must be reported whether or not the file ends with a
+//! newline (#1884).
+//!
+//! `rledger check` exited 0 on a ledger whose last line it had not understood,
+//! purely because the file lacked a trailing `\n` — two files differing by one
+//! `0a` byte gave opposite verdicts. Python beancount reports the same error
+//! either way (its lexer treats EOF as a terminator), so this was a plain
+//! compatibility defect, not a deliberate deviation.
+//!
+//! The error-recovery walkers flushed a pending line only on `NEWLINE` and had
+//! no EOF flush, in BOTH the green and red conversion paths.
+
+/// The reported case: garbage with and without the trailing newline agree.
+#[test]
+fn a_malformed_final_line_is_reported_without_a_trailing_newline() {
+    for body in [
+        "@@@ not beancount @@@",
+        "2024-01-01 invalid directive",
+        "2024-01-01 open Assets:Cash USD\n@@@ garbage @@@",
+    ] {
+        let without = rustledger_parser::parse(body);
+        let with = rustledger_parser::parse(&format!("{body}\n"));
+        assert!(
+            !without.errors.is_empty(),
+            "no diagnostic for {body:?} without a trailing newline — this is \
+             the silent pass of #1884"
+        );
+        assert_eq!(
+            without.errors.len(),
+            with.errors.len(),
+            "{body:?}: error count depends on the trailing newline"
+        );
+    }
+}
+
+/// A transaction body's last line is covered too, not just top level.
+#[test]
+fn a_malformed_final_body_line_is_reported_without_a_trailing_newline() {
+    let body = "2024-01-01 * \"x\"\n  Assets:A  1 USD\n  @@@ junk";
+    let without = rustledger_parser::parse(body);
+    let with = rustledger_parser::parse(&format!("{body}\n"));
+    assert!(!without.errors.is_empty(), "body junk went unreported");
+    assert_eq!(without.errors.len(), with.errors.len());
+}
+
+/// A trailing org-mode section marker still yields its comment.
+#[test]
+fn a_final_section_marker_is_recorded_without_a_trailing_newline() {
+    let without = rustledger_parser::parse("* Section");
+    let with = rustledger_parser::parse("* Section\n");
+    assert_eq!(without.comments.len(), 1, "section comment dropped at EOF");
+    assert_eq!(without.comments.len(), with.comments.len());
+}
+
+/// The flush must not INVENT diagnostics: valid or empty tails stay clean.
+///
+/// The risk of "flush whatever is pending at EOF" is firing on a line that was
+/// never a problem, which would be a far worse regression than the bug.
+#[test]
+fn the_eof_flush_does_not_invent_errors() {
+    for body in [
+        "",
+        "   ",
+        "\n\n",
+        "; a trailing comment",
+        "2024-01-01 open Assets:Cash USD",
+        "2024-01-01 open Assets:Cash USD\n2024-01-02 close Assets:Cash",
+        "option \"title\" \"x\"",
+        "* Section",
+    ] {
+        let r = rustledger_parser::parse(body);
+        assert!(
+            r.errors.is_empty(),
+            "{body:?} must parse clean, got {:?}",
+            r.errors.iter().map(ToString::to_string).collect::<Vec<_>>()
+        );
+    }
+}
+
+/// Green and red must agree on unterminated input.
+///
+/// Green is gated by a differential oracle against red, and `parse_red_only`
+/// is the hook that oracle uses. Fixing only green would have made the two
+/// disagree on exactly the inputs this is about — the existing corpus contains
+/// no unterminated case, so nothing would have caught it. Verified by
+/// sabotage: removing either path's EOF flush fails this.
+#[test]
+fn green_and_red_agree_on_unterminated_input() {
+    for body in [
+        "@@@ garbage @@@",
+        "* section header",
+        "2024-01-01 open Assets:A USD\n@@@ junk",
+        "2024-01-01 * \"x\"\n  Assets:A 1 USD\n  @@@ junk",
+        "2024-01-01 open Assets:A USD",
+        "; trailing comment",
+        "",
+        "   ",
+        "\n\n@@@ x",
+    ] {
+        let green = rustledger_parser::parse(body);
+        let red = rustledger_parser::cst::parse_red_only(body);
+        assert_eq!(
+            green.errors.len(),
+            red.errors.len(),
+            "{body:?}: green {} errors, red {} — the differential oracle's \
+             invariant is broken",
+            green.errors.len(),
+            red.errors.len()
+        );
+        assert_eq!(
+            green.comments.len(),
+            red.comments.len(),
+            "{body:?}: comment counts differ between green and red"
+        );
+        assert_eq!(
+            green.directives.len(),
+            red.directives.len(),
+            "{body:?}: directive counts differ between green and red"
+        );
+    }
+}
+
+/// The newline makes no difference, on either path.
+#[test]
+fn the_trailing_newline_does_not_change_the_parse() {
+    for body in [
+        "@@@ garbage @@@",
+        "* section header",
+        "2024-01-01 open Assets:A USD\n@@@ junk",
+        "2024-01-01 * \"x\"\n  Assets:A 1 USD\n  @@@ junk",
+    ] {
+        for parse in [
+            rustledger_parser::parse as fn(&str) -> rustledger_parser::ParseResult,
+            rustledger_parser::cst::parse_red_only,
+        ] {
+            let a = parse(body);
+            let b = parse(&format!("{body}\n"));
+            assert_eq!(
+                (a.errors.len(), a.comments.len(), a.directives.len()),
+                (b.errors.len(), b.comments.len(), b.directives.len()),
+                "{body:?}: the trailing newline changed the parse"
+            );
+        }
+    }
+}

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -293,6 +293,12 @@ describe('Tool Handlers', () => {
     // test, which is the point — the marker cannot outlive the defect, and
     // whoever fixes the binding is told to delete the `.fails` rather than
     // discovering a stale skip years later.
+    //
+    // #1884 is FIXED in the parser (EOF now terminates a line), but this
+    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
+    // clears on the next release rather than at that merge. When a release
+    // lands and this turns red, delete the `.fails` — that is the signal, not
+    // a regression.
     it.fails('should report validation errors', () => {
       const result = handleToolCall('validate', { source: '2024-01-01 invalid directive' });
       expect(result.content[0].text).toContain('error');
@@ -409,6 +415,12 @@ describe('Tool Handlers', () => {
     // test, which is the point — the marker cannot outlive the defect, and
     // whoever fixes the binding is told to delete the `.fails` rather than
     // discovering a stale skip years later.
+    //
+    // #1884 is FIXED in the parser (EOF now terminates a line), but this
+    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
+    // clears on the next release rather than at that merge. When a release
+    // lands and this turns red, delete the `.fails` — that is the signal, not
+    // a regression.
     it.fails('returns an error response when parsing fails', () => {
       // Pre-fix this would have silently produced a categorization
       // prompt with an empty accounts list; now it surfaces the parser
@@ -457,6 +469,12 @@ describe('Tool Handlers', () => {
     // test, which is the point — the marker cannot outlive the defect, and
     // whoever fixes the binding is told to delete the `.fails` rather than
     // discovering a stale skip years later.
+    //
+    // #1884 is FIXED in the parser (EOF now terminates a line), but this
+    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
+    // clears on the next release rather than at that merge. When a release
+    // lands and this turns red, delete the `.fails` — that is the signal, not
+    // a regression.
     it.fails('returns an error response when parsing fails', () => {
       const result = handleToolCall('import_review', {
         source: '@@@ not beancount @@@',


### PR DESCRIPTION
`rledger check` exited **0** on a ledger whose final line it had not understood, whenever the file lacked a trailing newline. Two files differing by one `0a` byte gave opposite verdicts:

```
$ rledger check no_nl.bean      # ends "2024-01-01 invalid directive"
exit=0   no errors
$ rledger check with_nl.bean    # same, plus "\n"
exit=1   P0012
```

Silent acceptance is the worst failure mode for a validator — nothing prompts the user to look.

Reported as a wasm bug in #1884 because my repro strings had no trailing newline. **My diagnosis there was wrong**; it's neither wasm-specific nor new. I corrected the issue before writing this.

## Not a deliberate deviation

Checked against **beancount 3.2.3** directly rather than reasoning about it — it reports the same error with or without the newline (its lexer treats EOF as a terminator), so we were simply the less correct side. No `KNOWN_RUST_DIVERGENCES` entry, no deviation checklist.

| fixture | beancount | rustledger (before) | rustledger (after) |
|---|---|---|---|
| `no_nl` | exit 1 | **exit 0** | exit 1 |
| `g_no_nl` | exit 1 | **exit 0** | exit 1 |
| `mix_no_nl` | exit 1 | **exit 0** | exit 1 |
| `*_with_nl` (3) | exit 1 | exit 1 | exit 1 |

## Cause

Three error-recovery line-walkers flush a pending line only on `NEWLINE`, with no EOF flush — so a final unterminated line was never emitted: `error_node_check` (top-level junk), `transaction_body_check` (junk in a transaction body), `section_marker_check` (org-mode markers → comments).

**Fixed in both conversion paths.** Green alone would have been worse than nothing: green is pinned byte-identical to red by a differential oracle, the existing corpus contains no unterminated input, and the divergence would have sat there silently until some input bailed to red. I found this by sabotage — removing red's flush changed nothing, which showed my red change was unverified until the test drove `parse_red_only` explicitly.

The shared emit is factored out per path rather than inlined at both call sites; a copy at the newline site and another at the EOF site is exactly how these two drift apart again.

## `CACHE_VERSION` 14 → 15

The parse output changes and the on-disk cache stores it. Without the bump, a cache written by a pre-fix binary serves the silent-pass result to a fixed one — resurrecting the bug for every already-cached ledger, where the symptom is *"no error reported"*.

Caught because `rledger check` **still exited 0** after the parser was fixed, while `--no-cache` exited 1.

Both cache tripwires fired and were resolved by moving `FIXTURE_VERSION` only: this changes which diagnostics are emitted, not any archived layout — and the byte/hash assertions that follow the version check prove that rather than assume it.

## Verification

- Workspace tests green; clippy clean.
- All six CLI fixtures match beancount.
- New `eof_terminates_line.rs`: 6 tests, including one that the EOF flush must **not invent** errors on valid/empty/comment tails, and a green-vs-red parity test via `parse_red_only`.
- Sabotage-verified: removing either path's flush independently fails the suite.
- A wasm built from this tree returns `valid: false, errors: 1, P0012` for inputs that returned `valid: true`; `query`/`balances`/`parse` report through the same path.

## Note for reviewers

The `it.fails` markers in `packages/mcp-server` **stay**. That package depends on the *published* `@rustledger/wasm`, so they clear on the next release, not at this merge. Comment updated to say so, since otherwise the next person sees a fixed bug with a live marker and assumes it's stale.

Closes #1884.