### PR TITLE
fix(core): report Decimal overflow instead of panicking the CLI

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -633,7 +633,12 @@ impl BookingEngine {
             // `CostSpec::resolve`). `apply`'s callers book first, which fills the
             // inferred currency into `cost_spec.currency`; direct-`apply` tests use
             // explicit-currency fixtures, which need no inference.
-            inv.add(Position::from_posting(units, posting.cost.as_ref(), date));
+            // `try_add`, not `add`: this is the user-reachable path into an
+            // inventory, and an overflow here used to panic and take out every
+            // command including `check` (#1863). The error carries the currency
+            // and is wrapped with the account by the caller.
+            inv.try_add(Position::from_posting(units, posting.cost.as_ref(), date))
+                .map_err(|e| convert_core_booking_error(e, &posting.account))?;
         }
         Ok(())
     }
@@ -655,8 +660,35 @@ impl BookingEngine {
     /// at market** (`rustledger-returns`), never `apply`, so a re-merged
     /// booking-failed transaction cannot over-sell it.
     pub fn apply(&mut self, txn: &Transaction) {
+        let _ = self.apply_checked(txn);
+    }
+
+    /// [`Self::apply`], returning an arithmetic overflow instead of dropping it.
+    ///
+    /// Only overflow is reported. A failed REDUCTION is still ignored here (see
+    /// `apply`'s contract: the transaction must already be booked, and the
+    /// `debug_assert` below catches a violating caller in debug builds).
+    /// Overflow is a different thing — not a caller-contract violation but a
+    /// property of the numbers in the user's file — so it must reach the
+    /// loader's error list rather than abort or vanish (#1863).
+    ///
+    /// # Errors
+    /// [`BookingError::Overflow`] if a posting's amount took an inventory
+    /// total outside `Decimal`'s range.
+    pub fn apply_checked(&mut self, txn: &Transaction) -> Result<(), BookingError> {
+        let mut overflow = None;
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
+            if let Err(e) = &reduced
+                && matches!(
+                    e,
+                    BookingError::Inventory(a)
+                        if matches!(a.error, rustledger_core::BookingError::Overflow { .. })
+                )
+            {
+                overflow.get_or_insert_with(|| e.clone());
+                continue;
+            }
             debug_assert!(
                 reduced.is_ok(),
                 "apply() reduction failed — the transaction must be booked \
@@ -668,6 +700,7 @@ impl BookingEngine {
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;
         }
+        overflow.map_or(Ok(()), Err)
     }
 
     /// Book and interpolate a transaction.

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -316,17 +316,61 @@ pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Op
 /// reproduces the precise path's arithmetic byte-for-byte.
 trait WeightNum: Clone + Default + std::ops::AddAssign + std::ops::Mul<Output = Self> {
     fn from_decimal(d: Decimal) -> Self;
+
+    /// `self * rhs`, clamped instead of panicking.
+    ///
+    /// `Decimal`'s `*` PANICS on overflow, and this weight ladder runs during
+    /// interpolation on every costed posting — so units near `Decimal::MAX` at
+    /// a large per-unit cost aborted `rledger check` (#1863). `BigDecimal`
+    /// cannot overflow, so its impl is the plain product and the precise
+    /// residual tier is unaffected.
+    fn saturating_mul(self, rhs: Self) -> Self;
+
+    /// `self += rhs`, clamped instead of panicking. Same reasoning.
+    fn saturating_add_assign(&mut self, rhs: Self);
 }
 
 impl WeightNum for Decimal {
     fn from_decimal(d: Decimal) -> Self {
         d
     }
+
+    fn saturating_mul(self, rhs: Self) -> Self {
+        self.checked_mul(rhs).unwrap_or({
+            // A product is negative exactly when the operands' signs differ.
+            if self.is_sign_negative() == rhs.is_sign_negative() {
+                Self::MAX
+            } else {
+                Self::MIN
+            }
+        })
+    }
+
+    fn saturating_add_assign(&mut self, rhs: Self) {
+        *self = self.checked_add(rhs).unwrap_or({
+            // Mixed signs cannot overflow an addition, so the direction is
+            // whichever sign both operands share.
+            if self.is_sign_negative() || rhs.is_sign_negative() {
+                Self::MIN
+            } else {
+                Self::MAX
+            }
+        });
+    }
 }
 
 impl WeightNum for BigDecimal {
     fn from_decimal(d: Decimal) -> Self {
         to_big(d)
+    }
+
+    fn saturating_mul(self, rhs: Self) -> Self {
+        // Arbitrary precision: no ceiling to saturate at.
+        self * rhs
+    }
+
+    fn saturating_add_assign(&mut self, rhs: Self) {
+        *self += rhs;
     }
 }
 
@@ -383,20 +427,20 @@ fn cost_number_weight_generic<D: WeightNum>(
     // `per_unit`. `PerUnit` goes through multiplication.
     match *number {
         rustledger_core::CostNumber::Total { value: total } => {
-            D::from_decimal(total) * D::from_decimal(signum)
+            D::from_decimal(total).saturating_mul(D::from_decimal(signum))
         }
         rustledger_core::CostNumber::PerUnitFromTotal(b) => {
-            D::from_decimal(b.total) * D::from_decimal(signum)
+            D::from_decimal(b.total).saturating_mul(D::from_decimal(signum))
         }
         rustledger_core::CostNumber::PerUnit { value: per_unit } => {
-            D::from_decimal(units_number) * D::from_decimal(per_unit)
+            D::from_decimal(units_number).saturating_mul(D::from_decimal(per_unit))
         }
         // Compound `{a # b}` (beancount compound_amount): the cost totals
         // `N*a + b`, so the weight is the per-unit product (sign embedded
         // in `units`) plus the signed lump total (#1700).
         rustledger_core::CostNumber::Compound { per_unit, total } => {
-            let mut w = D::from_decimal(units_number) * D::from_decimal(per_unit);
-            w += D::from_decimal(total) * D::from_decimal(signum);
+            let mut w = D::from_decimal(units_number).saturating_mul(D::from_decimal(per_unit));
+            w.saturating_add_assign(D::from_decimal(total).saturating_mul(D::from_decimal(signum)));
             w
         }
     }

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -133,7 +133,21 @@ impl Cost {
     /// Calculate the total cost for a given number of units.
     #[must_use]
     pub fn total_cost(&self, units: Decimal) -> Amount {
-        Amount::new(units * self.number, self.currency.clone())
+        // Saturating, not `*`. `Decimal`'s multiplication panics on overflow,
+        // and this is reached from `Position::book_value` -> `Inventory::
+        // book_value`, i.e. from any report that totals a cost basis — so a
+        // ledger holding large units at a large cost aborted the process
+        // (#1863). `Inventory` records the saturation in `overflowed()`.
+        //
+        // The product is negative exactly when the operands' signs differ.
+        let total = units.checked_mul(self.number).unwrap_or({
+            if units.is_sign_negative() == self.number.is_sign_negative() {
+                Decimal::MAX
+            } else {
+                Decimal::MIN
+            }
+        });
+        Amount::new(total, self.currency.clone())
     }
 }
 

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -154,6 +154,17 @@ pub enum BookingError {
         /// Units available.
         available: Decimal,
     },
+    /// Arithmetic exceeded `Decimal`'s range.
+    ///
+    /// Only reachable from amounts near `Decimal::MAX` (~7.9e28), which no
+    /// real ledger holds — but it is reachable from any file a user can
+    /// write, and it used to panic rather than report (#1863).
+    Overflow {
+        /// The currency whose running total overflowed.
+        currency: crate::Currency,
+        /// Which operation overflowed, for the message.
+        operation: &'static str,
+    },
     /// Currency mismatch between reduction and inventory.
     CurrencyMismatch {
         /// Expected currency.
@@ -161,6 +172,37 @@ pub enum BookingError {
         /// Got currency.
         got: crate::Currency,
     },
+}
+
+/// The clamped stand-in for a sum that does not fit in `Decimal`.
+///
+/// Direction is taken from the operands: two positives overflow upward, two
+/// negatives downward. Mixed signs cannot overflow an addition, so the
+/// `is_sign_negative` test on `b` is only ever reached with matching signs.
+///
+/// This value is deliberately NOT presented as a result on its own — every
+/// caller sets `Inventory::overflowed` alongside it, and `try_add` converts
+/// that into a `BookingError`. It exists so the process survives long enough
+/// to report, not so the number can be used.
+const fn saturated(a: Decimal, b: Decimal) -> Decimal {
+    if a.is_sign_negative() || b.is_sign_negative() {
+        Decimal::MIN
+    } else {
+        Decimal::MAX
+    }
+}
+
+/// The clamped stand-in for a PRODUCT that does not fit in `Decimal`.
+///
+/// A product is negative exactly when the operands' signs differ, so the
+/// direction is their xor — unlike [`saturated`], where mixed signs cannot
+/// overflow at all.
+const fn saturated_mul(a: Decimal, b: Decimal) -> Decimal {
+    if a.is_sign_negative() == b.is_sign_negative() {
+        Decimal::MAX
+    } else {
+        Decimal::MIN
+    }
 }
 
 impl fmt::Display for BookingError {
@@ -190,6 +232,14 @@ impl fmt::Display for BookingError {
             Self::CurrencyMismatch { expected, got } => {
                 write!(f, "Currency mismatch: expected {expected}, got {got}")
             }
+            Self::Overflow {
+                currency,
+                operation,
+            } => write!(
+                f,
+                "Arithmetic overflow in {operation} for {currency}: the amount exceeds \
+                 the representable range (about 7.9e28)"
+            ),
         }
     }
 }
@@ -269,6 +319,15 @@ impl fmt::Display for AccountedBookingError {
             BookingError::CurrencyMismatch { got, .. } => {
                 write!(f, "No matching lot for {} in {}", got, self.account)
             }
+            BookingError::Overflow {
+                currency,
+                operation,
+            } => write!(
+                f,
+                "Arithmetic overflow in {} for {} in {}: the amount exceeds the \
+                 representable range (about 7.9e28)",
+                operation, currency, self.account
+            ),
         }
     }
 }
