### PR TITLE
fix(core): report Decimal overflow instead of panicking or clamping

### DIFF
--- a/crates/rustledger-booking/fuzz/Cargo.lock
+++ b/crates/rustledger-booking/fuzz/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustledger-booking"
-version = "0.16.5"
+version = "0.21.0"
 dependencies = [
  "bigdecimal",
  "rust_decimal",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.16.5"
+version = "0.21.0"
 dependencies = [
  "imbl",
  "jiff",

--- a/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
+++ b/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
@@ -166,9 +166,13 @@ fuzz_target!(|input: FuzzTransaction| {
             .with_synthesized_posting(posting)
             .with_synthesized_posting(counter);
 
-        // Ignore errors — we're building up state, some combos may fail
+        // Ignore errors — we're building up state, some combos may fail.
+        // That includes `apply`'s overflow error (#1863): the fuzzer generates
+        // arbitrary units and costs, so an out-of-range product is a legitimate
+        // input to explore past, not a crash. Unwrapping here would abort the
+        // run and report a false finding — the opposite of this target's job.
         if let Ok(result) = engine.book_and_interpolate(&txn) {
-            engine.apply(&result.transaction).expect("fixture fits in Decimal");
+            let _ = engine.apply(&result.transaction);
         }
     }
 

--- a/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
+++ b/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
@@ -168,7 +168,7 @@ fuzz_target!(|input: FuzzTransaction| {
 
         // Ignore errors — we're building up state, some combos may fail
         if let Ok(result) = engine.book_and_interpolate(&txn) {
-            engine.apply(&result.transaction);
+            engine.apply(&result.transaction).expect("fixture fits in Decimal");
         }
     }
 

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -694,6 +694,42 @@ impl BookingEngine {
     /// non-fatal preserves every existing caller's release-build behavior;
     /// only the overflow path is new.
     pub fn apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
+        // Snapshot every account this transaction touches, so an overflow
+        // partway through cannot leave the earlier postings applied.
+        //
+        // Without this, a transaction the loader then DROPS (`run_booking`'s
+        // `failed_indices`) still moved the running balances, and every later
+        // transaction booked against the corruption — silently wrong reports
+        // and lot matching, which is the outcome this whole change exists to
+        // prevent. `Inventory`'s positions are an `imbl::Vector`, so each
+        // clone is O(1) structural sharing.
+        //
+        // `None` records an account that did not exist yet, which must be
+        // REMOVED rather than restored to an empty inventory: `apply` is the
+        // only thing that creates entries here, and leaving a phantom empty
+        // one changes `into_inventories`' output.
+        let mut snapshot: FxHashMap<rustledger_core::Account, Option<Inventory>> =
+            FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
+        for posting in &txn.postings {
+            snapshot
+                .entry(posting.account.clone())
+                .or_insert_with(|| self.inventories.get(&posting.account).cloned());
+        }
+        let rollback =
+            |engine: &mut Self,
+             snapshot: FxHashMap<rustledger_core::Account, Option<Inventory>>| {
+                for (account, prior) in snapshot {
+                    match prior {
+                        Some(inv) => {
+                            engine.inventories.insert(account, inv);
+                        }
+                        None => {
+                            engine.inventories.remove(&account);
+                        }
+                    }
+                }
+            };
+
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
             if matches!(
@@ -705,6 +741,7 @@ impl BookingEngine {
                     }
                 ))
             ) {
+                rollback(self, snapshot);
                 return reduced;
             }
             debug_assert!(
@@ -2270,6 +2307,46 @@ mod tests {
                 Directive::Transaction(t) if t.narration.as_ref() == "Sell at phantom cost basis"
             )),
             "failed sell must not appear in booked"
+        );
+    }
+
+    /// A transaction whose `apply` overflows partway must leave the running
+    /// balances exactly as it found them.
+    ///
+    /// The loader DROPS such a transaction (`run_booking`'s `failed_indices`),
+    /// so any posting applied before the failing one is a mutation from an
+    /// entry the user is told was rejected. Every later transaction then books
+    /// against it — wrong lot matching and wrong balances, reported as fact.
+    /// Found in review of #1863; the pad path had the identical defect.
+    #[test]
+    fn a_failed_apply_leaves_no_partial_mutation() {
+        let mut engine = BookingEngine::new();
+
+        // Park an account at the ceiling so the SECOND posting overflows.
+        let load = Transaction::new(date(2024, 1, 5), "load")
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(Decimal::MAX, "USD")));
+        engine.apply(&load).expect("one MAX position fits");
+
+        let bad = Transaction::new(date(2024, 2, 1), "partial")
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(10.00), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(Decimal::MAX, "USD")));
+        engine
+            .apply(&bad)
+            .expect_err("the second posting overflows");
+
+        let inventories = engine.into_inventories();
+        assert!(
+            !inventories.contains_key(&rustledger_core::Account::from("Assets:A")),
+            "an account first seen in the failed transaction must not survive it"
+        );
+        assert_eq!(
+            inventories
+                .get(&rustledger_core::Account::from("Assets:B"))
+                .expect("Assets:B predates the failed transaction")
+                .units(&rustledger_core::Currency::from("USD")),
+            Decimal::MAX,
+            "an account that predates the failed transaction must be restored to \
+             its prior value, not left doubled or cleared"
         );
     }
 }

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -666,8 +666,9 @@ impl BookingEngine {
     /// the ledger's numbers, not of the caller, so it is reported rather than
     /// asserted. A failed *reduction* keeps the historical
     /// debug-assert-then-ignore contract below: that means the caller applied
-    /// an unbooked transaction, which is a bug in the caller, and every
-    /// existing caller relies on release builds continuing past it.
+    /// an unbooked transaction, which is a bug in the caller. Keeping it
+    /// non-fatal preserves every existing caller's release-build behavior;
+    /// only the overflow path is new.
     pub fn apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -267,7 +267,31 @@ impl BookingEngine {
                     Some(rustledger_core::CostNumber::Compound { per_unit, total })
                         if !units.number.is_zero() =>
                     {
-                        let combined = units.number.abs() * per_unit + total;
+                        // Checked (#1863): `N*a + b` for a compound cost is a
+                        // product of two user-supplied numbers, so it leaves
+                        // `Decimal`'s range on inputs well inside it. This is
+                        // the ONE reachable site the first pass of the fix
+                        // missed — the sweep that was supposed to catch it ran
+                        // against a wrongly-assigned binary path and silently
+                        // tested nothing.
+                        let combined = units
+                            .number
+                            .abs()
+                            .checked_mul(per_unit)
+                            .and_then(|v| v.checked_add(total))
+                            .ok_or_else(|| {
+                                convert_core_booking_error(
+                                    rustledger_core::BookingError::Overflow(
+                                        rustledger_core::OverflowError {
+                                            currency: cost_spec
+                                                .currency
+                                                .clone()
+                                                .unwrap_or_else(|| units.currency.clone()),
+                                        },
+                                    ),
+                                    &posting.account,
+                                )
+                            })?;
                         Some(CostSpec {
                             number: Some(rustledger_core::CostNumber::PerUnitFromTotal(
                                 rustledger_core::BookedCost::new(

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -633,7 +633,13 @@ impl BookingEngine {
             // `CostSpec::resolve`). `apply`'s callers book first, which fills the
             // inferred currency into `cost_spec.currency`; direct-`apply` tests use
             // explicit-currency fixtures, which need no inference.
-            inv.add(Position::from_posting(units, posting.cost.as_ref(), date));
+            inv.add(Position::from_posting(units, posting.cost.as_ref(), date))
+                .map_err(|e| {
+                    convert_core_booking_error(
+                        rustledger_core::BookingError::Overflow(e),
+                        &posting.account,
+                    )
+                })?;
         }
         Ok(())
     }
@@ -654,9 +660,28 @@ impl BookingEngine {
     /// this lot-matching realization — e.g. the returns engine values **net units
     /// at market** (`rustledger-returns`), never `apply`, so a re-merged
     /// booking-failed transaction cannot over-sell it.
-    pub fn apply(&mut self, txn: &Transaction) {
+    /// # Errors
+    ///
+    /// [`BookingError`] only for arithmetic overflow (#1863) — a property of
+    /// the ledger's numbers, not of the caller, so it is reported rather than
+    /// asserted. A failed *reduction* keeps the historical
+    /// debug-assert-then-ignore contract below: that means the caller applied
+    /// an unbooked transaction, which is a bug in the caller, and every
+    /// existing caller relies on release builds continuing past it.
+    pub fn apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
         for posting in &txn.postings {
             let reduced = self.try_apply_posting(posting, txn.date);
+            if matches!(
+                reduced,
+                Err(BookingError::Inventory(
+                    rustledger_core::AccountedBookingError {
+                        error: rustledger_core::BookingError::Overflow(_),
+                        ..
+                    }
+                ))
+            ) {
+                return reduced;
+            }
             debug_assert!(
                 reduced.is_ok(),
                 "apply() reduction failed — the transaction must be booked \
@@ -668,6 +693,7 @@ impl BookingEngine {
             // Release builds keep the historical ignore-and-continue behavior.
             let _ = reduced;
         }
+        Ok(())
     }
 
     /// Book and interpolate a transaction.
@@ -741,11 +767,14 @@ pub fn book_transactions(
     let mut results = Vec::with_capacity(transactions.len());
 
     for txn in transactions {
-        let result = engine.book_and_interpolate(txn);
-        if let Ok(ref interpolated) = result {
+        // An apply-time overflow belongs to THIS transaction's result, so a
+        // caller iterating results sees it rather than silently getting a
+        // running balance that never absorbed the posting (#1863).
+        let result = engine.book_and_interpolate(txn).and_then(|interpolated| {
             // Apply the booked transaction (with filled-in costs), not the original
-            engine.apply(&interpolated.transaction);
-        }
+            engine.apply(&interpolated.transaction)?;
+            Ok(interpolated)
+        });
         results.push(result);
     }
 
@@ -801,8 +830,10 @@ pub fn book(directives: &[Directive], method: BookingMethod) -> LedgerBookResult
                 Ok(result) => {
                     // Apply the booked transaction (filled-in costs), not
                     // the original, so subsequent lot matching is correct.
-                    engine.apply(&result.transaction);
-                    booked_txns[i] = Some(result.transaction);
+                    match engine.apply(&result.transaction) {
+                        Ok(()) => booked_txns[i] = Some(result.transaction),
+                        Err(e) => booking_errors[i] = Some(e),
+                    }
                 }
                 Err(e) => booking_errors[i] = Some(e),
             }
@@ -855,7 +886,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Check inventory
         let inv = engine.inventory(&"Assets:Stock".into()).unwrap();
@@ -883,8 +914,12 @@ mod tests {
                     Amount::new(dec!(-100), "USD"),
                 ))
         };
-        engine.apply(&buy("lot-a"));
-        engine.apply(&buy("lot-b"));
+        engine
+            .apply(&buy("lot-a"))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&buy("lot-b"))
+            .expect("fixture fits in Decimal");
 
         // Sell 5 X explicitly from lot-b.
         let mut sell_cost = CostSpec::empty()
@@ -931,7 +966,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Sell 5 AAPL at $175 with empty cost (needs lot matching)
         let sell = Transaction::new(date(2024, 6, 15), "Sell stock")
@@ -989,7 +1024,7 @@ mod tests {
                 Amount::new(dec!(-300.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Check inventory
         let inv = engine.inventory(&"Assets:Stock".into()).unwrap();
@@ -1026,7 +1061,9 @@ mod tests {
 
         // Use book() to test the booking path with total cost
         let booked_buy = engine.book(&buy).unwrap();
-        engine.apply(&booked_buy.transaction);
+        engine
+            .apply(&booked_buy.transaction)
+            .expect("fixture fits in Decimal");
 
         // Check that per-unit cost was calculated (300/1.763)
         let buy_posting = &booked_buy.transaction.postings[0];
@@ -1093,7 +1130,9 @@ mod tests {
         let booked = engine
             .book_and_interpolate(&sell)
             .expect("booking should succeed");
-        engine.apply(&booked.transaction);
+        engine
+            .apply(&booked.transaction)
+            .expect("fixture fits in Decimal");
 
         let inv = engine.inventory(&"Assets:Stock".into()).unwrap();
 
@@ -1140,7 +1179,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Sell 5 AAPL with total price annotation (not per-unit)
         // Total price = $875 for 5 shares = $175/share
@@ -1277,7 +1316,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Now try to book another buy (augmentation, not reduction)
         // This has empty cost but same sign as inventory, so it's not a reduction
@@ -1347,7 +1386,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // Sell at same price - zero gain
         let sell = Transaction::new(date(2024, 6, 15), "Sell stock")
@@ -1400,8 +1439,12 @@ mod tests {
                     Amount::new(-n * cost, "USD"),
                 ))
         };
-        engine.apply(&lot(date(2020, 1, 1), dec!(5), dec!(100)));
-        engine.apply(&lot(date(2020, 6, 1), dec!(5), dec!(120)));
+        engine
+            .apply(&lot(date(2020, 1, 1), dec!(5), dec!(100)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 6, 1), dec!(5), dec!(120)))
+            .expect("fixture fits in Decimal");
 
         // Sell 8 @ 150: FIFO takes 5 from lot 1 (@100) then 3 from lot 2 (@120).
         let sell = Transaction::new(date(2021, 1, 1), "sell")
@@ -1435,20 +1478,24 @@ mod tests {
     fn test_book_total_price_single_lot_exact() {
         let mut engine = BookingEngine::new();
         // Buy 3 AAPL at $30 (basis 90).
-        engine.apply(
-            &Transaction::new(date(2024, 1, 1), "buy")
-                .with_synthesized_posting(
-                    Posting::new("Assets:Stock", Amount::new(dec!(3), "AAPL")).with_cost(
-                        CostSpec::empty()
-                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(30) })
-                            .with_currency("USD"),
-                    ),
-                )
-                .with_synthesized_posting(Posting::new(
-                    "Assets:Cash",
-                    Amount::new(dec!(-90), "USD"),
-                )),
-        );
+        engine
+            .apply(
+                &Transaction::new(date(2024, 1, 1), "buy")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(3), "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(30),
+                                })
+                                .with_currency("USD"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-90), "USD"),
+                    )),
+            )
+            .expect("fixture fits in Decimal");
         // Sell all 3 for a TOTAL of $100 (100 / 3 does not terminate).
         let sell = Transaction::new(date(2024, 6, 1), "sell")
             .with_synthesized_posting(
@@ -1484,8 +1531,12 @@ mod tests {
                     Amount::new(-n * cost, "USD"),
                 ))
         };
-        engine.apply(&lot(date(2020, 1, 1), dec!(5), dec!(100)));
-        engine.apply(&lot(date(2020, 6, 1), dec!(5), dec!(120)));
+        engine
+            .apply(&lot(date(2020, 1, 1), dec!(5), dec!(100)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 6, 1), dec!(5), dec!(120)))
+            .expect("fixture fits in Decimal");
         // Sell 8 for a TOTAL of $1200: FIFO 5 from lot 1, 3 from lot 2.
         let sell = Transaction::new(date(2021, 1, 1), "sell")
             .with_synthesized_posting(
@@ -1527,8 +1578,12 @@ mod tests {
                     Amount::new(-n * cost, "USD"),
                 ))
         };
-        engine.apply(&lot(date(2020, 1, 1), dec!(1), dec!(10)));
-        engine.apply(&lot(date(2020, 6, 1), dec!(2), dec!(10)));
+        engine
+            .apply(&lot(date(2020, 1, 1), dec!(1), dec!(10)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 6, 1), dec!(2), dec!(10)))
+            .expect("fixture fits in Decimal");
         // Sell 3 for a round-dollar TOTAL of 100 (scale 0): FIFO 1 + 2. 100/3 does
         // not terminate — the shares must NOT be rounded to whole dollars.
         let sell = Transaction::new(date(2021, 1, 1), "sell")
@@ -1572,10 +1627,18 @@ mod tests {
                 )
                 .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(-n, "USD")))
         };
-        engine.apply(&lot(date(2020, 1, 1), dec!(3)));
-        engine.apply(&lot(date(2020, 2, 1), dec!(3)));
-        engine.apply(&lot(date(2020, 3, 1), dec!(3)));
-        engine.apply(&lot(date(2020, 4, 1), dec!(1)));
+        engine
+            .apply(&lot(date(2020, 1, 1), dec!(3)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 2, 1), dec!(3)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 3, 1), dec!(3)))
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(&lot(date(2020, 4, 1), dec!(1)))
+            .expect("fixture fits in Decimal");
         // Sell all 10 for a round-dollar total of 2 (scale 0), FIFO 3+3+3+1.
         let sell = Transaction::new(date(2021, 1, 1), "sell")
             .with_synthesized_posting(
@@ -1603,20 +1666,24 @@ mod tests {
     fn test_book_cross_currency_disposal_records_both_currencies() {
         let mut engine = BookingEngine::new();
         // Buy 3 AAPL at cost 30 USD.
-        engine.apply(
-            &Transaction::new(date(2024, 1, 1), "buy")
-                .with_synthesized_posting(
-                    Posting::new("Assets:Stock", Amount::new(dec!(3), "AAPL")).with_cost(
-                        CostSpec::empty()
-                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(30) })
-                            .with_currency("USD"),
-                    ),
-                )
-                .with_synthesized_posting(Posting::new(
-                    "Assets:Cash",
-                    Amount::new(dec!(-90), "USD"),
-                )),
-        );
+        engine
+            .apply(
+                &Transaction::new(date(2024, 1, 1), "buy")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(3), "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(30),
+                                })
+                                .with_currency("USD"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-90), "USD"),
+                    )),
+            )
+            .expect("fixture fits in Decimal");
         // Sell priced in EUR.
         let sell = Transaction::new(date(2024, 6, 1), "sell")
             .with_synthesized_posting(
@@ -1642,34 +1709,42 @@ mod tests {
     fn test_book_mixed_currency_lots_records_both() {
         let mut engine = BookingEngine::new(); // FIFO
         // Lot 1: 5 AAPL at 100 USD (2020). Lot 2: 5 AAPL at 90 EUR (2021).
-        engine.apply(
-            &Transaction::new(date(2020, 1, 1), "buy usd")
-                .with_synthesized_posting(
-                    Posting::new("Assets:Stock", Amount::new(dec!(5), "AAPL")).with_cost(
-                        CostSpec::empty()
-                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
-                            .with_currency("USD"),
-                    ),
-                )
-                .with_synthesized_posting(Posting::new(
-                    "Assets:Cash",
-                    Amount::new(dec!(-500), "USD"),
-                )),
-        );
-        engine.apply(
-            &Transaction::new(date(2021, 1, 1), "buy eur")
-                .with_synthesized_posting(
-                    Posting::new("Assets:Stock", Amount::new(dec!(5), "AAPL")).with_cost(
-                        CostSpec::empty()
-                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(90) })
-                            .with_currency("EUR"),
-                    ),
-                )
-                .with_synthesized_posting(Posting::new(
-                    "Assets:Cash",
-                    Amount::new(dec!(-450), "EUR"),
-                )),
-        );
+        engine
+            .apply(
+                &Transaction::new(date(2020, 1, 1), "buy usd")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(5), "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(100),
+                                })
+                                .with_currency("USD"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-500), "USD"),
+                    )),
+            )
+            .expect("fixture fits in Decimal");
+        engine
+            .apply(
+                &Transaction::new(date(2021, 1, 1), "buy eur")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(5), "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(90),
+                                })
+                                .with_currency("EUR"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-450), "EUR"),
+                    )),
+            )
+            .expect("fixture fits in Decimal");
         // Sell 8 @ 150 USD: FIFO takes 5 from the USD lot, 3 from the EUR lot.
         let sell = Transaction::new(date(2023, 1, 1), "sell")
             .with_synthesized_posting(
@@ -1701,20 +1776,24 @@ mod tests {
     fn test_book_short_cover_gain_sign_and_flag() {
         let mut engine = BookingEngine::new();
         // Open the short: sell 5 not held, at cost 100 (the price shorted at).
-        engine.apply(
-            &Transaction::new(date(2020, 1, 1), "open short")
-                .with_synthesized_posting(
-                    Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL")).with_cost(
-                        CostSpec::empty()
-                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
-                            .with_currency("USD"),
-                    ),
-                )
-                .with_synthesized_posting(Posting::new(
-                    "Assets:Cash",
-                    Amount::new(dec!(500), "USD"),
-                )),
-        );
+        engine
+            .apply(
+                &Transaction::new(date(2020, 1, 1), "open short")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL")).with_cost(
+                            CostSpec::empty()
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(100),
+                                })
+                                .with_currency("USD"),
+                        ),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(500), "USD"),
+                    )),
+            )
+            .expect("fixture fits in Decimal");
         // Cover: buy 5 back at 80.
         let cover = Transaction::new(date(2020, 6, 1), "cover")
             .with_synthesized_posting(
@@ -1766,7 +1845,9 @@ mod tests {
 
         // Book and apply the opening
         let booked = engine.book(&open).unwrap();
-        engine.apply(&booked.transaction);
+        engine
+            .apply(&booked.transaction)
+            .expect("fixture fits in Decimal");
 
         // Check that the cost spec was filled in with USD
         let cost_spec = booked.transaction.postings[0].cost.as_ref().unwrap();
@@ -1829,7 +1910,7 @@ mod tests {
                 ),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-50), "USD")));
-        engine.apply(&buy1);
+        engine.apply(&buy1).expect("fixture fits in Decimal");
 
         // Lot 2: 100 ADA at $0.52 (2022-05-19)
         let buy2 = Transaction::new(date(2022, 5, 19), "Buy lot 2")
@@ -1842,7 +1923,7 @@ mod tests {
                 ),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-52), "USD")));
-        engine.apply(&buy2);
+        engine.apply(&buy2).expect("fixture fits in Decimal");
 
         // Verify initial inventory: 200 ADA total
         let inv = engine.inventory(&"Assets:Crypto".into()).unwrap();
@@ -1856,7 +1937,9 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(25), "USD")));
         let booked1 = engine.book(&sell1).unwrap();
-        engine.apply(&booked1.transaction);
+        engine
+            .apply(&booked1.transaction)
+            .expect("fixture fits in Decimal");
 
         // Verify: 150 ADA remaining (50 in lot 1, 100 in lot 2)
         let inv = engine.inventory(&"Assets:Crypto".into()).unwrap();
@@ -1888,7 +1971,9 @@ mod tests {
         );
 
         // Apply and verify final inventory: 70 ADA remaining (all in lot 2)
-        engine.apply(&booked2.unwrap().transaction);
+        engine
+            .apply(&booked2.unwrap().transaction)
+            .expect("fixture fits in Decimal");
         let inv = engine.inventory(&"Assets:Crypto".into()).unwrap();
         assert_eq!(
             inv.units("ADA"),
@@ -1969,7 +2054,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(-150), "EUR")));
 
-        engine.apply(&buy1);
+        engine.apply(&buy1).expect("fixture fits in Decimal");
 
         // 2024-01-15: Sell 25 HOOG without cost spec (price-only)
         let sell = Transaction::new(date(2024, 1, 15), "Sell 25 HOOG without cost spec")
@@ -1979,7 +2064,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(40), "EUR")));
 
-        engine.apply(&sell);
+        engine.apply(&sell).expect("fixture fits in Decimal");
 
         // 2024-01-20: Buy 50 more HOOG {1.70 EUR} - this MUST succeed
         let buy2 = Transaction::new(date(2024, 1, 20), "Buy 50 more HOOG - should succeed")
@@ -2004,7 +2089,9 @@ mod tests {
         );
 
         let booked = result.unwrap();
-        engine.apply(&booked.transaction);
+        engine
+            .apply(&booked.transaction)
+            .expect("fixture fits in Decimal");
 
         // Verify final inventory state
         let inv = engine.inventory(&"Assets:Stocks".into()).unwrap();

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -75,6 +75,24 @@ pub enum InterpolationError {
         /// The residual amount.
         residual: Decimal,
     },
+
+    /// The weight arithmetic left `rust_decimal`'s ~7.9e28 range, so the
+    /// amount to interpolate cannot be represented (#1863).
+    ///
+    /// This is reported rather than clamped because an interpolated amount is
+    /// WRITTEN INTO the posting and then flows to every report, BQL result and
+    /// balance check as if the user had typed it. A saturated value there is a
+    /// fabricated figure presented as the user's own data.
+    #[error(
+        "amounts in this transaction exceed the {} range, so the {currency} \
+         posting amount cannot be computed; split the transaction or use \
+         smaller units",
+        "±7.9e28"
+    )]
+    Unrepresentable {
+        /// The currency group whose arithmetic left the range.
+        currency: Currency,
+    },
 }
 
 /// Result of interpolation.
@@ -86,6 +104,34 @@ pub struct InterpolationResult {
     pub filled_indices: Vec<usize>,
     /// Residuals after interpolation (should all be near zero).
     pub residuals: HashMap<Currency, Decimal>,
+}
+
+/// Add `amount` into `currency`'s running residual.
+///
+/// On overflow the currency is recorded in `unrepresentable` and its running
+/// total is left untouched, rather than panicking (#1863) or aborting outright.
+///
+/// The distinction matters: a residual that cannot be represented is only
+/// FATAL when interpolation must actually solve an amount from it — that
+/// amount would be written into the posting as if the user had typed it. When
+/// every posting is explicit, interpolation has nothing to solve and the
+/// balance validator recomputes the residual in `BigDecimal`, reporting the
+/// exact imbalance (matching Python beancount, whose `decimal` context has no
+/// magnitude ceiling). Aborting here would replace that precise diagnostic
+/// with a vaguer one.
+fn accumulate_residual(
+    residuals: &mut HashMap<Currency, Decimal>,
+    unrepresentable: &mut std::collections::HashSet<Currency>,
+    currency: &Currency,
+    amount: Decimal,
+) {
+    let slot = residuals.entry(currency.clone()).or_default();
+    match slot.checked_add(amount) {
+        Some(v) => *slot = v,
+        None => {
+            unrepresentable.insert(currency.clone());
+        }
+    }
 }
 
 /// Round an interpolated amount to match existing scale, but never round
@@ -163,6 +209,8 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Pre-allocate for typical case (1-2 currencies per transaction)
     let num_postings = transaction.postings.len();
     let mut residuals: HashMap<Currency, Decimal> = HashMap::with_capacity(num_postings.min(4));
+    // Currencies whose running residual left `rust_decimal`'s range (#1863).
+    let mut unrepresentable: std::collections::HashSet<Currency> = std::collections::HashSet::new();
     let mut missing_by_currency: HashMap<Currency, Vec<usize>> = HashMap::with_capacity(2);
     let mut unassigned_missing: Vec<usize> = Vec::with_capacity(2);
 
