### PR TITLE
fix(query,docs): apply render_commas consistently across output surfaces

### DIFF
--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -337,11 +337,21 @@ impl DisplayContext {
     /// Only `render_commas` is affected — precision is a property of the data
     /// and is identical on every surface. See [`OutputSurface`] for why the
     /// distinction exists.
+    ///
+    /// Borrows unless the flag actually has to change, so the common cases
+    /// cost nothing: a ledger without `render_commas` (almost all of them) and
+    /// any human-facing surface both borrow. Only suppressing separators for a
+    /// machine or ledger-text surface clones, and that clone carries the
+    /// per-currency histograms — worth avoiding on a REPL's hot path, and
+    /// wasted entirely on the JSON writer, which ignores the context.
     #[must_use]
-    pub fn for_surface(&self, surface: OutputSurface) -> Self {
+    pub fn for_surface(&self, surface: OutputSurface) -> std::borrow::Cow<'_, Self> {
+        if !self.render_commas || surface.renders_thousands_separators() {
+            return std::borrow::Cow::Borrowed(self);
+        }
         let mut ctx = self.clone();
-        ctx.render_commas = self.render_commas && surface.renders_thousands_separators();
-        ctx
+        ctx.render_commas = false;
+        std::borrow::Cow::Owned(ctx)
     }
 
     /// Set the `render_commas` flag.
@@ -1803,6 +1813,36 @@ mod custom_directive_precision_tests {
             !OutputSurface::LedgerText.renders_thousands_separators(),
             "ledger text has one canonical form; `format` strips separators \
              and `query --format beancount` must agree with it"
+        );
+    }
+
+    /// `for_surface` avoids cloning whenever the flag does not have to change.
+    ///
+    /// The clone carries the per-currency histograms, and the JSON writer
+    /// ignores the context entirely, so paying for one on every query would be
+    /// pure waste (review catch on #1893). The two cases that matter most are
+    /// the cheap ones: a ledger that never set `render_commas`, and any
+    /// human-facing surface.
+    #[test]
+    fn for_surface_borrows_unless_the_flag_must_change() {
+        use std::borrow::Cow;
+
+        let mut plain = DisplayContext::new();
+        plain.set_fixed_precision("USD", 2);
+        assert!(
+            matches!(plain.for_surface(OutputSurface::Machine), Cow::Borrowed(_)),
+            "a ledger without render_commas never needs a clone"
+        );
+
+        let mut commas = DisplayContext::new();
+        commas.set_render_commas(true);
+        assert!(
+            matches!(commas.for_surface(OutputSurface::Human), Cow::Borrowed(_)),
+            "a human surface keeps the flag, so no clone"
+        );
+        assert!(
+            matches!(commas.for_surface(OutputSurface::Machine), Cow::Owned(_)),
+            "only actually suppressing separators clones"
         );
     }
 

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -118,6 +118,43 @@ pub enum Precision {
     Maximum,
 }
 
+/// What kind of consumer an output surface is written for.
+///
+/// Decides whether thousands separators appear. They are a HUMAN-READING
+/// affordance, so they belong only in rendered tables and reports:
+///
+/// - **machine interchange** (CSV, JSON) must stay parseable — a separator
+///   forces the field to be quoted and is then rejected by ordinary decimal
+///   parsers (issue #1892);
+/// - **ledger text** (`format`, `query --format beancount`) has one canonical
+///   on-disk form, and `,` is locale-ambiguous.
+///
+/// This exists so the rule is stated ONCE. It was previously re-derived per
+/// writer, and the surfaces had already drifted apart: `query --format
+/// beancount` emitted separators into ledger text while `format` stripped
+/// them, and CSV emitted them while JSON did not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputSurface {
+    /// A rendered table or report read by a person.
+    Human,
+    /// CSV/JSON consumed by another program.
+    Machine,
+    /// Beancount source text.
+    LedgerText,
+}
+
+impl OutputSurface {
+    /// Whether this surface renders thousands separators when the ledger asks
+    /// for them.
+    #[must_use]
+    pub const fn renders_thousands_separators(self) -> bool {
+        match self {
+            Self::Human => true,
+            Self::Machine | Self::LedgerText => false,
+        }
+    }
+}
+
 /// Display context for formatting numbers with consistent precision per currency.
 ///
 /// Tracks a frequency distribution of decimal places per currency and exposes