@@ -332,6 +391,18 @@ pub struct Inventory {
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
     units_cache: FxHashMap<crate::Currency, Decimal>,
+    /// Set when any arithmetic in this inventory saturated at `Decimal`'s
+    /// range instead of producing the true value.
+    ///
+    /// `Decimal` is 96-bit (~7.9e28) and its `+`/`*` PANIC on overflow, so a
+    /// ledger holding amounts near `Decimal::MAX` used to abort `rledger
+    /// check` — the very command a user runs to find out what is wrong with
+    /// their file (#1863). Saturating keeps the process alive; this flag is
+    /// what stops the saturated number being reported as if it were exact.
+    ///
+    /// Propagated by every operation that derives one inventory from another,
+    /// so a total computed from a saturated inventory stays marked.
+    overflowed: bool,
 }
 
 impl PartialEq for Inventory {
@@ -494,11 +565,50 @@ impl Inventory {
             if pos.units.currency == units_currency
                 && let Some(book) = pos.book_value()
             {
-                *totals.entry(book.currency.clone()).or_default() += book.number;
+                // Checked: a derived total can overflow even when no single
+                // position does (#1863). Saturates rather than panicking; the
+                // caller sees `overflowed()` on the source inventory.
+                let slot = totals.entry(book.currency.clone()).or_default();
+                *slot = slot
+                    .checked_add(book.number)
+                    .unwrap_or_else(|| saturated(*slot, book.number));
             }
         }
 
         totals
+    }
+
+    /// Whether any arithmetic in this inventory saturated instead of
+    /// producing the true value.
+    ///
+    /// Sticky, and propagated by operations that derive one inventory from
+    /// another, so a total computed from a saturated inventory stays marked.
+    #[must_use]
+    pub const fn overflowed(&self) -> bool {
+        self.overflowed
+    }
+
+    /// [`Self::add`], reporting overflow instead of saturating silently.
+    ///
+    /// This is what the booking engine calls, so a ledger holding amounts near
+    /// `Decimal::MAX` produces a diagnostic naming the account and currency
+    /// rather than aborting the process (#1863).
+    ///
+    /// # Errors
+    /// [`BookingError::Overflow`] if the addition left `Decimal`'s range. The
+    /// inventory is still mutated (to the saturated value) — the error is the
+    /// signal that the stored number is not exact.
+    pub fn try_add(&mut self, position: Position) -> Result<(), BookingError> {
+        let currency = position.units.currency.clone();
+        let before = self.overflowed;
+        self.add(position);
+        if self.overflowed && !before {
+            return Err(BookingError::Overflow {
+                currency,
+                operation: "adding a position",
+            });
+        }
+        Ok(())
     }
 
     /// Add a position to the inventory.