@@ -234,9 +282,25 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 // the SAME `CostNumber` ladder `calculate_residual` uses — so
                 // interpolation and the balance residual can no longer disagree
                 // (the rule: cost beats price; else price; else units).
-                let cost_contribution = crate::cost_weight::<Decimal>(posting, amount, || {
+                let Ok(cost_contribution) = crate::cost_weight::<Decimal>(posting, amount, || {
                     get_inferred_currency(&mut inferred_cost_currency)
-                });
+                }) else {
+                    // This posting's weight is out of range. Mark the
+                    // currency the weight WOULD have been denominated in —
+                    // marking `amount.currency` instead would leave the
+                    // cost currency's residual quietly short by this
+                    // posting while looking representable (#1863).
+                    let weight_currency = crate::cost_currency_of(posting, || {
+                        get_inferred_currency(&mut inferred_cost_currency)
+                    })
+                    .unwrap_or_else(|| amount.currency.clone());
+                    unrepresentable.insert(weight_currency);
+                    // `continue`, NOT `None`: falling through would reach
+                    // the `posting.cost.is_some()` branch and be counted as
+                    // an empty-`{}` cost unknown, turning an arithmetic
+                    // problem into a spurious #1026 "multiple unknowns".
+                    continue;
+                };
 
                 if let Some((currency, cost_amount)) = cost_contribution {
                     // Cost-based posting: weight is in the cost currency.
@@ -244,7 +308,12 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                     // `max_scale_by_currency` — see its declaration for the
                     // rationale (Python beancount with default
                     // `infer_tolerance_from_cost = False`).
-                    *residuals.entry(currency).or_default() += cost_amount;
+                    accumulate_residual(
+                        &mut residuals,
+                        &mut unrepresentable,
+                        &currency,
+                        cost_amount,
+                    );
                 } else if posting.cost.is_some() {
                     // Cost spec exists but has no determinable cost number (e.g.,
                     // an empty `{}` spec where the lot's cost will be filled by
@@ -351,7 +420,17 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         let (curr, signed) = match price.kind {
                             rustledger_core::PriceKind::Unit => (
                                 price_amt.currency.clone(),
-                                amount.number.abs() * price_amt.number * amount.number.signum(),
+                                if let Some(v) = amount
+                                    .number
+                                    .abs()
+                                    .checked_mul(price_amt.number)
+                                    .and_then(|v| v.checked_mul(amount.number.signum()))
+                                {
+                                    v
+                                } else {
+                                    unrepresentable.insert(price_amt.currency.clone());
+                                    continue;
+                                },
                             ),
                             rustledger_core::PriceKind::Total => {
                                 let scale = price_amt.number.scale();
@@ -363,18 +442,35 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                                 }
                                 (
                                     price_amt.currency.clone(),
-                                    price_amt.number * amount.number.signum(),
+                                    if let Some(v) =
+                                        price_amt.number.checked_mul(amount.number.signum())
+                                    {
+                                        v
+                                    } else {
+                                        unrepresentable.insert(price_amt.currency.clone());
+                                        continue;
+                                    },
                                 )
                             }
                         };
-                        *residuals.entry(curr).or_default() += signed;
+                        accumulate_residual(&mut residuals, &mut unrepresentable, &curr, signed);
                     } else {
                         // Incomplete/empty price annotation — fall back to units
-                        *residuals.entry(amount.currency.clone()).or_default() += amount.number;
+                        accumulate_residual(
+                            &mut residuals,
+                            &mut unrepresentable,
+                            &amount.currency,
+                            amount.number,
+                        );
                     }
                 } else {
                     // Simple posting: weight is just the units
-                    *residuals.entry(amount.currency.clone()).or_default() += amount.number;
+                    accumulate_residual(
+                        &mut residuals,
+                        &mut unrepresentable,
+                        &amount.currency,
+                        amount.number,
+                    );
                 }
             }
             Some(IncompleteAmount::CurrencyOnly(currency)) => {
@@ -426,6 +522,32 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 unassigned_missing.push(i);
             }
         }
+    }
+
+    // An out-of-range residual (#1863) is fatal ONLY if this transaction has
+    // something to interpolate: the solved amount is written into the posting
+    // and thereafter indistinguishable from user input, so it must never be
+    // derived from a total we could not compute. With nothing to solve, we
+    // return normally and the balance validator recomputes the residual in
+    // `BigDecimal` and reports the exact imbalance — strictly more useful than
+    // failing here, and what Python beancount prints.
+    if !unrepresentable.is_empty()
+        && (!missing_by_currency.is_empty()
+            || !cost_unknowns_by_currency.is_empty()
+            || !unassigned_missing.is_empty())
+    {
+        // Deterministic choice of currency for the message.
+        let mut names: Vec<&Currency> = unrepresentable.iter().collect();
+        names.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        return Err(InterpolationError::Unrepresentable {
+            currency: (*names.first().expect("non-empty")).clone(),
+        });
+    }
+    // Nothing was solved, so hand back no residual for those currencies rather
+    // than the partial sum we stopped accumulating — a wrong number in a
+    // public field is exactly the failure mode this fix exists to remove.
+    for currency in &unrepresentable {
+        residuals.remove(currency);
     }
 
     // Check for multiple unknowns in the same currency group. An "unknown"