@@ -293,6 +330,18 @@ impl DisplayContext {
     #[must_use]
     pub fn has_fixed_precision(&self, currency: &str) -> bool {
         self.fixed_precisions.contains_key(currency)
+    }
+
+    /// This context, adjusted for the surface it will be written to.
+    ///
+    /// Only `render_commas` is affected — precision is a property of the data
+    /// and is identical on every surface. See [`OutputSurface`] for why the
+    /// distinction exists.
+    #[must_use]
+    pub fn for_surface(&self, surface: OutputSurface) -> Self {
+        let mut ctx = self.clone();
+        ctx.render_commas = self.render_commas && surface.renders_thousands_separators();
+        ctx
     }
 
     /// Set the `render_commas` flag.
@@ -1741,5 +1790,45 @@ mod custom_directive_precision_tests {
         ];
         let ctx = DisplayContext::from_directives(directives.iter(), std::iter::empty());
         assert_eq!(ctx.get_precision("USD"), Some(2));
+    }
+
+    /// The surface rule, stated once and asserted here so a new
+    /// `OutputSurface` variant cannot quietly default to rendering separators
+    /// (#1892).
+    #[test]
+    fn only_human_surfaces_render_thousands_separators() {
+        assert!(OutputSurface::Human.renders_thousands_separators());
+        assert!(!OutputSurface::Machine.renders_thousands_separators());
+        assert!(
+            !OutputSurface::LedgerText.renders_thousands_separators(),
+            "ledger text has one canonical form; `format` strips separators \
+             and `query --format beancount` must agree with it"
+        );
+    }
+
+    /// `for_surface` narrows ONLY the separator flag — precision is a property
+    /// of the data and must survive on every surface.
+    #[test]
+    fn for_surface_narrows_separators_but_keeps_precision() {
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        ctx.set_fixed_precision("USD", 2);
+
+        let human = ctx.for_surface(OutputSurface::Human);
+        let machine = ctx.for_surface(OutputSurface::Machine);
+        assert!(human.render_commas());
+        assert!(!machine.render_commas());
+        assert_eq!(
+            machine.format_amount_number(rust_decimal_macros::dec!(1234.5), "USD"),
+            human
+                .format_amount_number(rust_decimal_macros::dec!(1234.5), "USD")
+                .replace(',', ""),
+            "the two differ ONLY by separators, never by precision"
+        );
+
+        // A ledger that never asked for separators is unaffected either way.
+        let mut plain = DisplayContext::new();
+        plain.set_fixed_precision("USD", 2);
+        assert!(!plain.for_surface(OutputSurface::Human).render_commas());
     }
 }

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -71,7 +71,7 @@ pub use directive::{
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,
     booking_sort_key, parse_precision_meta, sort_directives,
 };