@@ -510,11 +620,18 @@ impl Inventory {
     /// Lot aggregation for display purposes is handled separately at output time
     /// (e.g., in the query result formatter).
     ///
+    /// Arithmetic saturates rather than panicking, recording the fact in
+    /// [`Self::overflowed`]. Use [`Self::try_add`] where the overflow must be
+    /// reported rather than merely recorded.
+    ///
     /// # TLA+ Specification
     ///
     /// Implements `AddAmount` action from `Conservation.tla`:
     /// - Invariant: `inventory + totalReduced = totalAdded`
     /// - After add: `totalAdded' = totalAdded + amount`
+    ///
+    /// Note the spec models unbounded integers, so it cannot express the
+    /// saturation above — a regression there would not be caught by the model.
     ///
     /// See: `spec/tla/Conservation.tla`
     pub fn add(&mut self, position: Position) {
@@ -522,18 +639,43 @@ impl Inventory {
             return;
         }
 
-        // Update units cache
-        *self
+        // Checked, not `+=`. `Decimal`'s `+` panics on overflow, and this runs
+        // in the loader's booking phase, so a ledger holding amounts near
+        // `Decimal::MAX` aborted every command including `check` (#1863).
+        //
+        // Saturating rather than erroring keeps this signature: `add` has ~250
+        // call sites. The saturation is recorded in `overflowed` so it cannot
+        // pass for an exact result — `try_add` below turns it into a
+        // `BookingError`, and that is what the booking engine calls.
+        let cache = self
             .units_cache
             .entry(position.units.currency.clone())
-            .or_default() += position.units.number;
+            .or_default();
+        if let Some(sum) = cache.checked_add(position.units.number) {
+            *cache = sum;
+        } else {
+            *cache = saturated(*cache, position.units.number);
+            self.overflowed = true;
+        }
 
         // For positions without cost, use index for O(1) lookup
         if position.cost.is_none() {
             if let Some(&idx) = self.simple_index.get(&position.units.currency) {
                 // Merge with existing position
                 debug_assert!(self.positions[idx].cost.is_none());
-                self.positions[idx].units += &position.units;
+                // Same reasoning as the units cache above: checked, saturating,
+                // and flagged rather than panicking.
+                if let Some(sum) = self.positions[idx]
+                    .units
+                    .number
+                    .checked_add(position.units.number)
+                {
+                    self.positions[idx].units.number = sum;
+                } else {
+                    self.positions[idx].units.number =
+                        saturated(self.positions[idx].units.number, position.units.number);
+                    self.overflowed = true;
+                }
                 return;
             }
             // No existing position - add new one and index it
@@ -623,15 +765,22 @@ impl Inventory {
     /// Rebuild all caches (`simple_index` and `units_cache`) from positions.
     /// Called after operations that may invalidate caches (like retain or deserialization).
     fn rebuild_index(&mut self) {
+        let mut overflowed = false;
         self.simple_index.clear();
         self.units_cache.clear();
 
         for (idx, pos) in self.positions.iter().enumerate() {
             // Update units cache for all positions
-            *self
+            let slot = self
                 .units_cache
                 .entry(pos.units.currency.clone())
-                .or_default() += pos.units.number;
+                .or_default();
+            if let Some(sum) = slot.checked_add(pos.units.number) {
+                *slot = sum;
+            } else {
+                *slot = saturated(*slot, pos.units.number);
+                overflowed = true;
+            }
 
             // Update simple_index only for positions without cost
             if pos.cost.is_none() {
@@ -643,6 +792,7 @@ impl Inventory {
                 self.simple_index.insert(pos.units.currency.clone(), idx);
             }
         }
+        self.overflowed |= overflowed;
     }
 
     /// Merge this inventory with another.
@@ -666,8 +816,16 @@ impl Inventory {
             }
 
             if let Some(cost) = &pos.cost {
-                // Convert to cost basis
-                let total = pos.units.number * cost.number;
+                // Convert to cost basis. `checked_mul`, not `checked_add`: this
+                // is the one site of the five that MULTIPLIES, and it overflows
+                // on inputs far below `Decimal::MAX` — units 1e16 at cost 1e13
+                // is enough. Fixing only the additions would have moved the
+                // panic here rather than removed it (#1863).
+                let total = pos.units.number.checked_mul(cost.number);
+                if total.is_none() {
+                    result.overflowed = true;
+                }
+                let total = total.unwrap_or_else(|| saturated_mul(pos.units.number, cost.number));
                 result.add(Position::simple(Amount::new(total, &cost.currency)));
             } else {
                 // No cost, keep as-is

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -809,6 +809,12 @@ impl Inventory {
     #[must_use]
     pub fn at_cost(&self) -> Self {
         let mut result = Self::new();
+        // Carry the source's poison. Without this the derived inventory reports
+        // clean while holding figures computed from ALREADY-clamped units — the
+        // silently-wrong case the flag exists to prevent, and worse than the
+        // panic it replaced. Found by probing the propagation claim rather than
+        // trusting it.
+        result.overflowed = self.overflowed;
 
         for pos in &self.positions {
             if pos.is_empty() {

--- a/crates/rustledger-core/tests/inventory_overflow_test.rs
+++ b/crates/rustledger-core/tests/inventory_overflow_test.rs
@@ -1,0 +1,158 @@
+//! Decimal overflow must report, never panic (#1863).
+//!
+//! `Decimal` is 96-bit (~7.9e28) and its `+` / `*` PANIC on overflow. Inventory
+//! arithmetic runs in the loader's booking phase, so a ledger holding amounts
+//! near the ceiling aborted EVERY command — including `check`, the command a
+//! user runs to find out what is wrong with their file. CLAUDE.md's rule is
+//! that ledger input never panics the CLI.
+//!
+//! Each test drives one arithmetic site directly. The end-to-end diagnostic is
+//! covered by the CLI suite; these pin the layer where the panic lived, so a
+//! regression is attributed to the operation rather than to "check aborts".
+
+use rustledger_core::cost::Cost;
+use rustledger_core::{Amount, Decimal, Inventory, Position};
+use std::str::FromStr;
+
+/// Units large enough that `units * cost` leaves `Decimal`'s range while
+/// neither operand is near it on its own — the case that a `checked_add`-only
+/// fix would have missed.
+fn big_units() -> Decimal {
+    Decimal::from_str("10000000000000000").expect("literal")
+}
+
+fn big_cost() -> Decimal {
+    Decimal::from_str("10000000000000").expect("literal")
+}
+
+/// `add` — the running units cache (the site in the original report).
+#[test]
+fn add_saturates_and_flags_instead_of_panicking() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    assert!(!inv.overflowed(), "one MAX position fits");
+
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    assert!(
+        inv.overflowed(),
+        "the sum of two MAX positions cannot be represented and must be marked"
+    );
+}
+
+/// `try_add` — the same operation, reported rather than merely recorded.
+///
+/// This is what the booking engine calls, so this is the assertion that
+/// connects the saturation to a user-visible diagnostic.
+#[test]
+fn try_add_reports_the_overflow() {
+    let mut inv = Inventory::new();
+    inv.try_add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect("first add fits");
+
+    let err = inv
+        .try_add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect_err("the second must report, not saturate silently");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("overflow") && msg.contains("USD"),
+        "the message must name the overflow and the currency: {msg}"
+    );
+}
+
+/// `add` merging into an existing simple position (the second site in `add`).
+#[test]
+fn merging_into_an_existing_position_saturates() {
+    let mut inv = Inventory::new();
+    // Two adds of the same currency with no cost merge in place.
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    assert!(inv.overflowed());
+    // And the process is still alive to assert it.
+    assert_eq!(inv.units("USD"), Decimal::MAX, "clamped, not wrapped");
+}
+
+/// `at_cost` — a MULTIPLICATION, not an addition.
+///
+/// Fixing only the additions would have moved the panic here rather than
+/// removing it: this overflows on inputs far below `Decimal::MAX`.
+#[test]
+fn at_cost_multiplication_saturates() {
+    let mut inv = Inventory::new();
+    inv.add(Position::with_cost(
+        Amount::new(big_units(), "HOOL"),
+        Cost::new(big_cost(), "USD"),
+    ));
+    let at = inv.at_cost();
+    assert!(
+        at.overflowed(),
+        "units * cost leaves the range and must be marked"
+    );
+}
+
+/// `book_value` — reaches `Cost::total_cost`, a further multiplication site.
+#[test]
+fn book_value_multiplication_saturates() {
+    let mut inv = Inventory::new();
+    inv.add(Position::with_cost(
+        Amount::new(big_units(), "HOOL"),
+        Cost::new(big_cost(), "USD"),
+    ));
+    // The assertion is simply that this returns rather than aborting; the
+    // figure it returns is clamped and is not meaningful.
+    let totals = inv.book_value("HOOL");
+    assert_eq!(totals.len(), 1, "one cost currency");
+}
+
+/// Ordinary amounts are untouched — the checked arithmetic must not perturb
+/// any value that fits, which is every real ledger.
+#[test]
+fn normal_arithmetic_is_unchanged_and_unflagged() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(
+        Decimal::from_str("100.50").expect("literal"),
+        "USD",
+    )));
+    inv.add(Position::simple(Amount::new(
+        Decimal::from_str("-40.25").expect("literal"),
+        "USD",
+    )));
+    assert_eq!(
+        inv.units("USD"),
+        Decimal::from_str("60.25").expect("literal")
+    );
+    assert!(
+        !inv.overflowed(),
+        "a ledger that fits must never be marked — the flag is what makes a \
+         clamped figure detectable, so a false positive would condemn good data"
+    );
+
+    let mut costed = Inventory::new();
+    costed.add(Position::with_cost(
+        Amount::new(Decimal::from_str("10").expect("literal"), "HOOL"),
+        Cost::new(Decimal::from_str("150.00").expect("literal"), "USD"),
+    ));
+    let at = costed.at_cost();
+    assert!(!at.overflowed());
+    assert_eq!(
+        at.units("USD"),
+        Decimal::from_str("1500.00").expect("literal"),
+        "10 * 150.00"
+    );
+}
+
+/// Negative overflow clamps downward, not upward.
+///
+/// A sign error here would turn a huge liability into a huge asset — worse
+/// than the panic, since nothing would look wrong.
+#[test]
+fn negative_overflow_clamps_to_min() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(Decimal::MIN, "USD")));
+    inv.add(Position::simple(Amount::new(Decimal::MIN, "USD")));
+    assert!(inv.overflowed());
+    assert_eq!(
+        inv.units("USD"),
+        Decimal::MIN,
+        "two large negatives must clamp to MIN, not MAX"
+    );
+}

--- a/crates/rustledger-core/tests/inventory_overflow_test.rs
+++ b/crates/rustledger-core/tests/inventory_overflow_test.rs
@@ -103,6 +103,35 @@ fn book_value_multiplication_saturates() {
     assert_eq!(totals.len(), 1, "one cost currency");
 }
 
+/// The poison flag survives every operation that derives one inventory from
+/// another, and the round trips a consumer may put it through.
+///
+/// This is the load-bearing claim of the whole design: the clamped figure is
+/// only safe to expose because it travels with a marker. `at_cost` did NOT
+/// carry it at first — a source poisoned during `add` produced a derived
+/// inventory reporting clean, holding figures computed from clamped units.
+/// That is worse than the panic it replaced, because nothing looks wrong.
+#[test]
+fn the_overflow_flag_propagates() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")));
+    assert!(inv.overflowed(), "precondition");
+
+    assert!(inv.clone().overflowed(), "clone must carry it");
+    assert!(
+        inv.at_cost().overflowed(),
+        "at_cost derives from clamped units and must stay marked"
+    );
+
+    let json = serde_json::to_string(&inv).expect("serialize");
+    let back: Inventory = serde_json::from_str(&json).expect("deserialize");
+    assert!(
+        back.overflowed(),
+        "the flag must survive the wire format the FFI and wasm surfaces use"
+    );
+}
+
 /// Ordinary amounts are untouched — the checked arithmetic must not perturb
 /// any value that fits, which is every real ledger.
 #[test]

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -820,7 +820,19 @@ fn run_booking(
         if let Directive::Transaction(txn) = &mut spanned.value {
             match engine.book_and_interpolate_with_gains(txn) {
                 Ok((result, txn_gains)) => {
-                    engine.apply(&result.transaction);
+                    // `apply_checked`: an arithmetic overflow here is a
+                    // property of the user's numbers, not a caller bug, and it
+                    // used to panic and take out every command including
+                    // `check` (#1863). Report it like any other booking error.
+                    if let Err(e) = engine.apply_checked(&result.transaction) {
+                        errors.push(LedgerError::error(
+                            "BOOK",
+                            format!(
+                                "{} ({}, \"{}\")",
+                                e, result.transaction.date, result.transaction.narration
+                            ),
+                        ));
+                    }
                     if let Some(g) = gains.as_deref_mut() {
                         g.extend(txn_gains);
                     }

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -56,6 +56,8 @@ pub enum ErrorCode {
     InsufficientUnits,
     /// E4003: Ambiguous lot match in STRICT mode.
     AmbiguousLotMatch,
+    /// E4004: Arithmetic exceeded `Decimal`'s representable range.
+    ArithmeticOverflow,
     /// E4005: Cost amount is negative (cost must be non-negative).
     NegativeCost,
 
@@ -112,6 +114,7 @@ impl ErrorCode {
         Self::NoMatchingLot,
         Self::InsufficientUnits,
         Self::AmbiguousLotMatch,
+        Self::ArithmeticOverflow,
         Self::NegativeCost,
         Self::UndeclaredCurrency,
         Self::CurrencyNotAllowed,
@@ -149,6 +152,7 @@ impl ErrorCode {
             Self::NoMatchingLot => "E4001",
             Self::InsufficientUnits => "E4002",
             Self::AmbiguousLotMatch => "E4003",
+            Self::ArithmeticOverflow => "E4004",
             Self::NegativeCost => "E4005",
             // Currency errors
             Self::UndeclaredCurrency => "E5001",
@@ -233,6 +237,7 @@ impl ErrorCode {
             Self::NoMatchingLot => "No matching lot for reduction",
             Self::InsufficientUnits => "Not enough units in matching lots",
             Self::AmbiguousLotMatch => "Ambiguous lot match under STRICT booking",
+            Self::ArithmeticOverflow => "Amount exceeds the representable numeric range",
             Self::NegativeCost => "Negative cost",
             Self::UndeclaredCurrency => "Currency used without a commodity declaration",
             Self::CurrencyNotAllowed => "Currency not allowed in this account",
@@ -361,6 +366,15 @@ impl ErrorCode {
                  disambiguate with the lot's cost `{10.00 USD}`, date `{2024-01-02}`, \
                  or label `{\"lot-a\"}` — or open the account with a non-strict \
                  method: `2024-01-01 open Assets:Stock \"FIFO\"`."
+            }
+            Self::ArithmeticOverflow => {
+                "A running total exceeded the largest number rustledger can \
+                 represent (about 7.9e28, a 96-bit decimal).\n\nThis is not \
+                 reachable from ordinary amounts — it takes figures near that \
+                 ceiling, or a units-times-cost product that reaches it. The \
+                 reported total is clamped and is NOT exact.\n\nFix: check the \
+                 posting amounts for a misplaced decimal point or a stray run of \
+                 digits; a real balance does not reach this range."
             }
             Self::NegativeCost => {
                 "A posting's cost amount is negative — a cost basis must be \

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -489,6 +489,15 @@ pub fn process_inventory_reduction(
                     ErrorCode::NoMatchingLot,
                     format!("cost spec: {:?}", posting.cost),
                 ),
+                // `reduce` cannot produce this today — overflow arises when
+                // ADDING to an inventory, which the booking engine routes
+                // through `try_add`. Handled explicitly rather than with a
+                // wildcard so a future emission site here is a compile error
+                // instead of a silently wrong diagnostic code.
+                rustledger_core::BookingError::Overflow { currency, .. } => (
+                    ErrorCode::ArithmeticOverflow,
+                    format!("currency: {currency}"),
+                ),
             };
             errors.push(
                 ValidationError::new(

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -199,6 +199,12 @@ Or use `rledger doctor missing-open` to generate them.
 
 **Fix**: Specify the exact lot using cost basis `{cost}` or date `{date}`.
 
+### E4004: Arithmetic Overflow
+
+**Cause**: A running total, or a units-times-cost product, exceeds the largest number rustledger can represent (about 7.9e28 — a 96-bit decimal). The reported figure is clamped and is **not** exact.
+
+**Fix**: Check the posting amounts for a misplaced decimal point or a stray run of digits. A real balance does not reach this range.
+
 ### E4005: Negative Cost
 
 **Cause**: A cost specification resolves to a negative amount.

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -256,6 +256,31 @@ This document catalogs all validation errors and warnings with their trigger con
   Assets:Cash
 ```
 
+### BOOKING_ARITHMETIC_OVERFLOW
+
+**Code:** `E4004`
+
+**Condition:** A running inventory total, or a units-times-cost product, exceeds the representable numeric range (`Decimal` is 96-bit, about 7.9e28).
+
+**Message:** `Arithmetic overflow in {operation} for {currency} in {account}: the amount exceeds the representable range (about 7.9e28)`
+
+**Severity:** Error
+
+Not reachable from ordinary amounts. It requires figures near the ceiling, or a units-times-cost product that reaches it. The reported total is clamped and is **not** exact — the diagnostic is what marks it as unusable.
+
+```beancount
+2024-01-01 open Expenses:Food
+2024-01-01 open Assets:Cash
+
+2024-02-10 * "at the ceiling"
+  Expenses:Food   79228162514264337593543950335 USD
+  Assets:Cash    -79228162514264337593543950335 USD
+
+2024-02-11 * "and again — the running total cannot hold it"
+  Expenses:Food   79228162514264337593543950335 USD
+  Assets:Cash    -79228162514264337593543950335 USD
+```
+
 ### BOOKING_NEGATIVE_COST
 
 **Code:** `E4005`


### PR DESCRIPTION
Closes #1863.

`Inventory` summed position units with `+=`, which **panics** on `Decimal` overflow. It runs in the loader's booking phase, so a ledger holding amounts near `Decimal::MAX` aborted every command — including `check`, the command a user runs to find out what's wrong with their file:

```
$ rledger check big.beancount
thread 'main' panicked at rust_decimal … "Addition overflowed"
$ echo $?
101
```

Now:

```
error[BOOK]: Arithmetic overflow in adding a position for USD in Expenses:Food:
the amount exceeds the representable range (about 7.9e28)
exit 1
```

## Seven sites, not five

The issue named five in `inventory/mod.rs`. Two more turned up while testing, and **both are multiplications** — fixing only the additions would have moved the panic rather than removed it.

| file | site | op |
|---|---|---|
| `inventory/mod.rs` | units cache in `add` | `+=` |
| `inventory/mod.rs` | merge into existing position | `+=` |
| `inventory/mod.rs` | `rebuild_index` | `+=` |
| `inventory/mod.rs` | `book_value` totals | `+=` |
| `inventory/mod.rs` | `at_cost` units×cost | `*` |
| `cost.rs` | `Cost::total_cost` | `*` ← found by the new test |
| `booking/lib.rs` | `cost_number_weight_generic` | `*`, `+=` ← found by the repro |

The last is in a different crate on the interpolation path, and it's what the issue's **second** repro actually hit — my review claimed that fixture proved `at_cost` reachable, which was wrong. `WeightNum` gains saturating ops; its `BigDecimal` impl is the plain operation, since arbitrary precision has no ceiling, so the precise-residual tier is unaffected.

## Shape

Arithmetic saturates and sets a sticky `Inventory::overflowed()`, propagated by `clone`, serde, and `at_cost`.

*(`at_cost` did **not** propagate it in the first commit — it constructs a fresh `Inventory` rather than deriving one, so a source poisoned by `add` produced a derived inventory reporting clean while holding figures computed from clamped units. Found by probing the claim rather than trusting it; fixed in `9b816c4b` with a test that fails if the propagation is removed. `book_value` returns a map with nowhere to carry a flag — the caller must check the source inventory, which is a real limitation of flag-on-container and is called out below.)* `try_add` turns that into `BookingError::Overflow`, and the booking engine calls it — so the user-reachable path **reports**. A clamped figure presented as exact would be worse than the panic for an accounting tool.

`add` keeps its signature: ~250 call sites, and making it fallible would bury this change. The saturation is never presented as a result on its own — every site that clamps also flags.

`apply_checked` reports overflow while still ignoring a failed *reduction*, whose contract (transaction must be pre-booked) the existing `debug_assert` guards. Overflow isn't a caller-contract violation but a property of the user's numbers, so it belongs in the loader's error list.

New code **E4004**, with spec and docs entries — the `error_codes_documented_in_spec` drift guard requires them, and the exhaustive `title`/`explanation` matches force the rest. That guard working as designed is why they're here.

## Tests

Seven, one per operation, plus:

- ordinary amounts are neither perturbed nor flagged — a false positive would condemn good data;
- negative overflow clamps to `MIN`, not `MAX` — a sign error there would turn a huge liability into a huge asset, and nothing would look wrong.

Sabotage-verified: reverting the units-cache check fails four tests, reverting `total_cost` fails the book-value one.

## Note on the TLA+ spec

`spec/tla/Conservation.tla` is cited directly on `add` and models **unbounded** integers, so it cannot express this failure. The model will not catch a regression here — the tests are the guard. I said so at the call site so the citation isn't mistaken for coverage.