@@ -920,7 +1042,9 @@ mod tests {
         let result = interpolate(&txn).expect("interpolation should succeed");
 
         // The independent residual engine (sharing cost_weight) sees balance.
-        for (currency, value) in crate::calculate_residual(&result.transaction) {
+        for (currency, value) in
+            crate::calculate_residual(&result.transaction).expect("fixture fits in Decimal")
+        {
             assert!(
                 value.abs() < dec!(0.0001),
                 "interpolated result not balanced per calculate_residual: {value} {currency}"
@@ -1832,7 +1956,7 @@ mod tests {
             .with_synthesized_posting(Posting::auto("Income:Capital-Gains"));
 
         let mut engine = BookingEngine::new();
-        engine.apply(&buy);
+        engine.apply(&buy).expect("fixture fits in Decimal");
 
         // book_and_interpolate handles the empty `{}` lot match AND
         // runs interpolation on the booked transaction. The Income

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -420,13 +420,12 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         let (curr, signed) = match price.kind {
                             rustledger_core::PriceKind::Unit => (
                                 price_amt.currency.clone(),
-                                if let Some(v) = amount
-                                    .number
-                                    .abs()
-                                    .checked_mul(price_amt.number)
-                                    .and_then(|v| v.checked_mul(amount.number.signum()))
-                                {
-                                    v
+                                if let Some(v) = amount.number.abs().checked_mul(price_amt.number) {
+                                    // `* signum` is exact: signum is -1, 0 or
+                                    // 1, and `-Decimal::MIN == Decimal::MAX`
+                                    // is representable, so only the price
+                                    // product above can leave the range.
+                                    v * amount.number.signum()
                                 } else {
                                     unrepresentable.insert(price_amt.currency.clone());
                                     continue;
@@ -442,14 +441,10 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                                 }
                                 (
                                     price_amt.currency.clone(),
-                                    if let Some(v) =
-                                        price_amt.number.checked_mul(amount.number.signum())
-                                    {
-                                        v
-                                    } else {
-                                        unrepresentable.insert(price_amt.currency.clone());
-                                        continue;
-                                    },
+                                    // Exact for the same reason as the
+                                    // per-unit branch: multiplying by a signum
+                                    // cannot leave the range.
+                                    price_amt.number * amount.number.signum(),
                                 )
                             }
                         };

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -85,8 +85,9 @@ pub enum InterpolationError {
     /// fabricated figure presented as the user's own data.
     #[error(
         "amounts in this transaction exceed the {} range, so the {currency} \
-         posting amount cannot be computed; split the transaction or use \
-         smaller units",
+         posting amount cannot be computed; split the transaction, or \
+         denominate it in larger units (thousands, millions) so the number \
+         is smaller",
         "±7.9e28"
     )]
     Unrepresentable {
@@ -114,11 +115,12 @@ pub struct InterpolationResult {
 /// The distinction matters: a residual that cannot be represented is only
 /// FATAL when interpolation must actually solve an amount from it — that
 /// amount would be written into the posting as if the user had typed it. When
-/// every posting is explicit, interpolation has nothing to solve and the
-/// balance validator recomputes the residual in `BigDecimal`, reporting the
-/// exact imbalance (matching Python beancount, whose `decimal` context has no
-/// magnitude ceiling). Aborting here would replace that precise diagnostic
-/// with a vaguer one.
+/// there is nothing to solve (no elided posting AND no unresolved `{}` cost
+/// spec — see the gate after the posting loop), the balance validator
+/// recomputes the residual in `BigDecimal` and reports the exact imbalance,
+/// matching Python beancount, whose `decimal` context has no magnitude
+/// ceiling. Aborting here would replace that precise diagnostic with a vaguer
+/// one.
 fn accumulate_residual(
     residuals: &mut HashMap<Currency, Decimal>,
     unrepresentable: &mut std::collections::HashSet<Currency>,

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -710,10 +710,18 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> FxHashMap<Curren
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn is_balanced(transaction: &Transaction, tolerances: &FxHashMap<Currency, Decimal>) -> bool {
-    // Overflow in the fast tier means the residual is far outside any
-    // tolerance, so the transaction is not balanced. (The validation pipeline
-    // does not come through here — it escalates to BigDecimal and reports the
-    // exact residual.)
+    // Overflow in the fast tier means this tier has no answer, NOT that the
+    // transaction is unbalanced: accumulation is order-dependent, so postings
+    // of `[+7e28, +7e28, -7e28, -7e28]` overflow the running sum even though
+    // they total exactly zero. Returning `false` is therefore a conservative
+    // under-approximation — it can report a balanced transaction as unbalanced,
+    // never the reverse.
+    //
+    // Acceptable only because this is a low-level primitive that the pipeline
+    // does not use (see the doc above): `validate_transaction_balance`
+    // escalates to `calculate_residual_precise`, which has no ceiling and gets
+    // the exact answer. A caller who needs that must do the same rather than
+    // trust this `false`.
     let Some(residuals) = calculate_residual(transaction) else {
         return false;
     };

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -314,19 +314,45 @@ pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Op
 /// `abs`/`signum` are taken on the source `Decimal` (exact — they add no
 /// digits); only the *multiplications* run in `D`, so `D = BigDecimal`
 /// reproduces the precise path's arithmetic byte-for-byte.
-trait WeightNum: Clone + Default + std::ops::AddAssign + std::ops::Mul<Output = Self> {
+/// Arithmetic is CHECKED, not saturating. `rust_decimal` has a hard 96-bit
+/// magnitude ceiling (~7.9e28) whose `+`/`*` panic on overflow, and clamping
+/// instead is not an option here: `Decimal::MIN == -Decimal::MAX` exactly, so a
+/// clamped debit and a clamped credit cancel to a residual of *precisely zero*
+/// and the transaction certifies as balanced (PR #1890 shipped that and was
+/// closed — a ledger off by 1e40 passed `rledger check`). So `D = Decimal`
+/// reports "cannot represent" and the caller escalates to `D = BigDecimal`,
+/// which has no ceiling and gives Python beancount's answer exactly.
+trait WeightNum: Clone + Default {
     fn from_decimal(d: Decimal) -> Self;
+    /// `None` when the product is outside this backend's range.
+    fn checked_mul(self, rhs: Self) -> Option<Self>;
+    /// `None` when the sum is outside this backend's range.
+    fn checked_add(self, rhs: Self) -> Option<Self>;
 }
 
 impl WeightNum for Decimal {
     fn from_decimal(d: Decimal) -> Self {
         d
     }
+    fn checked_mul(self, rhs: Self) -> Option<Self> {
+        Self::checked_mul(self, rhs)
+    }
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        Self::checked_add(self, rhs)
+    }
 }
 
 impl WeightNum for BigDecimal {
     fn from_decimal(d: Decimal) -> Self {
         to_big(d)
+    }
+    // Arbitrary precision and unbounded magnitude: these never fail, which is
+    // what makes BigDecimal a sound escalation target for the Decimal tier.
+    fn checked_mul(self, rhs: Self) -> Option<Self> {
+        Some(self * rhs)
+    }
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        Some(self + rhs)
     }
 }
 
@@ -355,18 +381,28 @@ pub(crate) fn cost_currency_of(
 /// Returns `None` for a posting with no cost spec, an empty `{}` spec (no
 /// determinable number), or when no cost currency resolves. `interpolate`
 /// instantiates this at `Decimal`.
+/// The weight arithmetic left this backend's range. Distinct from `Ok(None)`,
+/// which means the posting legitimately contributes no cost weight.
+struct Overflow;
+
 fn cost_weight<D: WeightNum>(
     posting: &rustledger_core::Posting,
     units: &Amount,
     infer_currency: impl FnOnce() -> Option<Currency>,
-) -> Option<(Currency, D)> {
-    let cost_spec = posting.cost.as_ref()?;
+) -> Result<Option<(Currency, D)>, Overflow> {
+    let Some(cost_spec) = posting.cost.as_ref() else {
+        return Ok(None);
+    };
     // Match the number FIRST so an empty `{}` spec short-circuits without
     // resolving (and possibly inferring) the cost currency.
-    let number = cost_spec.number.as_ref()?;
-    let weight = cost_number_weight_generic::<D>(units.number, number);
-    let cost_curr = cost_currency_of(posting, infer_currency)?;
-    Some((cost_curr, weight))
+    let Some(number) = cost_spec.number.as_ref() else {
+        return Ok(None);
+    };
+    let weight = cost_number_weight_generic::<D>(units.number, number).ok_or(Overflow)?;
+    let Some(cost_curr) = cost_currency_of(posting, infer_currency) else {
+        return Ok(None);
+    };
+    Ok(Some((cost_curr, weight)))
 }
 
 /// The `CostNumber`-variant weight arithmetic, generic over the numeric
@@ -376,28 +412,27 @@ fn cost_weight<D: WeightNum>(
 fn cost_number_weight_generic<D: WeightNum>(
     units_number: Decimal,
     number: &rustledger_core::CostNumber,
-) -> D {
+) -> Option<D> {
     let signum = units_number.signum();
     // `PerUnitFromTotal` and `Total` both carry a preserved total — using it
     // avoids the division-then-multiplication precision loss of recomputing from
     // `per_unit`. `PerUnit` goes through multiplication.
     match *number {
         rustledger_core::CostNumber::Total { value: total } => {
-            D::from_decimal(total) * D::from_decimal(signum)
+            D::from_decimal(total).checked_mul(D::from_decimal(signum))
         }
         rustledger_core::CostNumber::PerUnitFromTotal(b) => {
-            D::from_decimal(b.total) * D::from_decimal(signum)
+            D::from_decimal(b.total).checked_mul(D::from_decimal(signum))
         }
         rustledger_core::CostNumber::PerUnit { value: per_unit } => {
-            D::from_decimal(units_number) * D::from_decimal(per_unit)
+            D::from_decimal(units_number).checked_mul(D::from_decimal(per_unit))
         }
         // Compound `{a # b}` (beancount compound_amount): the cost totals
         // `N*a + b`, so the weight is the per-unit product (sign embedded
         // in `units`) plus the signed lump total (#1700).
         rustledger_core::CostNumber::Compound { per_unit, total } => {
-            let mut w = D::from_decimal(units_number) * D::from_decimal(per_unit);
-            w += D::from_decimal(total) * D::from_decimal(signum);
-            w
+            let w = D::from_decimal(units_number).checked_mul(D::from_decimal(per_unit))?;
+            w.checked_add(D::from_decimal(total).checked_mul(D::from_decimal(signum))?)
         }
     }
 }
@@ -413,8 +448,21 @@ fn cost_number_weight_generic<D: WeightNum>(
 /// `N·a + b` (#1700). Consumers surfacing a per-posting weight (BQL `weight`
 /// column, `currency_accounts` grouping) MUST use this rather than re-derive
 /// the ladder, or they drift from `rledger check` on those shapes.
+///
+/// Returns `None` when the weight is outside `rust_decimal`'s ~7.9e28 range.
+/// Callers that need an answer regardless must recompute in `BigDecimal` (as
+/// the balance validator does); callers that merely display a weight should
+/// omit it rather than substitute a clamped figure, which would be reported as
+/// exact.
+///
+/// Deliberately checked rather than saturating: `Decimal::MIN` is exactly
+/// `-Decimal::MAX`, so clamped opposite-sign weights cancel to a residual of
+/// zero and an unbalanced transaction certifies as balanced (#1863).
 #[must_use]
-pub fn cost_number_weight(units_number: Decimal, number: &rustledger_core::CostNumber) -> Decimal {
+pub fn cost_number_weight(
+    units_number: Decimal,
+    number: &rustledger_core::CostNumber,
+) -> Option<Decimal> {
     cost_number_weight_generic::<Decimal>(units_number, number)
 }
 
@@ -426,13 +474,13 @@ pub fn cost_number_weight(units_number: Decimal, number: &rustledger_core::CostN
 /// is a positive magnitude in the source, so the weight is
 /// `price × sign(units)` — credit-side postings flip to `−price`
 /// (issue #1052). Zero units weigh zero for both kinds. Same single-source
-/// rule as [`cost_number_weight`].
+/// rule as [`cost_number_weight`], including its `None`-on-overflow contract.
 #[must_use]
 pub fn price_weight(
     units_number: Decimal,
     price_number: Decimal,
     kind: rustledger_core::PriceKind,
-) -> Decimal {
+) -> Option<Decimal> {
     price_weight_generic::<Decimal>(units_number, price_number, kind)
 }
 
@@ -470,6 +518,10 @@ pub fn price_weight(
 ///
 /// Aligning the two would change BQL `weight` results, so it is deliberately
 /// left alone here — but do not describe this as "the rule `check` uses".
+///
+/// Also `None` when the weight leaves `rust_decimal`'s range: BQL's `weight`
+/// column and the budget report render this figure directly, and a clamped
+/// number displayed as an exact total is worse than a blank cell.
 #[must_use]
 pub fn posting_weight(posting: &rustledger_core::Posting) -> Option<Amount> {
     let units = posting.amount()?;
@@ -478,7 +530,7 @@ pub fn posting_weight(posting: &rustledger_core::Posting) -> Option<Amount> {
         && let Some(currency) = cost_spec.currency.clone()
     {
         return Some(Amount::new(
-            cost_number_weight(units.number, number),
+            cost_number_weight(units.number, number)?,
             currency,
         ));
     }
@@ -486,7 +538,7 @@ pub fn posting_weight(posting: &rustledger_core::Posting) -> Option<Amount> {
         && let Some(price_amt) = price_ann.amount()
     {
         return Some(Amount::new(
-            price_weight(units.number, price_amt.number, price_ann.kind),
+            price_weight(units.number, price_amt.number, price_ann.kind)?,
             price_amt.currency.clone(),
         ));
     }
@@ -503,16 +555,14 @@ fn price_weight_generic<D: WeightNum>(
     units_number: Decimal,
     price_number: Decimal,
     kind: rustledger_core::PriceKind,
-) -> D {
+) -> Option<D> {
     let signum = units_number.signum();
     match kind {
-        rustledger_core::PriceKind::Unit => {
-            D::from_decimal(units_number.abs())
-                * D::from_decimal(price_number)
-                * D::from_decimal(signum)
-        }
+        rustledger_core::PriceKind::Unit => D::from_decimal(units_number.abs())
+            .checked_mul(D::from_decimal(price_number))?
+            .checked_mul(D::from_decimal(signum)),
         rustledger_core::PriceKind::Total => {
-            D::from_decimal(price_number) * D::from_decimal(signum)
+            D::from_decimal(price_number).checked_mul(D::from_decimal(signum))
         }
     }
 }
@@ -532,7 +582,7 @@ fn price_weight_generic<D: WeightNum>(
 /// Weight rule (Beancount): a cost spec puts the weight in the cost currency
 /// (`cost` beats `price`); else a price annotation puts it in the price
 /// currency; else the weight is the units themselves.
-fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currency, D> {
+fn residual_weight<D: WeightNum>(transaction: &Transaction) -> Option<FxHashMap<Currency, D>> {
     // Pre-allocate for typical case (1-2 currencies per transaction)
     let mut residuals: FxHashMap<Currency, D> =
         FxHashMap::with_capacity_and_hasher(transaction.postings.len().min(4), Default::default());
@@ -551,14 +601,24 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currenc
             continue;
         };
 
+        // Accumulate `amount` into `currency`'s running residual, or bail out
+        // of the whole computation if the sum leaves `D`'s range.
+        macro_rules! accumulate {
+            ($currency:expr, $amount:expr) => {{
+                let slot = residuals.entry($currency).or_default();
+                *slot = std::mem::take(slot).checked_add($amount)?;
+            }};
+        }
+
         // Determine the "weight" of this posting for balance purposes.
         let cost_contribution = cost_weight::<D>(posting, units, || {
             get_inferred_currency(&mut inferred_cost_currency)
-        });
+        })
+        .ok()?;
 
         if let Some((currency, amount)) = cost_contribution {
             // Cost-based posting: weight is in the cost currency
-            *residuals.entry(currency).or_default() += amount;
+            accumulate!(currency, amount);
         } else if posting.cost.is_some() {
             // Cost spec exists but has no determinable cost number
             // (e.g., empty `{}`). The CANONICAL weight of a cost-tracked
@@ -572,21 +632,20 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currenc
         } else if let Some(price) = &posting.price {
             // Price annotation: converts units to the price currency.
             if let Some(amt) = price.amount.as_ref().and_then(IncompleteAmount::as_amount) {
-                let signed = price_weight_generic::<D>(units.number, amt.number, price.kind);
-                *residuals.entry(amt.currency.clone()).or_default() += signed;
+                let signed = price_weight_generic::<D>(units.number, amt.number, price.kind)?;
+                accumulate!(amt.currency.clone(), signed);
             } else {
                 // Incomplete or bare-sigil price annotation — can't
                 // calculate a price-currency conversion, fall back to units.
-                *residuals.entry(units.currency.clone()).or_default() +=
-                    D::from_decimal(units.number);
+                accumulate!(units.currency.clone(), D::from_decimal(units.number));
             }
         } else {
             // Simple posting: weight is just the units
-            *residuals.entry(units.currency.clone()).or_default() += D::from_decimal(units.number);
+            accumulate!(units.currency.clone(), D::from_decimal(units.number));
         }
     }
 
-    residuals
+    Some(residuals)
 }
 
 /// Calculate the residual (imbalance) of a transaction.
@@ -606,7 +665,11 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currenc
 // clippy::implicit_hasher still fires for a concrete `FxBuildHasher` (it wants
 // the fn generic over `S: BuildHasher`); the explicit fast hasher is the point.
 #[allow(clippy::implicit_hasher)]
-pub fn calculate_residual(transaction: &Transaction) -> FxHashMap<Currency, Decimal> {
+/// Returns `None` when the residual arithmetic leaves `rust_decimal`'s ~7.9e28
+/// range. `None` means "unknown", NOT "balanced" — a caller must escalate to
+/// [`calculate_residual_precise`], which cannot fail. Treating `None` as an
+/// empty map would certify an arbitrarily unbalanced transaction as clean.
+pub fn calculate_residual(transaction: &Transaction) -> Option<FxHashMap<Currency, Decimal>> {
     residual_weight::<Decimal>(transaction)
 }
 
@@ -629,7 +692,11 @@ fn to_big(d: Decimal) -> BigDecimal {
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn calculate_residual_precise(transaction: &Transaction) -> FxHashMap<Currency, BigDecimal> {
+    // `BigDecimal`'s `WeightNum` ops are total, so `residual_weight` cannot
+    // return `None` here. This is the property that makes the Decimal tier's
+    // `None` recoverable rather than fatal.
     residual_weight::<BigDecimal>(transaction)
+        .expect("BigDecimal arithmetic is unbounded and cannot overflow")
 }
 
 /// Check if a transaction is balanced within the given tolerances
@@ -643,7 +710,13 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> FxHashMap<Curren
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn is_balanced(transaction: &Transaction, tolerances: &FxHashMap<Currency, Decimal>) -> bool {
-    let residuals = calculate_residual(transaction);
+    // Overflow in the fast tier means the residual is far outside any
+    // tolerance, so the transaction is not balanced. (The validation pipeline
+    // does not come through here — it escalates to BigDecimal and reports the
+    // exact residual.)
+    let Some(residuals) = calculate_residual(transaction) else {
+        return false;
+    };
 
     for (currency, residual) in residuals {
         let tolerance = tolerances.get(&currency).copied().unwrap_or(Decimal::ZERO); // Default 0 (exact balance for integer-only currencies)
@@ -719,7 +792,7 @@ mod tests {
         // PerUnit: units × per_unit.
         assert_eq!(
             cost_number_weight(dec!(10), &CostNumber::PerUnit { value: dec!(5.00) }),
-            dec!(50.00),
+            Some(dec!(50.00)),
         );
         // Total: preserved total, sign following units.
         assert_eq!(
@@ -729,7 +802,7 @@ mod tests {
                     value: dec!(100.00)
                 }
             ),
-            dec!(100.00),
+            Some(dec!(100.00)),
         );
         assert_eq!(
             cost_number_weight(
@@ -738,7 +811,7 @@ mod tests {
                     value: dec!(100.00)
                 }
             ),
-            dec!(-100.00),
+            Some(dec!(-100.00)),
         );
         // PerUnitFromTotal: the preserved total EXACTLY — not per_unit × units,
         // which for 100/3 would give 99.99999... at the 28-digit ceiling.
@@ -746,15 +819,15 @@ mod tests {
             per_unit: dec!(100.00) / dec!(3),
             total: dec!(100.00),
         });
-        assert_eq!(cost_number_weight(dec!(3), &booked), dec!(100.00));
-        assert_eq!(cost_number_weight(dec!(-3), &booked), dec!(-100.00));
+        assert_eq!(cost_number_weight(dec!(3), &booked), Some(dec!(100.00)));
+        assert_eq!(cost_number_weight(dec!(-3), &booked), Some(dec!(-100.00)));
         // Compound {a # b}: N·a + b, lump signed with units (#1700).
         let compound = CostNumber::Compound {
             per_unit: dec!(5.00),
             total: dec!(10.00),
         };
-        assert_eq!(cost_number_weight(dec!(10), &compound), dec!(60.00));
-        assert_eq!(cost_number_weight(dec!(-10), &compound), dec!(-60.00));
+        assert_eq!(cost_number_weight(dec!(10), &compound), Some(dec!(60.00)));
+        assert_eq!(cost_number_weight(dec!(-10), &compound), Some(dec!(-60.00)));
     }
 
     #[test]
@@ -763,26 +836,26 @@ mod tests {
         // `@` per-unit: units × price, sign through units.
         assert_eq!(
             price_weight(dec!(10), dec!(1.50), PriceKind::Unit),
-            dec!(15.00),
+            Some(dec!(15.00)),
         );
         assert_eq!(
             price_weight(dec!(-10), dec!(1.50), PriceKind::Unit),
-            dec!(-15.00),
+            Some(dec!(-15.00)),
         );
         // `@@` total: positive magnitude in source, sign follows units —
         // the #1052 credit-side flip.
         assert_eq!(
             price_weight(dec!(10), dec!(15.00), PriceKind::Total),
-            dec!(15.00),
+            Some(dec!(15.00)),
         );
         assert_eq!(
             price_weight(dec!(-10), dec!(15.00), PriceKind::Total),
-            dec!(-15.00),
+            Some(dec!(-15.00)),
         );
         // Zero units weigh zero for both kinds.
         assert_eq!(
             price_weight(dec!(0), dec!(15.00), PriceKind::Total),
-            dec!(0)
+            Some(dec!(0))
         );
     }
 
@@ -802,7 +875,7 @@ mod tests {
                 Amount::new(dec!(-50.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
 
@@ -818,7 +891,7 @@ mod tests {
                 Amount::new(dec!(-45.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(5.00)));
     }
 
@@ -950,7 +1023,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Cost posting contributes 10 * 150 = 1500 USD
         // Cash posting contributes -1500 USD
         // Residual should be 0
@@ -998,7 +1071,7 @@ mod tests {
             // simple
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-12.34), "USD")));
 
-        let fast = calculate_residual(&txn);
+        let fast = calculate_residual(&txn).expect("fixture fits in Decimal");
         let precise = calculate_residual_precise(&txn);
 
         assert_eq!(
@@ -1037,7 +1110,7 @@ mod tests {
                 Amount::new(dec!(-1500.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Total cost posting contributes 1500 * signum(10) = 1500 USD
         // Cash posting contributes -1500 USD
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
@@ -1061,7 +1134,7 @@ mod tests {
                 Amount::new(dec!(1500.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Total cost with negative units: 1500 * signum(-10) = -1500 USD
         // Cash posting contributes +1500 USD
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
@@ -1080,7 +1153,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-10), "AAPL")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Empty cost spec posting doesn't contribute, only the second posting does
         assert_eq!(residual.get("AAPL"), Some(&dec!(-10)));
     }
@@ -1109,7 +1182,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(1500), "USD")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Pre-fix: residual[USD] = 0 (price-as-weight contributed
         // -1500, cancelling cash's +1500).
         // Post-fix: residual[USD] = +1500 (cost-unknown skipped, only
@@ -1158,7 +1231,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Price posting: |-100| * 0.85 * signum(-100) = -85 EUR
         // EUR posting: +85 EUR
         // Total: 0 EUR
@@ -1177,7 +1250,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Total price: 85 * signum(-100) = -85 EUR
         // EUR posting: +85 EUR
         assert_eq!(residual.get("EUR"), Some(&dec!(0)));
@@ -1196,7 +1269,7 @@ mod tests {
                 Amount::new(dec!(-100.30), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Price posting: |85| * 1.18 * signum(85) = 100.30 USD
         // USD posting: -100.30 USD
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
@@ -1216,7 +1289,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("EUR"), Some(&dec!(0)));
     }
 
@@ -1234,7 +1307,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("EUR"), Some(&dec!(0)));
     }
 
@@ -1252,7 +1325,7 @@ mod tests {
                 Amount::new(dec!(-100.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Falls back to units since no currency in incomplete amount
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
@@ -1271,7 +1344,7 @@ mod tests {
                 Amount::new(dec!(-100.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
 
@@ -1288,7 +1361,7 @@ mod tests {
                 Amount::new(dec!(-100.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Falls back to units
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
@@ -1306,7 +1379,7 @@ mod tests {
                 Amount::new(dec!(-100.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
 
@@ -1336,7 +1409,7 @@ mod tests {
                 Amount::new(dec!(-1510.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // 10 * 150 + 10 - 1510 = 0
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
@@ -1365,7 +1438,7 @@ mod tests {
                 Amount::new(dec!(-250.00), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Stock posting with cost: -10 * 150 = -1500 USD (cost takes precedence)
         // Cash: +1750 USD
         // Gains: -250 USD
@@ -1404,7 +1477,7 @@ mod tests {
                 Amount::new(dec!(-500.00), "EUR"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
         assert_eq!(residual.get("EUR"), Some(&dec!(0)));
     }
@@ -1419,7 +1492,7 @@ mod tests {
             ))
             .with_synthesized_posting(Posting::auto("Assets:Cash")); // No units
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Only the complete posting is counted
         assert_eq!(residual.get("USD"), Some(&dec!(50.00)));
     }
@@ -1453,7 +1526,7 @@ mod tests {
                 Amount::new(dec!(-1000), "USD"),
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Cost posting should contribute 10 * 100 = 1000 USD (inferred from other posting)
         // Equity posting contributes -1000 USD
         // Residual should be 0
@@ -1479,7 +1552,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         assert_eq!(residual.get("USD"), Some(&dec!(0)));
     }
 
@@ -1500,7 +1573,7 @@ mod tests {
                 Amount::new(dec!(-1000), "USD"), // USD posting
             ));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Should use EUR (explicit) not USD (from other posting)
         assert_eq!(residual.get("EUR"), Some(&dec!(1000)));
         assert_eq!(residual.get("USD"), Some(&dec!(-1000)));
@@ -1521,7 +1594,7 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
 
-        let residual = calculate_residual(&txn);
+        let residual = calculate_residual(&txn).expect("fixture fits in Decimal");
         // Should use EUR (from price annotation) not USD (from other posting)
         assert_eq!(residual.get("EUR"), Some(&dec!(1000)));
         assert_eq!(residual.get("USD"), Some(&dec!(-1000)));

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -160,7 +160,15 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                     {
                         let position =
                             Position::from_posting(units, posting.cost.as_ref(), txn.date);
-                        inv.add(position);
+                        // A running balance that leaves range makes every pad
+                        // measured against it wrong, so report it here rather
+                        // than pad from a clamped total (#1863).
+                        if let Err(e) = inv.add(position) {
+                            errors.push(
+                                PadError::new(txn.date, e.to_string())
+                                    .with_account(posting.account.clone()),
+                            );
+                        }
                     }
                 }
             }
@@ -200,7 +208,22 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                         &bal.amount.currency,
                     );
 
-                    let difference = bal.amount.number - current;
+                    // A pad amount that cannot be represented must not be
+                    // clamped — the synthetic transaction it produces is
+                    // written into the ledger as if the user had entered it
+                    // (#1863).
+                    let Some(difference) = current.and_then(|c| bal.amount.number.checked_sub(c))
+                    else {
+                        errors.push(PadError::new(
+                            bal.date,
+                            format!(
+                                "cannot compute the pad amount for {}: the {} balance exceeds \
+                                 the representable range (±7.9e28)",
+                                bal.account, bal.amount.currency
+                            ),
+                        ));
+                        continue;
+                    };
 
                     if difference != Decimal::ZERO {
                         // Generate synthetic transaction
@@ -212,18 +235,33 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                             &bal.amount, // target balance for narration
                         );
 
-                        // Apply to inventories
-                        if let Some(inv) = inventories.get_mut(&pending.pad.account) {
-                            inv.add(Position::simple(Amount::new(
-                                difference,
-                                &bal.amount.currency,
-                            )));
-                        }
-                        if let Some(inv) = inventories.get_mut(&pending.pad.source_account) {
-                            inv.add(Position::simple(Amount::new(
-                                -difference,
-                                &bal.amount.currency,
-                            )));
+                        // Apply to inventories. `difference` was just derived
+                        // from these same balances, so an overflow here means
+                        // the pad target itself is out of range — report it
+                        // rather than pad to a clamped figure.
+                        let applied = inventories
+                            .get_mut(&pending.pad.account)
+                            .map(|inv| {
+                                inv.add(Position::simple(Amount::new(
+                                    difference,
+                                    &bal.amount.currency,
+                                )))
+                            })
+                            .transpose()
+                            .and_then(|_| {
+                                inventories
+                                    .get_mut(&pending.pad.source_account)
+                                    .map(|inv| {
+                                        inv.add(Position::simple(Amount::new(
+                                            -difference,
+                                            &bal.amount.currency,
+                                        )))
+                                    })
+                                    .transpose()
+                            });
+                        if let Err(e) = applied {
+                            errors.push(PadError::new(bal.date, e.to_string()));
+                            continue;
                         }
 
                         padding_transactions.push(pad_txn);

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -239,27 +239,30 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                         // from these same balances, so an overflow here means
                         // the pad target itself is out of range — report it
                         // rather than pad to a clamped figure.
-                        let applied = inventories
-                            .get_mut(&pending.pad.account)
-                            .map(|inv| {
-                                inv.add(Position::simple(Amount::new(
-                                    difference,
-                                    &bal.amount.currency,
-                                )))
-                            })
-                            .transpose()
-                            .and_then(|_| {
-                                inventories
-                                    .get_mut(&pending.pad.source_account)
-                                    .map(|inv| {
-                                        inv.add(Position::simple(Amount::new(
-                                            -difference,
-                                            &bal.amount.currency,
-                                        )))
-                                    })
-                                    .transpose()
-                            });
-                        if let Err(e) = applied {
+                        //
+                        // A pad is two halves of one entry, so it applies as a
+                        // unit: if the source overflows after the target
+                        // succeeded, the target is UNDONE. Leaving it applied
+                        // would credit the target without debiting the source
+                        // while emitting no synthetic transaction, so the
+                        // inventories and the directive list would disagree —
+                        // and a later assertion on the target could pass off a
+                        // pad that never happened. The undo is always
+                        // representable: it restores a total that existed a
+                        // moment ago.
+                        let currency = &bal.amount.currency;
+                        let mut apply = |account, number| {
+                            inventories
+                                .get_mut(account)
+                                .map(|inv| inv.add(Position::simple(Amount::new(number, currency))))
+                                .transpose()
+                        };
+                        if let Err(e) = apply(&pending.pad.account, difference) {
+                            errors.push(PadError::new(bal.date, e.to_string()));
+                            continue;
+                        }
+                        if let Err(e) = apply(&pending.pad.source_account, -difference) {
+                            drop(apply(&pending.pad.account, -difference));
                             errors.push(PadError::new(bal.date, e.to_string()));
                             continue;
                         }

--- a/crates/rustledger-booking/tests/booking_properties.rs
+++ b/crates/rustledger-booking/tests/booking_properties.rs
@@ -122,7 +122,7 @@ proptest! {
                     let mut c = Cost::new(Decimal::from(*cost), COST_CURRENCY)
                         .with_date(day_date(*day));
                     c.label = label.map(|i| LABELS[i].to_string());
-                    inv.add(Position::with_cost(Amount::new(n, CURRENCY), c));
+                    inv.add(Position::with_cost(Amount::new(n, CURRENCY), c)).expect("fixture fits in Decimal");
                     expected_total += n;
                 }
                 Op::Sell { units, label } => {
@@ -213,7 +213,7 @@ proptest! {
                     "Assets:Cash",
                     Amount::new(-Decimal::from(*units) * cost_number, COST_CURRENCY),
                 ));
-            engine.apply(&buy);
+            engine.apply(&buy).expect("fixture fits in Decimal");
         }
 
         // Sell 1..=100% of the chosen lot, matched by its label.
@@ -250,7 +250,7 @@ proptest! {
             "reduction must carry the matched lot's label",
         );
 
-        engine.apply(&result.transaction);
+        engine.apply(&result.transaction).expect("fixture fits in Decimal");
         let inv = engine
             .inventory(&"Assets:S".into())
             .expect("account has inventory");

--- a/crates/rustledger-booking/tests/pipeline_invariants.rs
+++ b/crates/rustledger-booking/tests/pipeline_invariants.rs
@@ -108,7 +108,9 @@ proptest! {
             .with_synthesized_posting(Posting::auto("Assets:Cash"));
 
         let filled = interpolate(&txn).expect("interpolation succeeds");
-        for (currency, residual) in calculate_residual(&filled.transaction) {
+        for (currency, residual) in
+            calculate_residual(&filled.transaction).expect("fixture fits in Decimal")
+        {
             prop_assert_eq!(
                 residual,
                 Decimal::ZERO,

--- a/crates/rustledger-booking/tests/tla_proptest.rs
+++ b/crates/rustledger-booking/tests/tla_proptest.rs
@@ -93,7 +93,7 @@ proptest! {
 
         if let Ok(interp_result) = result {
             // After interpolation, transaction should balance
-            let residuals = calculate_residual(&interp_result.transaction);
+            let residuals = calculate_residual(&interp_result.transaction).expect("fixture fits in Decimal");
 
             for (currency, residual) in &residuals {
                 prop_assert!(
@@ -189,8 +189,8 @@ proptest! {
             txn = txn.with_synthesized_posting(Posting::new(format!("Account:{i}"), amount.clone()));
         }
 
-        let residual1 = calculate_residual(&txn);
-        let residual2 = calculate_residual(&txn);
+        let residual1 = calculate_residual(&txn).expect("fixture fits in Decimal");
+        let residual2 = calculate_residual(&txn).expect("fixture fits in Decimal");
 
         for (currency, value1) in &residual1 {
             let value2 = residual2.get(currency).unwrap_or(&Decimal::ZERO);
@@ -227,7 +227,7 @@ proptest! {
             );
 
             // All residuals should be near zero
-            let residuals = calculate_residual(&interp_result.transaction);
+            let residuals = calculate_residual(&interp_result.transaction).expect("fixture fits in Decimal");
             for (currency, residual) in &residuals {
                 prop_assert!(
                     residual.abs() < dec!(0.01),
@@ -265,7 +265,7 @@ proptest! {
         );
 
         // Transaction should balance
-        let residuals = calculate_residual(&result.transaction);
+        let residuals = calculate_residual(&result.transaction).expect("fixture fits in Decimal");
         prop_assert!(
             residuals.get("USD").is_none_or(|r| r.abs() < dec!(0.01)),
             "Should balance"
@@ -287,7 +287,7 @@ proptest! {
 
         if let Ok(interp_result) = result {
             // Should succeed even though filled amount is zero
-            let residuals = calculate_residual(&interp_result.transaction);
+            let residuals = calculate_residual(&interp_result.transaction).expect("fixture fits in Decimal");
             for (currency, residual) in &residuals {
                 prop_assert!(
                     residual.abs() < dec!(0.01),

--- a/crates/rustledger-core/benches/inventory_bench.rs
+++ b/crates/rustledger-core/benches/inventory_bench.rs
@@ -27,7 +27,8 @@ fn generate_inventory(num_positions: usize) -> Inventory {
             1 + (i % 28) as u32,
         ));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "STOCK"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "STOCK"), cost))
+            .expect("fixture fits in Decimal");
     }
 
     inv
@@ -48,7 +49,8 @@ fn bench_inventory_add(c: &mut Criterion) {
                 let mut inv = Inventory::new();
                 for i in 0..size {
                     let cost = Cost::new(dec!(100.00) + Decimal::from(i), "USD");
-                    inv.add(Position::with_cost(Amount::new(dec!(10), "STOCK"), cost));
+                    inv.add(Position::with_cost(Amount::new(dec!(10), "STOCK"), cost))
+                        .expect("fixture fits in Decimal");
                 }
                 std::hint::black_box(inv)
             });
@@ -97,7 +99,9 @@ fn bench_inventory_book_value(c: &mut Criterion) {
         let inv = generate_inventory(size);
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &inv, |b, inv| {
-            b.iter(|| std::hint::black_box(inv.book_value("STOCK")));
+            b.iter(|| {
+                std::hint::black_box(inv.book_value("STOCK").expect("fixture fits in Decimal"))
+            });
         });
     }
 
@@ -111,7 +115,7 @@ fn bench_inventory_at_cost(c: &mut Criterion) {
         let inv = generate_inventory(size);
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &inv, |b, inv| {
-            b.iter(|| std::hint::black_box(inv.at_cost()));
+            b.iter(|| std::hint::black_box(inv.at_cost().expect("fixture fits in Decimal")));
         });
     }
 
@@ -203,7 +207,7 @@ fn bench_inventory_merge(c: &mut Criterion) {
                 b.iter_batched(
                     || inv1.clone(),
                     |mut inv| {
-                        inv.merge(inv2);
+                        inv.merge(inv2).expect("fixture fits in Decimal");
                         std::hint::black_box(inv)
                     },
                     criterion::BatchSize::SmallInput,

--- a/crates/rustledger-core/examples/conservation_trace_gen.rs
+++ b/crates/rustledger-core/examples/conservation_trace_gen.rs
@@ -96,7 +96,8 @@ fn main() {
                 inv.add(Position::with_cost(
                     Amount::new(Decimal::from(amount), "AAPL"),
                     cost.clone(),
-                ));
+                ))
+                .expect("fixture fits in Decimal");
                 total_added += amount;
             } else {
                 // Reduce — the model guard is `units <= inventory`; a failed

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -131,9 +131,17 @@ impl Cost {
     }
 
     /// Calculate the total cost for a given number of units.
+    ///
+    /// `None` when `units × number` leaves `rust_decimal`'s ~±7.9e28 range —
+    /// which happens for inputs well below the ceiling, since a product needs
+    /// the sum of its operands' digits (#1863). There is no in-range value to
+    /// substitute: a clamped cost basis would be rendered as an exact total.
     #[must_use]
-    pub fn total_cost(&self, units: Decimal) -> Amount {
-        Amount::new(units * self.number, self.currency.clone())
+    pub fn total_cost(&self, units: Decimal) -> Option<Amount> {
+        Some(Amount::new(
+            units.checked_mul(self.number)?,
+            self.currency.clone(),
+        ))
     }
 }
 
@@ -959,7 +967,7 @@ mod tests {
     #[test]
     fn test_cost_total() {
         let cost = Cost::new(dec!(150.00), "USD");
-        let total = cost.total_cost(dec!(10));
+        let total = cost.total_cost(dec!(10)).expect("fixture fits in Decimal");
         assert_eq!(total.number, dec!(1500.00));
         assert_eq!(total.currency, "USD");
     }

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -9,7 +9,7 @@ use rust_decimal::prelude::Signed;
 
 use smallvec::{SmallVec, smallvec};
 
-use super::{BookingError, BookingMethod, BookingResult, Inventory, MatchedLots};
+use super::{BookingError, BookingMethod, BookingResult, Inventory, MatchedLots, OverflowError};
 use crate::{Amount, Cost, CostSpec, Currency, Position};
 
 /// Compute weighted-average cost from a set of positions.
@@ -37,7 +37,18 @@ fn average_cost_from_positions(
             } else {
                 cost_currency = Some(cost.currency.clone());
             }
-            total_cost += pos.units.number * cost.number;
+            // Checked: the product needs the sum of its operands' digits, so
+            // it can leave range well below the ceiling (#1863).
+            total_cost = pos
+                .units
+                .number
+                .checked_mul(cost.number)
+                .and_then(|v| total_cost.checked_add(v))
+                .ok_or_else(|| {
+                    BookingError::Overflow(OverflowError {
+                        currency: cost.currency.clone(),
+                    })
+                })?;
         }
     }
 
@@ -328,7 +339,26 @@ impl Inventory {
 
             // Calculate cost basis for this portion
             if let Some(cost) = &pos.cost {
-                cost_basis += take * cost.number;
+                // Checked, not clamped: a clamped cost basis becomes a
+                // fabricated capital gain (#1863).
+                //
+                // DEFENSE-IN-DEPTH, not a currently-reachable fix: no ledger
+                // was found that gets here with an overflowing accumulation —
+                // to sum two in-range cost bases past the ceiling, the
+                // reducing posting's own weight must exceed it too, and that
+                // is reported earlier (verified by removing this check and
+                // re-running the multi-lot fixtures, which still did not
+                // panic). Kept because reachability rests on those upstream
+                // checks, and a future caller reaching `reduce` directly must
+                // not resurrect the panic.
+                cost_basis = take
+                    .checked_mul(cost.number)
+                    .and_then(|v| cost_basis.checked_add(v))
+                    .ok_or_else(|| {
+                        BookingError::Overflow(OverflowError {
+                            currency: cost.currency.clone(),
+                        })
+                    })?;
                 cost_currency = Some(cost.currency.clone());
             }
 
@@ -437,9 +467,17 @@ impl Inventory {
             let available = pos.units.number.abs();
             let take = remaining.min(available);
 
-            // Calculate cost basis for this portion
+            // Calculate cost basis for this portion (checked — see the
+            // matching site in the FIFO/LIFO ladder above).
             if let Some(cost) = &pos.cost {
-                cost_basis += take * cost.number;
+                cost_basis = take
+                    .checked_mul(cost.number)
+                    .and_then(|v| cost_basis.checked_add(v))
+                    .ok_or_else(|| {
+                        BookingError::Overflow(OverflowError {
+                            currency: cost.currency.clone(),
+                        })
+                    })?;
             }
 
             // Record what we matched
@@ -475,7 +513,14 @@ impl Inventory {
             .filter(|p| p.units.currency == units.currency && !p.is_empty())
             .collect();
 
-        let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
+        let total_units: Decimal = matching
+            .iter()
+            .try_fold(Decimal::ZERO, |acc, p| acc.checked_add(p.units.number))
+            .ok_or_else(|| {
+                BookingError::Overflow(OverflowError {
+                    currency: units.currency.clone(),
+                })
+            })?;
 
         if total_units.is_zero() {
             return Err(BookingError::InsufficientUnits {
@@ -497,7 +542,17 @@ impl Inventory {
         let avg = average_cost_from_positions(&matching, total_units)?;
         let cost_basis = avg
             .as_ref()
-            .map(|(avg_cost, currency)| Amount::new(reduction * *avg_cost, currency.clone()));
+            .map(|(avg_cost, currency)| {
+                reduction
+                    .checked_mul(*avg_cost)
+                    .map(|n| Amount::new(n, currency.clone()))
+                    .ok_or_else(|| {
+                        BookingError::Overflow(OverflowError {
+                            currency: currency.clone(),
+                        })
+                    })
+            })
+            .transpose()?;
 
         // Build a position of `number` units of the reduced currency at the
         // average cost (or costless if the lots had no cost).
@@ -548,7 +603,13 @@ impl Inventory {
     /// costs; only this realized view merges them (matching hledger's pool
     /// model). A currency whose lots net to zero is removed; a currency whose
     /// lots have mismatched cost currencies is left untouched.
-    pub fn merge_average(&mut self) {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when a currency's lots sum outside `rust_decimal`'s
+    /// range. The merged view is a realized balance, so a clamped total would
+    /// be rendered as an exact position (#1863).
+    pub fn merge_average(&mut self) -> Result<(), OverflowError> {
         let currencies: std::collections::BTreeSet<Currency> = self
             .positions
             .iter()
@@ -563,7 +624,12 @@ impl Inventory {
                     .iter()
                     .filter(|p| p.units.currency == currency && p.cost.is_some())
                     .collect();
-                let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
+                let total_units: Decimal = matching
+                    .iter()
+                    .try_fold(Decimal::ZERO, |acc, p| acc.checked_add(p.units.number))
+                    .ok_or_else(|| OverflowError {
+                        currency: currency.clone(),
+                    })?;
                 let avg = if total_units.is_zero() {
                     None
                 } else {
@@ -590,6 +656,7 @@ impl Inventory {
             }
         }
         self.rebuild_index();
+        Ok(())
     }
 
     /// Cost merge `{*}`: merge all lots of the currency into a single
@@ -638,7 +705,14 @@ impl Inventory {
                 None => return self.reduce_average(units),
             };
 
-        let cost_basis = Some(Amount::new(reduction * avg_cost, cost_currency.clone()));
+        let cost_basis = Some(Amount::new(
+            reduction.checked_mul(avg_cost).ok_or_else(|| {
+                BookingError::Overflow(OverflowError {
+                    currency: cost_currency.clone(),
+                })
+            })?,
+            cost_currency.clone(),
+        ));
 
         // Return a single synthetic matched position representing the merged lot.
         // This prevents the booking engine from expanding the posting into multiple
@@ -690,7 +764,7 @@ impl Inventory {
         // Check we have enough in the right direction
         if total_units.signum() == units.number.signum() || total_units.is_zero() {
             // This is an augmentation, not a reduction - just add it
-            self.add(Position::simple(units.clone()));
+            self.add(Position::simple(units.clone()))?;
             return Ok(BookingResult {
                 matched: SmallVec::new(),
                 cost_basis: None,
@@ -715,7 +789,7 @@ impl Inventory {
             self.add(Position::simple(Amount::new(
                 (requested - available) * sign,
                 units.currency.clone(),
-            )));
+            )))?;
             return Ok(result);
         }
 
@@ -742,7 +816,17 @@ impl Inventory {
         }
 
         // Calculate cost basis
-        let cost_basis = pos.cost.as_ref().map(|c| c.total_cost(requested));
+        let cost_basis = pos
+            .cost
+            .as_ref()
+            .map(|c| {
+                c.total_cost(requested).ok_or_else(|| {
+                    BookingError::Overflow(OverflowError {
+                        currency: c.currency.clone(),
+                    })
+                })
+            })
+            .transpose()?;
 
         // Record matched
         let (matched, _) = pos.split(requested * pos.units.number.signum());
@@ -807,7 +891,7 @@ mod reduction_tests {
     fn mk(lots: impl IntoIterator<Item = Position>) -> Inventory {
         let mut i = Inventory::new();
         for l in lots {
-            i.add(l);
+            i.add(l).expect("fixture fits in Decimal");
         }
         i
     }
@@ -918,8 +1002,9 @@ mod reduction_tests {
         i.add(Position::with_cost(
             Amount::new(dec!(10), "OTH"), // different currency: must be ignored
             Cost::new(dec!(888), "USD").with_date(naive_date(2024, 1, 1).unwrap()),
-        ));
-        i.add(lot(10, 100, 2)); // the real STK lot
+        ))
+        .expect("fixture fits in Decimal");
+        i.add(lot(10, 100, 2)).expect("fixture fits in Decimal"); // the real STK lot
         i
     }
 
@@ -970,8 +1055,8 @@ mod reduction_tests {
         // `signum() != signum()` → `==` mutant (== would match the short
         // lot or nothing).
         let mut i = Inventory::new();
-        i.add(lot(-10, 50, 1)); // short lot, same sign as a sell
-        i.add(lot(10, 100, 2)); // long lot
+        i.add(lot(-10, 50, 1)).expect("fixture fits in Decimal"); // short lot, same sign as a sell
+        i.add(lot(10, 100, 2)).expect("fixture fits in Decimal"); // long lot
         let r = try_reduce(&i, &sell_stk(5), BookingMethod::Fifo);
         assert_eq!(basis(&r), dec!(500)); // 5 * 100 from the long lot only
         assert!(r.matched.iter().all(|p| p.units.number.is_sign_positive()));
@@ -988,7 +1073,7 @@ mod reduction_tests {
         // the disjunction), turning 0 matches into 1 and succeeding via
         // `try_reduce_from_lot` instead of erroring.
         let mut i = Inventory::new();
-        i.add(lot(-10, 100, 1)); // short STK only; a sell is the same sign
+        i.add(lot(-10, 100, 1)).expect("fixture fits in Decimal"); // short STK only; a sell is the same sign
         let res = i.try_reduce(
             &sell_stk(5),
             Some(&CostSpec::default()),
@@ -1193,11 +1278,12 @@ mod reduction_tests {
     #[test]
     fn reduce_average_only_matching_currency() {
         let mut i = Inventory::new();
-        i.add(lot(10, 100, 2));
+        i.add(lot(10, 100, 2)).expect("fixture fits in Decimal");
         i.add(Position::with_cost(
             Amount::new(dec!(10), "OTH"),
             Cost::new(dec!(888), "USD").with_date(naive_date(2024, 1, 1).unwrap()),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         let r = i
             .reduce(
                 &sell_stk(5),
@@ -1216,8 +1302,8 @@ mod reduction_tests {
         // (book.rs) expand the reduction into one posting per lot, emptying the
         // position and booking a garbage gain.
         let mut i = Inventory::new();
-        i.add(lot(10, 150, 1));
-        i.add(lot(10, 170, 2));
+        i.add(lot(10, 150, 1)).expect("fixture fits in Decimal");
+        i.add(lot(10, 170, 2)).expect("fixture fits in Decimal");
         let r = i
             .reduce(
                 &sell_stk(5),
@@ -1251,7 +1337,8 @@ mod reduction_tests {
         i.add(Position::with_cost(
             Amount::new(dec!(-10), "STK"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         let r = i
             .reduce(
                 &Amount::new(dec!(5), "STK"),
@@ -1270,13 +1357,14 @@ mod reduction_tests {
         // The realized balance of an AVERAGE account is one pool at the
         // weighted-average cost: (10*150 + 10*170 - 5*160) / 15 = 160.
         let mut i = Inventory::new();
-        i.add(lot(10, 150, 1));
-        i.add(lot(10, 170, 2));
+        i.add(lot(10, 150, 1)).expect("fixture fits in Decimal");
+        i.add(lot(10, 170, 2)).expect("fixture fits in Decimal");
         i.add(Position::with_cost(
             Amount::new(dec!(-5), "STK"),
             Cost::new(dec!(160), "USD"),
-        ));
-        i.merge_average();
+        ))
+        .expect("fixture fits in Decimal");
+        i.merge_average().expect("fixture fits in Decimal");
         let stk: Vec<&Position> = i
             .positions()
             .filter(|p| p.units.currency == "STK")
@@ -1289,12 +1377,13 @@ mod reduction_tests {
     #[test]
     fn merge_average_net_zero_removes_lots() {
         let mut i = Inventory::new();
-        i.add(lot(10, 150, 1));
+        i.add(lot(10, 150, 1)).expect("fixture fits in Decimal");
         i.add(Position::with_cost(
             Amount::new(dec!(-10), "STK"),
             Cost::new(dec!(160), "USD"),
-        ));
-        i.merge_average();
+        ))
+        .expect("fixture fits in Decimal");
+        i.merge_average().expect("fixture fits in Decimal");
         assert_eq!(
             i.positions().filter(|p| p.units.currency == "STK").count(),
             0
@@ -1304,9 +1393,10 @@ mod reduction_tests {
     #[test]
     fn merge_average_leaves_costless_positions_untouched() {
         let mut i = Inventory::new();
-        i.add(Position::simple(Amount::new(dec!(100), "USD")));
-        i.add(lot(10, 150, 1));
-        i.merge_average();
+        i.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
+        i.add(lot(10, 150, 1)).expect("fixture fits in Decimal");
+        i.merge_average().expect("fixture fits in Decimal");
         // Cash stays; the single STK lot stays a single lot.
         assert_eq!(i.units("USD"), dec!(100));
         assert_eq!(
@@ -1341,13 +1431,14 @@ mod reduction_tests {
         // sell) and an unrelated OTH lot must be excluded from the merge
         // AND survive in the inventory.
         let mut inv = Inventory::new();
-        inv.add(lot(10, 100, 1)); // long STK
-        inv.add(lot(30, 200, 2)); // long STK
-        inv.add(lot(-5, 999, 3)); // short STK — excluded by the sign filter
+        inv.add(lot(10, 100, 1)).expect("fixture fits in Decimal"); // long STK
+        inv.add(lot(30, 200, 2)).expect("fixture fits in Decimal"); // long STK
+        inv.add(lot(-5, 999, 3)).expect("fixture fits in Decimal"); // short STK — excluded by the sign filter
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "OTH"), // different currency — excluded
             Cost::new(dec!(888), "USD").with_date(naive_date(2024, 1, 4).unwrap()),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         let spec = CostSpec {
             merge: true,
             ..CostSpec::default()
@@ -1376,7 +1467,8 @@ mod reduction_tests {
     #[test]
     fn reduce_none_exact_succeeds_over_reduction_shorts() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(10), "STK")));
+        inv.add(Position::simple(Amount::new(dec!(10), "STK")))
+            .expect("fixture fits in Decimal");
         assert!(
             inv.reduce(&sell_stk(10), None, BookingMethod::None).is_ok(),
             "exact NONE reduction should succeed"
@@ -1385,7 +1477,8 @@ mod reduction_tests {
         // instead of erroring (#1686 — previously InsufficientUnits, which
         // made the outcome depend on whether zero was crossed in one step).
         let mut inv2 = Inventory::new();
-        inv2.add(Position::simple(Amount::new(dec!(10), "STK")));
+        inv2.add(Position::simple(Amount::new(dec!(10), "STK")))
+            .expect("fixture fits in Decimal");
         assert!(
             inv2.reduce(&sell_stk(15), None, BookingMethod::None)
                 .is_ok(),

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -174,7 +174,12 @@ pub enum BookingError {
 ///
 /// `rust_decimal` is a 96-bit type with a hard ~±7.9e28 magnitude ceiling and
 /// its `+`/`*` panic on overflow. There is no in-range answer to substitute,
-/// so every reachable site reports this instead.
+/// so the arithmetic reports instead of clamping.
+///
+/// This type is the reporting channel for sites that own a currency and sit on
+/// a `Result` path. Others use a plain `Option` because they have no currency
+/// to name or no error channel to use — [`crate::Cost::total_cost`],
+/// [`sum_account_and_subaccounts`], and `rustledger_booking`'s weight ladder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OverflowError {
     /// The currency whose running total left the range.
@@ -186,7 +191,8 @@ impl fmt::Display for OverflowError {
         write!(
             f,
             "{} amount exceeds the representable range (±7.9e28); \
-             split the transaction or use smaller units",
+             split the transaction, or denominate it in larger units \
+             (thousands, millions) so the number is smaller",
             self.currency
         )
     }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -161,6 +161,43 @@ pub enum BookingError {
         /// Got currency.
         got: crate::Currency,
     },
+    /// The arithmetic left `rust_decimal`'s ~±7.9e28 range (#1863).
+    ///
+    /// Reported rather than clamped: `Decimal::MIN == -Decimal::MAX`, so
+    /// clamped debits and credits cancel to a residual of exactly zero and an
+    /// arbitrarily unbalanced ledger certifies as clean. Reported rather than
+    /// panicked because ledger input must never abort the CLI.
+    Overflow(OverflowError),
+}
+
+/// A `Decimal` computation whose result cannot be represented.
+///
+/// `rust_decimal` is a 96-bit type with a hard ~±7.9e28 magnitude ceiling and
+/// its `+`/`*` panic on overflow. There is no in-range answer to substitute,
+/// so every reachable site reports this instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverflowError {
+    /// The currency whose running total left the range.
+    pub currency: crate::Currency,
+}
+
+impl fmt::Display for OverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} amount exceeds the representable range (±7.9e28); \
+             split the transaction or use smaller units",
+            self.currency
+        )
+    }
+}
+
+impl std::error::Error for OverflowError {}
+
+impl From<OverflowError> for BookingError {
+    fn from(e: OverflowError) -> Self {
+        Self::Overflow(e)
+    }
 }
 
 impl fmt::Display for BookingError {
@@ -190,6 +227,7 @@ impl fmt::Display for BookingError {
             Self::CurrencyMismatch { expected, got } => {
                 write!(f, "Currency mismatch: expected {expected}, got {got}")
             }
+            Self::Overflow(e) => write!(f, "{e}"),
         }
     }
 }
@@ -238,6 +276,9 @@ pub struct AccountedBookingError {
 impl fmt::Display for AccountedBookingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.error {
+            // The currency is already named in the inner message; the account
+            // is the context this wrapper exists to add.
+            BookingError::Overflow(e) => write!(f, "{}: {e}", self.account),
             BookingError::InsufficientUnits {
                 requested,
                 available,
@@ -486,19 +527,36 @@ impl Inventory {
     /// Get the total book value (cost basis) for a currency.
     ///
     /// Returns the sum of all cost bases for positions of the given currency.
-    #[must_use]
-    pub fn book_value(&self, units_currency: &str) -> FxHashMap<crate::Currency, Decimal> {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when a position's book value, or the running
+    /// per-currency total, leaves `rust_decimal`'s range.
+    pub fn book_value(
+        &self,
+        units_currency: &str,
+    ) -> Result<FxHashMap<crate::Currency, Decimal>, OverflowError> {
         let mut totals: FxHashMap<crate::Currency, Decimal> = FxHashMap::default();
 
         for pos in &self.positions {
-            if pos.units.currency == units_currency
-                && let Some(book) = pos.book_value()
-            {
-                *totals.entry(book.currency.clone()).or_default() += book.number;
+            if pos.units.currency == units_currency {
+                // NOT `pos.book_value()`: its `None` conflates "no cost" with
+                // "product out of range", and skipping the latter would drop a
+                // position from the total silently — the same class of bug as
+                // clamping it (#1863).
+                let Some(cost) = pos.cost.as_ref() else {
+                    continue;
+                };
+                let overflow = || OverflowError {
+                    currency: cost.currency.clone(),
+                };
+                let book = cost.total_cost(pos.units.number).ok_or_else(overflow)?;
+                let slot = totals.entry(book.currency.clone()).or_default();
+                *slot = slot.checked_add(book.number).ok_or_else(overflow)?;
             }
         }
 
-        totals
+        Ok(totals)
     }
 
     /// Add a position to the inventory.
@@ -517,37 +575,74 @@ impl Inventory {
     /// - After add: `totalAdded' = totalAdded + amount`
     ///
     /// See: `spec/tla/Conservation.tla`
-    pub fn add(&mut self, position: Position) {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when the running total for this currency leaves
+    /// `rust_decimal`'s ~±7.9e28 range. The inventory is left UNCHANGED — the
+    /// units cache is only committed once the merge is known to fit, so a
+    /// caller that reports the error and moves on does not carry a
+    /// half-applied position (#1863).
+    pub fn add(&mut self, position: Position) -> Result<(), OverflowError> {
         if position.is_empty() {
-            return;
+            return Ok(());
         }
 
-        // Update units cache
-        *self
+        let overflow = || OverflowError {
+            currency: position.units.currency.clone(),
+        };
+
+        // Compute both running totals BEFORE mutating anything, so an overflow
+        // leaves the inventory untouched rather than half-updated.
+        let cached = self
             .units_cache
-            .entry(position.units.currency.clone())
-            .or_default() += position.units.number;
+            .get(&position.units.currency)
+            .copied()
+            .unwrap_or_default();
+        let new_cached = cached
+            .checked_add(position.units.number)
+            .ok_or_else(overflow)?;
+
+        let merge_idx = position
+            .cost
+            .is_none()
+            .then(|| self.simple_index.get(&position.units.currency).copied())
+            .flatten();
+        let merged_units = merge_idx
+            .map(|idx| {
+                self.positions[idx]
+                    .units
+                    .number
+                    .checked_add(position.units.number)
+                    .ok_or_else(overflow)
+            })
+            .transpose()?;
+
+        self.units_cache
+            .insert(position.units.currency.clone(), new_cached);
 
         // For positions without cost, use index for O(1) lookup
         if position.cost.is_none() {
-            if let Some(&idx) = self.simple_index.get(&position.units.currency) {
+            if let Some(idx) = merge_idx {
                 // Merge with existing position
                 debug_assert!(self.positions[idx].cost.is_none());
-                self.positions[idx].units += &position.units;
-                return;
+                self.positions[idx].units.number =
+                    merged_units.expect("merged_units is Some whenever merge_idx is");
+                return Ok(());
             }
             // No existing position - add new one and index it
             let idx = self.positions.len();
             self.simple_index
                 .insert(position.units.currency.clone(), idx);
             self.positions.push_back(position);
-            return;
+            return Ok(());
         }
 
         // For positions with cost, just add as a new lot.
         // This is O(1) and keeps all lots separate, matching Python beancount behavior.
         // Lot aggregation for display purposes is handled separately in query output.
         self.positions.push_back(position);
+        Ok(())
     }
 
     /// Reduce positions from the inventory using the specified booking method.
@@ -646,18 +741,30 @@ impl Inventory {
     }
 
     /// Merge this inventory with another.
-    pub fn merge(&mut self, other: &Self) {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when a merged running total leaves `rust_decimal`'s
+    /// range. `self` keeps the positions merged before the failure.
+    pub fn merge(&mut self, other: &Self) -> Result<(), OverflowError> {
         for pos in &other.positions {
-            self.add(pos.clone());
+            self.add(pos.clone())?;
         }
+        Ok(())
     }
 
     /// Convert inventory to cost basis.
     ///
     /// Returns a new inventory where all positions are converted to their
     /// cost basis. Positions without cost are returned as-is.
-    #[must_use]
-    pub fn at_cost(&self) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when a `units × cost` product, or the running total
+    /// of those products, leaves `rust_decimal`'s range. Note this can fire on
+    /// inputs far below the ceiling — the product overflows when neither
+    /// operand does.
+    pub fn at_cost(&self) -> Result<Self, OverflowError> {
         let mut result = Self::new();
 
         for pos in &self.positions {
@@ -667,23 +774,33 @@ impl Inventory {
 
             if let Some(cost) = &pos.cost {
                 // Convert to cost basis
-                let total = pos.units.number * cost.number;
-                result.add(Position::simple(Amount::new(total, &cost.currency)));
+                let total =
+                    pos.units
+                        .number
+                        .checked_mul(cost.number)
+                        .ok_or_else(|| OverflowError {
+                            currency: cost.currency.clone(),
+                        })?;
+                result.add(Position::simple(Amount::new(total, &cost.currency)))?;
             } else {
                 // No cost, keep as-is
-                result.add(pos.clone());
+                result.add(pos.clone())?;
             }
         }
 
-        result
+        Ok(result)
     }
 
     /// Convert inventory to units only.
     ///
     /// Returns a new inventory where all positions have their cost removed,
     /// effectively aggregating by currency only.
-    #[must_use]
-    pub fn at_units(&self) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when stripping costs merges lots whose combined units
+    /// leave `rust_decimal`'s range.
+    pub fn at_units(&self) -> Result<Self, OverflowError> {
         let mut result = Self::new();
 
         for pos in &self.positions {
@@ -692,10 +809,10 @@ impl Inventory {
             }
 
             // Strip cost, keep only units
-            result.add(Position::simple(pos.units.clone()));
+            result.add(Position::simple(pos.units.clone()))?;
         }
 
-        result
+        Ok(result)
     }
 }
 
@@ -714,19 +831,25 @@ impl Inventory {
 /// difference differently — booking summed only the leaf account
 /// (`Inventory::units`) while the validator summed sub-accounts — so a pad
 /// targeting a non-leaf account inserted the wrong synthetic amount.
+///
+/// Returns `None` when the sum leaves `rust_decimal`'s range (`Decimal`'s
+/// `Sum` impl panics rather than wrapping). Both callers surface that as a
+/// diagnostic on the assertion/pad rather than asserting against a clamped
+/// total (#1863).
 pub fn sum_account_and_subaccounts<'a, I>(
     inventories: I,
     account: &str,
     currency: &Currency,
-) -> Decimal
+) -> Option<Decimal>
 where
     I: IntoIterator<Item = (&'a Account, &'a Inventory)>,
 {
     inventories
         .into_iter()
         .filter(|(inv_account, _)| is_subaccount_or_equal(inv_account.as_str(), account))
-        .map(|(_, inv)| inv.units(currency))
-        .sum()
+        .try_fold(Decimal::ZERO, |acc, (_, inv)| {
+            acc.checked_add(inv.units(currency))
+        })
 }
 
 impl fmt::Display for Inventory {
@@ -762,13 +885,27 @@ impl fmt::Display for Inventory {
     }
 }
 
-impl FromIterator<Position> for Inventory {
-    fn from_iter<I: IntoIterator<Item = Position>>(iter: I) -> Self {
+impl Inventory {
+    /// Build an inventory from positions.
+    ///
+    /// Replaces the former `FromIterator<Position>` impl, which was removed
+    /// deliberately: `from_iter` cannot report failure, so it had to swallow
+    /// the overflow from [`Self::add`] and hand back an inventory holding a
+    /// wrong total with nothing to indicate it (#1863). A `collect()` that can
+    /// silently lie is worse than no `collect()`.
+    ///
+    /// # Errors
+    ///
+    /// [`OverflowError`] when a running total leaves `rust_decimal`'s range.
+    pub fn try_from_positions<I>(iter: I) -> Result<Self, OverflowError>
+    where
+        I: IntoIterator<Item = Position>,
+    {
         let mut inv = Self::new();
         for pos in iter {
-            inv.add(pos);
+            inv.add(pos)?;
         }
-        inv
+        Ok(inv)
     }
 }
 
@@ -793,7 +930,8 @@ mod tests {
     #[test]
     fn test_add_simple() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         assert!(!inv.is_empty());
         assert_eq!(inv.units("USD"), dec!(100));
@@ -802,8 +940,10 @@ mod tests {
     #[test]
     fn test_add_merge_simple() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
-        inv.add(Position::simple(Amount::new(dec!(50), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(50), "USD")))
+            .expect("fixture fits in Decimal");
 
         // Should merge into one position
         assert_eq!(inv.len(), 1);
@@ -817,8 +957,10 @@ mod tests {
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Should NOT merge - different costs
         assert_eq!(inv.len(), 2);
@@ -828,9 +970,12 @@ mod tests {
     #[test]
     fn test_currencies() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
-        inv.add(Position::simple(Amount::new(dec!(50), "EUR")));
-        inv.add(Position::simple(Amount::new(dec!(10), "AAPL")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(50), "EUR")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(10), "AAPL")))
+            .expect("fixture fits in Decimal");
 
         let currencies = inv.currencies();
         assert_eq!(currencies.len(), 3);
@@ -843,7 +988,8 @@ mod tests {
     fn test_reduce_strict_unique() {
         let mut inv = Inventory::new();
         let cost = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv
             .reduce(&Amount::new(dec!(-5), "AAPL"), None, BookingMethod::Strict)
@@ -861,8 +1007,10 @@ mod tests {
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Per Python beancount: a wildcard reduction (`-3 AAPL` with no cost
         // spec) against an inventory with lots at different costs is
@@ -887,8 +1035,10 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost.clone(),
-        ));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost));
+        ))
+        .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv
             .reduce(&Amount::new(dec!(-3), "AAPL"), None, BookingMethod::Strict)
@@ -908,8 +1058,10 @@ mod tests {
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 15));
         let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 15));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         let result = inv
             .reduce(&Amount::new(dec!(-5), "AAPL"), None, BookingMethod::Strict)
@@ -927,8 +1079,10 @@ mod tests {
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Selling exactly the entire inventory (10 + 5 = 15) is unambiguous
         // even with mixed costs — the user is liquidating the position.
@@ -948,8 +1102,10 @@ mod tests {
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Reducing with cost spec should work
         let spec = CostSpec::empty().with_date(date(2024, 1, 1));
@@ -973,9 +1129,12 @@ mod tests {
         let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 1));
         let cost3 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3))
+            .expect("fixture fits in Decimal");
 
         // FIFO should reduce from oldest (cost 100) first
         let result = inv
@@ -995,9 +1154,12 @@ mod tests {
         let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 1));
         let cost3 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3))
+            .expect("fixture fits in Decimal");
 
         // LIFO should reduce from newest (cost 200) first
         let result = inv
@@ -1013,7 +1175,8 @@ mod tests {
     fn test_reduce_insufficient() {
         let mut inv = Inventory::new();
         let cost = Cost::new(dec!(150.00), "USD");
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv.reduce(&Amount::new(dec!(-15), "AAPL"), None, BookingMethod::Fifo);
 
@@ -1030,17 +1193,20 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD");
         let cost2 = Cost::new(dec!(150.00), "USD");
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
-        let book = inv.book_value("AAPL");
+        let book = inv.book_value("AAPL").expect("fixture fits in Decimal");
         assert_eq!(book.get("USD"), Some(&dec!(1750.00))); // 10*100 + 5*150
     }
 
     #[test]
     fn test_display() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         let s = format!("{inv}");
         assert!(s.contains("100 USD"));
@@ -1059,7 +1225,7 @@ mod tests {
             Position::simple(Amount::new(dec!(50), "USD")),
         ];
 
-        let inv: Inventory = positions.into_iter().collect();
+        let inv = Inventory::try_from_positions(positions).expect("fixture fits in Decimal");
         assert_eq!(inv.units("USD"), dec!(150));
     }
 
@@ -1075,12 +1241,14 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost.clone(),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         assert_eq!(inv.len(), 1);
         assert_eq!(inv.units("AAPL"), dec!(10));
 
         // Sell 10 shares - kept as separate lot for tracking
-        inv.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
         assert_eq!(inv.len(), 2); // Both lots kept
         assert_eq!(inv.units("AAPL"), dec!(0)); // Net units still zero
     }
@@ -1096,10 +1264,12 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost.clone(),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Sell 3 shares - kept as separate lot
-        inv.add(Position::with_cost(Amount::new(dec!(-3), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(-3), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
         assert_eq!(inv.len(), 2); // Both lots kept
         assert_eq!(inv.units("AAPL"), dec!(7)); // Net units correct
     }
@@ -1113,10 +1283,12 @@ mod tests {
         let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
 
         // Buy 10 shares at 150
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
 
         // Sell 5 shares at 160 - should NOT cancel (different cost)
-        inv.add(Position::with_cost(Amount::new(dec!(-5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(-5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Should have two separate lots
         assert_eq!(inv.len(), 2);
@@ -1134,10 +1306,12 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost.clone(),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Buy 5 more shares with same cost - should NOT merge
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Should have two separate lots (different acquisitions)
         assert_eq!(inv.len(), 2);
@@ -1156,13 +1330,15 @@ mod tests {
         inv1.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost.clone(),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // inv2: sell 10 shares
-        inv2.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost));
+        inv2.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Merge keeps both lots, net units is zero
-        inv1.merge(&inv2);
+        inv1.merge(&inv2).expect("fixture fits in Decimal");
         assert_eq!(inv1.len(), 2); // Both lots preserved
         assert_eq!(inv1.units("AAPL"), dec!(0)); // Net units correct
     }
@@ -1181,9 +1357,12 @@ mod tests {
         let cost2 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 2, 1));
         let cost3 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost3))
+            .expect("fixture fits in Decimal");
 
         // HIFO with tied costs should reduce in some deterministic order
         let result = inv
@@ -1204,12 +1383,15 @@ mod tests {
         let cost_mid = Cost::new(dec!(100.00), "USD").with_date(date(2024, 2, 1));
         let cost_high = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_low));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_mid));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_low))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_mid))
+            .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost_high,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Reduce 15 shares - should take from highest cost (200) first
         let result = inv
@@ -1229,8 +1411,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Total: 20 shares, total cost = 10*100 + 10*200 = 3000, avg = 150/share
         // Reduce 5 shares using AVERAGE
@@ -1248,7 +1432,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Reduce all shares
         let result = inv
@@ -1267,7 +1452,8 @@ mod tests {
     fn test_none_booking_augmentation() {
         // NONE booking with same-sign amounts should augment, not reduce
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         // Adding more (same sign) - this is an augmentation
         let result = inv
@@ -1283,7 +1469,8 @@ mod tests {
     fn test_none_booking_reduction() {
         // NONE booking with opposite-sign should reduce
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         let result = inv
             .reduce(&Amount::new(dec!(-30), "USD"), None, BookingMethod::None)
@@ -1296,7 +1483,8 @@ mod tests {
     #[test]
     fn test_none_booking_shorts_past_zero() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         // NONE performs no booking: reducing past the balance shorts instead
         // of erroring (#1686 — previously InsufficientUnits, inconsistent
@@ -1313,7 +1501,8 @@ mod tests {
 
         // Add a lot with specific cost
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Try to reduce with a cost spec that doesn't match
         let wrong_spec = CostSpec::empty().with_date(date(2024, 12, 31));
@@ -1331,7 +1520,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Try to reduce more than available
         let result = inv.reduce(&Amount::new(dec!(-20), "AAPL"), None, BookingMethod::Fifo);
@@ -1357,8 +1547,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Reduce exactly 5 - should match the 5-share lot
         let result = inv
@@ -1381,8 +1573,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Reduce exactly 15 (total) - should succeed via total match exception
         let result = inv
@@ -1405,8 +1599,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Reduce 7 shares - doesn't match either lot exactly, not total
         let result = inv.reduce(
@@ -1425,7 +1621,8 @@ mod tests {
 
         // Short 10 shares
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(-10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         assert_eq!(inv.units("AAPL"), dec!(-10));
         assert!(!inv.is_empty());
@@ -1438,11 +1635,14 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
-        let at_cost = inv.at_cost();
+        let at_cost = inv.at_cost().expect("fixture fits in Decimal");
 
         // AAPL converted: 10*100 + 5*150 = 1000 + 750 = 1750 USD
         // Plus 100 USD simple position = 1850 USD total
@@ -1457,10 +1657,12 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
-        let at_units = inv.at_units();
+        let at_units = inv.at_units().expect("fixture fits in Decimal");
 
         // All AAPL lots merged
         assert_eq!(at_units.units("AAPL"), dec!(15));
@@ -1471,7 +1673,8 @@ mod tests {
     #[test]
     fn test_add_empty_position() {
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(0), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(0), "USD")))
+            .expect("fixture fits in Decimal");
 
         assert!(inv.is_empty());
         assert_eq!(inv.len(), 0);
@@ -1482,7 +1685,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         // Reduce all
         inv.reduce(&Amount::new(dec!(-10), "AAPL"), None, BookingMethod::Fifo)
@@ -1577,13 +1781,15 @@ mod tests {
 
         // Cost in USD
         let cost_usd = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_usd));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_usd))
+            .expect("fixture fits in Decimal");
 
         // Cost in EUR
         let cost_eur = Cost::new(dec!(90.00), "EUR").with_date(date(2024, 2, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_eur));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_eur))
+            .expect("fixture fits in Decimal");
 
-        let book = inv.book_value("AAPL");
+        let book = inv.book_value("AAPL").expect("fixture fits in Decimal");
         assert_eq!(book.get("USD"), Some(&dec!(1000.00)));
         assert_eq!(book.get("EUR"), Some(&dec!(450.00)));
     }
@@ -1593,7 +1799,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv.reduce(&Amount::new(dec!(-20), "AAPL"), None, BookingMethod::Hifo);
 
@@ -1608,7 +1815,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv.reduce(
             &Amount::new(dec!(-20), "AAPL"),
@@ -1645,11 +1853,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(160), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let merge_spec = CostSpec::empty().with_merge();
         let result = inv
@@ -1676,7 +1886,8 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let merge_spec = CostSpec::empty().with_merge();
         let result = inv.reduce(
@@ -1698,11 +1909,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(160), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let merge_spec = CostSpec::empty().with_merge();
         let result = inv
@@ -1727,7 +1940,8 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let merge_spec = CostSpec::empty().with_merge();
         let result = inv
@@ -1750,15 +1964,18 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(100), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(200), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Average cost: (1000 + 1500 + 2000) / 30 = 150 USD
         let merge_spec = CostSpec::empty().with_merge();
@@ -1784,11 +2001,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(130), "EUR"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let merge_spec = CostSpec::empty().with_merge();
         let result = inv.reduce(
@@ -1825,9 +2044,12 @@ mod tests {
         let mut inv = Inventory::new();
 
         // Add in non-alphabetical order
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
-        inv.add(Position::simple(Amount::new(dec!(50), "EUR")));
-        inv.add(Position::simple(Amount::new(dec!(10), "AAPL")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(50), "EUR")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(dec!(10), "AAPL")))
+            .expect("fixture fits in Decimal");
 
         let display = format!("{inv}");
 
@@ -1851,8 +2073,10 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost_high,
-        ));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_low));
+        ))
+        .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_low))
+            .expect("fixture fits in Decimal");
 
         let display = format!("{inv}");
 
@@ -1867,7 +2091,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         // No AAPL positions
-        inv.add(Position::simple(Amount::new(dec!(100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(100), "USD")))
+            .expect("fixture fits in Decimal");
 
         let result = inv.reduce(&Amount::new(dec!(-10), "AAPL"), None, BookingMethod::Hifo);
 
@@ -1883,8 +2108,10 @@ mod tests {
         let cost_new = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
         let cost_old = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_new));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_old));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_new))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_old))
+            .expect("fixture fits in Decimal");
 
         // FIFO should reduce from oldest (cost 100) first
         let result = inv
@@ -1904,8 +2131,10 @@ mod tests {
         let cost_old = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost_new = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_old));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_new));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_old))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_new))
+            .expect("fixture fits in Decimal");
 
         // LIFO should reduce from newest (cost 200) first
         let result = inv
@@ -1937,8 +2166,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(7), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(7), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Reduce exactly 7 - should match the 7-share lot at cost 200
         let result = inv
@@ -1962,8 +2193,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 6, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Both lots are size 5 — should pick the first (oldest) one
         let result = inv
@@ -1987,8 +2220,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // With cost spec filtering to the 200 USD lot, should find unique match
         let spec = CostSpec::empty().with_number(crate::CostNumber::PerUnit {
@@ -2017,12 +2252,15 @@ mod tests {
         let cost_mid = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 1));
         let cost_high = Cost::new(dec!(200.00), "USD").with_date(date(2024, 3, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_low));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_mid));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_low))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost_mid))
+            .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             cost_high,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Reduce 5 — should come from highest cost lot (200)
         let result = inv
@@ -2042,8 +2280,10 @@ mod tests {
         let cost_low = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost_high = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_low));
-        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_high));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_low))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost_high))
+            .expect("fixture fits in Decimal");
 
         // Reduce 8: 5 from high (200) + 3 from low (100)
         let result = inv
@@ -2063,8 +2303,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "EUR").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Filter to USD lots only
         let spec = CostSpec::empty().with_currency("USD");
@@ -2091,11 +2333,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_low,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_high,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Cover 5 shares (positive = reduce short position)
         // HIFO should pick the highest-cost short lot (200)
@@ -2117,8 +2361,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Average cost = (10*100 + 10*200) / 20 = 150
         let result = inv
@@ -2138,8 +2384,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         inv.reduce(&Amount::new(dec!(-5), "AAPL"), None, BookingMethod::Average)
             .unwrap();
@@ -2162,8 +2410,10 @@ mod tests {
         let cost1 = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
         let cost2 = Cost::new(dec!(200.00), "USD").with_date(date(2024, 2, 1));
 
-        inv.add(Position::with_cost(Amount::new(dec!(30), "AAPL"), cost1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+        inv.add(Position::with_cost(Amount::new(dec!(30), "AAPL"), cost1))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2))
+            .expect("fixture fits in Decimal");
 
         // Average cost = (30*100 + 10*200) / 40 = 5000/40 = 125
         let result = inv
@@ -2185,7 +2435,8 @@ mod tests {
         let mut inv = Inventory::new();
 
         let cost = Cost::new(dec!(100.00), "USD").with_date(date(2024, 1, 1));
-        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost))
+            .expect("fixture fits in Decimal");
 
         let result = inv
             .reduce(&Amount::new(dec!(-5), "AAPL"), None, BookingMethod::None)
@@ -2201,7 +2452,8 @@ mod tests {
     fn test_none_booking_short_cover() {
         // Covering a short position with NONE booking
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(-100), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(-100), "USD")))
+            .expect("fixture fits in Decimal");
 
         // Positive amount should reduce the negative position
         let result = inv
@@ -2238,11 +2490,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_old,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_new,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Cover 5 shares — FIFO should pick oldest short (cost 100)
         let result = inv
@@ -2264,11 +2518,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_old,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(-10), "AAPL"),
             cost_new,
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         // Cover 5 shares — LIFO should pick newest short (cost 200)
         let result = inv
@@ -2314,10 +2570,12 @@ mod tests {
 
         // Step 1: buy 100 HOOG with cost
         let cost = Cost::new(dec!(1.50), "EUR").with_date(date(2024, 1, 10));
-        inv.add(Position::with_cost(Amount::new(dec!(100), "HOOG"), cost));
+        inv.add(Position::with_cost(Amount::new(dec!(100), "HOOG"), cost))
+            .expect("fixture fits in Decimal");
 
         // Step 2: sell 25 HOOG without cost spec (simple position)
-        inv.add(Position::simple(Amount::new(dec!(-25), "HOOG")));
+        inv.add(Position::simple(Amount::new(dec!(-25), "HOOG")))
+            .expect("fixture fits in Decimal");
 
         // Step 3: check if buying 50 HOOG with cost spec would be a reduction
         let buy_units = Amount::new(dec!(50), "HOOG");
@@ -2347,7 +2605,8 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD").with_date(date(2024, 1, 1)),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
 
         let sell = Amount::new(dec!(-5), "AAPL"); // opposite sign of the held lot
         let buy = Amount::new(dec!(5), "AAPL"); // same sign
@@ -2367,18 +2626,24 @@ mod tests {
     #[test]
     fn sum_account_and_subaccounts_sums_children_not_prefix_siblings() {
         let mut bank = Inventory::new();
-        bank.add(Position::simple(Amount::new(dec!(10), "USD")));
+        bank.add(Position::simple(Amount::new(dec!(10), "USD")))
+            .expect("fixture fits in Decimal");
         let mut checking = Inventory::new(); // sub-account: included
-        checking.add(Position::simple(Amount::new(dec!(40), "USD")));
+        checking
+            .add(Position::simple(Amount::new(dec!(40), "USD")))
+            .expect("fixture fits in Decimal");
         let mut alias = Inventory::new(); // prefix sibling: excluded
-        alias.add(Position::simple(Amount::new(dec!(99), "USD")));
+        alias
+            .add(Position::simple(Amount::new(dec!(99), "USD")))
+            .expect("fixture fits in Decimal");
 
         let mut map: FxHashMap<Account, Inventory> = FxHashMap::default();
         map.insert(Account::from("Assets:Bank"), bank);
         map.insert(Account::from("Assets:Bank:Checking"), checking);
         map.insert(Account::from("Assets:BankAlias"), alias);
 
-        let total = sum_account_and_subaccounts(map.iter(), "Assets:Bank", &Currency::from("USD"));
+        let total = sum_account_and_subaccounts(map.iter(), "Assets:Bank", &Currency::from("USD"))
+            .expect("fixture fits in Decimal");
         assert_eq!(
             total,
             dec!(50),

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -176,10 +176,12 @@ pub enum BookingError {
 /// its `+`/`*` panic on overflow. There is no in-range answer to substitute,
 /// so the arithmetic reports instead of clamping.
 ///
-/// This type is the reporting channel for sites that own a currency and sit on
-/// a `Result` path. Others use a plain `Option` because they have no currency
-/// to name or no error channel to use — [`crate::Cost::total_cost`],
-/// [`sum_account_and_subaccounts`], and `rustledger_booking`'s weight ladder.
+/// Used where an operation MUTATES an inventory, so a caller that reports and
+/// continues needs to know which currency was left alone. Pure leaf arithmetic
+/// returns a plain `Option` instead and lets its caller supply the context:
+/// [`crate::Cost::total_cost`], [`sum_account_and_subaccounts`], and
+/// `rustledger_booking`'s weight ladder. The split is about who is positioned
+/// to write the diagnostic, not about which failures matter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OverflowError {
     /// The currency whose running total left the range.

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -88,8 +88,8 @@ pub use identifiers::{
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
-    AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,
-    sum_account_and_subaccounts,
+    AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, OverflowError,
+    ReductionScope, sum_account_and_subaccounts,
 };
 pub use meta_json::{json_to_meta_value, meta_value_to_json, meta_value_type_tag};
 pub use position::Position;

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -110,10 +110,13 @@ impl Position {
 
     /// Calculate the book value (total cost) of this position.
     ///
-    /// Returns `None` if there is no cost.
+    /// Returns `None` if there is no cost, or if `units × cost` leaves
+    /// `rust_decimal`'s range (see [`Cost::total_cost`]).
     #[must_use]
     pub fn book_value(&self) -> Option<Amount> {
-        self.cost.as_ref().map(|c| c.total_cost(self.units.number))
+        self.cost
+            .as_ref()
+            .and_then(|c| c.total_cost(self.units.number))
     }
 
     /// Check if this position matches a cost specification.

--- a/crates/rustledger-core/tests/decimal_overflow_test.rs
+++ b/crates/rustledger-core/tests/decimal_overflow_test.rs
@@ -1,0 +1,237 @@
+//! `Decimal` overflow is REPORTED at the API level, never clamped (#1863).
+//!
+//! `rust_decimal` is 96-bit with a ~±7.9e28 ceiling and its `+`/`*` panic on
+//! overflow. The CLI-level behavior is pinned in
+//! `rustledger/tests/decimal_overflow_test.rs`; this file pins the core API
+//! contracts those depend on, including the ones no ledger can currently
+//! reach through the CLI.
+//!
+//! # Why not saturate
+//!
+//! Saturation was implemented and rejected (PR #1890). `Decimal::MIN` is
+//! exactly `-Decimal::MAX`, so clamped opposite-sign values cancel to zero and
+//! an arbitrarily unbalanced ledger certifies as clean. The assertion in
+//! `min_is_exactly_negative_max` pins the property that makes clamping unsound,
+//! so anyone reaching for `saturating_*` here meets the reason first.
+
+use rustledger_core::cost::Cost;
+use rustledger_core::{Amount, Decimal, Inventory, Position};
+use std::str::FromStr;
+
+/// Units and cost that each fit comfortably but whose PRODUCT does not — a
+/// product needs roughly the sum of its operands' digits. A `checked_add`-only
+/// fix would sail past this.
+fn big_units() -> Decimal {
+    Decimal::from_str("10000000000000000").expect("literal")
+}
+
+fn big_cost() -> Decimal {
+    Decimal::from_str("10000000000000").expect("literal")
+}
+
+/// The property that makes saturation unsound. If this ever fails, clamping
+/// would become merely lossy rather than actively misleading — but it holds
+/// for `rust_decimal` and is the reason this whole fix is `checked_*`.
+#[test]
+fn min_is_exactly_negative_max() {
+    assert_eq!(
+        Decimal::MIN,
+        -Decimal::MAX,
+        "clamped debits and credits cancel to exactly zero, so a saturating \
+         residual cannot distinguish a real balance from an overflowed one"
+    );
+    assert_eq!(
+        Decimal::MAX.saturating_add(Decimal::MIN),
+        Decimal::ZERO,
+        "this is the sum that made a 1e40 imbalance pass `check` in PR #1890"
+    );
+}
+
+#[test]
+fn add_reports_overflow_instead_of_panicking() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect("one MAX position fits");
+
+    let err = inv
+        .add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect_err("the second cannot be represented and must be reported");
+    assert_eq!(
+        err.currency.as_str(),
+        "USD",
+        "the message must name the currency"
+    );
+}
+
+/// A rejected `add` must not half-apply: BOTH running totals are computed
+/// before either is committed.
+///
+/// The two can fail independently. `units_cache` tracks every position of the
+/// currency; the merge target holds only the uncosted ones. A costed `+MAX`
+/// against an uncosted `-MAX` nets the cache to zero while the merge target
+/// sits at `-MAX`, so adding `-1` more overflows the MERGE while the cache
+/// still fits — the ordering this test exists to pin. (Written after an
+/// earlier version of it passed with the commit deliberately moved before the
+/// check, because the cache happened to fail first in that fixture.)
+#[test]
+fn a_rejected_add_leaves_the_inventory_unchanged() {
+    let one = Decimal::from_str("1").expect("literal");
+    let mut inv = Inventory::new();
+    inv.add(Position::with_cost(
+        Amount::new(Decimal::MAX, "HOOL"),
+        Cost::new(one, "USD"),
+    ))
+    .expect("costed position fits");
+    inv.add(Position::simple(Amount::new(Decimal::MIN, "HOOL")))
+        .expect("cache nets to zero, uncosted total is MIN");
+
+    assert_eq!(inv.units("HOOL"), Decimal::ZERO, "precondition: cache is 0");
+    let positions_before = inv.positions().count();
+
+    // Cache: 0 + (-1) fits. Merge target: MIN + (-1) overflows.
+    inv.add(Position::simple(Amount::new(-one, "HOOL")))
+        .expect_err("the uncosted merge leaves the range");
+
+    assert_eq!(
+        inv.units("HOOL"),
+        Decimal::ZERO,
+        "the units cache must not be committed when the merge fails"
+    );
+    assert_eq!(
+        inv.positions().count(),
+        positions_before,
+        "no position may be appended by a failed add"
+    );
+}
+
+/// `at_cost` multiplies, so it overflows on inputs far below the ceiling.
+#[test]
+fn at_cost_reports_the_product_overflow() {
+    let mut inv = Inventory::new();
+    inv.add(Position::with_cost(
+        Amount::new(big_units(), "HOOL"),
+        Cost::new(big_cost(), "USD"),
+    ))
+    .expect("the position itself fits");
+
+    let err = inv.at_cost().expect_err("units * cost leaves the range");
+    assert_eq!(
+        err.currency.as_str(),
+        "USD",
+        "reported in the COST currency"
+    );
+}
+
+/// `book_value` must not confuse "no cost" with "out of range".
+///
+/// It deliberately does not go through `Position::book_value`, whose `None`
+/// means both. Skipping an overflowing position would silently drop it from
+/// the total — the same class of defect as clamping it.
+#[test]
+fn book_value_distinguishes_uncosted_from_unrepresentable() {
+    let mut costed = Inventory::new();
+    costed
+        .add(Position::with_cost(
+            Amount::new(big_units(), "HOOL"),
+            Cost::new(big_cost(), "USD"),
+        ))
+        .expect("fits");
+    costed
+        .book_value("HOOL")
+        .expect_err("an out-of-range product must be reported");
+
+    // An uncosted position is not an error — it contributes nothing.
+    let mut uncosted = Inventory::new();
+    uncosted
+        .add(Position::simple(Amount::new(big_units(), "HOOL")))
+        .expect("fits");
+    let totals = uncosted
+        .book_value("HOOL")
+        .expect("no cost is not an overflow");
+    assert!(totals.is_empty(), "an uncosted position has no book value");
+}
+
+/// `Cost::total_cost` is the shared multiplication behind book values and
+/// reduction cost bases.
+#[test]
+fn total_cost_reports_rather_than_panicking() {
+    let cost = Cost::new(big_cost(), "USD");
+    assert!(
+        cost.total_cost(big_units()).is_none(),
+        "the product leaves the range"
+    );
+    let ok = cost
+        .total_cost(Decimal::from_str("10").expect("literal"))
+        .expect("an ordinary quantity fits");
+    assert_eq!(
+        ok.number,
+        Decimal::from_str("100000000000000").expect("literal")
+    );
+}
+
+/// The subtree sum behind balance assertions and pads. `Decimal`'s `Sum` impl
+/// panics, so this had to stop using it.
+#[test]
+fn subtree_sum_reports_overflow() {
+    use rustledger_core::{Account, Currency};
+
+    let mut a = Inventory::new();
+    a.add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect("fits");
+    let mut b = Inventory::new();
+    b.add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+        .expect("fits");
+
+    let accounts = [
+        (Account::from("Assets:Bank"), a),
+        (Account::from("Assets:Bank:Sub"), b),
+    ];
+    let usd = Currency::from("USD");
+
+    assert!(
+        rustledger_core::sum_account_and_subaccounts(
+            accounts.iter().map(|(k, v)| (k, v)),
+            "Assets:Bank",
+            &usd,
+        )
+        .is_none(),
+        "two MAX sub-balances cannot be summed and must report, not panic"
+    );
+}
+
+/// Ordinary ledgers — every real one — must be completely unaffected.
+///
+/// Without this, "report an overflow" would be satisfiable by reporting one
+/// unconditionally.
+#[test]
+fn ordinary_arithmetic_is_untouched() {
+    let mut inv = Inventory::new();
+    inv.add(Position::simple(Amount::new(
+        Decimal::from_str("100.50").expect("literal"),
+        "USD",
+    )))
+    .expect("fits");
+    inv.add(Position::simple(Amount::new(
+        Decimal::from_str("-40.25").expect("literal"),
+        "USD",
+    )))
+    .expect("fits");
+    assert_eq!(
+        inv.units("USD"),
+        Decimal::from_str("60.25").expect("literal")
+    );
+
+    let mut costed = Inventory::new();
+    costed
+        .add(Position::with_cost(
+            Amount::new(Decimal::from_str("10").expect("literal"), "HOOL"),
+            Cost::new(Decimal::from_str("150.00").expect("literal"), "USD"),
+        ))
+        .expect("fits");
+    let at = costed.at_cost().expect("an ordinary product fits");
+    assert_eq!(
+        at.units("USD"),
+        Decimal::from_str("1500.00").expect("literal"),
+        "10 * 150.00"
+    );
+}

--- a/crates/rustledger-core/tests/property_tests.rs
+++ b/crates/rustledger-core/tests/property_tests.rs
@@ -74,7 +74,7 @@ fn arb_inventory() -> impl Strategy<Value = Inventory> {
     prop::collection::vec(arb_position(), 0..10).prop_map(|positions| {
         let mut inv = Inventory::new();
         for pos in positions {
-            inv.add(pos);
+            inv.add(pos).expect("fixture fits in Decimal");
         }
         inv
     })
@@ -174,7 +174,7 @@ proptest! {
         let currency = pos.units.currency.clone();
         let before = inv.units(&currency);
         let mut after_inv = inv;
-        after_inv.add(pos.clone());
+        after_inv.add(pos.clone()).expect("fixture fits in Decimal");
         let after = after_inv.units(&currency);
 
         prop_assert_eq!(after, before + pos.units.number);
@@ -187,7 +187,7 @@ proptest! {
         inv2 in arb_inventory()
     ) {
         let mut merged = inv1.clone();
-        merged.merge(&inv2);
+        merged.merge(&inv2).expect("fixture fits in Decimal");
 
         // Check that units match for common currencies
         for currency in ["USD", "EUR", "GBP", "AAPL", "BTC"] {
@@ -211,7 +211,7 @@ proptest! {
         let mut expected_units: std::collections::HashMap<rustledger_core::Currency, Decimal> = std::collections::HashMap::new();
 
         for pos in &positions {
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
             *expected_units.entry(pos.units.currency.clone()).or_default() += pos.units.number;
         }
 
@@ -232,7 +232,7 @@ proptest! {
         let mut inv = Inventory::new();
 
         for pos in positions {
-            inv.add(pos);
+            inv.add(pos).expect("fixture fits in Decimal");
         }
 
         // All positions should have non-negative units
@@ -249,7 +249,7 @@ proptest! {
     ) {
         let mut inv = Inventory::new();
         for pos in &positions {
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
         }
 
         // Pick a currency and try to reduce more than available

--- a/crates/rustledger-core/tests/tla_behavior_replay.rs
+++ b/crates/rustledger-core/tests/tla_behavior_replay.rs
@@ -136,7 +136,8 @@ fn replay_lot_selection(
                     inv.add(Position::with_cost(
                         Amount::new(units, CURRENCY),
                         lot_cost(key),
-                    ));
+                    ))
+                    .expect("fixture fits in Decimal");
                 }
                 "Reduce" => {
                     let units = dec(&params["units"]);
@@ -257,7 +258,8 @@ fn replay_every_strict_behavior() {
                     inv.add(Position::with_cost(
                         Amount::new(units, commodity(cur)),
                         Cost::new(Decimal::from(next_cost), "USD").with_date(day(1)),
-                    ));
+                    ))
+                    .expect("fixture fits in Decimal");
                     next_cost += 1;
                 }
                 "Reduce" => {
@@ -329,7 +331,8 @@ fn replay_every_average_behavior() {
                     inv.add(Position::with_cost(
                         Amount::new(dec(&params["units"]), CURRENCY),
                         Cost::new(dec(&params["cost"]), "USD").with_date(day(1)),
-                    ));
+                    ))
+                    .expect("fixture fits in Decimal");
                 }
                 "Reduce" => {
                     inv.reduce(
@@ -399,7 +402,8 @@ fn replay_every_none_behavior() {
             match action {
                 "AddUnits" => {
                     let units = dec(&params["units"]);
-                    inv.add(Position::simple(Amount::new(units, CURRENCY)));
+                    inv.add(Position::simple(Amount::new(units, CURRENCY)))
+                        .expect("fixture fits in Decimal");
                     added += units;
                 }
                 "Reduce" => {
@@ -472,7 +476,8 @@ fn replay_every_conservation_behavior() {
                     inv.add(Position::with_cost(
                         Amount::new(units, CURRENCY),
                         cost.clone(),
-                    ));
+                    ))
+                    .expect("fixture fits in Decimal");
                     total_added += units;
                 }
                 "Reduce" => {
@@ -538,7 +543,9 @@ fn replay_every_multi_currency_behavior() {
             let currency = params["currency"].as_str().expect("currency");
             let units = dec(&params["units"]);
             match action {
-                "Add" => inv.add(Position::simple(Amount::new(units, currency))),
+                "Add" => inv
+                    .add(Position::simple(Amount::new(units, currency)))
+                    .expect("fixture fits in Decimal"),
                 "Reduce" => {
                     inv.reduce(&Amount::new(-units, currency), None, BookingMethod::Fifo)
                         .unwrap_or_else(|e| {

--- a/crates/rustledger-core/tests/tla_fifo_bug_test.rs
+++ b/crates/rustledger-core/tests/tla_fifo_bug_test.rs
@@ -18,13 +18,15 @@ fn tla_fifo_should_select_oldest_by_date_not_insertion_order() {
     inv.add(Position::with_cost(
         Amount::new(dec!(10), "AAPL"),
         Cost::new(dec!(150), "USD").with_date(rustledger_core::naive_date(2024, 1, 2).unwrap()),
-    ));
+    ))
+    .expect("fixture fits in Decimal");
 
     // State 3: Add lot with date=1 (OLDER, but added second)
     inv.add(Position::with_cost(
         Amount::new(dec!(10), "AAPL"),
         Cost::new(dec!(100), "USD").with_date(rustledger_core::naive_date(2024, 1, 1).unwrap()),
-    ));
+    ))
+    .expect("fixture fits in Decimal");
 
     // State 4: Reduce using FIFO
     let result = inv

--- a/crates/rustledger-core/tests/tla_proptest.rs
+++ b/crates/rustledger-core/tests/tla_proptest.rs
@@ -97,7 +97,7 @@ proptest! {
         // Add all positions
         for pos in &positions {
             total_added += pos.units.number;
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
         }
 
         // Reduce by arbitrary amounts — possibly more than is held.
@@ -150,7 +150,7 @@ proptest! {
         let mut inv = Inventory::new();
 
         for pos in &positions {
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
         }
 
         // Try to reduce more than available — must fail, untouched.
@@ -202,11 +202,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date1),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(200), "USD").with_date(date2),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // Reduce using FIFO
         let result = inv.reduce(
@@ -244,11 +244,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date1),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(200), "USD").with_date(date2),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let result = inv.reduce(
             &Amount::new(dec!(-5), "AAPL"),
@@ -283,11 +283,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(Decimal::from(cost1), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(Decimal::from(cost2), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let result = inv.reduce(
             &Amount::new(dec!(-5), "AAPL"),
@@ -331,7 +331,7 @@ proptest! {
         from_account.add(Position::with_cost(
             Amount::new(Decimal::from(amount), "USD"),
             Cost::new(dec!(1), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let before_from = from_account.units("USD");
         let before_to = to_account.units("USD");
@@ -387,11 +387,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(Decimal::from(cost), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(Decimal::from(cost + 10), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let result = inv.reduce(
             &Amount::new(dec!(-5), "AAPL"),
@@ -421,7 +421,7 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units), "AAPL"),
             Cost::new(cost_dec, "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let reduce_amount = Decimal::from(units / 2).max(Decimal::ONE);
 
@@ -468,7 +468,7 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // NONE should allow reduction
         let result = inv.reduce(
@@ -505,7 +505,7 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(total_added, "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let to_reduce = Decimal::from(reduce_units).min(total_added);
         let result = inv.reduce(
@@ -554,11 +554,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units1), "AAPL"),
             Cost::new(Decimal::from(cost1), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units2), "AAPL"),
             Cost::new(Decimal::from(cost2), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // AVERAGE should succeed
         let result = inv.reduce(
@@ -593,7 +593,7 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(total_added, "AAPL"),
             Cost::new(Decimal::from(cost), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let result = inv.reduce(
             &Amount::new(-reduce_amount, "AAPL"),
@@ -639,14 +639,14 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_aapl), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         let total_added_aapl = Decimal::from(units_aapl);
 
         // Add GOOG
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_goog), "GOOG"),
             Cost::new(dec!(150), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         let total_added_goog = Decimal::from(units_goog);
 
         // Reduce AAPL
@@ -703,11 +703,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_aapl), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_goog), "GOOG"),
             Cost::new(dec!(150), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // Try to reduce more than available for each currency
         let _ = inv.reduce(
@@ -748,11 +748,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_aapl), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(units_goog), "GOOG"),
             Cost::new(dec!(150), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // Record GOOG balance before AAPL operation
         let goog_before = inv.units("GOOG");
@@ -789,11 +789,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(add1), "AAPL"),
             Cost::new(dec!(100), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(add2), "AAPL"),
             Cost::new(dec!(110), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let total_added = Decimal::from(add1 + add2);
         let mut total_reduced = Decimal::ZERO;
@@ -849,11 +849,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(lot1_size), "AAPL"),
             Cost::new(Decimal::from(cost1), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(lot2_size), "AAPL"),
             Cost::new(Decimal::from(cost2), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // Reduce exactly lot1_size — should match lot1 exactly
         let result = inv.reduce(
@@ -895,7 +895,7 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(lot_size), "AAPL"),
             Cost::new(Decimal::from(cost), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         let reduce_amount = lot_size / 2 + 1; // Always > 0, always <= lot_size
         let reduce_amount = reduce_amount.min(lot_size);
@@ -935,11 +935,11 @@ proptest! {
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(lot_size), "AAPL"),
             Cost::new(Decimal::from(cost1), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(Decimal::from(lot_size), "AAPL"),
             Cost::new(Decimal::from(cost2), "USD").with_date(date),
-        ));
+        )).expect("fixture fits in Decimal");
 
         // Reduce less than lot_size (no exact match, not total)
         let reduce = lot_size - 1;
@@ -1003,7 +1003,7 @@ proptest! {
 
         let mut inv = Inventory::new();
         for pos in &positions {
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
         }
 
         // Build a reduction that may be unsatisfiable in one of several ways.

--- a/crates/rustledger-core/tests/try_reduce_equivalence.rs
+++ b/crates/rustledger-core/tests/try_reduce_equivalence.rs
@@ -101,7 +101,7 @@ proptest! {
     ) {
         let mut inv = Inventory::new();
         for pos in &positions {
-            inv.add(pos.clone());
+            inv.add(pos.clone()).expect("fixture fits in Decimal");
         }
 
         let currency = if wrong_currency { "MSFT" } else { CURRENCY };

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1471,20 +1471,29 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
     // A bare directive list carries no ledger options, so classification and
     // the synthesized-summary account names fall back to beancount defaults
     // (#1806). The session's `clamp` uses the held options instead.
-    rustledger_ops::clamp::clamp_indexed(
+    // On overflow the opening-balance summary cannot be computed. The WIT
+    // signature has no error channel (`rustledger:ledger@3.0.0` returns a bare
+    // list), so we hand back the input UNCLAMPED rather than emit a summary
+    // built from a clamped total — the caller then sees real directives, never
+    // a fabricated opening balance (#1863). Surfacing this as a typed error
+    // needs a WIT contract change; tracked as follow-up.
+    let Ok(clamped) = rustledger_ops::clamp::clamp_indexed(
         &core,
         begin_date,
         end_date,
         &rustledger_ops::clamp::ClampAccounts::default(),
-    )
-    .into_iter()
-    .map(|(d, src)| match src.and_then(|j| orig_index.get(j)) {
-        // Pass-through: hand back the original WIT directive untouched.
-        Some(&i) => entries[i].clone(),
-        // Synthesized summary: build from core with the `<clamped>` source.
-        None => directive_from_core(&d, 0, "<clamped>"),
-    })
-    .collect()
+    ) else {
+        return entries;
+    };
+    clamped
+        .into_iter()
+        .map(|(d, src)| match src.and_then(|j| orig_index.get(j)) {
+            // Pass-through: hand back the original WIT directive untouched.
+            Some(&i) => entries[i].clone(),
+            // Synthesized summary: build from core with the `<clamped>` source.
+            None => directive_from_core(&d, 0, "<clamped>"),
+        })
+        .collect()
 }
 
 /// Run a BQL query against an already-loaded directive set (#1423).
@@ -2037,20 +2046,29 @@ impl SessionState {
         // `clamp` -> `directive_to_json(d, 0, "<clamped>")` mapping dropped.)
         // The held options drive classification + summary account names
         // (#1806), so a renamed-root ledger clamps into its own accounts.
-        rustledger_ops::clamp::clamp_indexed(
+        // See the note in the free-function `clamp` above: no WIT error
+        // channel, so an out-of-range opening balance degrades to unclamped
+        // output rather than a fabricated summary (#1863).
+        let Ok(clamped) = rustledger_ops::clamp::clamp_indexed(
             &self.directives,
             begin_date,
             end_date,
             &self.clamp_accounts(),
-        )
-        .into_iter()
-        .map(|(d, src)| {
-            let (line, file) = src
-                .and_then(|i| self.lines.get(i).copied().zip(self.files.get(i)))
-                .map_or((0, "<clamped>"), |(line, file)| (line, file.as_str()));
-            directive_from_core(&d, line, file)
-        })
-        .collect()
+        ) else {
+            // Same fallback as an unparsable date above: hand back every
+            // entry unclamped. Returning an empty list would silently drop the
+            // whole ledger, which is worse than not clamping.
+            return self.entries();
+        };
+        clamped
+            .into_iter()
+            .map(|(d, src)| {
+                let (line, file) = src
+                    .and_then(|i| self.lines.get(i).copied().zip(self.files.get(i)))
+                    .map_or((0, "<clamped>"), |(line, file)| (line, file.as_str()));
+                directive_from_core(&d, line, file)
+            })
+            .collect()
     }
 }
 

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -818,9 +818,17 @@ fn run_booking(
     for &i in &order {
         let spanned = &mut directives[i];
         if let Directive::Transaction(txn) = &mut spanned.value {
-            match engine.book_and_interpolate_with_gains(txn) {
+            match engine
+                .book_and_interpolate_with_gains(txn)
+                .and_then(|(result, txn_gains)| {
+                    // Applying is part of booking this transaction: an
+                    // overflow here must fail it, not merely warn. Otherwise
+                    // the transaction counts as booked while the running
+                    // balance it should have updated silently did not (#1863).
+                    engine.apply(&result.transaction)?;
+                    Ok((result, txn_gains))
+                }) {
                 Ok((result, txn_gains)) => {
-                    engine.apply(&result.transaction);
                     if let Some(g) = gains.as_deref_mut() {
                         g.extend(txn_gains);
                     }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -242,6 +242,32 @@ thread_local! {
         const { std::cell::Cell::new(0) };
 }
 
+/// Map a booking failure to the validation code that best describes it.
+///
+/// `rledger check` prints these under a single `BOOK` label, but LSP
+/// diagnostics carry a machine-readable code, so the classes are separated
+/// here. Only kinds that booking can actually return are listed; the catch-all
+/// keeps a new `BookingError` variant compiling rather than silently
+/// misclassifying it, at the cost of a less specific code until it is added.
+fn booking_error_code(err: &rustledger_booking::BookingError) -> rustledger_validate::ErrorCode {
+    use rustledger_booking::BookingError as B;
+    use rustledger_booking::InterpolationError as I;
+    use rustledger_core::BookingError as CoreB;
+    use rustledger_validate::ErrorCode;
+    match err {
+        B::Inventory(inner) => match inner.error {
+            CoreB::Overflow(_) => ErrorCode::ArithmeticOverflow,
+            CoreB::InsufficientUnits { .. } => ErrorCode::InsufficientUnits,
+            CoreB::AmbiguousMatch { .. } => ErrorCode::AmbiguousLotMatch,
+            CoreB::NoMatchingLot { .. } | CoreB::CurrencyMismatch { .. } => {
+                ErrorCode::NoMatchingLot
+            }
+        },
+        B::Interpolation(I::Unrepresentable { .. }) => ErrorCode::ArithmeticOverflow,
+        B::Interpolation(_) => ErrorCode::TransactionUnbalanced,
+    }
+}
+
 pub(crate) fn run_ledger_validation(
     mut booked_directives: Vec<Spanned<Directive>>,
     validation_options: ValidationOptions,
@@ -260,17 +286,42 @@ pub(crate) fn run_ledger_validation(
     // Use Strict booking method to match rledger check's default behavior.
     let mut booking_engine = BookingEngine::with_method(BookingMethod::Strict);
     booking_engine.register_account_methods(booked_directives.iter().map(|s| &s.value));
+    // Booking failures, surfaced as diagnostics below.
+    //
+    // `rledger check` reports these itself (`run_booking` pushes a BOOK error
+    // and drops the transaction before Late validation). The LSP used to drop
+    // the error on the floor and let validation re-derive something from the
+    // un-interpolated transaction, which produced a DIFFERENT and misleading
+    // message for the same file — "does not balance: residual 1e29 USD" where
+    // `check` said the posting amount could not be computed (#1863). The
+    // balance validator now declines to judge a transaction with unfilled
+    // postings, so without this the transaction would go silent instead.
+    let mut booking_errors: Vec<ValidationError> = Vec::new();
     for spanned in &mut booked_directives {
-        if let Directive::Transaction(txn) = &mut spanned.value
-            && let Ok(result) = booking_engine.book_and_interpolate(txn)
-        {
-            // An overflow leaves the transaction unbooked here; the
-            // validation pass below reports it as E4004 (#1863).
-            if booking_engine.apply(&result.transaction).is_ok() {
-                *txn = result.transaction;
-            }
+        let (span, file_id) = (spanned.span, spanned.file_id);
+        let Directive::Transaction(txn) = &mut spanned.value else {
+            continue;
+        };
+        let date = txn.date;
+        let outcome = booking_engine.book_and_interpolate(txn).and_then(|result| {
+            booking_engine.apply(&result.transaction)?;
+            Ok(result)
+        });
+        match outcome {
+            Ok(result) => *txn = result.transaction,
+            // Leave the transaction as-is: the remaining validators still
+            // check what they can (account lifecycle, currency constraints).
+            Err(e) => booking_errors.push(ValidationError::with_location(
+                booking_error_code(&e),
+                e.to_string(),
+                date,
+                &Spanned {
+                    value: (),
+                    span,
+                    file_id,
+                },
+            )),
         }
-        // If booking fails, we leave the transaction as-is and let validation catch it
     }
 
     let mut plugin_errors_out = Vec::new();
@@ -333,6 +384,19 @@ pub(crate) fn run_ledger_validation(
     let (session, late_errs) = session.run_late_spanned(&booked_directives, today);
     errors.extend(late_errs);
     errors.extend(session.finalize());
+    // The transaction stays in the validation input (so account-lifecycle and
+    // currency checks still run on it), which means a validator can re-derive
+    // the same failure from the same inventories — an inventory overflow is
+    // reported both by `apply` here and by `update_inventories` there, word
+    // for word. Keep one. Booking failures the validators cannot restate,
+    // such as an unrepresentable interpolation, are unaffected.
+    let seen: std::collections::HashSet<(rustledger_validate::ErrorCode, String)> =
+        errors.iter().map(|e| (e.code, e.message.clone())).collect();
+    errors.extend(
+        booking_errors
+            .into_iter()
+            .filter(|e| !seen.contains(&(e.code, e.message.clone()))),
+    );
 
     LedgerValidation {
         errors,
@@ -2517,5 +2581,67 @@ plugin "auto_accounts"
             "auto_accounts (from the ledger) must still synthesize opens for the \
              unopened file even when the current file's parse is broken — got {b_codes:?}"
         );
+    }
+
+    /// A booking failure must reach the editor as the SAME diagnostic
+    /// `rledger check` prints, not as something a validator re-derived from
+    /// the half-booked transaction (#1863).
+    ///
+    /// `check` books before Late validation and drops failed transactions, so
+    /// it reports "the posting amount cannot be computed". The LSP collapses
+    /// Early+Late into one pass and therefore still validates the failed
+    /// transaction; before this fix the balance validator judged its
+    /// un-interpolated postings and reported "does not balance: residual 1e29
+    /// USD" — pointing the user at an imbalance that would vanish once the
+    /// real error was fixed.
+    #[test]
+    fn booking_failures_reach_the_editor_with_checks_wording() {
+        let src = "2024-01-01 open Assets:Stock\n\
+                   2024-01-01 open Assets:Cash\n\
+                   2024-02-01 * \"x\"\n\
+                  \x20 Assets:Stock  10000000000000000 HOOL {10000000000000.00 USD}\n\
+                  \x20 Assets:Cash\n";
+        let parsed = rustledger_parser::parse(src);
+        let diags = all_diagnostics(&parsed, src, None, None, None, &[], PositionEncoding::Utf16);
+
+        assert_eq!(diags.len(), 1, "exactly one diagnostic: {diags:?}");
+        let d = &diags[0];
+        assert!(
+            d.message.contains("cannot be computed"),
+            "must be the booking failure `check` reports: {}",
+            d.message
+        );
+        assert!(
+            !d.message.contains("does not balance"),
+            "must NOT re-derive a balance error from the unfilled postings: {}",
+            d.message
+        );
+    }
+
+    /// The complement: an overflow must not silence a transaction that IS
+    /// genuinely unbalanced, and must not fire on one that balances.
+    #[test]
+    fn overflow_handling_does_not_disturb_ordinary_balance_checking() {
+        for (src, want) in [
+            (
+                "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n2024-02-01 * \"x\"\n  Assets:A   10.00 USD\n  Assets:B  -10.00 USD\n",
+                None,
+            ),
+            (
+                "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n2024-02-01 * \"x\"\n  Assets:A   10.00 USD\n  Assets:B   -7.00 USD\n",
+                Some("residual 3.00 USD"),
+            ),
+        ] {
+            let parsed = rustledger_parser::parse(src);
+            let diags =
+                all_diagnostics(&parsed, src, None, None, None, &[], PositionEncoding::Utf16);
+            match want {
+                None => assert!(diags.is_empty(), "balanced ledger must be clean: {diags:?}"),
+                Some(needle) => assert!(
+                    diags.iter().any(|d| d.message.contains(needle)),
+                    "expected {needle:?} in {diags:?}"
+                ),
+            }
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -252,17 +252,13 @@ thread_local! {
 fn booking_error_code(err: &rustledger_booking::BookingError) -> rustledger_validate::ErrorCode {
     use rustledger_booking::BookingError as B;
     use rustledger_booking::InterpolationError as I;
-    use rustledger_core::BookingError as CoreB;
     use rustledger_validate::ErrorCode;
     match err {
-        B::Inventory(inner) => match inner.error {
-            CoreB::Overflow(_) => ErrorCode::ArithmeticOverflow,
-            CoreB::InsufficientUnits { .. } => ErrorCode::InsufficientUnits,
-            CoreB::AmbiguousMatch { .. } => ErrorCode::AmbiguousLotMatch,
-            CoreB::NoMatchingLot { .. } | CoreB::CurrencyMismatch { .. } => {
-                ErrorCode::NoMatchingLot
-            }
-        },
+        // Inventory failures share their classification with the Late
+        // validator, which provokes the same errors by replaying reductions.
+        B::Inventory(inner) => ErrorCode::for_booking_error(&inner.error),
+        // Interpolation failures have no validator counterpart: `check`
+        // reports them from booking, so the mapping lives here alone.
         B::Interpolation(I::Unrepresentable { .. }) => ErrorCode::ArithmeticOverflow,
         B::Interpolation(_) => ErrorCode::TransactionUnbalanced,
     }
@@ -390,6 +386,12 @@ pub(crate) fn run_ledger_validation(
     // reported both by `apply` here and by `update_inventories` there, word
     // for word. Keep one. Booking failures the validators cannot restate,
     // such as an unrepresentable interpolation, are unaffected.
+    //
+    // Matching on the rendered message is deliberate: it is the only signal
+    // precise enough to tell a restatement from a genuinely different finding
+    // (the two carry different spans, and several postings of one transaction
+    // legitimately share a code and date). If the wordings ever diverge the
+    // duplicate simply reappears — noise, never a lost diagnostic.
     let seen: std::collections::HashSet<(rustledger_validate::ErrorCode, String)> =
         errors.iter().map(|e| (e.code, e.message.clone())).collect();
     errors.extend(

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -264,8 +264,11 @@ pub(crate) fn run_ledger_validation(
         if let Directive::Transaction(txn) = &mut spanned.value
             && let Ok(result) = booking_engine.book_and_interpolate(txn)
         {
-            booking_engine.apply(&result.transaction);
-            *txn = result.transaction;
+            // An overflow leaves the transaction unbooked here; the
+            // validation pass below reports it as E4004 (#1863).
+            if booking_engine.apply(&result.transaction).is_ok() {
+                *txn = result.transaction;
+            }
         }
         // If booking fails, we leave the transaction as-is and let validation catch it
     }

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use rustledger_core::{
     AccountTypes, Amount, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory,
-    Metadata, NaiveDate, Position, Posting, Span, Spanned, Transaction,
+    Metadata, NaiveDate, OverflowError, Position, Posting, Span, Spanned, Transaction,
 };
 
 /// Account configuration for clamp's synthesized summaries (#1806).
@@ -195,17 +195,23 @@ fn earnings_transaction(
 ///
 /// `accounts` supplies the classification and synthesized-summary account
 /// names (#1806); pass [`ClampAccounts::default`] for beancount defaults.
-#[must_use]
+///
+/// # Errors
+///
+/// [`OverflowError`] when a pre-`begin` running balance leaves
+/// `rust_decimal`'s range, so the opening-balance summary cannot be computed
+/// (#1863). Reported rather than clamped: the summary is emitted as a
+/// synthetic transaction that downstream consumers treat as real ledger data.
 pub fn clamp(
     directives: &[Directive],
     begin: NaiveDate,
     end: NaiveDate,
     accounts: &ClampAccounts,
-) -> Vec<Directive> {
-    clamp_indexed(directives, begin, end, accounts)
+) -> Result<Vec<Directive>, OverflowError> {
+    Ok(clamp_indexed(directives, begin, end, accounts)?
         .into_iter()
         .map(|(d, _)| d)
-        .collect()
+        .collect())
 }
 
 /// Like [`clamp`], but tags each output with its source-input index.
@@ -217,13 +223,12 @@ pub fn clamp(
 /// transaction or a carried-forward price keeps its real location, rather than
 /// every output being attributed to a synthetic `<clamped>` source (the loss
 /// that forced the JSON-path workaround in rustledger/rustledger#1425).
-#[must_use]
 pub fn clamp_indexed(
     directives: &[Directive],
     begin: NaiveDate,
     end: NaiveDate,
     accounts: &ClampAccounts,
-) -> Vec<(Directive, Option<usize>)> {
+) -> Result<Vec<(Directive, Option<usize>)>, OverflowError> {
     let mut balances: HashMap<String, Inventory> = HashMap::new();
     let mut latest_prices: HashMap<(String, String), (NaiveDate, Directive, usize)> =
         HashMap::new();
@@ -239,7 +244,10 @@ pub fn clamp_indexed(
                         if let Some(units) = p.units.as_ref().and_then(IncompleteAmount::as_amount)
                         {
                             let pos = posting_position(units, p.cost.as_ref(), t.date);
-                            balances.entry(p.account.to_string()).or_default().add(pos);
+                            balances
+                                .entry(p.account.to_string())
+                                .or_default()
+                                .add(pos)?;
                         }
                     }
                 }
@@ -280,8 +288,12 @@ pub fn clamp_indexed(
     for (account, inv) in &balances {
         if accounts.types.is_income_statement(account) {
             for position in inv.positions() {
-                *pnl.entry(position.units.currency.to_string()).or_default() +=
-                    position.units.number;
+                let slot = pnl.entry(position.units.currency.to_string()).or_default();
+                *slot = slot
+                    .checked_add(position.units.number)
+                    .ok_or_else(|| OverflowError {
+                        currency: position.units.currency.clone(),
+                    })?;
             }
         }
     }
@@ -314,7 +326,7 @@ pub fn clamp_indexed(
             // pass-throughs by `Option` ordering.
             .then_with(|| a.1.cmp(&b.1))
     });
-    all
+    Ok(all)
 }
 
 #[cfg(test)]
@@ -367,7 +379,8 @@ mod tests {
             previous_balances: "Vermogen:Beginsaldi".to_string(),
             previous_earnings: "Vermogen:Winst:Vorig".to_string(),
         };
-        let clamped = clamp(&directives, d(2024, 1, 1), d(2024, 12, 31), &accounts);
+        let clamped = clamp(&directives, d(2024, 1, 1), d(2024, 12, 31), &accounts)
+            .expect("fixture fits in Decimal");
 
         // The renamed asset account IS carried forward (string-match on
         // "Assets" would have classified it as non-balance-sheet and
@@ -412,7 +425,8 @@ mod tests {
                    2023-06-01 * \"pay\"\n  \
                    Assets:Bank  100.00 USD\n  \
                    Income:Salary  -100.00 USD\n";
-        let clamped = clamp(&dirs(src), d(2024, 1, 1), d(2024, 12, 31), &accounts);
+        let clamped = clamp(&dirs(src), d(2024, 1, 1), d(2024, 12, 31), &accounts)
+            .expect("fixture fits in Decimal");
         assert!(
             clamped
                 .iter()
@@ -444,7 +458,8 @@ mod tests {
             d(2024, 6, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         let summary = clamped
             .iter()
             .find(|dd| is_summary(dd) && mentions(dd, "Assets:Broker"))
@@ -482,7 +497,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
 
         // The in-range transaction is a pass-through pointing back at its input
         // (index 1), so a caller can restore its real filename/lineno.
@@ -510,7 +526,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         let indexed: Vec<_> = out.into_iter().map(|(dir, _)| dir).collect();
         assert_eq!(
             plain, indexed,
@@ -529,7 +546,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
 
         // No pre-begin entries survive.
         assert!(out.iter().all(|dir| dir.date() >= d(2024, 1, 1)));
@@ -553,7 +571,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         assert!(
             out.iter()
                 .all(|dir| !matches!(dir, Directive::Transaction(t)
@@ -569,7 +588,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         assert!(
             out.iter()
                 .all(|dir| !matches!(dir, Directive::Commodity(_)))
@@ -584,7 +604,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         assert!(out.iter().any(|dir| matches!(dir, Directive::Open(_))));
     }
 
@@ -598,7 +619,8 @@ mod tests {
             d(2024, 1, 1),
             d(2024, 12, 31),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
         assert!(
             out.iter()
                 .any(|dir| mentions(dir, "Equity:Earnings:Previous")),
@@ -625,7 +647,8 @@ mod tests {
             d(2014, 1, 1),
             d(2015, 1, 1),
             &ClampAccounts::default(),
-        );
+        )
+        .expect("fixture fits in Decimal");
 
         let opening = out
             .iter()

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -209,7 +209,10 @@ impl NativePlugin for CurrencyAccountsPlugin {
                         None => None,
                     };
                     let amount = match &number {
-                        Some(n) => rustledger_booking::cost_number_weight(units_num, n),
+                        // `None` from the weight ladder means the product left
+                        // `rust_decimal`'s range (#1863); the posting is then
+                        // skipped rather than grouped under a clamped weight.
+                        Some(n) => rustledger_booking::cost_number_weight(units_num, n)?,
                         // Empty `{}` — no determinable cost number; fall back
                         // to the units magnitude (pre-existing behavior; the
                         // spec is resolved by booking before plugins run).
@@ -225,7 +228,7 @@ impl NativePlugin for CurrencyAccountsPlugin {
                     } else {
                         PriceKind::Unit
                     };
-                    let amount = rustledger_booking::price_weight(units_num, price_num, kind);
+                    let amount = rustledger_booking::price_weight(units_num, price_num, kind)?;
                     Some((amount, currency))
                 } else {
                     Some((units_num, units.currency.clone()))

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -319,11 +319,15 @@ impl<'a> Executor<'a> {
                             match val {
                                 Value::Amount(amt) => {
                                     let pos = Position::simple(amt);
-                                    total_inventory.add(pos);
+                                    total_inventory
+                                        .add(pos)
+                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                                     has_positions = true;
                                 }
                                 Value::Position(pos) => {
-                                    total_inventory.add(*pos);
+                                    total_inventory
+                                        .add(*pos)
+                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                                     has_positions = true;
                                 }
                                 Value::Number(n) => {
@@ -348,17 +352,21 @@ impl<'a> Executor<'a> {
                             // If we have any amounts/positions, return as inventory
                             // (also add any plain numbers as __NUMBER__ currency)
                             if has_numbers && !total_number.is_zero() {
-                                total_inventory.add(Position::simple(Amount::new(
-                                    total_number,
-                                    "__NUMBER__".to_string(),
-                                )));
+                                total_inventory
+                                    .add(Position::simple(Amount::new(
+                                        total_number,
+                                        "__NUMBER__".to_string(),
+                                    )))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                             // Realize an AVERAGE-booked account as a single
                             // weighted-average pool: the journal keeps the real
                             // per-lot costs, but the account's balance merges
                             // them (matching its booking method).
                             if self.group_is_single_average_account(group) {
-                                total_inventory.merge_average();
+                                total_inventory
+                                    .merge_average()
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                             Ok(Value::Inventory(Box::new(total_inventory)))
                         } else if has_numbers {
@@ -758,11 +766,15 @@ impl<'a> Executor<'a> {
                                 self.evaluate_subquery_expr(&func.args[0], row, column_map)?;
                             match val {
                                 Value::Amount(amt) => {
-                                    total_inventory.add(Position::simple(amt));
+                                    total_inventory
+                                        .add(Position::simple(amt))
+                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                                     has_positions = true;
                                 }
                                 Value::Position(pos) => {
-                                    total_inventory.add(*pos);
+                                    total_inventory
+                                        .add(*pos)
+                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                                     has_positions = true;
                                 }
                                 Value::Number(n) => {
@@ -784,10 +796,12 @@ impl<'a> Executor<'a> {
 
                         if has_positions {
                             if has_numbers && !total_number.is_zero() {
-                                total_inventory.add(Position::simple(Amount::new(
-                                    total_number,
-                                    "__NUMBER__".to_string(),
-                                )));
+                                total_inventory
+                                    .add(Position::simple(Amount::new(
+                                        total_number,
+                                        "__NUMBER__".to_string(),
+                                    )))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                             Ok(Value::Inventory(Box::new(total_inventory)))
                         } else if has_numbers {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -512,7 +512,9 @@ impl Executor<'_> {
             let overridden_row;
             let row = if track_balance {
                 if let Some(Value::Position(pos)) = position_idx.map(|i| &row[i]) {
-                    running_balance.add((**pos).clone());
+                    running_balance
+                        .add((**pos).clone())
+                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                 }
                 let mut r = row.clone();
                 if let Some(i) = balance_idx {
@@ -947,7 +949,9 @@ impl Executor<'_> {
                         });
 
                         if let Some(ref p) = pos {
-                            cumulative_balance.add(p.clone());
+                            cumulative_balance
+                                .add(p.clone())
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
 
                         // Apply AT function if specified, using the at_mode
@@ -993,9 +997,16 @@ impl Executor<'_> {
                         // AT mode; that diverged from bean-query, where AT
                         // cost collapses the balance to cost-currency totals
                         // and AT units strips lots from the balance.
+                        // An out-of-range cost basis is reported, not
+                        // clamped: a query cell showing a saturated total is
+                        // indistinguishable from a real one (#1863).
                         let balance_for_row = match at_mode {
-                            AtMode::Cost => cumulative_balance.at_cost(),
-                            AtMode::Units => cumulative_balance.at_units(),
+                            AtMode::Cost => cumulative_balance
+                                .at_cost()
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?,
+                            AtMode::Units => cumulative_balance
+                                .at_units()
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?,
                             AtMode::None | AtMode::Other => cumulative_balance.clone(),
                         };
 
@@ -1056,12 +1067,16 @@ impl Executor<'_> {
                 match at_func.to_uppercase().as_str() {
                     "COST" => {
                         // Sum up cost basis
-                        let cost_inventory = balance.at_cost();
+                        let cost_inventory = balance
+                            .at_cost()
+                            .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         Value::Inventory(Box::new(cost_inventory))
                     }
                     "UNITS" => {
                         // Just the units (remove cost info)
-                        let units_inventory = balance.at_units();
+                        let units_inventory = balance
+                            .at_units()
+                            .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         Value::Inventory(Box::new(units_inventory))
                     }
                     _ => Value::Inventory(Box::new(balance.clone())),

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -524,7 +524,8 @@ impl<'a> Executor<'a> {
                                     let bal = account_balances
                                         .entry(posting.account.clone())
                                         .or_default();
-                                    bal.add(pos);
+                                    bal.add(pos)
+                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                                 }
                             }
                         }
@@ -558,7 +559,8 @@ impl<'a> Executor<'a> {
                     let resolved = resolve_position(posting, txn.date);
                     if needs_account_balance && let Some(pos) = resolved.clone() {
                         let bal = account_balances.entry(posting.account.clone()).or_default();
-                        bal.add(pos);
+                        bal.add(pos)
+                            .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                     }
 
                     // Callers that only want the per-account totals (BALANCES, via
@@ -625,7 +627,9 @@ impl<'a> Executor<'a> {
                     // query doesn't read `balance`.
                     if needs_balance {
                         if let Some(pos) = resolved {
-                            cumulative_balance.add(pos);
+                            cumulative_balance
+                                .add(pos)
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
                         ctx.balance = Some(cumulative_balance.clone());
                     }
@@ -825,7 +829,9 @@ impl<'a> Executor<'a> {
                         // Return inventory with just units (no cost info)
                         let mut units_inv = Inventory::new();
                         for pos in inv.positions() {
-                            units_inv.add(Position::simple(pos.units.clone()));
+                            units_inv
+                                .add(Position::simple(pos.units.clone()))
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
                         Ok(Value::Inventory(Box::new(units_inv)))
                     }
@@ -1162,7 +1168,9 @@ impl<'a> Executor<'a> {
                             .collect();
                         let mut new_inv = Inventory::new();
                         for pos in filtered {
-                            new_inv.add(pos);
+                            new_inv
+                                .add(pos)
+                                .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
                         Ok(Value::Inventory(Box::new(new_inv)))
                     }
@@ -1289,12 +1297,18 @@ impl<'a> Executor<'a> {
                         let mut result = Inventory::default();
                         for pos in inv.positions() {
                             if pos.units.currency == target_currency {
-                                result.add(Position::simple(pos.units.clone()));
+                                result
+                                    .add(Position::simple(pos.units.clone()))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             } else if let Some(converted) = convert_amount(&pos.units) {
-                                result.add(Position::simple(converted));
+                                result
+                                    .add(Position::simple(converted))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             } else {
                                 // No conversion available - keep original (Python beancount behavior)
-                                result.add(Position::simple(pos.units.clone()));
+                                result
+                                    .add(Position::simple(pos.units.clone()))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                         }
                         // If result has single currency matching target, return as Amount
@@ -1491,13 +1505,26 @@ impl<'a> Executor<'a> {
                         let mut result = Inventory::new();
                         for pos in inv.positions() {
                             if let Some(cost) = &pos.cost {
-                                let total = pos.units.number * cost.number;
-                                result.add(Position::simple(Amount::new(
-                                    total,
-                                    cost.currency.clone(),
-                                )));
+                                // Checked: `units * cost` leaves range on
+                                // inputs well below the ceiling (#1863).
+                                let total =
+                                    pos.units.number.checked_mul(cost.number).ok_or_else(|| {
+                                        QueryError::Evaluation(format!(
+                                            "{} cost basis exceeds the representable range \
+                                             (±7.9e28)",
+                                            cost.currency
+                                        ))
+                                    })?;
+                                result
+                                    .add(Position::simple(Amount::new(
+                                        total,
+                                        cost.currency.clone(),
+                                    )))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             } else {
-                                result.add(Position::simple(pos.units.clone()));
+                                result
+                                    .add(Position::simple(pos.units.clone()))
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                         }
                         Ok(Value::Inventory(Box::new(result)))
@@ -1866,7 +1893,8 @@ impl<'a> Executor<'a> {
                         } else {
                             pos.units.clone()
                         };
-                        out.add(rustledger_core::Position::simple(units));
+                        out.add(rustledger_core::Position::simple(units))
+                            .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                     }
                     return Ok(Value::Inventory(Box::new(out)));
                 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -53,6 +53,18 @@ use crate::error::QueryError;
 /// both [`Executor::build_postings_table`] (the `#postings` table
 /// builder) and [`Executor::evaluate_column`] (the default-FROM column
 /// accessor) so the two paths can't drift again.
+/// The BQL-facing rendering of a `Decimal` overflow (#1863).
+///
+/// A query cell has no error code, so this carries the currency in the message
+/// instead — the same information `E4004` puts in its context field.
+fn overflow_err(currency: &rustledger_core::Currency) -> QueryError {
+    QueryError::Evaluation(format!(
+        "{currency} amount exceeds the representable range (±7.9e28); \
+         split the transaction, or denominate it in larger units \
+         (thousands, millions) so the number is smaller"
+    ))
+}
+
 pub(super) fn compute_posting_weight(posting: &rustledger_core::Posting) -> Value {
     rustledger_booking::posting_weight(posting).map_or(Value::Null, Value::Amount)
 }
@@ -847,7 +859,11 @@ impl<'a> Executor<'a> {
                     Value::Position(p) => {
                         if let Some(cost) = &p.cost {
                             // Preserve sign: buys give positive cost, sells give negative
-                            let total = p.units.number * cost.number;
+                            let total = p
+                                .units
+                                .number
+                                .checked_mul(cost.number)
+                                .ok_or_else(|| overflow_err(&cost.currency))?;
                             Ok(Value::Amount(Amount::new(total, cost.currency.clone())))
                         } else {
                             Ok(Value::Amount(p.units.clone()))
@@ -859,12 +875,19 @@ impl<'a> Executor<'a> {
                         let mut currency: Option<rustledger_core::Currency> = None;
                         for pos in inv.positions() {
                             if let Some(cost) = &pos.cost {
-                                total += pos.units.number * cost.number;
+                                total = pos
+                                    .units
+                                    .number
+                                    .checked_mul(cost.number)
+                                    .and_then(|v| total.checked_add(v))
+                                    .ok_or_else(|| overflow_err(&cost.currency))?;
                                 if currency.is_none() {
                                     currency = Some(cost.currency.clone());
                                 }
                             } else {
-                                total += pos.units.number;
+                                total = total
+                                    .checked_add(pos.units.number)
+                                    .ok_or_else(|| overflow_err(&pos.units.currency))?;
                                 if currency.is_none() {
                                     currency = Some(pos.units.currency.clone());
                                 }

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -275,13 +275,15 @@ fn test_inventory_hash_includes_cost() {
     inv1.add(Position::with_cost(
         Amount::new(dec!(10), "AAPL"),
         Cost::new(dec!(100), "USD"),
-    ));
+    ))
+    .expect("fixture fits in Decimal");
 
     let mut inv2 = Inventory::new();
     inv2.add(Position::with_cost(
         Amount::new(dec!(10), "AAPL"),
         Cost::new(dec!(200), "USD"),
-    ));
+    ))
+    .expect("fixture fits in Decimal");
 
     let hash1 = hash_single_value(&Value::Inventory(Box::new(inv1)));
     let hash2 = hash_single_value(&Value::Inventory(Box::new(inv2)));

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -536,14 +536,19 @@ impl PriceDatabase {
 
     /// Convert an amount to a target currency.
     ///
-    /// Returns the converted amount, or None if no price is available.
+    /// Returns the converted amount, or `None` if no price is available — or
+    /// if the converted value would leave `rust_decimal`'s range (#1863).
+    /// Both callers already keep the raw units when this returns `None`, which
+    /// is the right answer for an unrepresentable conversion too: showing the
+    /// original amount is honest, showing a clamped one is not.
     pub fn convert(&self, amount: &Amount, to_currency: &str, date: NaiveDate) -> Option<Amount> {
         if amount.currency == to_currency {
             return Some(amount.clone());
         }
 
         self.get_price(&amount.currency, to_currency, date)
-            .map(|price| Amount::new(amount.number * price, to_currency))
+            .and_then(|price| amount.number.checked_mul(price))
+            .map(|n| Amount::new(n, to_currency))
     }
 
     /// Adapt this price index to the returns engine's
@@ -560,13 +565,17 @@ impl PriceDatabase {
     }
 
     /// Convert an amount using the latest available price.
+    ///
+    /// `None` on no price OR on an unrepresentable product — see
+    /// [`Self::convert`] for why those share a return value.
     pub fn convert_latest(&self, amount: &Amount, to_currency: &str) -> Option<Amount> {
         if amount.currency == to_currency {
             return Some(amount.clone());
         }
 
         self.get_latest_price(&amount.currency, to_currency)
-            .map(|price| Amount::new(amount.number * price, to_currency))
+            .and_then(|price| amount.number.checked_mul(price))
+            .map(|n| Amount::new(n, to_currency))
     }
 
     /// Get all currencies that have prices defined.

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -56,6 +56,8 @@ pub enum ErrorCode {
     InsufficientUnits,
     /// E4003: Ambiguous lot match in STRICT mode.
     AmbiguousLotMatch,
+    /// E4004: Arithmetic exceeded the representable decimal range.
+    ArithmeticOverflow,
     /// E4005: Cost amount is negative (cost must be non-negative).
     NegativeCost,
 
@@ -112,6 +114,7 @@ impl ErrorCode {
         Self::NoMatchingLot,
         Self::InsufficientUnits,
         Self::AmbiguousLotMatch,
+        Self::ArithmeticOverflow,
         Self::NegativeCost,
         Self::UndeclaredCurrency,
         Self::CurrencyNotAllowed,
@@ -149,6 +152,7 @@ impl ErrorCode {
             Self::NoMatchingLot => "E4001",
             Self::InsufficientUnits => "E4002",
             Self::AmbiguousLotMatch => "E4003",
+            Self::ArithmeticOverflow => "E4004",
             Self::NegativeCost => "E4005",
             // Currency errors
             Self::UndeclaredCurrency => "E5001",
@@ -233,6 +237,7 @@ impl ErrorCode {
             Self::NoMatchingLot => "No matching lot for reduction",
             Self::InsufficientUnits => "Not enough units in matching lots",
             Self::AmbiguousLotMatch => "Ambiguous lot match under STRICT booking",
+            Self::ArithmeticOverflow => "Amount exceeds the representable range",
             Self::NegativeCost => "Negative cost",
             Self::UndeclaredCurrency => "Currency used without a commodity declaration",
             Self::CurrencyNotAllowed => "Currency not allowed in this account",
@@ -361,6 +366,15 @@ impl ErrorCode {
                  disambiguate with the lot's cost `{10.00 USD}`, date `{2024-01-02}`, \
                  or label `{\"lot-a\"}` — or open the account with a non-strict \
                  method: `2024-01-01 open Assets:Stock \"FIFO\"`."
+            }
+            Self::ArithmeticOverflow => {
+                "An amount, or a running total, is larger than rledger's decimal type \
+                 can represent (about ±7.9×10²⁸ — a 96-bit type with ~28 significant \
+                 digits).\n\nrledger reports this instead of rounding or clamping: a \
+                 clamped figure would be printed as if it were exact, and two clamped \
+                 figures of opposite sign cancel to zero, which would make an \
+                 unbalanced transaction look balanced.\n\nFix: split the transaction, \
+                 or use larger units (thousands, millions) for the commodity."
             }
             Self::NegativeCost => {
                 "A posting's cost amount is negative — a cost basis must be \

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -93,6 +93,27 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
+    /// The code for an inventory-level booking failure.
+    ///
+    /// CANONICAL: the LSP surfaces booking errors it caught itself, and the
+    /// Late validator surfaces the ones it provokes by replaying reductions —
+    /// two call sites, one classification. They had byte-identical `match`
+    /// arms; a reclassification applied to one and not the other would give
+    /// the same ledger different codes in the editor and on the command line
+    /// (CLAUDE.md, Canonical-Function Discipline).
+    #[must_use]
+    pub const fn for_booking_error(err: &rustledger_core::BookingError) -> Self {
+        use rustledger_core::BookingError as B;
+        match err {
+            B::Overflow(_) => Self::ArithmeticOverflow,
+            B::InsufficientUnits { .. } => Self::InsufficientUnits,
+            B::AmbiguousMatch { .. } => Self::AmbiguousLotMatch,
+            B::NoMatchingLot { .. } | B::CurrencyMismatch { .. } => Self::NoMatchingLot,
+        }
+    }
+}
+
+impl ErrorCode {
     /// Every error-code variant. Used by the spec-drift guard test (and any
     /// catalog enumeration). MUST list every variant — keep it in sync with the
     /// enum; the exhaustive [`code`](Self::code) match is the compiler-enforced

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1266,7 +1266,8 @@ mod tests {
         for (name, amt) in fixture {
             let acct = Account::from(name);
             let mut inv = Inventory::new();
-            inv.add(rustledger_core::Position::simple(Amount::new(amt, "USD")));
+            inv.add(rustledger_core::Position::simple(Amount::new(amt, "USD")))
+                .expect("fixture fits in Decimal");
             state.inventories.insert(acct.clone(), inv);
             state.inventory_accounts.insert(acct);
         }
@@ -1284,7 +1285,8 @@ mod tests {
             let indexed =
                 sum_account_subtree(&state.inventories, &state.inventory_accounts, &acct, &cur);
             let scan =
-                rustledger_core::sum_account_and_subaccounts(state.inventories.iter(), name, &cur);
+                rustledger_core::sum_account_and_subaccounts(state.inventories.iter(), name, &cur)
+                    .expect("fixture fits in Decimal");
             assert_eq!(indexed, scan, "indexed vs scan disagree for {name}");
         }
 

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -217,21 +217,32 @@ pub fn validate_balance_late(
                 let difference = expected - actual;
 
                 if difference != Decimal::ZERO {
-                    // Add padding amount to target account
-                    if let Some(target_inv) = state.inventories.get_mut(&bal.account) {
-                        target_inv.add(Position::simple(Amount::new(
-                            difference,
-                            &bal.amount.currency,
-                        )));
-                    }
+                    // A pad amount that cannot be represented is reported, not
+                    // clamped — padding to a clamped figure would silently
+                    // satisfy the very assertion being checked (#1863).
+                    let mut pad_into = |account, number| {
+                        state
+                            .inventories
+                            .get_mut(account)
+                            .map(|inv| {
+                                inv.add(Position::simple(Amount::new(number, &bal.amount.currency)))
+                            })
+                            .transpose()
+                            .err()
+                    };
+                    // Add to the target account, subtract from the source.
+                    let overflow = pad_into(&bal.account, difference)
+                        .or_else(|| pad_into(&pending_pad.source_account, -difference));
 
-                    // Subtract padding amount from source account
-                    if let Some(source_inv) = state.inventories.get_mut(&pending_pad.source_account)
-                    {
-                        source_inv.add(Position::simple(Amount::new(
-                            -difference,
-                            &bal.amount.currency,
-                        )));
+                    if let Some(e) = overflow {
+                        errors.push(
+                            ValidationError::new(
+                                ErrorCode::ArithmeticOverflow,
+                                e.to_string(),
+                                bal.date,
+                            )
+                            .with_context(format!("account: {}", bal.account)),
+                        );
                     }
 
                     // Record that this pad covered the asserted currency.

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -230,9 +230,18 @@ pub fn validate_balance_late(
                             .transpose()
                             .err()
                     };
-                    // Add to the target account, subtract from the source.
-                    let overflow = pad_into(&bal.account, difference)
-                        .or_else(|| pad_into(&pending_pad.source_account, -difference));
+                    // Add to the target account, subtract from the source. A
+                    // pad is two halves of one entry, so if the source half
+                    // overflows the target half is UNDONE — otherwise the
+                    // target carries a credit with no matching debit, and a
+                    // later assertion on it could pass off a pad that never
+                    // happened. The undo restores a total that existed a
+                    // moment ago, so it cannot itself overflow.
+                    let overflow = pad_into(&bal.account, difference).or_else(|| {
+                        pad_into(&pending_pad.source_account, -difference).inspect(|_| {
+                            drop(pad_into(&bal.account, -difference));
+                        })
+                    });
 
                     if let Some(e) = overflow {
                         errors.push(

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -345,10 +345,12 @@ pub fn validate_transaction_balance(
     // calculation. We only skip on exact zero (not "within tolerance")
     // because Decimal arithmetic can lose precision during cost/price
     // multiplication, potentially under-reporting a non-zero residual.
-    let fast_residuals = rustledger_booking::calculate_residual(txn);
-    let all_zero = fast_residuals
-        .values()
-        .all(|residual| *residual == Decimal::ZERO);
+    // `None` = the fast tier's arithmetic left `rust_decimal`'s range, so it
+    // has no opinion; fall through to the exact tier rather than skipping.
+    // Short-circuiting on `None` here would pass an arbitrarily unbalanced
+    // transaction (#1863).
+    let all_zero = rustledger_booking::calculate_residual(txn)
+        .is_some_and(|residuals| residuals.values().all(|r| *r == Decimal::ZERO));
 
     if all_zero {
         return;
@@ -431,8 +433,17 @@ pub fn update_inventories(
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);
-        } else {
-            process_inventory_addition(inv, posting, units, txn);
+        } else if let Err(e) = process_inventory_addition(inv, posting, units, txn) {
+            errors.push(
+                ValidationError::new(
+                    ErrorCode::ArithmeticOverflow,
+                    rustledger_core::BookingError::Overflow(e.clone())
+                        .with_account(posting.account.clone())
+                        .to_string(),
+                    txn.date,
+                )
+                .with_context(format!("currency: {}", e.currency)),
+            );
         }
     }
 }
@@ -489,6 +500,10 @@ pub fn process_inventory_reduction(
                     ErrorCode::NoMatchingLot,
                     format!("cost spec: {:?}", posting.cost),
                 ),
+                rustledger_core::BookingError::Overflow(e) => (
+                    ErrorCode::ArithmeticOverflow,
+                    format!("currency: {}", e.currency),
+                ),
             };
             errors.push(
                 ValidationError::new(
@@ -503,15 +518,20 @@ pub fn process_inventory_reduction(
 }
 
 /// Process an inventory addition (buying/adding units).
+///
+/// # Errors
+///
+/// [`rustledger_core::OverflowError`] when the account's running total leaves
+/// `rust_decimal`'s range (#1863).
 pub fn process_inventory_addition(
     inv: &mut Inventory,
     posting: &Posting,
     units: &Amount,
     txn: &Transaction,
-) {
+) -> Result<(), rustledger_core::OverflowError> {
     let position = rustledger_core::Position::from_posting(units, posting.cost.as_ref(), txn.date);
 
-    inv.add(position);
+    inv.add(position)
 }
 
 #[cfg(test)]

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -340,6 +340,23 @@ pub fn validate_transaction_balance(
         return;
     }
 
+    // Same rule, other cause: a posting whose units interpolation never filled
+    // in. The residual of a half-filled transaction is an artifact of the
+    // failure, not a fact about the user's file — reporting it sends them
+    // hunting for an imbalance that would not exist once the real error is
+    // fixed.
+    //
+    // Unreachable from `rledger check`, whose pipeline books BEFORE Late
+    // validation and drops failed transactions (`run_booking`'s
+    // `failed_indices`), so every posting it sees is filled. It matters for
+    // the LSP, which collapses Early+Late into one pass and therefore does
+    // validate transactions whose booking failed: without this it reported
+    // "does not balance: residual 1e29 USD" where `check` reported that the
+    // posting amount could not be computed at all (#1863).
+    if txn.postings.iter().any(|p| p.amount().is_none()) {
+        return;
+    }
+
     // Fast path: use rust_decimal first. If ALL residuals are exactly zero,
     // the transaction definitely balances — skip the expensive BigDecimal
     // calculation. We only skip on exact zero (not "within tolerance")

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -353,6 +353,16 @@ pub fn validate_transaction_balance(
     // validate transactions whose booking failed: without this it reported
     // "does not balance: residual 1e29 USD" where `check` reported that the
     // posting amount could not be computed at all (#1863).
+    //
+    // Returning silently is right ONLY because something else has already
+    // spoken: `check` reports the booking error, and the LSP surfaces it
+    // directly (`booking_error_code`). One case is not covered — a
+    // post-booking plugin that emits a posting with no units. Nothing in-tree
+    // does, and the plugin wire format permitting it is the deeper problem,
+    // but such a transaction would now pass silently where it previously drew
+    // a (misleading) E3001. Fixing it properly means the caller telling this
+    // validator whether booking succeeded, rather than it inferring from the
+    // postings.
     if txn.postings.iter().any(|p| p.amount().is_none()) {
         return;
     }
@@ -503,24 +513,23 @@ pub fn process_inventory_reduction(
             // On pre-booked directives, reduce() with a fully-specified cost
             // should not fail. If it does, report the error — this catches
             // bugs in the booking engine or standalone validation without booking.
-            let (code, context) = match &err {
-                rustledger_core::BookingError::InsufficientUnits { .. } => (
-                    ErrorCode::InsufficientUnits,
-                    format!("currency: {}", units.currency),
-                ),
-                rustledger_core::BookingError::AmbiguousMatch { .. } => (
-                    ErrorCode::AmbiguousLotMatch,
-                    "Specify cost, date, or label to disambiguate".to_string(),
-                ),
+            // Code from the canonical mapping (shared with the LSP); only the
+            // CONTEXT string is local, since it draws on this posting.
+            let code = ErrorCode::for_booking_error(&err);
+            let context = match &err {
+                rustledger_core::BookingError::InsufficientUnits { .. } => {
+                    format!("currency: {}", units.currency)
+                }
+                rustledger_core::BookingError::AmbiguousMatch { .. } => {
+                    "Specify cost, date, or label to disambiguate".to_string()
+                }
                 rustledger_core::BookingError::NoMatchingLot { .. }
-                | rustledger_core::BookingError::CurrencyMismatch { .. } => (
-                    ErrorCode::NoMatchingLot,
-                    format!("cost spec: {:?}", posting.cost),
-                ),
-                rustledger_core::BookingError::Overflow(e) => (
-                    ErrorCode::ArithmeticOverflow,
-                    format!("currency: {}", e.currency),
-                ),
+                | rustledger_core::BookingError::CurrencyMismatch { .. } => {
+                    format!("cost spec: {:?}", posting.cost)
+                }
+                rustledger_core::BookingError::Overflow(e) => {
+                    format!("currency: {}", e.currency)
+                }
             };
             errors.push(
                 ValidationError::new(

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -483,8 +483,11 @@ include "accounts.beancount"
             if let Directive::Transaction(txn) = directive
                 && let Ok(result) = engine.book_and_interpolate(txn)
             {
-                // Same as the LSP: on overflow leave the transaction
-                // unbooked and let validation report E4004 (#1863).
+                // This test replicates the loader's booking loop by hand;
+                // production wasm books via `helpers::load_and_book`, which
+                // goes through `rustledger_loader` and needs no change here.
+                // Skip the write-back on overflow so the loop matches what the
+                // loader does with a transaction that fails to apply (#1863).
                 if engine.apply(&result.transaction).is_ok() {
                     *txn = result.transaction;
                 }

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -483,8 +483,11 @@ include "accounts.beancount"
             if let Directive::Transaction(txn) = directive
                 && let Ok(result) = engine.book_and_interpolate(txn)
             {
-                engine.apply(&result.transaction);
-                *txn = result.transaction;
+                // Same as the LSP: on overflow leave the transaction
+                // unbooked and let validation report E4004 (#1863).
+                if engine.apply(&result.transaction).is_ok() {
+                    *txn = result.transaction;
+                }
             }
         }
         // Sort by date for proper validation

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -717,11 +717,13 @@ mod tests {
         inv.add(Position::with_cost(
             Amount::new(dec!(8.373), "RGAGX"),
             Cost::new(dec!(128.99), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         inv.add(Position::with_cost(
             Amount::new(dec!(8.199), "RGAGX"),
             Cost::new(dec!(131.73), "USD"),
-        ));
+        ))
+        .expect("fixture fits in Decimal");
         let value = Value::Inventory(Box::new(inv));
         let ctx = DisplayContext::new();
         let rendered = format_value(&value, false, &ctx);
@@ -779,7 +781,8 @@ mod tests {
 
         // Sub-cent residual: -0.0003183 USD is "zero at USD precision".
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")))
+            .expect("fixture fits in Decimal");
 
         let rendered = format_value(&Value::Inventory(Box::new(inv)), false, &ctx);
         assert_eq!(
@@ -820,7 +823,8 @@ mod tests {
         ctx.update(dec!(2.00), "USD");
 
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(-0.01), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(-0.01), "USD")))
+            .expect("fixture fits in Decimal");
 
         let rendered = format_value(&Value::Inventory(Box::new(inv)), false, &ctx);
         assert!(
@@ -848,7 +852,8 @@ mod tests {
         let amount_val = Value::Amount(Amount::new(over_scale, "USD"));
         let pos_val = Value::Position(Box::new(Position::simple(Amount::new(over_scale, "USD"))));
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(over_scale, "USD")));
+        inv.add(Position::simple(Amount::new(over_scale, "USD")))
+            .expect("fixture fits in Decimal");
         let inv_val = Value::Inventory(Box::new(inv));
 
         assert_eq!(format_value(&amount_val, true, &ctx), "-1202.01");
@@ -877,7 +882,8 @@ mod tests {
         ctx.update(dec!(2.00), "USD");
 
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")))
+            .expect("fixture fits in Decimal");
 
         let mut result = QueryResult::new(vec!["account".into(), "sum".into()]);
         result.add_row(vec![
@@ -918,7 +924,8 @@ mod tests {
         ctx.update(dec!(2.00), "USD");
 
         let mut inv = Inventory::new();
-        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")));
+        inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")))
+            .expect("fixture fits in Decimal");
 
         let mut result = QueryResult::new(vec!["sum".into()]);
         result.add_row(vec![Value::Inventory(Box::new(inv))]);

--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -15,7 +15,7 @@ pub(super) fn report_balances<W: Write>(
 ) -> Result<()> {
     // Single source of truth for per-account balances (see
     // `super::account_balances`); no report re-derives them itself.
-    let balances = super::account_balances(directives);
+    let balances = super::account_balances(directives)?;
 
     // Collect data for output. `cost` is the beancount-style lot annotation
     // (e.g. ` {150.00 USD}`) for held commodities, empty for plain currency.

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -26,7 +26,7 @@ pub(super) fn report_balsheet<W: Write>(
     // ledger with `option "name_assets" "Activa"` must still fill the
     // balance sheet), never by hardcoded root prefixes.
     use rustledger_core::AccountTypeKind as K;
-    for (account, inv) in super::account_balances(directives) {
+    for (account, inv) in super::account_balances(directives)? {
         let section = match account_types.kind(&account) {
             Some(K::Assets) => &mut assets,
             Some(K::Liabilities) => &mut liabilities,

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -25,7 +25,7 @@ pub(super) fn report_income<W: Write>(
     // ledger with `option "name_income" "Revenue"` previously rendered an
     // EMPTY income statement here).
     use rustledger_core::AccountTypeKind as K;
-    for (account, inv) in super::account_balances(directives) {
+    for (account, inv) in super::account_balances(directives)? {
         let section = match account_types.kind(&account) {
             Some(K::Income) => &mut income,
             Some(K::Expenses) => &mut expenses,

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -819,9 +819,16 @@ fn render<W: io::Write>(
 /// drift-guard test comparing the two on the same ledger.
 ///
 /// [`apply`]: rustledger_booking::BookingEngine::apply
+///
+/// # Errors
+///
+/// When a running balance leaves `rust_decimal`'s range (#1863). Reports print
+/// these inventories as exact totals, so an unrepresentable one must abort the
+/// report rather than render a clamped figure.
 pub(super) fn account_balances(
     directives: &[rustledger_core::Directive],
-) -> std::collections::BTreeMap<rustledger_core::Account, rustledger_core::Inventory> {
+) -> anyhow::Result<std::collections::BTreeMap<rustledger_core::Account, rustledger_core::Inventory>>
+{
     use rustledger_core::Directive;
     // Realize via the booking engine so held commodities carry their lots at
     // cost and reductions match those lots (FIFO/LIFO/etc. per each account's
@@ -832,12 +839,12 @@ pub(super) fn account_balances(
     engine.register_account_methods(directives.iter());
     for directive in directives {
         if let Directive::Transaction(txn) = directive {
-            engine.apply(txn);
+            engine.apply(txn)?;
         }
     }
     // FxHashMap has non-deterministic order; collect into a BTreeMap so report
     // rows come out account-sorted and stable across runs.
-    engine.into_inventories().into_iter().collect()
+    Ok(engine.into_inventories().into_iter().collect())
 }
 
 // CSV/JSON escaping: single-sourced in core. `escape_json` is the RFC-8259

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -902,7 +902,7 @@ mod tests {
         // Independently value `account_balances`' inventories at market for the
         // same scope, then compare to `terminal_value`.
         let mut ab_total = Decimal::ZERO;
-        for (account, inv) in super::super::account_balances(&dirs) {
+        for (account, inv) in super::super::account_balances(&dirs).expect("fixture fits") {
             if !rustledger_core::is_subaccount_or_equal(account.as_str(), "Assets:Broker") {
                 continue;
             }

--- a/crates/rustledger/tests/decimal_overflow_test.rs
+++ b/crates/rustledger/tests/decimal_overflow_test.rs
@@ -1,0 +1,212 @@
+//! Ledger input must never panic the CLI, and must never be answered with a
+//! clamped number (#1863).
+//!
+//! `rust_decimal` is a 96-bit type with a hard ~±7.9e28 ceiling whose `+`/`*`
+//! PANIC on overflow. Inventory and weight arithmetic runs in the loader's
+//! booking phase, so a ledger holding large amounts aborted EVERY command —
+//! including `check`, the command you run to find out what is wrong with your
+//! file.
+//!
+//! # Why these tests assert on the message, not just the exit code
+//!
+//! The obvious fix — saturate instead of panicking — was implemented and
+//! REJECTED (PR #1890). `Decimal::MIN == -Decimal::MAX` exactly, so a clamped
+//! debit and a clamped credit cancel to a residual of *precisely zero*: a
+//! ledger off by 1e40 passed `check` with exit 0. Asserting only "doesn't
+//! panic" would have passed that build. Every test here therefore pins WHAT is
+//! reported, and `unbalanced_reports_the_exact_residual_like_beancount` pins
+//! the exact figure Python beancount computes.
+
+mod common;
+
+use std::process::Command;
+
+/// Run `rledger check` on `source`, returning `(exit_code, combined_output)`.
+///
+/// `--no-cache` is deliberate: a cached parse can mask a booking-phase change,
+/// which has hidden a fix in this area before.
+fn check(source: &str) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!(
+        "rledger-overflow-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("ledger.beancount");
+    std::fs::write(&path, source).expect("write fixture");
+
+    let Some(bin) = common::rledger_binary() else {
+        eprintln!("Skipping: rledger binary not found");
+        return (None, String::new());
+    };
+    let out = Command::new(bin)
+        .args(["check", "--no-cache"])
+        .arg(&path)
+        .output()
+        .expect("run rledger check");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let mut combined = String::from_utf8_lossy(&out.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    (Some(out.status.code().unwrap_or(-1)), combined)
+}
+
+/// The process survived and said something about it.
+fn assert_reported_not_panicked(code: Option<i32>, output: &str, what: &str) {
+    let Some(code) = code else { return }; // binary unavailable; already logged
+    assert!(
+        !output.contains("panicked"),
+        "{what}: ledger input must never panic the CLI\n{output}"
+    );
+    assert_ne!(code, 101, "{what}: exit 101 is a Rust panic\n{output}");
+    assert_eq!(code, 1, "{what}: expected a reported error\n{output}");
+}
+
+/// Two postings whose sum needs 29 digits.
+///
+/// The residual is computed in `BigDecimal` (the escalation tier), so the
+/// reported figure is exact rather than an overflow complaint.
+#[test]
+fn oversized_sum_reports_the_exact_residual() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:A\n\
+         2024-01-01 open Assets:B\n\
+         2024-02-01 * \"two big plain postings\"\n\
+        \x20 Assets:A   40000000000000000000000000000 USD\n\
+        \x20 Assets:B   40000000000000000000000000000 USD\n",
+    );
+    assert_reported_not_panicked(code, &out, "oversized sum");
+    if code.is_none() {
+        return;
+    }
+    assert!(
+        out.contains("80000000000000000000000000000"),
+        "the residual must be reported exactly (8e28, past the Decimal \
+         ceiling) — a clamped one would read 7.92...e28 or zero:\n{out}"
+    );
+}
+
+/// THE case that killed the saturating design.
+///
+/// Python beancount computes this residual as `-1.000000000000000000000000000E+40`
+/// (its `decimal` context keeps 28 significant digits but has effectively
+/// unbounded magnitude — `Emax` is 999999). rledger must agree.
+///
+/// Under saturation both weights clamped, cancelled to zero, and `check`
+/// printed `✓ No errors found` with exit 0 for a ledger off by 1e40.
+#[test]
+fn unbalanced_reports_the_exact_residual_like_beancount() {
+    let (code, out) = check(
+        "2020-01-01 open Assets:A\n\
+         2020-01-01 open Assets:B\n\
+         2020-02-01 * \"off by 1e40 USD\"\n\
+        \x20 Assets:A   100000000000000000000 HOOL {100000000000000000000 USD}\n\
+        \x20 Assets:B  -100000000000000000000 HOOL {200000000000000000000 USD}\n",
+    );
+    assert_reported_not_panicked(code, &out, "1e40 imbalance");
+    if code.is_none() {
+        return;
+    }
+    assert!(
+        !out.contains("No errors found"),
+        "a ledger off by 1e40 must never certify as balanced — this is the \
+         exact regression that closed PR #1890:\n{out}"
+    );
+    assert!(
+        out.contains("does not balance"),
+        "expected the balance diagnostic:\n{out}"
+    );
+    assert!(
+        out.contains("-10000000000000000000000000000000000000000"),
+        "the residual must match Python beancount's -1e40 exactly, which is \
+         only possible via the BigDecimal escalation tier:\n{out}"
+    );
+}
+
+/// An elided posting whose amount cannot be represented.
+///
+/// Here there is no correct number to report — the amount would be WRITTEN
+/// INTO the posting and thereafter indistinguishable from user input — so this
+/// is the case that must be refused rather than escalated.
+#[test]
+fn unrepresentable_interpolation_is_refused() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:Stock\n\
+         2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"elided counter-posting\"\n\
+        \x20 Assets:Stock  10000000000000000 HOOL {10000000000000.00 USD}\n\
+        \x20 Assets:Cash\n",
+    );
+    assert_reported_not_panicked(code, &out, "unrepresentable interpolation");
+    if code.is_none() {
+        return;
+    }
+    assert!(
+        out.contains("representable range") || out.contains("cannot be computed"),
+        "expected an out-of-range diagnostic naming the limit:\n{out}"
+    );
+    assert!(
+        !out.contains("79228162514264337593543950335"),
+        "a clamped Decimal::MAX must never reach the user as a posting \
+         amount:\n{out}"
+    );
+}
+
+/// Selling a lot whose cost basis (`units × cost`) leaves the range.
+///
+/// Reaches `Inventory::reduce`'s cost-basis accumulation — a site the earlier
+/// attempt left panicking, because its integration test used these very
+/// numbers but only exercised `at_cost`, never the sell side.
+#[test]
+fn oversized_cost_basis_on_reduction_is_reported() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:Stock\n\
+         2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"buy\"\n\
+        \x20 Assets:Stock  10000000000000000 HOOL {10000000000000.00 USD}\n\
+        \x20 Assets:Cash  -10000000000000000 CASHU\n\
+         2024-03-01 * \"sell\"\n\
+        \x20 Assets:Stock -10000000000000000 HOOL {}\n\
+        \x20 Assets:Cash   10000000000000000 CASHU\n",
+    );
+    assert_reported_not_panicked(code, &out, "oversized cost basis");
+    if code.is_none() {
+        return;
+    }
+    assert!(
+        out.contains("representable range"),
+        "expected the out-of-range diagnostic from the reduce path:\n{out}"
+    );
+}
+
+/// The whole point of the ceiling being far above real ledgers: ordinary input
+/// must be completely unaffected.
+///
+/// Without this, "report an overflow" could be satisfied by reporting one for
+/// every ledger.
+#[test]
+fn ordinary_amounts_are_untouched() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:Stock\n\
+         2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"buy\"\n\
+        \x20 Assets:Stock  10 HOOL {150.00 USD}\n\
+        \x20 Assets:Cash\n\
+         2024-03-01 * \"sell\"\n\
+        \x20 Assets:Stock -10 HOOL {}\n\
+        \x20 Assets:Cash   1600.00 USD\n\
+        \x20 Income:Gains\n",
+    );
+    let Some(code) = code else { return };
+    assert!(!out.contains("panicked"), "{out}");
+    assert!(
+        !out.contains("representable range"),
+        "a ledger that fits must never see an overflow diagnostic:\n{out}"
+    );
+    // `Income:Gains` is unopened, so this reports E1001 — the point is only
+    // that it is NOT an arithmetic complaint.
+    assert!(
+        code == 0 || out.contains("E1001"),
+        "unexpected output:\n{out}"
+    );
+}

--- a/crates/rustledger/tests/decimal_overflow_test.rs
+++ b/crates/rustledger/tests/decimal_overflow_test.rs
@@ -210,3 +210,76 @@ fn ordinary_amounts_are_untouched() {
         "unexpected output:\n{out}"
     );
 }
+
+/// A pad that cannot be applied must leave NEITHER account changed.
+///
+/// A pad is two halves of one entry. When the source half overflows after the
+/// target half succeeded, an earlier version left the target credited, emitted
+/// no synthetic transaction, and reported the error — so a LATER assertion on
+/// the target passed off a pad that never happened. Sabotage-verified: dropping
+/// the undo makes the final assertion report
+/// `expected 0 USD, got 40000000000000000000000000000 USD`.
+#[test]
+fn a_failed_pad_credits_neither_account() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:A\n\
+         2024-01-01 open Assets:Big\n\
+         2024-01-01 open Equity:O\n\
+         2024-01-05 * \"load the pad source close to the ceiling\"\n\
+        \x20 Assets:Big   70000000000000000000000000000 USD\n\
+        \x20 Equity:O    -70000000000000000000000000000 USD\n\
+         2024-02-01 pad Assets:A Equity:O\n\
+         2024-03-01 balance Assets:A  40000000000000000000000000000 USD\n\
+         2024-04-01 balance Assets:A  0 USD\n",
+    );
+    assert_reported_not_panicked(code, &out, "unappliable pad");
+    if code.is_none() {
+        return;
+    }
+    assert!(
+        out.contains("E4004"),
+        "the pad that could not be applied must be reported:\n{out}"
+    );
+    assert!(
+        !out.contains("E2001") && !out.contains("Balance failed"),
+        "the target must not keep a credit from a pad that was never emitted — \
+         the closing `balance Assets:A 0 USD` proves it was undone:\n{out}"
+    );
+}
+
+/// A transaction that BALANCES but whose running sum overflows partway.
+///
+/// Accumulation is order-dependent: `[+7e28, +7e28, -7e28, -7e28]` leaves
+/// `Decimal`'s range at the second posting even though the total is exactly
+/// zero. The fast tier therefore has no answer, and the only correct response
+/// is to escalate — reporting an error here would condemn a perfectly good
+/// transaction.
+///
+/// This is the sharpest test of the escalation: a fix that merely refused on
+/// overflow (rather than recomputing in `BigDecimal`) passes every other test
+/// in this file and fails this one.
+#[test]
+fn intermediate_overflow_in_a_balanced_transaction_is_clean() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:A\n\
+         2024-01-01 open Assets:B\n\
+         2024-01-01 open Assets:C\n\
+         2024-01-01 open Assets:D\n\
+         2024-02-01 * \"balances exactly; the running sum does not\"\n\
+        \x20 Assets:A   70000000000000000000000000000 USD\n\
+        \x20 Assets:B   70000000000000000000000000000 USD\n\
+        \x20 Assets:C  -70000000000000000000000000000 USD\n\
+        \x20 Assets:D  -70000000000000000000000000000 USD\n",
+    );
+    let Some(code) = code else { return };
+    assert!(!out.contains("panicked"), "{out}");
+    assert_eq!(
+        code, 0,
+        "the true residual is zero, so this must pass cleanly — the fast tier \
+         overflowing is not evidence of an imbalance:\n{out}"
+    );
+    assert!(
+        !out.contains("representable range"),
+        "a balanced transaction must never draw an overflow diagnostic:\n{out}"
+    );
+}

--- a/crates/rustledger/tests/decimal_overflow_test.rs
+++ b/crates/rustledger/tests/decimal_overflow_test.rs
@@ -51,6 +51,32 @@ fn check(source: &str) -> (Option<i32>, String) {
     (Some(out.status.code().unwrap_or(-1)), combined)
 }
 
+/// Run `rledger query` and return `(exit_code, combined_output)`.
+fn query(source: &str, sql: &str) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!(
+        "rledger-overflow-q-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("ledger.beancount");
+    std::fs::write(&path, source).expect("write fixture");
+    let Some(bin) = common::rledger_binary() else {
+        eprintln!("Skipping: rledger binary not found");
+        return (None, String::new());
+    };
+    let out = Command::new(bin)
+        .arg("query")
+        .arg(&path)
+        .arg(sql)
+        .output()
+        .expect("run rledger query");
+    let _ = std::fs::remove_dir_all(&dir);
+    let mut combined = String::from_utf8_lossy(&out.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    (Some(out.status.code().unwrap_or(-1)), combined)
+}
+
 /// The process survived and said something about it.
 fn assert_reported_not_panicked(code: Option<i32>, output: &str, what: &str) {
     let Some(code) = code else { return }; // binary unavailable; already logged
@@ -282,4 +308,51 @@ fn intermediate_overflow_in_a_balanced_transaction_is_clean() {
         !out.contains("representable range"),
         "a balanced transaction must never draw an overflow diagnostic:\n{out}"
     );
+}
+
+/// A compound cost `{a # b}`, whose `N*a + b` normalization multiplies two
+/// user-supplied numbers.
+///
+/// Found only after the panic sweep was rebuilt: the first sweep assigned its
+/// binary path with `BIN=$(cargo build ...; echo path)`, which captured the
+/// build banner, so every invocation failed with "command not found" and the
+/// run reported zero panics while testing nothing.
+#[test]
+fn compound_cost_normalization_is_reported() {
+    let (code, out) = check(
+        "2024-01-01 open Assets:S\n\
+         2024-01-01 open Assets:C\n\
+         2024-02-01 * \"compound cost\"\n\
+        \x20 Assets:S  10000000000000000 HOOL {10000000000000.00 # 40000000000000000000000000000 USD}\n\
+        \x20 Assets:C\n",
+    );
+    assert_reported_not_panicked(code, &out, "compound cost");
+}
+
+/// BQL surfaces are reachable from ledger input too, and a query cell showing
+/// a clamped total is indistinguishable from a real one.
+///
+/// `cost()` over an aggregated inventory and `value()` (which multiplies by a
+/// price) were both still panicking after the first pass.
+#[test]
+fn bql_cost_and_value_report_instead_of_panicking() {
+    let src = "2024-01-01 open Assets:S\n\
+               2024-01-01 open Assets:C\n\
+               2024-02-01 * \"buy\"\n\
+              \x20 Assets:S  10000000000000000 HOOL {10000000000000.00 USD}\n\
+              \x20 Assets:C  -10000000000000000 CASHU\n";
+    for sql in [
+        "SELECT account, cost(sum(position))",
+        "SELECT account, value(sum(position))",
+        "SELECT account, sum(position) AT COST",
+        "SELECT sum(cost(position))",
+    ] {
+        let (code, out) = query(src, sql);
+        let Some(code) = code else { return };
+        assert!(
+            !out.contains("panicked"),
+            "`{sql}` must not panic the CLI:\n{out}"
+        );
+        assert_ne!(code, 101, "`{sql}` exited 101 (a panic):\n{out}");
+    }
 }

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -264,7 +264,7 @@ This document catalogs all validation errors and warnings with their trigger con
 of rledger's decimal type (a 96-bit type, roughly ±7.9×10²⁸ with ~28 significant
 digits).
 
-**Message:** `{currency} amount exceeds the representable range (±7.9e28); split the transaction or use smaller units`
+**Message:** `{currency} amount exceeds the representable range (±7.9e28); split the transaction, or denominate it in larger units (thousands, millions) so the number is smaller`
 
 **Severity:** Error
 

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -256,6 +256,45 @@ This document catalogs all validation errors and warnings with their trigger con
   Assets:Cash
 ```
 
+### ARITHMETIC_OVERFLOW
+
+**Code:** `E4004`
+
+**Condition:** An amount, or a running total derived from one, exceeds the range
+of rledger's decimal type (a 96-bit type, roughly ±7.9×10²⁸ with ~28 significant
+digits).
+
+**Message:** `{currency} amount exceeds the representable range (±7.9e28); split the transaction or use smaller units`
+
+**Severity:** Error
+
+rledger reports this rather than rounding or clamping the value. Clamping would
+be unsound in both directions: a clamped figure is printed as if it were exact,
+and because `Decimal::MIN == -Decimal::MAX`, a clamped debit and a clamped credit
+cancel to a residual of exactly zero — an arbitrarily unbalanced transaction
+would certify as balanced.
+
+Note that a *product* can leave the range while both of its operands are far
+inside it, since a product needs roughly the sum of its operands' digits. A
+transaction can therefore parse cleanly and still overflow during booking.
+
+Python beancount does not have this limit: its `decimal` context keeps 28
+significant digits but has effectively unbounded magnitude. Where rledger can
+reach the same answer it does — a transaction whose postings are all explicit is
+checked in arbitrary precision, so its imbalance is reported exactly (E3001)
+rather than as an overflow. E4004 is emitted where a representable result is
+genuinely required: an interpolated posting amount, an inventory total, or a
+cost basis.
+
+```beancount
+2024-01-01 open Assets:Stock
+2024-01-01 open Assets:Cash
+
+2024-02-01 * "cost basis needs 33 digits"
+  Assets:Stock  10000000000000000 HOOL {10000000000000.00 USD}
+  Assets:Cash   ; ERROR: the interpolated USD amount cannot be represented
+```
+
 ### BOOKING_NEGATIVE_COST
 
 **Code:** `E4005`


### PR DESCRIPTION
Closes #1863.

`rust_decimal` is 96-bit with a hard ~±7.9e28 ceiling and its `+`/`*` **panic** on overflow. Inventory and weight arithmetic runs in the loader's booking phase, so a ledger holding large amounts aborted **every** command with exit 101 — including `check`, the command you run to find out what is wrong with your file.

All arithmetic reachable from ledger input is now **checked**. Where a correct answer is available it is computed; where none exists the transaction fails with a diagnostic. Nothing is clamped.

## This is not the saturating fix

[#1890](https://github.com/rustledger/rustledger/pull/1890) saturated and was closed. `Decimal::MIN == -Decimal::MAX` **exactly**, so a clamped debit and a clamped credit cancel to a residual of *precisely zero* — the fast residual reads 0, the two-tier check never escalates, and a ledger off by 1e40 passed `check` with exit 0 where main panicked. For an accounting tool, trading a loud abort for a silently wrong ledger is the wrong direction.

`min_is_exactly_negative_max` pins that property as a test, so anyone reaching for `saturating_*` here meets the reason first.

## Escalate where an exact answer exists

Python beancount has no such limit: its `decimal` context keeps 28 significant digits but `Emax` is 999999, so magnitude is effectively unbounded. rustledger already carries a `BigDecimal` tier for the precise residual check (#1240) — so the `Decimal` tier now reports "cannot represent" and the balance validator **escalates** instead of skipping.

A fully-explicit transaction therefore gets beancount's exact answer:

| fixture | main | #1890 | this PR |
|---|---|---|---|
| off by 1e40 | panic, 101 | `✓ No errors found`, **0** | `E3001 … residual -1e40 USD` |
| two 4e28 postings | panic, 101 | panic, 101 | `E3001 … residual 8e28 USD` |
| elided posting | panic, 101 | **exit 0, fabricated amount** | `E4004`-class, exit 1 |
| sell a large lot | panic, 101 | panic, 101 | reported, exit 1 |

The 1e40 residual is reported as `-10000000000000000000000000000000000000000 USD`, matching Python's `-1.000000000000000000000000000E+40`.

**E4004** is reserved for where a representable result is genuinely required: an interpolated posting amount (it is written *into* the posting and is thereafter indistinguishable from user input), an inventory total, or a cost basis.

## Fallible signatures

`Inventory::add` and friends now return `Result`. #1890 rejected this over "~250 call sites" — that count was ~95% tests. Production sites are about **33**, and roughly half were already inside `Result`-returning functions.

- `add` computes both running totals *before* committing either, so a rejected add leaves the inventory untouched rather than half-applied.
- **`FromIterator<Position> for Inventory` is removed** in favor of `try_from_positions`. `from_iter` cannot report failure, so it had to swallow the overflow and return an inventory holding a wrong total with nothing to indicate it. A `collect()` that can silently lie is worse than no `collect()`.
- `apply` gains an error path for overflow **only**. A failed *reduction* keeps its debug-assert-then-continue contract — that means the caller applied an unbooked transaction, which is a caller bug rather than ledger data. One API, not a parallel `apply_checked`.

## Verification

Every test was **sabotage-verified** — fix reverted, test observed to fail:

- restoring saturation → the 1e40 fixture prints `✓ No errors found` again; caught.
- short-circuiting the escalation → caught by two tests.
- restoring the unchecked `total_cost` in `reduce_from_lot` → caught.

One test was **rewritten after it passed under sabotage**: its fixture tripped the units-cache check before reaching the merge check it claimed to pin. The replacement uses a costed `+MAX` against an uncosted `−MAX` so only the merge overflows, and it now fails when the commit is moved before the check.

The FIFO/LIFO ladder's cost-basis accumulation is checked as **defense-in-depth and documented as such** — no ledger was found that reaches it, because the reducing posting's own weight exceeds the ceiling first and is reported earlier. Removing that check does not make any fixture panic, so the comment says so rather than implying coverage.

## Notes for review

- **No `CACHE_VERSION` bump.** main *panics* everywhere behavior changes, so it can never have written a cache entry holding a wrong answer. Verified by warming the cache with a main-built binary and re-running.
- **Breaking API changes** in `rustledger-core` / `-booking` / `-ops`: `Inventory::{add, merge, at_cost, at_units, book_value}`, `Cost::total_cost`, `sum_account_and_subaccounts`, `calculate_residual`, `cost_number_weight`, `price_weight`, `clamp`/`clamp_indexed`, and the removed `FromIterator`.
- **One known gap, deliberately not fixed here:** the WIT contract (`rustledger:ledger@3.0.0`) returns a bare list from `clamp`, with no error channel. On overflow the FFI degrades to returning the entries *unclamped* rather than emitting a summary built from a clamped total — real directives, never a fabricated opening balance. Surfacing it as a typed error needs a WIT change; worth a follow-up issue.

4279 tests pass · clippy clean at the CI-pinned 1.97.0 · `cargo doc -D warnings` clean.
