### PR TITLE
fix(report): bucket networth weeks by ISO week-year, not calendar year

### DIFF
--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -260,11 +260,16 @@ impl Executor<'_> {
             "MONTH" => i64::from(date.month()),
             "DAY" => i64::from(date.day()),
             "QUARTER" => i64::from(rustledger_core::quarter_index0(date.month() as u32) + 1),
-            "WEEK" => {
-                // ISO week number via strftime %V
-                let week_str = jiff::fmt::strtime::format("%V", date).unwrap_or_default();
-                week_str.trim().parse::<i64>().unwrap_or(0)
-            }
+            // Typed accessor, not a `%V` format-then-parse round trip: that
+            // spelling carried `unwrap_or_default()` + `unwrap_or(0)`, so any
+            // failure silently reported week 0 rather than erroring (#1864).
+            //
+            // NOTE for callers: this is the ISO week NUMBER alone. Pairing it
+            // with `DATE_PART(date, 'YEAR')` to build a label is wrong at a year
+            // boundary — 2024-12-31 is week 1 of ISO year 2025, not 2024. BQL
+            // exposes no ISO-week-year field; use `DATE_TRUNC('WEEK', date)`,
+            // which returns the week's Monday and cannot be mismatched.
+            "WEEK" => i64::from(date.iso_week_date().week()),
             "WEEKDAY" | "DOW" => i64::from(date.weekday().to_monday_zero_offset()),
             "DOY" => {
                 let jan1 = jiff::civil::date(date.year(), 1, 1);

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -63,15 +63,26 @@ pub(super) fn report_networth<W: Write>(
     let format_period = |date: rustledger_core::NaiveDate, period: &str| -> String {
         match period {
             "daily" => date.to_string(),
-            "weekly" => format!(
-                "{}-W{:02}",
-                date.year(),
-                jiff::fmt::strtime::format("%V", date)
-                    .unwrap_or_default()
-                    .trim()
-                    .parse::<u32>()
-                    .unwrap_or(0)
-            ),
+            // Bucket by the ISO week's Monday, then label from THAT date.
+            //
+            // Two bugs lived in the previous spelling. It paired the ISO week
+            // number (`%V`) with the CALENDAR year, and those disagree across a
+            // year boundary: 2024-12-31 is ISO 2025-W01 but was labeled
+            // `2024-W01`, colliding with the real 2024-W01 and silently summing
+            // two different weeks into one row (#1864). And it went through
+            // `format(...).unwrap_or_default().parse().unwrap_or(0)` — two
+            // silent fallbacks, either of which would have labeled every row
+            // `W00` and collapsed the whole report into a single bucket.
+            //
+            // `CalendarPeriod::Week` is the shared definition of "which week is
+            // this", already used by BQL's `DATE_TRUNC('WEEK', ...)`. Deriving
+            // both the bucket and its label from one `start_of` makes them
+            // agree by construction rather than by coincidence.
+            "weekly" => {
+                let start = rustledger_core::CalendarPeriod::Week.start_of(date);
+                let iso = start.iso_week_date();
+                format!("{}-W{:02}", iso.year(), iso.week())
+            }
             "yearly" => format!("{}", date.year()),
             _ => format!("{}-{:02}", date.year(), date.month()),
         }

--- a/crates/rustledger/tests/report_networth_period_test.rs
+++ b/crates/rustledger/tests/report_networth_period_test.rs
@@ -1,0 +1,147 @@
+//! `rledger report networth --period` — bucketing and labeling.
+//!
+//! The weekly bucket used to be labeled from the ISO week NUMBER paired with
+//! the CALENDAR year, and those disagree at a year boundary: 2024-12-31 is ISO
+//! week 1 of 2025 but rendered `2024-W01`, colliding with the real 2024-W01 and
+//! silently summing two different weeks into one row (#1864). Nothing on screen
+//! said a merge had happened, so the reported net worth for early January was
+//! simply wrong.
+
+mod common;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Two transactions in ISO weeks that collide under the buggy label: one in
+/// 2024-W01, one in 2025-W01 (which falls on 2024-12-31, a CALENDAR-2024 date).
+const YEAR_BOUNDARY: &str = r#"option "operating_currency" "USD"
+
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:Opening
+
+2024-01-03 * "early jan — ISO 2024-W01"
+  Assets:Cash    100.00 USD
+  Equity:Opening
+
+2024-12-31 * "new year eve — ISO 2025-W01"
+  Assets:Cash    200.00 USD
+  Equity:Opening
+"#;
+
+fn write_fixture(source: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("report-networth-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(source.as_bytes()).expect("write fixture");
+    f
+}
+
+fn run(binary: &PathBuf, args: &[&str]) -> String {
+    let out = Command::new(binary)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run rledger {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "rledger {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Weeks in different ISO years are different buckets.
+#[test]
+fn weeks_in_different_iso_years_do_not_share_a_bucket() {
+    let bin = require_rledger!();
+    let f = write_fixture(YEAR_BOUNDARY);
+    let path = f.path().to_str().unwrap();
+    let csv = run(
+        &bin,
+        &[
+            "report", path, "networth", "--period", "weekly", "--format", "csv",
+        ],
+    );
+
+    let rows = csv.lines().filter(|l| l.starts_with("20")).count();
+    assert_eq!(
+        rows, 2,
+        "the two dates are in different ISO weeks and must not merge; got:\n{csv}"
+    );
+
+    // 2024-12-31 is ISO week 1 of 2025 — labeled by the ISO week-YEAR, not the
+    // calendar year it happens to fall in.
+    assert!(csv.contains("2024-W01"), "missing the 2024-W01 row:\n{csv}");
+    assert!(
+        csv.contains("2025-W01"),
+        "2024-12-31 belongs to ISO 2025-W01; a `2024-W01` label here is the \
+         collision this test exists for:\n{csv}"
+    );
+}
+
+/// The amounts land in the right buckets, not merely in separate rows.
+///
+/// A label fix that still bucketed by the old key would produce two rows with
+/// the wrong contents, and a row-count assertion alone would pass.
+#[test]
+fn each_iso_week_carries_its_own_running_total() {
+    let bin = require_rledger!();
+    let f = write_fixture(YEAR_BOUNDARY);
+    let path = f.path().to_str().unwrap();
+    let csv = run(
+        &bin,
+        &[
+            "report", path, "networth", "--period", "weekly", "--format", "csv",
+        ],
+    );
+
+    let row = |label: &str| -> String {
+        csv.lines()
+            .find(|l| l.starts_with(label))
+            .unwrap_or_else(|| panic!("no {label} row in:\n{csv}"))
+            .to_string()
+    };
+    // Net worth is cumulative: the first week holds 100, and by the last week
+    // the running total is 300.
+    assert!(
+        row("2024-W01").contains("100.00"),
+        "2024-W01 should hold only the early-January 100.00: {}",
+        row("2024-W01")
+    );
+    assert!(
+        row("2025-W01").contains("300.00"),
+        "2025-W01 is cumulative and should hold 300.00: {}",
+        row("2025-W01")
+    );
+}
+
+/// The other periods are unaffected — they use calendar fields with no
+/// week-year mismatch, and the fix must not disturb them.
+#[test]
+fn monthly_and_yearly_buckets_are_unchanged() {
+    let bin = require_rledger!();
+    let f = write_fixture(YEAR_BOUNDARY);
+    let path = f.path().to_str().unwrap();
+
+    let monthly = run(
+        &bin,
+        &[
+            "report", path, "networth", "--period", "monthly", "--format", "csv",
+        ],
+    );
+    assert!(monthly.contains("2024-01"), "monthly:\n{monthly}");
+    assert!(monthly.contains("2024-12"), "monthly:\n{monthly}");
+
+    let yearly = run(
+        &bin,
+        &[
+            "report", path, "networth", "--period", "yearly", "--format", "csv",
+        ],
+    );
+    // Both dates are in CALENDAR 2024, so yearly is a single bucket — the
+    // calendar year is the right key here, unlike for ISO weeks.
+    let rows = yearly.lines().filter(|l| l.starts_with("20")).count();
+    assert_eq!(rows, 1, "both dates are calendar-2024:\n{yearly}");
+}


### PR DESCRIPTION
Closes #1864.

`report networth --period weekly` labeled a bucket with the ISO week **number** paired with the **calendar** year. Those disagree at a year boundary, so `2024-12-31` — ISO week 1 of **2025** — rendered `2024-W01`, collided with the real 2024-W01, and the two weeks were silently summed:

```
$ rledger report nw.beancount networth --period weekly --format csv
period,currency,amount
2024-W01,USD,300.00        ← one row; two different weeks
```

Early-January net worth was overstated by an entire later week, with nothing on screen indicating a merge. After:

```
2024-W01,USD,100.00
2025-W01,USD,300.00
```

## The fix

Bucketed by `CalendarPeriod::Week.start_of(date)`, with the label derived from that same start date — so bucket and label agree by construction rather than by coincidence.

That's the shared definition of "which week is this", already used by BQL's `DATE_TRUNC('WEEK', …)` and the budget report. Networth was a third spelling, which is exactly the drift CLAUDE.md's canonical-function rule is about.

## The old code was worse than the collision alone

```rust
jiff::fmt::strtime::format("%V", date)
    .unwrap_or_default()      // format fails → ""
    .trim().parse::<u32>()
    .unwrap_or(0)             // parse fails  → week 0
```

Two silent fallbacks in a *labeling* function. Either firing would label every row `W00` and collapse the whole report into one bucket, with no error — a strictly worse version of the reported bug.

## `DATE_PART(date, 'WEEK')`

Shared the same `%V` round-trip and both fallbacks; now uses the typed `iso_week_date().week()`.

Its **value** was already correct — a bare ISO week number — so this isn't a second instance of the bug. But I left a note there: BQL exposes no ISO-week-year field, so pairing `DATE_PART('WEEK')` with `DATE_PART('YEAR')` walks into the same trap. `DATE_TRUNC('WEEK', date)` returns the Monday and can't be mismatched.

## Tests

Three, in a new `report_networth_period_test.rs`:

1. the two dates don't share a bucket, and both ISO labels appear;
2. each bucket carries the right **amount** — a label-only fix that still bucketed by the old key would produce two rows with wrong contents, and a row-count assertion alone would pass;
3. `monthly`/`yearly` are undisturbed.

All three sabotage-verified: reverting the label fails (1) and (2); perturbing the yearly bucket fails (3).

## Scope

Only `weekly` was affected — `daily`, `monthly` and `yearly` use calendar fields with no week-year mismatch.