-pub use display_context::{DEFAULT_CURRENCY, DisplayContext, Precision};
+pub use display_context::{DEFAULT_CURRENCY, DisplayContext, OutputSurface, Precision};
 pub use extract::{
     DEFAULT_CURRENCIES, extract_accounts, extract_accounts_iter, extract_currencies,
     extract_currencies_iter, extract_links, extract_links_iter, extract_payees,

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -96,6 +96,21 @@ pub enum OutputFormat {
     Beancount,
 }
 
+impl From<OutputFormat> for rustledger_core::OutputSurface {
+    /// Which consumer each query output format is written for.
+    ///
+    /// Exhaustive on purpose: a new output format must state whether it is
+    /// read by a person, parsed by a program, or ledger text, rather than
+    /// silently inheriting whatever the previous arm did (#1892).
+    fn from(f: OutputFormat) -> Self {
+        match f {
+            OutputFormat::Text => Self::Human,
+            OutputFormat::Csv | OutputFormat::Json => Self::Machine,
+            OutputFormat::Beancount => Self::LedgerText,
+        }
+    }
+}
+
 impl std::fmt::Display for OutputFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -37,8 +37,10 @@ pub(super) fn execute_query<W: Write>(
         .execute(&query)
         .with_context(|| "failed to execute query")?;
 
-    // Output results using display context for consistent number formatting
-    let ctx = &settings.display_context;
+    // Output results using display context for consistent number formatting.
+    // `render_commas` is resolved ONCE here, against the surface being written,
+    // so each writer receives a context it can use verbatim (#1892).
+    let ctx = &settings.display_context.for_surface(settings.format.into());
     match settings.format {
         super::OutputFormat::Text => write_text(&result, writer, settings.numberify, ctx)?,
         super::OutputFormat::Csv => write_csv(&result, writer, settings.numberify, ctx)?,
@@ -227,17 +229,8 @@ fn write_csv<W: Write>(
     numberify: bool,
     ctx: &DisplayContext,
 ) -> Result<()> {
-    // CSV is machine interchange, so `render_commas` is dropped here even when
-    // the ledger sets it: a thousands separator inside a numeric field forces
-    // the field to be quoted and then rejected by ordinary decimal parsers
-    // (issue #1892 — it broke a reconciliation script's `Decimal()`).
-    //
-    // This matches `write_json`, which never applied the flag. Precision is
-    // untouched: only the separator is suppressed, so a value still renders at
-    // the ledger's display precision.
-    let mut ctx = ctx.clone();
-    ctx.set_render_commas(false);
-    let ctx = &ctx;
+    // `ctx` already has `render_commas` resolved for this surface by the
+    // dispatcher, so it is used verbatim here.
 
     // Print header
     writeln!(writer, "{}", result.columns.join(","))?;
@@ -1895,31 +1888,47 @@ mod tests {
         );
     }
 
-    /// CSV is machine interchange: it must never emit thousands separators,
-    /// even when the ledger asks for them (#1892).
+    /// Machine-readable surfaces must never emit thousands separators, even
+    /// when the ledger asks for them (#1892).
     ///
     /// A separator forces the field to be quoted and then breaks ordinary
-    /// decimal parsers. JSON already behaved this way; CSV was the outlier.
+    /// decimal parsers. Asserted through the SAME surface resolution the
+    /// dispatcher performs, so this covers the wiring and not just the
+    /// writer: a future format mapped to the wrong `OutputSurface` fails here.
     #[test]
-    fn csv_never_emits_thousands_separators() {
+    fn machine_surfaces_never_emit_thousands_separators() {
+        use rustledger_core::OutputSurface;
         use rustledger_query::QueryResult;
-        let mut ctx = DisplayContext::new();
-        ctx.set_render_commas(true);
-        ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
+        let mut ledger_ctx = DisplayContext::new();
+        ledger_ctx.set_render_commas(true);
+        ledger_ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
 
         let mut result = QueryResult::new(vec!["sum".into()]);
         result.add_row(vec![Value::Number(rust_decimal_macros::dec!(1234567.89))]);
 
-        let mut out = Vec::new();
-        write_csv(&result, &mut out, false, &ctx).expect("write");
-        let csv = String::from_utf8(out).expect("utf8");
-        assert!(
-            csv.contains("1234567.89"),
-            "value must render unseparated: {csv}"
-        );
-        assert!(
-            !csv.contains("1,234,567.89") && !csv.contains('"'),
-            "no separators and therefore no quoting: {csv}"
-        );
+        for format in [
+            super::super::OutputFormat::Csv,
+            super::super::OutputFormat::Json,
+            super::super::OutputFormat::Beancount,
+        ] {
+            let surface: OutputSurface = format.into();
+            assert!(
+                !surface.renders_thousands_separators(),
+                "{format:?} is not a human-reading surface"
+            );
+            let ctx = ledger_ctx.for_surface(surface);
+
+            let mut out = Vec::new();
+            write_csv(&result, &mut out, false, &ctx).expect("write");
+            let csv = String::from_utf8(out).expect("utf8");
+            assert!(
+                csv.contains("1234567.89"),
+                "{format:?}: value must render unseparated: {csv}"
+            );
+            assert!(
+                !csv.contains("1,234,567.89") && !csv.contains('"'),
+                "{format:?}: no separators and therefore no quoting: {csv}"
+            );
+        }
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -67,6 +67,15 @@ fn write_text<W: Write>(
     // calling it per row would inflate the ledger's sample frequencies by N
     // and could shift the column's effective mode. Caught by Copilot review.
     let mut col_contexts: Vec<DisplayContext> = vec![DisplayContext::new(); result.columns.len()];
+    // `render_commas` is presentation policy for the whole table, not a
+    // per-column precision fact, so every column carries it regardless of what
+    // it holds. It used to arrive only as a side effect of the Number-column
+    // `update_from` below, which meant `SUM(number)` printed `1,234,567.89`
+    // while `SUM(position)` in the same query printed `1234567.89 USD`
+    // (issue #1892).
+    for col in &mut col_contexts {
+        col.set_render_commas(ctx.render_commas());
+    }
     let mut col_inherited: Vec<bool> = vec![false; result.columns.len()];
     for row in &result.rows {
         for (i, value) in row.iter().enumerate() {
@@ -218,6 +227,18 @@ fn write_csv<W: Write>(
     numberify: bool,
     ctx: &DisplayContext,
 ) -> Result<()> {
+    // CSV is machine interchange, so `render_commas` is dropped here even when
+    // the ledger sets it: a thousands separator inside a numeric field forces
+    // the field to be quoted and then rejected by ordinary decimal parsers
+    // (issue #1892 — it broke a reconciliation script's `Decimal()`).
+    //
+    // This matches `write_json`, which never applied the flag. Precision is
+    // untouched: only the separator is suppressed, so a value still renders at
+    // the ledger's display precision.
+    let mut ctx = ctx.clone();
+    ctx.set_render_commas(false);
+    let ctx = &ctx;
+
     // Print header
     writeln!(writer, "{}", result.columns.join(","))?;
 
@@ -1838,6 +1859,67 @@ mod tests {
         assert_eq!(
             last_cell, "0.00",
             "currency-named column drives padding regardless of PIVOT path; row was {data_row:?}"
+        );
+    }
+
+    /// `render_commas` is a property of the TABLE, not of a column's contents:
+    /// every column honors it, whatever kind of value it holds (#1892).
+    ///
+    /// It previously arrived only as a side effect of the Number-column
+    /// precision inheritance, so one query printed `SUM(number)` with
+    /// separators and `SUM(position)` without them.
+    #[test]
+    fn render_commas_applies_to_every_column_kind() {
+        use rustledger_core::{Amount, Position};
+        use rustledger_query::QueryResult;
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
+
+        let mut result = QueryResult::new(vec!["num".into(), "pos".into()]);
+        result.add_row(vec![
+            Value::Number(rust_decimal_macros::dec!(1234567.89)),
+            Value::Position(Box::new(Position::simple(Amount::new(
+                rust_decimal_macros::dec!(1234567.89),
+                "USD",
+            )))),
+        ]);
+
+        let mut out = Vec::new();
+        write_text(&result, &mut out, false, &ctx).expect("write");
+        let text = String::from_utf8(out).expect("utf8");
+        assert_eq!(
+            text.matches("1,234,567.89").count(),
+            2,
+            "both the Number and the Position column must carry separators:\n{text}"
+        );
+    }
+
+    /// CSV is machine interchange: it must never emit thousands separators,
+    /// even when the ledger asks for them (#1892).
+    ///
+    /// A separator forces the field to be quoted and then breaks ordinary
+    /// decimal parsers. JSON already behaved this way; CSV was the outlier.
+    #[test]
+    fn csv_never_emits_thousands_separators() {
+        use rustledger_query::QueryResult;
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
+
+        let mut result = QueryResult::new(vec!["sum".into()]);
+        result.add_row(vec![Value::Number(rust_decimal_macros::dec!(1234567.89))]);
+
+        let mut out = Vec::new();
+        write_csv(&result, &mut out, false, &ctx).expect("write");
+        let csv = String::from_utf8(out).expect("utf8");
+        assert!(
+            csv.contains("1234567.89"),
+            "value must render unseparated: {csv}"
+        );
+        assert!(
+            !csv.contains("1,234,567.89") && !csv.contains('"'),
+            "no separators and therefore no quoting: {csv}"
         );
     }
 }

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -89,6 +89,19 @@ pub enum OutputFormat {
     Json,
 }
 
+impl From<&OutputFormat> for rustledger_core::OutputSurface {
+    /// Which consumer each report output format is written for.
+    ///
+    /// Exhaustive on purpose: a new format must state whether it is read by a
+    /// person or parsed by a program (#1892).
+    fn from(f: &OutputFormat) -> Self {
+        match f {
+            OutputFormat::Text => Self::Human,
+            OutputFormat::Csv | OutputFormat::Json => Self::Machine,
+        }
+    }
+}
+
 impl OutputFormat {
     /// Parse from a string (for config file values).
     #[must_use]
@@ -581,6 +594,12 @@ fn render<W: io::Write>(
 ) -> Result<()> {
     let directives = &loaded.directives;
 
+    // Thousands separators are resolved ONCE for the surface being written:
+    // they belong in a rendered table, never in CSV/JSON a program parses
+    // (#1892). Every renderer below takes this context rather than the raw
+    // ledger one.
+    let display_context = loaded.display_context.for_surface(format.into());
+
     // Balance-computing reports read the pad-expanded view when one
     // was built (the ledger has pads), otherwise the source stream
     // directly. `unwrap_or` makes the no-pad fast path explicit: same
@@ -597,7 +616,7 @@ fn render<W: io::Write>(
             balances::report_balances(
                 balance_input,
                 account.as_deref(),
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
             )?;
@@ -606,7 +625,7 @@ fn render<W: io::Write>(
             balsheet::report_balsheet(
                 balance_input,
                 &loaded.account_types,
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
             )?;
@@ -615,7 +634,7 @@ fn render<W: io::Write>(
             income::report_income(
                 balance_input,
                 &loaded.account_types,
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
             )?;
@@ -628,7 +647,7 @@ fn render<W: io::Write>(
                 balance_input,
                 &loaded.account_types,
                 account.as_deref(),
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
             )?;
@@ -642,7 +661,7 @@ fn render<W: io::Write>(
             networth::report_networth(
                 balance_input,
                 &loaded.account_types,
-                &loaded.display_context,
+                &display_context,
                 period,
                 currency.as_deref(),
                 account.as_deref(),
@@ -678,7 +697,7 @@ fn render<W: io::Write>(
                 currency.as_deref(),
                 end.as_deref(),
                 *by_group,
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
                 warnings,
@@ -724,7 +743,7 @@ fn render<W: io::Write>(
                 &filter,
                 *long_term_days,
                 *irr,
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
                 warnings,
@@ -784,7 +803,7 @@ fn render<W: io::Write>(
                 balance_input,
                 &filter,
                 &loaded.account_types,
-                &loaded.display_context,
+                &display_context,
                 format,
                 writer,
                 warnings,

--- a/crates/rustledger/tests/report_display_context_test.rs
+++ b/crates/rustledger/tests/report_display_context_test.rs
@@ -103,10 +103,19 @@ fn income_totals_render_at_ledger_precision() {
 }
 
 #[test]
-fn csv_amounts_with_render_commas_are_quoted() {
-    // `option "render_commas" "TRUE"` puts thousands separators in
-    // formatted numbers; CSV fields containing commas must be quoted
-    // (RFC-4180) or the row grows extra columns (review catch on U4).
+fn csv_omits_thousands_separators_under_render_commas() {
+    // SUPERSEDES `csv_amounts_with_render_commas_are_quoted` (#1750).
+    //
+    // That test encoded a real review catch: with separators in CSV fields,
+    // the fields MUST be quoted (RFC-4180) or a row grows extra columns. The
+    // quoting was correct — but #1892 showed that correctly-quoted
+    // `"2,357.65"` is still rejected by ordinary decimal parsers, so a
+    // consumer could read the row and not the number.
+    //
+    // CSV now omits separators entirely, which subsumes the original concern:
+    // no comma in the field means no quoting, so no column can be split. The
+    // column-count assertion below is kept from the original test, since that
+    // is the property #1750 actually protected.
     let bin = require_rledger!();
     let source = format!("option \"render_commas\" \"TRUE\"\n{MIXED_PRECISION}");
     let mut f = tempfile::Builder::new()
@@ -119,12 +128,15 @@ fn csv_amounts_with_render_commas_are_quoted() {
 
     let csv = run_report(&bin, &path, &["balances", "--format", "csv"]);
     assert!(
-        csv.contains("\"2,357.65\""),
-        "comma-bearing amounts must be CSV-quoted: {csv}",
+        csv.contains(",2357.65,"),
+        "CSV must render the amount unseparated and unquoted: {csv}",
     );
-    // Every data row must still have exactly the header's 4 columns when
-    // parsed with quote-awareness — approximate by checking no row has a
-    // bare (unquoted) thousands comma.
+    assert!(
+        !csv.contains("2,357.65"),
+        "no thousands separator may reach a machine-readable surface: {csv}",
+    );
+    // Retained from #1750: every data row still has exactly the header's 4
+    // columns. Now trivially true (nothing is quoted), which is the point.
     for line in csv.lines().skip(1) {
         let quoted_stripped: String = {
             let mut out = String::new();

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -117,8 +117,9 @@ Separators are a **display** concern, so they appear in rendered output
 
 | Surface | Separators? |
 |---------|-------------|
-| `report`, `query` (text) | yes, when the option is set |
-| `query --format csv` / `json` | **no** — these are machine interchange, and a separator breaks ordinary decimal parsers |
+| `report`, `query` — text | yes, when the option is set |
+| `report`, `query` — `--format csv` / `json` | **no** — machine interchange, and a separator breaks ordinary decimal parsers |
+| `query --format beancount` | **no** — it is ledger text, so it follows the same rule as `format` |
 | `format` (the file on disk) | **no** — see below |
 
 `rledger format` deliberately writes numbers without separators even when this

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -112,6 +112,26 @@ Use commas as thousand separators.
 option "render_commas" "TRUE"
 ```
 
+Separators are a **display** concern, so they appear in rendered output
+(`report`, `query` text) and never in ledger text or machine-readable output:
+
+| Surface | Separators? |
+|---------|-------------|
+| `report`, `query` (text) | yes, when the option is set |
+| `query --format csv` / `json` | **no** — these are machine interchange, and a separator breaks ordinary decimal parsers |
+| `format` (the file on disk) | **no** — see below |
+
+`rledger format` deliberately writes numbers without separators even when this
+option is set: the formatter's job is one canonical on-disk representation, and
+`,` is locale-ambiguous. This differs from Beancount's `bean-format`, which
+leaves numerals untouched, though Beancount's own `printer` also drops them.
+
+The practical consequence: a file containing `1,234,567.89` will always be
+reported as unformatted by `format --check` (exit 1), which fails a CI
+formatting gate. Run `rledger format` once to canonicalize the file; it is
+stable from then on. The parser accepts separators on input either way, so
+existing files keep loading.
+
 ### inferred_tolerance_default
 
 Default tolerance for balance checking.


### PR DESCRIPTION
Answers #1892 and fixes the two inconsistencies that investigating it turned up.

## The question: is `format` stripping separators deliberate?

**Yes, and it is pinned by tests** — not an oversight. `rustledger-ffi-component/src/convert.rs` states the policy outright, and two tests in `rustledger-core/src/format/mod.rs` set `render_commas(true)` and assert the formatter emits none (`number_display_context_pads_without_separators`, `number_display_context_threads_through_directives`). The loader only calls `set_render_commas` on the display path, never the format path.

The reporter's inference from #1807/#1750 was reasonable — display options *do* reach the formatter — but `render_commas` is excluded on purpose while precision is not.

## Two things that were genuinely wrong

**`SUM(position)` ignored the flag while `SUM(number)` honored it**, in the same query and the same output format:

```
SELECT account, sum(number)    ->  Assets:Bank    1,234,567.89
SELECT account, sum(position)  ->  Assets:Bank   1234567.89 USD
```

Per-column `DisplayContext`s start empty, and the ledger context was merged in **only on the first `Value::Number` cell** — that inheritance exists to give naked decimal columns a precision fallback (#954). `render_commas` was riding along as a side effect, so any column holding a Position or Inventory never received it. It is presentation policy for the whole table, so it is now set on every column context directly; the Number-only precision inheritance is untouched.

**CSV emitted separators; JSON did not.**

```
csv  -> Assets:Bank,"1,234,567.89"
json -> "1234567.89"
```

Both are machine interchange. The separator forces the field to be quoted and is then rejected by ordinary decimal parsers — it broke the reporter's reconciliation script. CSV now matches JSON. Precision is untouched; only the separator is suppressed.

## Documentation

`docs/reference/options.md` described `render_commas` with no scope at all, which is why expecting `format` to honor it was reasonable. It now carries a per-surface table and the rationale, including the consequence the reporter identified: a separator-bearing file is permanently "unformatted" to `format --check` (exit 1), so a CI gate needs `rledger format` run once to canonicalize. The parser accepts separators on input either way, so existing files keep loading.

## Verification

| surface | before | after |
|---|---|---|
| `report` | `1,234,567.89 USD` | unchanged |
| `query` text `sum(number)` | `1,234,567.89` | unchanged |
| `query` text `sum(position)` | `1234567.89 USD` | **`1,234,567.89 USD`** |
| `query -f csv` | `"1,234,567.89"` | **`1234567.89`** |
| `query -f json` | `1234567.89` | unchanged |
| `format` | `1234567.89` | unchanged (by design) |

Both tests sabotage-verified — each fails with its fix removed.

With `render_commas` unset (every existing ledger), output is byte-identical to main across text/csv/json for both query shapes; with it set, only the two intended surfaces change. The BQL compat harness does not set the option, so it is unaffected.

4288 tests · clippy clean at the CI-pinned 1.97.0 · `cargo doc -D warnings` clean.
