### PR TITLE
feat(format): let a ledger declare thousands separators in its own files

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -82,6 +82,32 @@ impl fmt::Display for MetaValue {
 /// Metadata is a key-value map attached to directives and postings.
 pub type Metadata = FxHashMap<String, MetaValue>;
 
+/// Read a boolean-valued metadata entry, accepting the spellings a ledger
+/// author might reasonably write.
+///
+/// `TRUE` is an uppercase bare word, so depending on context the parser may
+/// classify it as a boolean, a currency, or a string rather than one canonical
+/// variant. Accepting all three keeps `render_commas: TRUE` working however it
+/// lexes, instead of silently ignoring the declaration — the failure mode that
+/// makes a display option look broken.
+///
+/// Returns `None` for anything not recognizably boolean, so callers can leave
+/// the default in place rather than guess.
+#[must_use]
+pub fn meta_value_as_bool(value: &MetaValue) -> Option<bool> {
+    let word = match value {
+        MetaValue::Bool(b) => return Some(*b),
+        MetaValue::String(s) => s.as_str(),
+        MetaValue::Currency(c) => c.as_str(),
+        _ => return None,
+    };
+    match word.to_ascii_uppercase().as_str() {
+        "TRUE" | "T" | "YES" | "1" => Some(true),
+        "FALSE" | "F" | "NO" | "0" => Some(false),
+        _ => None,
+    }
+}
+
 /// Try to interpret a [`MetaValue`] as a non-negative integer ≤ `u32::MAX`.
 ///
 /// Used by the `precision` metadata feature on `commodity` directives (issue

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -82,28 +82,40 @@ impl fmt::Display for MetaValue {
 /// Metadata is a key-value map attached to directives and postings.
 pub type Metadata = FxHashMap<String, MetaValue>;
 
-/// Read a boolean-valued metadata entry, accepting the spellings a ledger
-/// author might reasonably write.
+/// The spellings of a boolean accepted in ledger source.
+///
+/// Stated ONCE because a boolean can arrive two ways — `option "x" "TRUE"` and
+/// `x: TRUE` metadata — and they are the same concept to a ledger author. Two
+/// separate vocabularies would mean `render_commas: YES` grouping numerals
+/// while `option "render_commas" "YES"` warns and does nothing.
+///
+/// `None` means "not recognizably boolean": the option parser turns that into
+/// an E7002 warning, and metadata leaves the default in place.
+#[must_use]
+pub fn parse_bool_word(word: &str) -> Option<bool> {
+    if word.eq_ignore_ascii_case("true") || word == "1" {
+        Some(true)
+    } else if word.eq_ignore_ascii_case("false") || word == "0" {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Read a boolean-valued metadata entry.
 ///
 /// `TRUE` is an uppercase bare word, so depending on context the parser may
 /// classify it as a boolean, a currency, or a string rather than one canonical
 /// variant. Accepting all three keeps `render_commas: TRUE` working however it
 /// lexes, instead of silently ignoring the declaration — the failure mode that
-/// makes a display option look broken.
-///
-/// Returns `None` for anything not recognizably boolean, so callers can leave
-/// the default in place rather than guess.
+/// makes a display option look broken. The VALUE vocabulary is
+/// [`parse_bool_word`]'s, shared with the option parser.
 #[must_use]
 pub fn meta_value_as_bool(value: &MetaValue) -> Option<bool> {
-    let word = match value {
-        MetaValue::Bool(b) => return Some(*b),
-        MetaValue::String(s) => s.as_str(),
-        MetaValue::Currency(c) => c.as_str(),
-        _ => return None,
-    };
-    match word.to_ascii_uppercase().as_str() {
-        "TRUE" | "T" | "YES" | "1" => Some(true),
-        "FALSE" | "F" | "NO" | "0" => Some(false),
+    match value {
+        MetaValue::Bool(b) => Some(*b),
+        MetaValue::String(s) => parse_bool_word(s),
+        MetaValue::Currency(c) => parse_bool_word(c),
         _ => None,
     }
 }
@@ -1512,6 +1524,56 @@ impl fmt::Display for Directive {
             Self::Price(p) => write!(f, "{p}"),
             Self::Custom(c) => write!(f, "{c}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod bool_vocabulary_tests {
+    use super::*;
+
+    /// One concept, one vocabulary: what `option "x" "V"` accepts is exactly
+    /// what `x: V` metadata accepts.
+    ///
+    /// The loader's option parser calls [`parse_bool_word`] directly, so this
+    /// pins the shared set rather than a copy of it. Before they were unified,
+    /// metadata took `YES`/`T` while the option warned on them.
+    #[test]
+    fn options_and_metadata_accept_the_same_spellings() {
+        for word in ["TRUE", "true", "True", "1"] {
+            assert_eq!(parse_bool_word(word), Some(true), "{word}");
+        }
+        for word in ["FALSE", "false", "False", "0"] {
+            assert_eq!(parse_bool_word(word), Some(false), "{word}");
+        }
+        for word in ["YES", "NO", "T", "F", "on", "", "2", "maybe"] {
+            assert_eq!(
+                parse_bool_word(word),
+                None,
+                "{word} is not accepted by `option`, so metadata must not take \
+                 it either — the option parser warns (E7002) and metadata \
+                 leaves the default"
+            );
+        }
+    }
+
+    /// An uppercase bare word's token classification depends on context, so
+    /// the same declaration can arrive as three different `MetaValue`s.
+    #[test]
+    fn a_bare_word_is_read_however_it_lexed() {
+        assert_eq!(meta_value_as_bool(&MetaValue::Bool(true)), Some(true));
+        assert_eq!(
+            meta_value_as_bool(&MetaValue::String("TRUE".into())),
+            Some(true)
+        );
+        assert_eq!(
+            meta_value_as_bool(&MetaValue::Currency("TRUE".into())),
+            Some(true)
+        );
+        assert_eq!(
+            meta_value_as_bool(&MetaValue::Currency("FALSE".into())),
+            Some(false)
+        );
+        assert_eq!(meta_value_as_bool(&MetaValue::Currency("USD".into())), None);
     }
 }
 

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -120,19 +120,32 @@ pub enum Precision {
 
 /// What kind of consumer an output surface is written for.
 ///
-/// Decides whether thousands separators appear. They are a HUMAN-READING
-/// affordance, so they belong only in rendered tables and reports:
+/// Decides whether thousands separators appear. The question is not "will a
+/// person read this" but **does the consumer have a grammar**:
 ///
-/// - **machine interchange** (CSV, JSON) must stay parseable — a separator
-///   forces the field to be quoted and is then rejected by ordinary decimal
-///   parsers (issue #1892);
-/// - **ledger text** (`format`, `query --format beancount`) has one canonical
-///   on-disk form, and `,` is locale-ambiguous.
+/// - **machine interchange** (CSV, JSON) does not. A separator forces the
+///   field to be quoted and is then rejected by ordinary decimal parsers —
+///   `Decimal(field)` breaks (issue #1892). Suppressed unconditionally, and
+///   that suppression outranks any ledger or per-commodity declaration.
+/// - **ledger text** (`format`, `query --format beancount`) does. Grouped
+///   numerals are part of Beancount syntax, so every conforming reader must
+///   accept them; the parser, not the file, is the machine boundary. Honors
+///   the ledger's declaration (#1896).
+/// - **rendered tables** read by a person likewise honor it.
 ///
 /// This exists so the rule is stated ONCE. It was previously re-derived per
 /// writer, and the surfaces had already drifted apart: `query --format
 /// beancount` emitted separators into ledger text while `format` stripped
 /// them, and CSV emitted them while JSON did not.
+///
+/// `LedgerText` initially suppressed them, on the premise that ledger text has
+/// one canonical on-disk form. #1896 abandoned that premise deliberately —
+/// `rledger format --ledger` now GROUPS, because a ledger that asks for
+/// separators should get them in the file it owns — which put the two ledger
+/// text producers back in disagreement until this arm followed. Beancount
+/// itself groups here: `grammar.py` calls `dcontext.set_commas(options
+/// ["render_commas"])` while parsing, and `printer.py` renders through that
+/// same context.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputSurface {
     /// A rendered table or report read by a person.
@@ -146,11 +159,14 @@ pub enum OutputSurface {
 impl OutputSurface {
     /// Whether this surface renders thousands separators when the ledger asks
     /// for them.
+    ///
+    /// Only [`Self::Machine`] refuses, because only its consumers lack a
+    /// grammar that admits the separator.
     #[must_use]
     pub const fn renders_thousands_separators(self) -> bool {
         match self {
-            Self::Human => true,
-            Self::Machine | Self::LedgerText => false,
+            Self::Human | Self::LedgerText => true,
+            Self::Machine => false,
         }
     }
 }
@@ -1887,13 +1903,18 @@ mod custom_directive_precision_tests {
     /// `OutputSurface` variant cannot quietly default to rendering separators
     /// (#1892).
     #[test]
-    fn only_human_surfaces_render_thousands_separators() {
+    fn only_machine_surfaces_suppress_thousands_separators() {
         assert!(OutputSurface::Human.renders_thousands_separators());
-        assert!(!OutputSurface::Machine.renders_thousands_separators());
         assert!(
-            !OutputSurface::LedgerText.renders_thousands_separators(),
-            "ledger text has one canonical form; `format` strips separators \
-             and `query --format beancount` must agree with it"
+            !OutputSurface::Machine.renders_thousands_separators(),
+            "CSV/JSON consumers have no grammar admitting a separator; this \
+             suppression outranks any ledger or per-commodity declaration"
+        );
+        assert!(
+            OutputSurface::LedgerText.renders_thousands_separators(),
+            "grouped numerals are Beancount syntax, so every conforming \
+             reader accepts them — `format --ledger` groups and `query \
+             --format beancount` must agree with it (#1896)"
         );
     }
 

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -249,6 +249,29 @@ impl DisplayContext {
         if other.render_commas {
             self.render_commas = true;
         }
+        // Per-commodity grouping declarations travel with the flag they
+        // override. Merging the ledger-wide bit alone silently downgraded a
+        // commodity's own `render_commas:` to the global default (#1896).
+        for (currency, render) in &other.group_overrides {
+            self.group_overrides
+                .entry(currency.clone())
+                .or_insert(*render);
+        }
+    }
+
+    /// Adopt `other`'s grouping policy wholesale: the ledger-wide flag and
+    /// every per-commodity override.
+    ///
+    /// Distinct from [`Self::update_from`], which merges precision *facts*
+    /// inferred from data and is one-way for grouping. Separator rendering is
+    /// presentation policy for a whole table, so a derived context — the query
+    /// writer's per-column contexts, say — must take it entire rather than
+    /// reconstruct it. Reconstructing it is exactly how `SUM(number)` came to
+    /// disagree with `SUM(position)` in one query (#1892), and how a
+    /// commodity's own declaration came to be dropped (#1896).
+    pub fn adopt_grouping_from(&mut self, other: &Self) {
+        self.render_commas = other.render_commas;
+        self.group_overrides.clone_from(&other.group_overrides);
     }
 
     /// Set the inference policy for [`Self::get_precision`].
@@ -351,18 +374,26 @@ impl DisplayContext {
     /// distinction exists.
     ///
     /// Borrows unless the flag actually has to change, so the common cases
-    /// cost nothing: a ledger without `render_commas` (almost all of them) and
+    /// cost nothing: a ledger where nothing groups (almost all of them) and
     /// any human-facing surface both borrow. Only suppressing separators for a
     /// machine or ledger-text surface clones, and that clone carries the
     /// per-currency histograms — worth avoiding on a REPL's hot path, and
     /// wasted entirely on the JSON writer, which ignores the context.
+    ///
+    /// The borrow test is [`Self::renders_any_commas`], not the ledger-wide
+    /// flag: a commodity may declare `render_commas: TRUE` while the ledger
+    /// default is off, and borrowing on the strength of the global flag alone
+    /// would leak that commodity's separators onto a machine surface.
     #[must_use]
     pub fn for_surface(&self, surface: OutputSurface) -> std::borrow::Cow<'_, Self> {
-        if !self.render_commas || surface.renders_thousands_separators() {
+        if !self.renders_any_commas() || surface.renders_thousands_separators() {
             return std::borrow::Cow::Borrowed(self);
         }
         let mut ctx = self.clone();
         ctx.render_commas = false;
+        // Suppression is absolute: a per-commodity opt-in must not survive
+        // onto a surface whose consumer has no grammar for separators.
+        ctx.group_overrides.clear();
         std::borrow::Cow::Owned(ctx)
     }
 
@@ -699,7 +730,7 @@ impl DisplayContext {
             let rounded = number.round_dp(effective_dp);
             let formatted = format!("{rounded}");
             let formatted = Self::ensure_decimal_places(&formatted, effective_dp);
-            if self.render_commas {
+            if self.render_commas_for(currency) {
                 Self::add_commas(&formatted)
             } else {
                 formatted
@@ -707,7 +738,7 @@ impl DisplayContext {
         } else {
             // No tracked precision - use natural formatting
             let formatted = number.normalize().to_string();
-            if self.render_commas {
+            if self.render_commas_for(currency) {
                 Self::add_commas(&formatted)
             } else {
                 formatted
@@ -790,7 +821,7 @@ impl DisplayContext {
             }
             None => number.normalize().to_string(),
         };
-        if self.render_commas {
+        if self.render_commas_for(currency) {
             Self::add_commas(&raw)
         } else {
             raw
@@ -1863,6 +1894,96 @@ mod custom_directive_precision_tests {
             !OutputSurface::LedgerText.renders_thousands_separators(),
             "ledger text has one canonical form; `format` strips separators \
              and `query --format beancount` must agree with it"
+        );
+    }
+
+    /// A commodity's own `render_commas` declaration governs report and query
+    /// text, not just `rledger format`.
+    ///
+    /// Review catch on #1896: the per-commodity overrides were parsed and
+    /// stored but only the CST formatter consulted them, so `format` and
+    /// `format_quantized` — which have the currency right there in the
+    /// signature — still asked the ledger-wide flag. A commodity opting out of
+    /// grouping was silently grouped in every report.
+    #[test]
+    fn a_commoditys_own_declaration_governs_report_text() {
+        let mut ctx = DisplayContext::new();
+        ctx.set_fixed_precision("USD", 2);
+        ctx.set_fixed_precision("IQD", 2);
+        ctx.set_render_commas(true);
+        ctx.set_render_commas_for("USD", false);
+
+        assert_eq!(
+            ctx.format(Decimal::from_str_exact("1234567.89").unwrap(), "USD"),
+            "1234567.89",
+            "USD declared render_commas: FALSE — a report must honor it"
+        );
+        assert_eq!(
+            ctx.format(Decimal::from_str_exact("1234567.89").unwrap(), "IQD"),
+            "1,234,567.89",
+            "IQD declared nothing and takes the ledger-wide default"
+        );
+        // The ledger-text path (`query --format beancount`) resolves per
+        // currency too, so the two surfaces cannot disagree.
+        assert_eq!(
+            ctx.format_quantized(Decimal::from_str_exact("1234567.89").unwrap(), "USD"),
+            "1234567.89"
+        );
+        assert_eq!(
+            ctx.format_quantized(Decimal::from_str_exact("1234567.89").unwrap(), "IQD"),
+            "1,234,567.89"
+        );
+
+        // And the inverse tier: nothing global, one commodity opting IN.
+        let mut opted_in = DisplayContext::new();
+        opted_in.set_fixed_precision("IQD", 2);
+        opted_in.set_render_commas_for("IQD", true);
+        assert_eq!(
+            opted_in.format(Decimal::from_str_exact("1234567.89").unwrap(), "IQD"),
+            "1,234,567.89"
+        );
+    }
+
+    /// Suppressing separators for a machine surface must clear the
+    /// per-commodity opt-ins too, not just the ledger-wide flag.
+    ///
+    /// The borrow fast path used to test `render_commas` alone. A ledger whose
+    /// global flag is off but which has one commodity declaring
+    /// `render_commas: TRUE` would take that path and hand the CSV writer a
+    /// context that still groups that commodity — `Decimal(field)` breaks on
+    /// the result.
+    #[test]
+    fn machine_surfaces_suppress_per_commodity_opt_ins() {
+        use std::borrow::Cow;
+
+        let mut ctx = DisplayContext::new();
+        ctx.set_fixed_precision("IQD", 2);
+        ctx.set_render_commas_for("IQD", true); // global stays FALSE
+
+        assert!(
+            !ctx.render_commas(),
+            "precondition: nothing is set ledger-wide"
+        );
+        assert!(ctx.renders_any_commas(), "but one commodity opts in");
+
+        let machine = ctx.for_surface(OutputSurface::Machine);
+        assert!(
+            matches!(machine, Cow::Owned(_)),
+            "the global flag is off, but an override still has to be cleared"
+        );
+        assert!(!machine.render_commas_for("IQD"));
+        assert_eq!(
+            machine.format(Decimal::from_str_exact("1234567.89").unwrap(), "IQD"),
+            "1234567.89",
+            "a CSV/JSON consumer has no grammar for separators"
+        );
+
+        // Human surface keeps the opt-in, and still borrows.
+        let human = ctx.for_surface(OutputSurface::Human);
+        assert!(matches!(human, Cow::Borrowed(_)));
+        assert_eq!(
+            human.format(Decimal::from_str_exact("1234567.89").unwrap(), "IQD"),
+            "1,234,567.89"
         );
     }
 

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -170,7 +170,19 @@ pub struct DisplayContext {
     distributions: HashMap<String, Distribution>,
 
     /// Whether to render commas in numbers (from `option "render_commas"`).
+    ///
+    /// The LEDGER-WIDE default. A commodity may override it — see
+    /// [`Self::render_commas_for`] — so a 4000:1 currency can be grouped
+    /// without also grouping two-digit USD amounts.
     render_commas: bool,
+    /// Per-commodity overrides of [`Self::render_commas`], from
+    /// `render_commas:` metadata on a `commodity` directive.
+    ///
+    /// Mirrors `fixed_precisions`: grouping and precision are both per-currency
+    /// display style, resolved by the same three tiers (inference / global
+    /// option / commodity metadata). Grouping had only the global tier, which
+    /// is the asymmetry this closes.
+    group_overrides: rustc_hash::FxHashMap<String, bool>,
 
     /// Fixed precision overrides (from `option "display_precision"`).
     /// These take precedence over inferred precision under any policy.
@@ -359,6 +371,34 @@ impl DisplayContext {
         self.render_commas = render_commas;
     }
 
+    /// Declare whether `currency` renders thousands separators, overriding the
+    /// ledger-wide [`Self::set_render_commas`].
+    pub fn set_render_commas_for(&mut self, currency: &str, render: bool) {
+        self.group_overrides.insert(currency.to_string(), render);
+    }
+
+    /// Whether `currency` renders thousands separators: its own declaration if
+    /// it has one, else the ledger-wide default.
+    ///
+    /// Numerals with no currency in scope — metadata values, `custom`
+    /// directive values — have nothing to look up and take the default.
+    #[must_use]
+    pub fn render_commas_for(&self, currency: &str) -> bool {
+        self.group_overrides
+            .get(currency)
+            .copied()
+            .unwrap_or(self.render_commas)
+    }
+
+    /// Whether ANY currency renders separators.
+    ///
+    /// Lets a caller skip the per-numeral lookup entirely for the overwhelming
+    /// majority of ledgers, which declare nothing.
+    #[must_use]
+    pub fn renders_any_commas(&self) -> bool {
+        self.render_commas || self.group_overrides.values().any(|v| *v)
+    }
+
     /// Get the `render_commas` flag.
     #[must_use]
     pub const fn render_commas(&self) -> bool {
@@ -505,6 +545,16 @@ impl DisplayContext {
                 && let Ok(precision) = crate::parse_precision_meta(value)
             {
                 ctx.set_fixed_precision(comm.currency.as_str(), precision);
+            }
+            // Same tier, same walk: per-commodity `render_commas: TRUE|FALSE`.
+            // Deliberately the same mechanism as `precision:` — beancount
+            // ignores metadata keys it does not know, so a ledger carrying this
+            // still round-trips through beancount and fava untouched.
+            if let Directive::Commodity(comm) = directive
+                && let Some(value) = comm.meta.get("render_commas")
+                && let Some(render) = crate::meta_value_as_bool(value)
+            {
+                ctx.set_render_commas_for(comm.currency.as_str(), render);
             }
         }
 

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec}
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,
-    booking_sort_key, parse_precision_meta, sort_directives,
+    booking_sort_key, meta_value_as_bool, parse_precision_meta, sort_directives,
 };
 pub use display_context::{DEFAULT_CURRENCY, DisplayContext, OutputSurface, Precision};
 pub use extract::{

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec}
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,
-    booking_sort_key, meta_value_as_bool, parse_precision_meta, sort_directives,
+    booking_sort_key, meta_value_as_bool, parse_bool_word, parse_precision_meta, sort_directives,
 };
 pub use display_context::{DEFAULT_CURRENCY, DisplayContext, OutputSurface, Precision};
 pub use extract::{

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1828,8 +1828,10 @@ impl SessionState {
     /// only the config differs. `render_commas` IS honored here: this path
     /// holds the ledger's options, and a grouped numeral is something every
     /// conforming reader must accept (the grammar admits it), so the parser —
-    /// not the file — is the machine boundary. `rledger format` still emits
-    /// ungrouped text because it has no options in scope.
+    /// not the file — is the machine boundary. `rledger format` groups only
+    /// when given `--ledger <root>`, which is how it brings a ledger's options
+    /// into scope; bare `rledger format <file>` has none and emits ungrouped
+    /// text.
     pub fn format(&self) -> Result<String, String> {
         let mut ctx = rustledger_core::DisplayContext::from_directives(
             self.directives.iter(),

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1825,17 +1825,28 @@ impl SessionState {
     /// options' `display_precision` overrides, then per-commodity
     /// `precision:` metadata) and renders through the same
     /// `canonicalize_directives` path as the free `format` interface —
-    /// only the config differs. `render_commas` is NOT set: ledger text
-    /// never carries thousands separators (`format_plain` ignores the
-    /// flag; it stays a report/query concern).
+    /// only the config differs. `render_commas` IS honored here: this path
+    /// holds the ledger's options, and a grouped numeral is something every
+    /// conforming reader must accept (the grammar admits it), so the parser —
+    /// not the file — is the machine boundary. `rledger format` still emits
+    /// ungrouped text because it has no options in scope.
     pub fn format(&self) -> Result<String, String> {
-        let ctx = rustledger_core::DisplayContext::from_directives(
+        let mut ctx = rustledger_core::DisplayContext::from_directives(
             self.directives.iter(),
             self.options
                 .display_precision
                 .iter()
                 .map(|(c, p)| (c.as_str(), *p)),
         );
+        // The session holds the ledger's options, so this path can honor
+        // `render_commas` on disk — the boundary a machine consumer crosses is
+        // the PARSER, and the grammar admits grouped numerals. (Contrast the
+        // csv/json surfaces, whose consumers have no grammar; those stay
+        // separator-free unconditionally.) `rledger format` still passes
+        // `false` because it is a per-file text transform with no options in
+        // scope; giving it a context is a separate decision about whether
+        // `format` becomes a ledger operation.
+        ctx.set_render_commas(self.options.render_commas);
         let config = rustledger_core::format::FormatConfig {
             number_display: Some(ctx),
             ..Default::default()

--- a/crates/rustledger-loader/src/discover.rs
+++ b/crates/rustledger-loader/src/discover.rs
@@ -1,0 +1,112 @@
+//! Finding a ledger's root journal without being told where it is.
+//!
+//! Both the language server and `rledger format` need this: neither is
+//! handed a root, but both must resolve options (`render_commas`,
+//! per-commodity declarations) that only exist there. The list of names
+//! lives here so the two cannot disagree about what a root looks like —
+//! a file the LSP formats one way and the CLI another is precisely the
+//! failure this is meant to prevent.
+
+use std::path::{Path, PathBuf};
+
+/// Common root journal filenames, in priority order.
+pub const COMMON_ROOT_NAMES: &[&str] = &[
+    "main.bean",
+    "main.beancount",
+    "ledger.bean",
+    "ledger.beancount",
+    "journal.bean",
+    "journal.beancount",
+    "index.bean",
+    "index.beancount",
+];
+
+/// The root journal directly inside `dir`, if one is there.
+///
+/// Checks [`COMMON_ROOT_NAMES`] in order and returns the first that exists
+/// as a file. Does not recurse and does not walk upward — see
+/// [`discover_journal_upward`] for that.
+#[must_use]
+pub fn discover_journal_file(dir: &Path) -> Option<PathBuf> {
+    for name in COMMON_ROOT_NAMES {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// The nearest root journal at or above `start`.
+///
+/// Walks toward the filesystem root and returns the first directory that
+/// holds one. Nearest wins, so a nested sub-ledger with its own root beats
+/// an outer one — the same "most specific enclosing scope" rule an editor
+/// or a version-control tool uses.
+///
+/// `start` is a DIRECTORY. Callers with a file path should pass its parent.
+#[must_use]
+pub fn discover_journal_upward(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        if let Some(found) = discover_journal_file(d) {
+            return Some(found);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_a_root_beside_the_file_and_prefers_the_nearest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outer = dir.path();
+        let inner = outer.join("sub/deeper");
+        std::fs::create_dir_all(&inner).expect("mkdir");
+
+        std::fs::write(outer.join("main.beancount"), "").expect("write outer");
+        assert_eq!(
+            discover_journal_upward(&inner),
+            Some(outer.join("main.beancount")),
+            "walks up when nothing is nearer"
+        );
+
+        let nested = outer.join("sub").join("ledger.beancount");
+        std::fs::write(&nested, "").expect("write inner");
+        assert_eq!(
+            discover_journal_upward(&inner),
+            Some(nested),
+            "a nearer root wins over an outer one"
+        );
+    }
+
+    #[test]
+    fn name_priority_is_stable_and_directories_do_not_count() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A DIRECTORY named like a root must not be mistaken for one.
+        std::fs::create_dir(dir.path().join("main.bean")).expect("mkdir");
+        assert_eq!(discover_journal_file(dir.path()), None);
+
+        std::fs::write(dir.path().join("journal.beancount"), "").expect("write");
+        std::fs::write(dir.path().join("main.beancount"), "").expect("write");
+        assert_eq!(
+            discover_journal_file(dir.path()),
+            Some(dir.path().join("main.beancount")),
+            "`main.beancount` outranks `journal.beancount`"
+        );
+    }
+
+    #[test]
+    fn returns_none_when_there_is_no_ledger_anywhere_above() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let deep = dir.path().join("a/b/c");
+        std::fs::create_dir_all(&deep).expect("mkdir");
+        // The walk reaches the filesystem root and stops; tempdirs live
+        // under /tmp, which has no journal.
+        assert_eq!(discover_journal_upward(&deep), None);
+    }
+}

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -39,6 +39,7 @@
 #[cfg(feature = "cache")]
 pub mod cache;
 mod dedup;
+pub mod discover;
 mod options;
 mod phase;
 mod process;
@@ -60,6 +61,7 @@ pub use cache::{
     save_cache_entry,
 };
 pub use dedup::{reintern_directives, reintern_plain_directives};
+pub use discover::{COMMON_ROOT_NAMES, discover_journal_file, discover_journal_upward};
 pub use options::Options;
 pub use source_map::{SourceFile, SourceMap};
 pub use vfs::{DiskFileSystem, FileSystem, VirtualFileSystem};

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -414,10 +414,12 @@ impl Options {
                 self.booking_method = value.to_string();
             }
             "render_commas" => {
-                // Accept TRUE/FALSE, true/false, 1/0 (Python beancount compatibility)
-                let is_true = value.eq_ignore_ascii_case("true") || value == "1";
-                let is_false = value.eq_ignore_ascii_case("false") || value == "0";
-                if !is_true && !is_false {
+                // Accept TRUE/FALSE, true/false, 1/0 (Python beancount
+                // compatibility). Shared with `render_commas:` metadata so one
+                // concept has one vocabulary — see `parse_bool_word`.
+                let parsed = rustledger_core::parse_bool_word(value);
+                let is_true = parsed == Some(true);
+                if parsed.is_none() {
                     self.warnings.push(OptionWarning {
                         code: "E7002",
                         message: format!(

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -376,17 +376,22 @@ impl Options {
                 }
             }
             "infer_tolerance_from_cost" => {
-                if !value.eq_ignore_ascii_case("true") && !value.eq_ignore_ascii_case("false") {
+                // Same vocabulary as every other boolean in ledger source
+                // (`parse_bool_word`). This arm used to take TRUE/FALSE only
+                // and warn on `1`, which Python beancount accepts as true for
+                // every boolean option.
+                let parsed = rustledger_core::parse_bool_word(value);
+                if parsed.is_none() {
                     self.warnings.push(OptionWarning {
                         code: "E7002",
                         message: format!(
-                            "Invalid value \"{value}\" for option \"{key}\": expected TRUE or FALSE"
+                            "Invalid value \"{value}\" for option \"{key}\": expected TRUE, FALSE, 1 or 0"
                         ),
                         option: key.to_string(),
                         value: value.to_string(),
                     });
                 }
-                self.infer_tolerance_from_cost = value.eq_ignore_ascii_case("true");
+                self.infer_tolerance_from_cost = parsed == Some(true);
             }
             "booking_method" => {
                 let valid_methods = [
@@ -423,7 +428,7 @@ impl Options {
                     self.warnings.push(OptionWarning {
                         code: "E7002",
                         message: format!(
-                            "Invalid value \"{value}\" for option \"{key}\": expected TRUE or FALSE"
+                            "Invalid value \"{value}\" for option \"{key}\": expected TRUE, FALSE, 1 or 0"
                         ),
                         option: key.to_string(),
                         value: value.to_string(),
@@ -816,7 +821,55 @@ mod tests {
 
         assert_eq!(opts.warnings.len(), 1);
         assert_eq!(opts.warnings[0].code, "E7002");
-        assert!(opts.warnings[0].message.contains("TRUE or FALSE"));
+        assert!(
+            opts.warnings[0].message.contains("TRUE, FALSE, 1 or 0"),
+            "the message must name the vocabulary actually accepted: {}",
+            opts.warnings[0].message
+        );
+    }
+
+    /// Every boolean option in ledger source shares one vocabulary, and the
+    /// E7002 message names it accurately.
+    ///
+    /// `infer_tolerance_from_cost` used to take TRUE/FALSE only and warn on
+    /// `1`, which Python beancount accepts as true for every boolean option;
+    /// `render_commas` took `1`/`0` as well. The message said "TRUE or FALSE"
+    /// on both. A test that only checks the rejected value cannot catch a
+    /// message that under-promises, so this asserts the accepted ones too.
+    #[test]
+    fn boolean_options_share_one_vocabulary() {
+        for key in ["infer_tolerance_from_cost", "render_commas"] {
+            for (value, expected) in [
+                ("TRUE", true),
+                ("true", true),
+                ("1", true),
+                ("FALSE", false),
+                ("false", false),
+                ("0", false),
+            ] {
+                let mut opts = Options::new();
+                opts.set(key, value);
+                assert!(
+                    opts.warnings.is_empty(),
+                    "{key} = {value:?} must be accepted without a warning: {:?}",
+                    opts.warnings
+                );
+                let actual = if key == "render_commas" {
+                    opts.render_commas
+                } else {
+                    opts.infer_tolerance_from_cost
+                };
+                assert_eq!(actual, expected, "{key} = {value:?}");
+            }
+
+            let mut opts = Options::new();
+            opts.set(key, "yes");
+            assert_eq!(
+                opts.warnings.len(),
+                1,
+                "{key}: `yes` is outside the shared vocabulary and must warn"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -10,6 +10,7 @@ use lsp_types::{
 };
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
+use rustledger_parser::format::GroupingStyle;
 use std::collections::HashMap;
 
 use super::formatting::format_document;
@@ -119,6 +120,7 @@ pub fn handle_execute_command(
     parse_result: &ParseResult,
     uri: &Uri,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> ExecuteCommandResponse {
     match params.command.as_str() {
         "rledger.insertDate" => {
@@ -128,7 +130,7 @@ pub fn handle_execute_command(
             let silent = is_silent_invocation(&params.arguments);
             handle_sort_transactions(source, parse_result, uri, silent, encoding)
         }
-        "rledger.alignAmounts" => handle_align_amounts(source, parse_result, uri, encoding),
+        "rledger.alignAmounts" => handle_align_amounts(source, parse_result, uri, encoding, style),
         "rledger.showAccountBalance" => {
             handle_show_account_balance(&params.arguments, parse_result)
         }
@@ -279,8 +281,9 @@ fn handle_align_amounts(
     parse_result: &ParseResult,
     uri: &Uri,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> ExecuteCommandResponse {
-    let Some(edits) = format_document(source, parse_result, encoding) else {
+    let Some(edits) = format_document(source, parse_result, encoding, style) else {
         // Parse errors: surface via window/showMessage so the user
         // actually sees the failure. executeCommand responses are
         // discarded by VS Code etc.; showMessage is the spec-mandated
@@ -635,7 +638,13 @@ mod tests {
             "2024-01-15 * \"Coffee\"\n  Assets:Bank:Checking -5.00 USD\n  Expenses:Food 5.00 USD\n";
         let result = parse(misaligned);
         let uri: Uri = "file:///test.beancount".parse().unwrap();
-        let response = handle_align_amounts(misaligned, &result, &uri, PositionEncoding::Utf16);
+        let response = handle_align_amounts(
+            misaligned,
+            &result,
+            &uri,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        );
         let out = response
             .response
             .expect("align should return a JSON response");
@@ -676,8 +685,13 @@ mod tests {
         // align") instead.
         let aligned = "2024-01-15 open Assets:Bank USD\n";
         let aligned_parsed = parse(aligned);
-        let response2 =
-            handle_align_amounts(aligned, &aligned_parsed, &uri, PositionEncoding::Utf16);
+        let response2 = handle_align_amounts(
+            aligned,
+            &aligned_parsed,
+            &uri,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        );
         assert!(
             response2.response.is_none(),
             "no-op input should not return a workspace edit, got {:?}",

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -29,7 +29,9 @@ use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
 use rustledger_parser::ParseResult;
 #[cfg(test)]
 use rustledger_parser::format::format_source;
-use rustledger_parser::format::{format_source_with_parsed, lf_to_crlf_outside_strings};
+use rustledger_parser::format::{
+    GroupingStyle, format_node_grouped, format_source_with_parsed, lf_to_crlf_outside_strings,
+};
 
 use super::utils::{LineIndex, PositionEncoding};
 
@@ -44,8 +46,9 @@ pub fn handle_formatting(
     source: &str,
     parse_result: &ParseResult,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> Option<Vec<TextEdit>> {
-    if let Some(edits) = format_document(source, parse_result, encoding) {
+    if let Some(edits) = format_document(source, parse_result, encoding, style) {
         return Some(edits);
     }
     // Parse error or already canonical. The "already canonical" case
@@ -81,6 +84,7 @@ pub fn format_document(
     source: &str,
     parse_result: &ParseResult,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> Option<Vec<TextEdit>> {
     if !parse_result.errors.is_empty() {
         return None;
@@ -94,7 +98,16 @@ pub fn format_document(
     // `format_source(source)`; pinned by
     // `format_source_with_parsed_matches_format_source` in the
     // parser crate's tests.
-    let mut formatted = format_source_with_parsed(parse_result, source);
+    let mut formatted = if style.groups_anything() {
+        // The alignment cached on `ParseResult` was measured WITHOUT
+        // grouping, and a grouped numeral is wider, so it cannot be
+        // reused here — see `format_node_with_style`'s invariant. Take
+        // the re-measuring path instead of emitting a misaligned
+        // currency column.
+        format_node_grouped(&parse_result.syntax_node(), style)
+    } else {
+        format_source_with_parsed(parse_result, source)
+    };
     if source.contains("\r\n") {
         formatted = lf_to_crlf_outside_strings(&formatted);
     }
@@ -394,8 +407,14 @@ mod tests {
     fn removes_trailing_whitespace() {
         let source = "2024-01-01 open Assets:Bank USD   \n";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert_eq!(after, "2024-01-01 open Assets:Bank USD\n");
@@ -405,8 +424,14 @@ mod tests {
     fn converts_tabs_to_spaces() {
         let source = "2024-01-15 * \"Test\"\n\tAssets:Bank  -5.00 USD\n\tExpenses:Food\n";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert!(!after.contains('\t'), "got {after:?}");
@@ -428,8 +453,14 @@ mod tests {
             result.errors
         );
 
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
 
@@ -460,8 +491,14 @@ mod tests {
     Expenses:Food
 ";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert!(after.contains("; my comment"), "got {after:?}");
@@ -476,8 +513,14 @@ mod tests {
   Expenses:Food
 ";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         let cli = format_source(source);
@@ -488,8 +531,14 @@ mod tests {
     fn source_without_trailing_newline_gets_one() {
         let source = "; comment";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert_eq!(after, "; comment\n");
@@ -503,8 +552,14 @@ mod tests {
         let source = "\n\n\n\n";
         let result = parse(source);
         assert_eq!(format_source(source), "\n");
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("blanks-only file should reflow to a single newline");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("blanks-only file should reflow to a single newline");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert_eq!(after, "\n");
@@ -514,8 +569,14 @@ mod tests {
     fn non_ascii_payee_roundtrips() {
         let source = "2024-01-15 * \"Café\"\n    Assets:Bank  -1.00 USD\n  Expenses:Food\n";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         let cli = format_source(source);
@@ -538,8 +599,14 @@ mod tests {
   Expenses:Coffee
 ";
         let result = parse(source);
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         let cli = format_source(source);
@@ -557,8 +624,14 @@ mod tests {
         let source = "2024-01-01 open Assets:Bank   \n2024-01-02 not_a_directive\n\tAssets:Bank\n";
         let result = parse(source);
         assert!(!result.errors.is_empty());
-        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16)
-            .expect("expected cleanup edits");
+        let edits = handle_formatting(
+            &params(),
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected cleanup edits");
         assert_well_formed(&edits);
         let after = apply(source, &edits);
         assert!(!after.contains('\t'));
@@ -571,7 +644,15 @@ mod tests {
         let source = "2024-01-01 not_a_directive\n";
         let result = parse(source);
         assert!(!result.errors.is_empty());
-        assert!(format_document(source, &result, PositionEncoding::Utf16).is_none());
+        assert!(
+            format_document(
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default()
+            )
+            .is_none()
+        );
     }
 
     // --- surface_cleanup_edits regression tests -----------------------
@@ -702,5 +783,123 @@ mod tests {
             "expected exactly one non-Equal op; similar's compact pass changed semantics: {non_equal:?}"
         );
         assert_eq!(non_equal[0].tag(), DiffTag::Replace);
+    }
+}
+
+#[cfg(test)]
+mod grouping_tests {
+    use super::*;
+    use rustledger_core::DisplayContext;
+    use rustledger_parser::parse;
+
+    fn params() -> DocumentFormattingParams {
+        serde_json::from_value(serde_json::json!({
+            "textDocument": { "uri": "file:///t.beancount" },
+            "options": { "tabSize": 2, "insertSpaces": true }
+        }))
+        .expect("params")
+    }
+
+    fn apply(source: &str, edits: &[TextEdit]) -> String {
+        let mut out = source.to_string();
+        let mut sorted = edits.to_vec();
+        sorted.sort_by_key(|e| (e.range.start.line, e.range.start.character));
+        for edit in sorted.iter().rev() {
+            let idx = |line: u32, ch: u32| -> usize {
+                let mut off = 0usize;
+                for (n, l) in out.split('\n').enumerate() {
+                    if n as u32 == line {
+                        return off + ch as usize;
+                    }
+                    off += l.len() + 1;
+                }
+                out.len()
+            };
+            let s = idx(edit.range.start.line, edit.range.start.character);
+            let e = idx(edit.range.end.line, edit.range.end.character);
+            out.replace_range(s..e, &edit.new_text);
+        }
+        out
+    }
+
+    const SOURCE: &str = "2020-01-02 * \"x\"\n  Assets:Local  1234567.89 IQD\n  Equity:Opening\n";
+
+    /// Format-on-save honors the ledger's `render_commas`.
+    ///
+    /// The #1892 reporter edits in VS Code, so the CLI's `--ledger` flag alone
+    /// would not have reached them: format-on-save kept stripping the
+    /// separators they had typed.
+    #[test]
+    fn format_on_save_groups_when_the_ledger_asks() {
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        let style = GroupingStyle::from_context(&ctx);
+
+        let result = parse(SOURCE);
+        let edits = handle_formatting(&params(), SOURCE, &result, PositionEncoding::Utf16, style)
+            .expect("grouping changes the buffer, so there must be edits");
+        let after = apply(SOURCE, &edits);
+        assert!(
+            after.contains("1,234,567.89 IQD"),
+            "expected grouped output, got:\n{after}"
+        );
+        // Idempotent: formatting the grouped buffer again is a no-op.
+        let reparsed = parse(&after);
+        assert!(
+            handle_formatting(&params(), &after, &reparsed, PositionEncoding::Utf16, style)
+                .is_none(),
+            "grouped output must already be canonical under the same style"
+        );
+    }
+
+    /// The default style is unchanged — separators are stripped, exactly as
+    /// before this feature existed.
+    #[test]
+    fn the_default_style_still_strips_separators() {
+        let grouped = "2020-01-02 * \"x\"\n  Assets:Local  1,234,567.89 IQD\n  Equity:Opening\n";
+        let result = parse(grouped);
+        let edits = handle_formatting(
+            &params(),
+            grouped,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("stripping changes the buffer");
+        let after = apply(grouped, &edits);
+        assert!(
+            after.contains("1234567.89 IQD") && !after.contains(','),
+            "default style strips: {after}"
+        );
+    }
+
+    /// Grouped output must still align its currency column.
+    ///
+    /// `format_document`'s fast path reuses the alignment cached on
+    /// `ParseResult`, which was measured UNGROUPED. Reusing it here would put
+    /// the currency column three characters off per separator.
+    #[test]
+    fn grouped_output_is_still_aligned() {
+        let source =
+            "2020-01-02 * \"x\"\n  Assets:Local  1234567.89 IQD\n  Assets:Other  1.00 IQD\n";
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        let style = GroupingStyle::from_context(&ctx);
+
+        let result = parse(source);
+        let edits = handle_formatting(&params(), source, &result, PositionEncoding::Utf16, style)
+            .expect("edits");
+        let after = apply(source, &edits);
+
+        let cols: Vec<usize> = after
+            .lines()
+            .filter(|l| l.contains("IQD"))
+            .map(|l| l.find("IQD").expect("IQD"))
+            .collect();
+        assert_eq!(cols.len(), 2, "two posting lines: {after}");
+        assert_eq!(
+            cols[0], cols[1],
+            "currency column must line up under grouping:\n{after}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -63,7 +63,10 @@
 
 use lsp_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
 use rustledger_parser::ParseResult;
-use rustledger_parser::format::{format_node_range_with_alignment, lf_to_crlf_outside_strings};
+use rustledger_parser::format::{
+    GroupingStyle, format_node_range_grouped, format_node_range_with_alignment,
+    lf_to_crlf_outside_strings,
+};
 
 use super::formatting::format_document;
 use super::utils::{LineIndex, PositionEncoding};
@@ -82,6 +85,7 @@ pub fn handle_range_formatting(
     source: &str,
     parse_result: &ParseResult,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> Option<Vec<TextEdit>> {
     // Happy path: the file parses cleanly, run the minimal-diff
     // pipeline. The fallback below covers ONLY the case where
@@ -90,7 +94,7 @@ pub fn handle_range_formatting(
     // `format_document` returns None for the OTHER reason: no edits
     // needed) must still surface as None so the client sees a no-op,
     // not a coarse CST-snap reformat over an already-canonical file.
-    if let Some(all_edits) = format_document(source, parse_result, encoding) {
+    if let Some(all_edits) = format_document(source, parse_result, encoding, style) {
         return clip_edits_to_range(params, source, encoding, all_edits);
     }
     // Fallback: file has parse errors. Try the CST-snap path on the
@@ -100,7 +104,7 @@ pub fn handle_range_formatting(
     // intersected) we surface None, matching the "nothing to format"
     // shape the happy path returns on already-canonical input.
     if !parse_result.errors.is_empty() {
-        return fallback_cst_snap_edit(params, source, parse_result, encoding);
+        return fallback_cst_snap_edit(params, source, parse_result, encoding, style);
     }
     None
 }
@@ -231,6 +235,7 @@ fn fallback_cst_snap_edit(
     source: &str,
     parse_result: &ParseResult,
     encoding: PositionEncoding,
+    style: GroupingStyle<'_>,
 ) -> Option<Vec<TextEdit>> {
     let line_index = LineIndex::new(source, encoding);
     let orig_start =
@@ -276,8 +281,19 @@ fn fallback_cst_snap_edit(
     // matters on format-on-type clients that send a
     // rangeFormatting request per keystroke while the user is
     // editing through a parse error in a large ledger.
-    let (snap_cst, mut new_text) =
-        format_node_range_with_alignment(&node, cst_range, parse_result.alignment)?;
+    //
+    // When the ledger groups numerals that cached alignment is unusable —
+    // it was measured ungrouped, and a separator widens the number column
+    // — so pay for one `compute_alignment` under the real style instead.
+    // Emitting with mismatched alignment would misplace the currency
+    // column; emitting ungrouped would strip separators the file's other
+    // lines still carry. Grouping is opt-in, so the common path keeps the
+    // per-keystroke fast path.
+    let (snap_cst, mut new_text) = if style.groups_anything() {
+        format_node_range_grouped(&node, cst_range, style)?
+    } else {
+        format_node_range_with_alignment(&node, cst_range, parse_result.alignment)?
+    };
 
     // CRLF preservation: `format_node_range` always emits LF (it
     // re-uses the canonical-form pipeline, which is LF-only by
@@ -333,7 +349,16 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(0, 27),
         });
-        assert!(handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none());
+        assert!(
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -344,8 +369,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(3, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert!(!edits.is_empty());
     }
 
@@ -362,8 +393,14 @@ mod tests {
             start: Position::new(4, 0),
             end: Position::new(7, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         for edit in &edits {
             // Inclusive lower bound, exclusive upper bound.
             assert!(
@@ -385,8 +422,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(3, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .unwrap_or_default();
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .unwrap_or_default();
         let line_index = LineIndex::new(source, PositionEncoding::Utf16);
         let range_start = line_index
             .position_to_offset(p.range.start.line, p.range.start.character)
@@ -421,8 +464,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(0, source.encode_utf16().count() as u32),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("expected edits");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("expected edits");
         assert!(
             !edits.is_empty(),
             "the trailing-newline insertion must be kept"
@@ -447,8 +496,14 @@ mod tests {
             start: Position::new(1, 0),
             end: Position::new(1, line1.encode_utf16().count() as u32),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("EOL selection should preserve the line-replace edit");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("EOL selection should preserve the line-replace edit");
         assert!(!edits.is_empty(), "got {edits:?}");
     }
 
@@ -462,7 +517,16 @@ mod tests {
             start: Position::new(0, 5),
             end: Position::new(0, 5),
         });
-        assert!(handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none());
+        assert!(
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none()
+        );
     }
 
     /// Cursor on an empty line: the EOL snap MUST run after the
@@ -481,7 +545,14 @@ mod tests {
             end: Position::new(1, 0),
         });
         assert!(
-            handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none(),
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none(),
             "empty range on '\\n' byte must NOT be widened by the snap"
         );
     }
@@ -503,8 +574,14 @@ mod tests {
             start: Position::new(1, 0),
             end: Position::new(1, line1.encode_utf16().count() as u32),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("CRLF EOL selection should preserve the line-replace edit");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("CRLF EOL selection should preserve the line-replace edit");
         assert!(!edits.is_empty(), "got {edits:?}");
     }
 
@@ -519,8 +596,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(2, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("whole-document CRLF selection should produce edits");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("whole-document CRLF selection should produce edits");
         assert!(!edits.is_empty(), "got {edits:?}");
     }
 
@@ -539,7 +622,14 @@ mod tests {
             end: Position::new(1, 0),
         });
         assert!(
-            handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none(),
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none(),
             "selection covers only ERROR_NODE; fallback must surface None",
         );
     }
@@ -565,8 +655,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(1, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("CST-snap fallback must fire");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("CST-snap fallback must fire");
         // Single TextEdit (the fallback is coarse-grained by design).
         assert_eq!(edits.len(), 1, "expected one fallback edit, got {edits:?}");
         let edit = &edits[0];
@@ -617,7 +713,14 @@ mod tests {
             end: Position::new(3, 0),
         });
         assert!(
-            handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none(),
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none(),
             "selection covering valid + ERROR_NODE + valid must bail; \
              deleting the ERROR_NODE is content loss the user did not opt into",
         );
@@ -639,8 +742,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(1, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("CRLF source still gets a fallback edit");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("CRLF source still gets a fallback edit");
         assert_eq!(edits.len(), 1);
         let edit = &edits[0];
         assert!(
@@ -672,7 +781,14 @@ mod tests {
             end: Position::new(0, 5),
         });
         assert!(
-            handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none(),
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none(),
             "cursor-only request on a parse-error file must return None, \
              matching empty_range_is_a_noop on the happy path",
         );
@@ -701,8 +817,14 @@ mod tests {
             start: Position::new(0, 0),
             end: Position::new(1, 0),
         });
-        let edits = handle_range_formatting(&p, source, &result, PositionEncoding::Utf16)
-            .expect("CST-snap fallback must fire on BOM-prefixed broken file");
+        let edits = handle_range_formatting(
+            &p,
+            source,
+            &result,
+            PositionEncoding::Utf16,
+            GroupingStyle::default(),
+        )
+        .expect("CST-snap fallback must fire on BOM-prefixed broken file");
         assert_eq!(edits.len(), 1);
         let edit = &edits[0];
         // Edit's range.start must map to the byte AFTER the BOM:
@@ -737,7 +859,14 @@ mod tests {
             end: Position::new(1, 0),
         });
         assert!(
-            handle_range_formatting(&p, source, &result, PositionEncoding::Utf16).is_none(),
+            handle_range_formatting(
+                &p,
+                source,
+                &result,
+                PositionEncoding::Utf16,
+                GroupingStyle::default(),
+            )
+            .is_none(),
             "clean + canonical file must return None; fallback must not fire",
         );
     }

--- a/crates/rustledger-lsp/src/ledger_state.rs
+++ b/crates/rustledger-lsp/src/ledger_state.rs
@@ -11,35 +11,21 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// Common root journal filenames to check, in priority order.
-const COMMON_ROOT_NAMES: &[&str] = &[
-    "main.bean",
-    "main.beancount",
-    "ledger.bean",
-    "ledger.beancount",
-    "journal.bean",
-    "journal.beancount",
-    "index.bean",
-    "index.beancount",
-];
-
 /// Discover the root journal file in a workspace directory.
 ///
-/// Checks for common root filenames in the workspace root directory.
-/// Returns the first one found that exists.
+/// Delegates to the loader so the LSP and `rledger format` agree on what a
+/// root looks like; a file the two disagree about is a file that formats
+/// differently on save than in a pre-commit hook.
 pub fn discover_journal_file(workspace_root: &Path) -> Option<PathBuf> {
-    for name in COMMON_ROOT_NAMES {
-        let candidate = workspace_root.join(name);
-        if candidate.exists() && candidate.is_file() {
-            tracing::info!("Auto-discovered journal file: {}", candidate.display());
-            return Some(candidate);
-        }
+    let found = rustledger_loader::discover_journal_file(workspace_root);
+    match &found {
+        Some(p) => tracing::info!("Auto-discovered journal file: {}", p.display()),
+        None => tracing::debug!(
+            "No journal file found in workspace root: {}",
+            workspace_root.display()
+        ),
     }
-    tracing::debug!(
-        "No journal file found in workspace root: {}",
-        workspace_root.display()
-    );
-    None
+    found
 }
 
 /// Extract currency from a price annotation if available. `kind`

--- a/crates/rustledger-lsp/src/ledger_state.rs
+++ b/crates/rustledger-lsp/src/ledger_state.rs
@@ -237,6 +237,31 @@ impl LedgerState {
         self.ledger.as_ref()
     }
 
+    /// How numerals should be grouped when formatting `path`.
+    ///
+    /// Formatting honors the ledger's `render_commas` (and any per-commodity
+    /// override) the same way `rledger format --ledger <root>` does — the
+    /// options come from the journal ROOT, which is the only place they can
+    /// come from, since the buffer being formatted is often an `include`d file
+    /// with no options of its own.
+    ///
+    /// Returns the no-grouping default in the two cases where those options
+    /// cannot be said to apply:
+    ///
+    /// - no ledger is loaded (startup race, or the load failed) — formatting
+    ///   must still work, so it falls back rather than blocking;
+    /// - the buffer is not part of the loaded ledger. Editing a stray
+    ///   `.beancount` file that no journal includes must not pick up an
+    ///   unrelated ledger's display policy.
+    pub fn grouping_style_for(&self, path: &Path) -> rustledger_parser::format::GroupingStyle<'_> {
+        match &self.ledger {
+            Some(ledger) if self.contains_file(path) => {
+                rustledger_parser::format::GroupingStyle::from_context(&ledger.display_context)
+            }
+            _ => rustledger_parser::format::GroupingStyle::default(),
+        }
+    }
+
     /// Get all included files.
     pub fn included_files(&self) -> &HashSet<PathBuf> {
         &self.included_files
@@ -354,4 +379,90 @@ pub type SharedLedgerState = Arc<RwLock<LedgerState>>;
 /// Create a new shared ledger state.
 pub fn new_shared_ledger_state() -> SharedLedgerState {
     Arc::new(RwLock::new(LedgerState::new()))
+}
+
+#[cfg(test)]
+mod grouping_style_tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Writes a two-file ledger whose ROOT declares `render_commas`, plus an
+    /// unrelated file no journal includes. Returns (dir, root, included,
+    /// outsider).
+    fn ledger_with_grouping() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("main.beancount");
+        let included = dir.path().join("postings.beancount");
+        let outsider = dir.path().join("scratch.beancount");
+
+        let mut f = std::fs::File::create(&root).expect("create root");
+        writeln!(f, "option \"render_commas\" \"TRUE\"").unwrap();
+        writeln!(f, "include \"postings.beancount\"").unwrap();
+        writeln!(f, "2020-01-01 open Assets:Local").unwrap();
+        writeln!(f, "2020-01-01 open Equity:Opening").unwrap();
+
+        let mut f = std::fs::File::create(&included).expect("create include");
+        writeln!(f, "2020-01-02 * \"x\"").unwrap();
+        writeln!(f, "  Assets:Local     1234567.89 IQD").unwrap();
+        writeln!(f, "  Equity:Opening").unwrap();
+
+        std::fs::write(&outsider, "2020-01-01 open Assets:Other\n").expect("create outsider");
+        (dir, root, included, outsider)
+    }
+
+    /// The journal ROOT's options govern formatting of an INCLUDED buffer.
+    ///
+    /// This is the whole point of the gate: the file the user is editing
+    /// usually has no `option` lines of its own, exactly like the CLI's
+    /// `rledger format --ledger <root> <included-file>`.
+    #[test]
+    fn an_included_buffer_inherits_the_roots_grouping() {
+        let (_dir, root, included, _outsider) = ledger_with_grouping();
+        let mut state = LedgerState::new();
+        state.load(&root).expect("load");
+
+        assert!(
+            state.grouping_style_for(&root).groups_anything(),
+            "the root declared render_commas"
+        );
+        assert!(
+            state.grouping_style_for(&included).groups_anything(),
+            "an included file has no options of its own and must inherit the root's"
+        );
+    }
+
+    /// A buffer outside the loaded ledger must NOT pick up its display policy,
+    /// and neither must anything before a ledger has loaded.
+    #[test]
+    fn a_buffer_outside_the_ledger_does_not_group() {
+        let (_dir, root, _included, outsider) = ledger_with_grouping();
+
+        let fresh = LedgerState::new();
+        assert!(
+            !fresh.grouping_style_for(&root).groups_anything(),
+            "no ledger loaded yet (startup race, or load failed): formatting \
+             must still work, ungrouped"
+        );
+
+        let mut state = LedgerState::new();
+        state.load(&root).expect("load");
+        assert!(
+            !state.grouping_style_for(&outsider).groups_anything(),
+            "a stray file no journal includes must not inherit an unrelated \
+             ledger's grouping"
+        );
+    }
+
+    /// A ledger that declares nothing groups nothing — the overwhelmingly
+    /// common case, and the one that keeps the cached-alignment fast path.
+    #[test]
+    fn a_ledger_without_the_option_does_not_group() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("main.beancount");
+        std::fs::write(&root, "2020-01-01 open Assets:Local\n").expect("write");
+
+        let mut state = LedgerState::new();
+        state.load(&root).expect("load");
+        assert!(!state.grouping_style_for(&root).groups_anything());
+    }
 }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1060,6 +1060,29 @@ impl MainLoopState {
     }
 
     /// Handle the textDocument/formatting request.
+    /// Run `f` with the grouping style that formatting `uri` should use.
+    ///
+    /// The style borrows the loaded ledger's `DisplayContext`, so it cannot
+    /// outlive the read guard — hence the closure rather than a return value.
+    /// Stated once here because all four formatting entry points (document,
+    /// range, and both `executeCommand` paths) need the same resolution, and
+    /// a per-site copy is how they would drift.
+    ///
+    /// A URI that does not resolve to a path yields the no-grouping default,
+    /// as does a buffer outside the loaded ledger — see
+    /// [`LedgerState::grouping_style_for`].
+    fn with_grouping_style<T>(
+        &self,
+        uri: &Uri,
+        f: impl FnOnce(rustledger_parser::format::GroupingStyle<'_>) -> T,
+    ) -> T {
+        let ledger_guard = self.ledger_state.read();
+        match uri_to_path(uri) {
+            Ok(path) => f(ledger_guard.grouping_style_for(path.as_path())),
+            Err(_) => f(rustledger_parser::format::GroupingStyle::default()),
+        }
+    }
+
     fn handle_formatting_request(
         &self,
         req: lsp_server::Request,
@@ -1070,7 +1093,9 @@ impl MainLoopState {
         let uri = &params.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        let response = handle_formatting(&params, &text, &parse_result, self.position_encoding);
+        let response = self.with_grouping_style(uri, |style| {
+            handle_formatting(&params, &text, &parse_result, self.position_encoding, style)
+        });
 
         serde_json::to_value(response).map_err(|e| e.to_string())
     }
@@ -1102,8 +1127,9 @@ impl MainLoopState {
         let uri = &params.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        let response =
-            handle_range_formatting(&params, &text, &parse_result, self.position_encoding);
+        let response = self.with_grouping_style(uri, |style| {
+            handle_range_formatting(&params, &text, &parse_result, self.position_encoding, style)
+        });
 
         serde_json::to_value(response).map_err(|e| e.to_string())
     }
@@ -1511,8 +1537,16 @@ impl MainLoopState {
 
         if let Some(uri) = uri_from_args {
             let (text, parse_result) = self.get_document_data(&uri);
-            let result =
-                handle_execute_command(&params, &text, &parse_result, &uri, self.position_encoding);
+            let result = self.with_grouping_style(&uri, |style| {
+                handle_execute_command(
+                    &params,
+                    &text,
+                    &parse_result,
+                    &uri,
+                    self.position_encoding,
+                    style,
+                )
+            });
             self.send_show_message(result.show_message);
             return Ok(result.response.unwrap_or(serde_json::Value::Null));
         }
@@ -1535,8 +1569,16 @@ impl MainLoopState {
             .map_err(|e| format!("no file URI for {}: {e}", path.display()))?;
 
         let (text, parse_result) = self.get_document_data(&uri);
-        let result =
-            handle_execute_command(&params, &text, &parse_result, &uri, self.position_encoding);
+        let result = self.with_grouping_style(&uri, |style| {
+            handle_execute_command(
+                &params,
+                &text,
+                &parse_result,
+                &uri,
+                self.position_encoding,
+                style,
+            )
+        });
         self.send_show_message(result.show_message);
         Ok(result.response.unwrap_or(serde_json::Value::Null))
     }

--- a/crates/rustledger-lsp/tests/encoding_coverage.rs
+++ b/crates/rustledger-lsp/tests/encoding_coverage.rs
@@ -77,7 +77,13 @@ fn formatting_positions_round_trip_under_both_encodings() {
         work_done_progress_params: Default::default(),
     };
     for encoding in [PositionEncoding::Utf8, PositionEncoding::Utf16] {
-        if let Some(edits) = handle_formatting(&params, SOURCE, &parsed, encoding) {
+        if let Some(edits) = handle_formatting(
+            &params,
+            SOURCE,
+            &parsed,
+            encoding,
+            rustledger_parser::format::GroupingStyle::default(),
+        ) {
             for edit in edits {
                 assert_range_round_trips(edit.range, SOURCE, encoding);
             }

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1482,3 +1482,99 @@ fn references_span_included_files() {
         "references must include the usage in the included file; got: {uris:?}"
     );
 }
+
+/// Format-on-save groups numerals when the journal ROOT asks for it, on a
+/// buffer that is an `include`d file with no options of its own (#1896).
+///
+/// End-to-end through the real request dispatch, because the gate lives there:
+/// the handler resolves a `GroupingStyle` from the loaded ledger keyed on the
+/// buffer's own path. The unit tests cover the gate and the formatter
+/// separately; this covers the wiring between them.
+#[test]
+fn format_on_save_groups_an_included_buffer_per_the_root_options() {
+    use lsp_types::request::Formatting;
+    use lsp_types::{DocumentFormattingParams, FormattingOptions};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let journal_path = dir.path().join("journal.beancount");
+    let postings_path = dir.path().join("postings.beancount");
+
+    std::fs::write(
+        &postings_path,
+        "2024-01-02 * \"x\"\n  \
+           Assets:Bank  1234567.89 USD\n  \
+           Equity:Opening\n",
+    )
+    .expect("write postings");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "option \"render_commas\" \"TRUE\"\n\
+             2024-01-01 open Assets:Bank\n\
+             2024-01-01 open Equity:Opening\n\
+             include \"{}\"\n",
+            include_name(&postings_path)
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+
+    let uri = uri_for(&postings_path);
+    let source = std::fs::read_to_string(&postings_path).expect("read postings");
+    client.open_document(&uri, &source);
+
+    let edits: Option<Vec<lsp_types::TextEdit>> =
+        client.request::<Formatting>(DocumentFormattingParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.parse().unwrap(),
+            },
+            options: FormattingOptions {
+                tab_size: 2,
+                insert_spaces: true,
+                ..Default::default()
+            },
+            work_done_progress_params: Default::default(),
+        });
+
+    let edits = edits.expect("grouping changes the buffer, so edits are expected");
+
+    // Apply the edits rather than inspecting them: these are MINIMAL diffs, so
+    // a grouped numeral arrives as an edit like `,234,` and never appears whole
+    // in any single `new_text`. Asserting on the concatenation would be
+    // asserting on the diff algorithm, not on the result the editor shows.
+    let after = apply_edits(&source, &edits);
+    assert!(
+        after.contains("1,234,567.89 USD"),
+        "the root's `render_commas` must reach an included buffer's \
+         format-on-save; buffer became:\n{after}"
+    );
+}
+
+/// Apply LSP `TextEdit`s to `source` the way a client would.
+///
+/// Edits are non-overlapping, so applying them from the end backwards keeps
+/// every remaining range valid. Test sources here are ASCII, so an LSP UTF-16
+/// character offset is a byte offset.
+fn apply_edits(source: &str, edits: &[lsp_types::TextEdit]) -> String {
+    let mut sorted = edits.to_vec();
+    sorted.sort_by_key(|e| (e.range.start.line, e.range.start.character));
+    let mut out = source.to_string();
+    for edit in sorted.iter().rev() {
+        let offset = |line: u32, character: u32| -> usize {
+            let mut off = 0usize;
+            for (n, l) in out.split('\n').enumerate() {
+                if n as u32 == line {
+                    return off + character as usize;
+                }
+                off += l.len() + 1;
+            }
+            out.len()
+        };
+        let start = offset(edit.range.start.line, edit.range.start.character);
+        let end = offset(edit.range.end.line, edit.range.end.character);
+        out.replace_range(start..end, &edit.new_text);
+    }
+    out
+}

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -337,7 +337,10 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
     // `ParseResult::alignment` rustdoc for the cache contract;
     // the equivalence with a fresh `compute_alignment` call is
     // pinned by `parse_result_alignment_cache::*` (lib.rs tests).
-    let alignment = crate::cst::format::compute_alignment(&source_file, false);
+    let alignment = crate::cst::format::compute_alignment(
+        &source_file,
+        crate::cst::format::GroupingStyle::default(),
+    );
 
     // Capture the green root before we drop `source_file`. The
     // `.green()` call returns a Cow so we promote to owned with

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -337,7 +337,7 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
     // `ParseResult::alignment` rustdoc for the cache contract;
     // the equivalence with a fresh `compute_alignment` call is
     // pinned by `parse_result_alignment_cache::*` (lib.rs tests).
-    let alignment = crate::cst::format::compute_alignment(&source_file);
+    let alignment = crate::cst::format::compute_alignment(&source_file, false);
 
     // Capture the green root before we drop `source_file`. The
     // `.green()` call returns a Cow so we promote to owned with

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -96,6 +96,14 @@ pub struct PostingAlignment {
     /// Width of the number field; shorter numbers are left-padded
     /// with spaces so the currency column stays uniform.
     pub number_width: usize,
+    /// Whether numerals carry thousands separators.
+    ///
+    /// Lives HERE rather than in a separate parameter because grouping changes
+    /// a numeral's width: the width pre-pass and the emitter must agree, and
+    /// they agree by construction if both read it off the same struct. Getting
+    /// that wrong is what made `rledger format` and `bean-format` fail to
+    /// converge in #1290.
+    pub group_digits: bool,
 }
 
 /// Two-space indent for directive bodies (postings, metadata).
@@ -119,10 +127,25 @@ const INDENT: &str = "  ";
 /// promise that line endings are LF-only on output.
 #[must_use]
 pub fn format_source(source: &str) -> String {
+    format_source_grouped(source, false)
+}
+
+/// [`format_source`], with the thousands-separator rule supplied by the caller.
+///
+/// `group_digits` comes from the LEDGER, not from the tool: `option
+/// "render_commas"`, resolved by whoever holds the options (the CLI after a
+/// load, the LSP from its ledger state, the FFI session from its own). That is
+/// what keeps this a canonical form rather than a knob — the output is still a
+/// function of the input, the option simply travels with it.
+///
+/// `format_source` passes `false`, so every existing caller and every ledger
+/// that has not opted in is byte-for-byte unaffected.
+#[must_use]
+pub fn format_source_grouped(source: &str, group_digits: bool) -> String {
     let (stripped, _had_bom) = crate::bom::strip_leading(source);
     let normalized = crlf_to_lf_outside_strings(stripped);
     let parsed = SourceFile::parse(&normalized);
-    format_node(parsed.syntax())
+    format_node_grouped(parsed.syntax(), group_digits)
 }
 
 /// Like [`format_source`] but reuses the caller's
@@ -391,7 +414,15 @@ where
             reparsed: reparsed_count,
         });
     }
-    Ok(format_source(&raw))
+    // The second pass re-canonicalizes LAYOUT over the core emitter's text.
+    // It must carry the same grouping rule, or it would strip the separators
+    // the first pass just wrote — which is exactly why this shim used to
+    // preserve precision but not grouping.
+    let group = config
+        .number_display
+        .as_ref()
+        .is_some_and(rustledger_core::DisplayContext::render_commas);
+    Ok(format_source_grouped(&raw, group))
 }
 
 /// Error returned by [`canonicalize_directives`].
@@ -622,12 +653,18 @@ const fn advance_source_state(
 /// tests.
 #[must_use]
 pub fn format_node(node: &crate::SyntaxNode) -> String {
-    // Precondition: `node` is the SOURCE_FILE parse root (the only thing callers
-    // pass); a wrong node is a caller bug, not input-driven.
+    // The SOURCE_FILE precondition is asserted by `format_node_grouped`.
+    format_node_grouped(node, false)
+}
+
+/// [`format_node`], with the thousands-separator rule supplied by the caller.
+#[must_use]
+pub fn format_node_grouped(node: &crate::SyntaxNode, group_digits: bool) -> String {
+    // Precondition as in `format_node`.
     #[allow(clippy::expect_used)]
     let source_file =
-        SourceFile::cast(node.clone()).expect("format_node called on non-SOURCE_FILE node");
-    let alignment = compute_alignment(&source_file);
+        SourceFile::cast(node.clone()).expect("format_node_grouped called on non-SOURCE_FILE node");
+    let alignment = compute_alignment(&source_file, group_digits);
     format_node_with_alignment(node, alignment)
 }
 
@@ -827,7 +864,7 @@ pub fn format_node_range(
     // rationale. The selected subset always uses the full file's
     // alignment columns. Hot paths with a precomputed `PostingAlignment`
     // should call `format_node_range_with_alignment` instead.
-    let alignment = compute_alignment(&source_file);
+    let alignment = compute_alignment(&source_file, false);
     format_node_range_with_alignment(node, range, alignment)
 }
 
@@ -1069,7 +1106,7 @@ fn range_intersects(child: rowan::TextRange, sel: rowan::TextRange) -> bool {
 /// `parse_result_alignment_cache::*` regression tests (7 fixtures) in
 /// this module.
 #[must_use]
-pub fn compute_alignment(sf: &SourceFile) -> PostingAlignment {
+pub fn compute_alignment(sf: &SourceFile, group_digits: bool) -> PostingAlignment {
     let mut max_lhs: usize = 0;
     let mut max_num: usize = 0;
     // Tracks postings that actually render a number — the only ones that
@@ -1105,7 +1142,7 @@ pub fn compute_alignment(sf: &SourceFile) -> PostingAlignment {
             // `amount_number_text` is the shared predicate that keeps
             // this pre-pass in lockstep with `emit_posting`.
             if let Some(amt) = p.amount()
-                && let Some(text) = amount_number_text(&amt)
+                && let Some(text) = amount_number_text(&amt, group_digits)
             {
                 any_aligned_posting = true;
                 max_lhs = max_lhs.max(lhs);
@@ -1114,13 +1151,17 @@ pub fn compute_alignment(sf: &SourceFile) -> PostingAlignment {
         }
     }
     if !any_aligned_posting {
-        return PostingAlignment::default();
+        return PostingAlignment {
+            group_digits,
+            ..PostingAlignment::default()
+        };
     }
     // 2 spaces between the longest account end and the number field,
     // matching the conventional Beancount layout.
     PostingAlignment {
         number_col: INDENT.len() + max_lhs + 2,
         number_width: max_num,
+        group_digits,
     }
 }
 
@@ -1135,18 +1176,18 @@ pub fn compute_alignment(sf: &SourceFile) -> PostingAlignment {
 /// disagree about which postings participate in alignment — the bug
 /// class behind #1290 (amount-less postings) and its currency-only
 /// sibling.
-fn amount_number_text(amt: &ast::Amount) -> Option<String> {
-    let text = amount_value_text(amt);
+fn amount_number_text(amt: &ast::Amount, group: bool) -> Option<String> {
+    let text = amount_value_text(amt, group);
     (!text.is_empty()).then_some(text)
 }
 
 /// Render an amount's value portion (number or arithmetic
 /// expression) as a string, EXCLUDING the trailing currency.
 /// Mirrors the value half of [`format_amount`].
-fn amount_value_text(amt: &ast::Amount) -> String {
+fn amount_value_text(amt: &ast::Amount, group: bool) -> String {
     let mut buf = String::new();
     if amt.is_arithmetic() {
-        emit_amount_subnode_expression(amt.syntax(), &mut buf);
+        emit_amount_subnode_expression(amt.syntax(), group, &mut buf);
         return buf;
     }
     if let Some(sign) = amt.sign()
@@ -1155,7 +1196,7 @@ fn amount_value_text(amt: &ast::Amount) -> String {
         buf.push('-');
     }
     if let Some(n) = amt.number() {
-        buf.push_str(&canonical_number(n.text()));
+        buf.push_str(&canonical_number(n.text(), group));
     }
     buf
 }
@@ -1176,23 +1217,23 @@ fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String)
 
     let len_before = out.len();
     match d {
-        ast::Directive::Open(d) => emit_open(d, out),
-        ast::Directive::Close(d) => emit_close(d, out),
-        ast::Directive::Commodity(d) => emit_commodity(d, out),
-        ast::Directive::Note(d) => emit_note(d, out),
-        ast::Directive::Event(d) => emit_event(d, out),
-        ast::Directive::Query(d) => emit_query(d, out),
-        ast::Directive::Pad(d) => emit_pad(d, out),
-        ast::Directive::Document(d) => emit_document(d, out),
-        ast::Directive::Price(d) => emit_price(d, out),
-        ast::Directive::Balance(d) => emit_balance(d, out),
-        ast::Directive::Custom(d) => emit_custom(d, out),
+        ast::Directive::Open(d) => emit_open(d, align.group_digits, out),
+        ast::Directive::Close(d) => emit_close(d, align.group_digits, out),
+        ast::Directive::Commodity(d) => emit_commodity(d, align.group_digits, out),
+        ast::Directive::Note(d) => emit_note(d, align.group_digits, out),
+        ast::Directive::Event(d) => emit_event(d, align.group_digits, out),
+        ast::Directive::Query(d) => emit_query(d, align.group_digits, out),
+        ast::Directive::Pad(d) => emit_pad(d, align.group_digits, out),
+        ast::Directive::Document(d) => emit_document(d, align.group_digits, out),
+        ast::Directive::Price(d) => emit_price(d, align.group_digits, out),
+        ast::Directive::Balance(d) => emit_balance(d, align.group_digits, out),
+        ast::Directive::Custom(d) => emit_custom(d, align.group_digits, out),
         ast::Directive::Option(d) => emit_option(d, out),
         ast::Directive::Include(d) => emit_include(d, out),
         ast::Directive::Plugin(d) => emit_plugin(d, out),
         ast::Directive::Pushtag(d) => emit_pushtag(d, out),
         ast::Directive::Poptag(d) => emit_poptag(d, out),
-        ast::Directive::Pushmeta(d) => emit_pushmeta(d, out),
+        ast::Directive::Pushmeta(d) => emit_pushmeta(d, align.group_digits, out),
         ast::Directive::Popmeta(d) => emit_popmeta(d, out),
         ast::Directive::Transaction(d) => emit_transaction(d, align, out),
     }
@@ -1342,7 +1383,7 @@ fn collect_trailing_comment(node: &crate::SyntaxNode) -> Option<String> {
 
 // ---- Single-line directives ------------------------------------
 
-fn emit_open(d: &ast::OpenDirective, out: &mut String) {
+fn emit_open(d: &ast::OpenDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1363,10 +1404,10 @@ fn emit_open(d: &ast::OpenDirective, out: &mut String) {
         out.push_str(booking.text());
     }
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_close(d: &ast::CloseDirective, out: &mut String) {
+fn emit_close(d: &ast::CloseDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1376,10 +1417,10 @@ fn emit_close(d: &ast::CloseDirective, out: &mut String) {
     out.push_str(" close ");
     out.push_str(&account);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_commodity(d: &ast::CommodityDirective, out: &mut String) {
+fn emit_commodity(d: &ast::CommodityDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let currency = d
         .currency()
@@ -1389,10 +1430,10 @@ fn emit_commodity(d: &ast::CommodityDirective, out: &mut String) {
     out.push_str(" commodity ");
     out.push_str(&currency);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_note(d: &ast::NoteDirective, out: &mut String) {
+fn emit_note(d: &ast::NoteDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1405,10 +1446,10 @@ fn emit_note(d: &ast::NoteDirective, out: &mut String) {
     out.push(' ');
     out.push_str(&text);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_event(d: &ast::EventDirective, out: &mut String) {
+fn emit_event(d: &ast::EventDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let event_type = d
         .event_type()
@@ -1421,10 +1462,10 @@ fn emit_event(d: &ast::EventDirective, out: &mut String) {
     out.push(' ');
     out.push_str(&value);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_query(d: &ast::QueryDirective, out: &mut String) {
+fn emit_query(d: &ast::QueryDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let name = d.name().map(|s| s.text().to_string()).unwrap_or_default();
     let query = d.query().map(|s| s.text().to_string()).unwrap_or_default();
@@ -1434,10 +1475,10 @@ fn emit_query(d: &ast::QueryDirective, out: &mut String) {
     out.push(' ');
     out.push_str(&query);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_pad(d: &ast::PadDirective, out: &mut String) {
+fn emit_pad(d: &ast::PadDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let target = d
         .target_account()
@@ -1453,10 +1494,10 @@ fn emit_pad(d: &ast::PadDirective, out: &mut String) {
     out.push(' ');
     out.push_str(&source);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_document(d: &ast::DocumentDirective, out: &mut String) {
+fn emit_document(d: &ast::DocumentDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1498,10 +1539,10 @@ fn emit_document(d: &ast::DocumentDirective, out: &mut String) {
         }
     }
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_price(d: &ast::PriceDirective, out: &mut String) {
+fn emit_price(d: &ast::PriceDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let base = d
         .base_currency()
@@ -1515,14 +1556,14 @@ fn emit_price(d: &ast::PriceDirective, out: &mut String) {
     out.push_str(" price ");
     out.push_str(&base);
     out.push(' ');
-    emit_amount_expression(d.syntax(), out);
+    emit_amount_expression(d.syntax(), group, out);
     out.push(' ');
     out.push_str(&quote);
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_balance(d: &ast::BalanceDirective, out: &mut String) {
+fn emit_balance(d: &ast::BalanceDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1536,11 +1577,11 @@ fn emit_balance(d: &ast::BalanceDirective, out: &mut String) {
     out.push_str(" balance ");
     out.push_str(&account);
     out.push(' ');
-    emit_amount_expression(d.syntax(), out);
+    emit_amount_expression(d.syntax(), group, out);
     out.push(' ');
     out.push_str(&currency);
     // Optional `~ tolerance [CCY]` — walk raw tokens.
-    if let Some((tolerance, tol_currency)) = balance_tolerance(d.syntax()) {
+    if let Some((tolerance, tol_currency)) = balance_tolerance(d.syntax(), group) {
         out.push_str(" ~ ");
         out.push_str(&tolerance);
         if let Some(c) = tol_currency {
@@ -1549,10 +1590,10 @@ fn emit_balance(d: &ast::BalanceDirective, out: &mut String) {
         }
     }
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_custom(d: &ast::CustomDirective, out: &mut String) {
+fn emit_custom(d: &ast::CustomDirective, group: bool, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let custom_type = d
         .custom_type()
@@ -1596,7 +1637,7 @@ fn emit_custom(d: &ast::CustomDirective, out: &mut String) {
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text()));
+            out.push_str(&canonical_number(t.text(), group));
             if matches!(
                 tokens.get(i + 1).map(rowan::SyntaxToken::kind),
                 Some(crate::SyntaxKind::CURRENCY)
@@ -1612,7 +1653,7 @@ fn emit_custom(d: &ast::CustomDirective, out: &mut String) {
         i += 1;
     }
     out.push('\n');
-    emit_meta_entries_of(d.syntax(), out);
+    emit_meta_entries_of(d.syntax(), group, out);
 }
 
 // ---- Top-level non-dated directives -----------------------------
@@ -1661,7 +1702,7 @@ fn emit_poptag(d: &ast::PoptagDirective, out: &mut String) {
     out.push('\n');
 }
 
-fn emit_pushmeta(d: &ast::PushmetaDirective, out: &mut String) {
+fn emit_pushmeta(d: &ast::PushmetaDirective, group: bool, out: &mut String) {
     let key = d.key().map(|t| t.text().to_string()).unwrap_or_default();
     out.push_str("pushmeta ");
     out.push_str(&key);
@@ -1682,7 +1723,7 @@ fn emit_pushmeta(d: &ast::PushmetaDirective, out: &mut String) {
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text()));
+            out.push_str(&canonical_number(t.text(), group));
         } else {
             out.push_str(t.text());
         }
@@ -1770,7 +1811,7 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
                 if let Some(p) = ast::Posting::cast(n.clone()) {
                     emit_posting(&p, align, out);
                 } else if let Some(m) = ast::MetaEntry::cast(n) {
-                    emit_meta_entry(&m, INDENT, out);
+                    emit_meta_entry(&m, INDENT, align.group_digits, out);
                 }
             }
             rowan::NodeOrToken::Token(t) => {
@@ -1843,7 +1884,7 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
         // `amount_number_text` is the shared "does this render a number?"
         // predicate (see `compute_alignment`); a currency-only amount
         // returns `None` and prints no number.
-        if let Some(value) = amount_number_text(&amt) {
+        if let Some(value) = amount_number_text(&amt, align.group_digits) {
             // Two stages of padding:
             //   1) Account end → start of number field (`number_col`).
             //      Fall back to 2 spaces when the LHS already exceeds
@@ -1864,11 +1905,11 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
             }
             if let Some(cs) = p.cost_spec() {
                 out.push(' ');
-                out.push_str(&format_cost_spec(&cs));
+                out.push_str(&format_cost_spec(&cs, align.group_digits));
             }
             if let Some(pa) = p.price_annotation() {
                 out.push(' ');
-                out.push_str(&format_price_annotation(&pa));
+                out.push_str(&format_price_annotation(&pa, align.group_digits));
             }
         }
     }
@@ -1902,7 +1943,7 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
                 // re-emitted here as a body comment. META_ENTRY nodes only
                 // appear in the body, after `past_header` is already set.
                 if let Some(m) = ast::MetaEntry::cast(n) {
-                    emit_meta_entry(&m, "    ", out);
+                    emit_meta_entry(&m, "    ", align.group_digits, out);
                 }
             }
             rowan::NodeOrToken::Token(t) => {
@@ -1931,10 +1972,10 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
 /// arithmetic shapes, emits the expression with single-space
 /// separators (parens tight); for plain shapes, emits
 /// `NUMBER CURRENCY` with thousands separators stripped.
-fn format_amount(amt: &ast::Amount) -> String {
+fn format_amount(amt: &ast::Amount, group: bool) -> String {
     let mut out = String::new();
     if amt.is_arithmetic() {
-        emit_amount_subnode_expression(amt.syntax(), &mut out);
+        emit_amount_subnode_expression(amt.syntax(), group, &mut out);
         if let Some(c) = amt.currency() {
             if !out.is_empty() {
                 out.push(' ');
@@ -1949,7 +1990,7 @@ fn format_amount(amt: &ast::Amount) -> String {
         out.push('-');
     }
     if let Some(n) = amt.number() {
-        out.push_str(&canonical_number(n.text()));
+        out.push_str(&canonical_number(n.text(), group));
     }
     if let Some(c) = amt.currency() {
         if !out.is_empty() && !out.ends_with('-') {
@@ -1968,7 +2009,7 @@ fn format_amount(amt: &ast::Amount) -> String {
 /// Commas separating cost components (`{N CCY, DATE, "label"}`)
 /// stay tight against the preceding token; every other adjacent
 /// token pair is joined with a single space.
-fn format_cost_spec(cs: &ast::CostSpec) -> String {
+fn format_cost_spec(cs: &ast::CostSpec, group: bool) -> String {
     let (open, close) = if cs.is_total() {
         ("{{", "}}")
     } else if cs.is_per_unit_plus_total() {
@@ -1999,7 +2040,7 @@ fn format_cost_spec(cs: &ast::CostSpec) -> String {
         })
         .collect();
     let mut inner = String::new();
-    write_canonical_token_sequence(&inner_tokens, &mut inner);
+    write_canonical_token_sequence(&inner_tokens, group, &mut inner);
     // The `{#` opener is a two-character marker; canonical form
     // separates it from the first inner token with a single space
     // (matching the rendering in this function's rustdoc). `{` and
@@ -2013,10 +2054,10 @@ fn format_cost_spec(cs: &ast::CostSpec) -> String {
 
 /// Canonical price annotation: `@ amount` (per-unit) or
 /// `@@ amount` (total).
-fn format_price_annotation(pa: &ast::PriceAnnotation) -> String {
+fn format_price_annotation(pa: &ast::PriceAnnotation, group: bool) -> String {
     let op = if pa.is_total() { "@@" } else { "@" };
     match pa.amount() {
-        Some(a) => format!("{op} {}", format_amount(&a)),
+        Some(a) => format!("{op} {}", format_amount(&a, group)),
         None => op.to_string(),
     }
 }
@@ -2039,15 +2080,46 @@ const fn is_trivia_kind(kind: crate::SyntaxKind) -> bool {
     )
 }
 
-/// Strip thousands-separator commas from a NUMBER token's text;
-/// preserve the user's decimal-place count. Per the locked
-/// canonical-form decision: `1,000.00` → `1000.00`, `1.0` → `1.0`.
-fn canonical_number(text: &str) -> String {
-    if text.contains(',') {
-        text.replace(',', "")
-    } else {
-        text.to_string()
+/// Render a `NUMBER` token in canonical form: the user's decimal-place count
+/// is preserved, and digit grouping is imposed by `group` rather than by what
+/// the source happened to contain.
+///
+/// `group == false` → `1,000.00` becomes `1000.00`. `group == true` → the
+/// reverse: `1000.00` becomes `1,000.00`. Either way this is a TOTAL rewrite of
+/// the grouping, so the formatter still yields one form per value — the rule
+/// changes, not the guarantee.
+///
+/// Groups are always three digits, because that is the only shape the lexer
+/// accepts (`(\d{1,3}(,\d{3})*|\d+)(\.\d*)?`). Anything else — Indian lakh
+/// grouping, say — would emit text this parser then REJECTS, so widening this
+/// needs a lexer change first, not just a formatter one.
+fn canonical_number(text: &str, group: bool) -> String {
+    let bare = text.replace(',', "");
+    if !group {
+        return bare;
     }
+    let (int_part, frac) = match bare.split_once('.') {
+        Some((i, f)) => (i, Some(f)),
+        None => (bare.as_str(), None),
+    };
+    // Defensive: a non-digit integer part is not ours to regroup. Unreachable
+    // for a lexed NUMBER, whose sign is a separate token.
+    if int_part.is_empty() || !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return bare;
+    }
+    let n = int_part.len();
+    let mut out = String::with_capacity(bare.len() + n / 3);
+    for (i, c) in int_part.chars().enumerate() {
+        if i > 0 && (n - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    if let Some(f) = frac {
+        out.push('.');
+        out.push_str(f);
+    }
+    out
 }
 
 /// Emit the arithmetic expression of a `PRICE` / `BALANCE`
@@ -2066,7 +2138,7 @@ fn canonical_number(text: &str) -> String {
 /// `1 + 2) USD USD`). Sign drift in BALANCE / PRICE is silent data
 /// corruption — a balance assertion that previously asserted a
 /// debit would assert a credit after a round-trip.
-fn emit_amount_expression(node: &crate::SyntaxNode, out: &mut String) {
+fn emit_amount_expression(node: &crate::SyntaxNode, group: bool, out: &mut String) {
     let raw: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
@@ -2094,14 +2166,14 @@ fn emit_amount_expression(node: &crate::SyntaxNode, out: &mut String) {
         }
     }
     let end = first_currency_idx.unwrap_or(raw.len());
-    write_canonical_token_sequence(&raw[..end], out);
+    write_canonical_token_sequence(&raw[..end], group, out);
 }
 
 /// Emit an `AMOUNT` subnode's expression region: every non-trivia
 /// token minus the trailing `CURRENCY` (caller re-emits the
 /// currency itself). Used by [`format_amount`] for arithmetic
 /// posting amounts like `-(1.00 + 2.00) USD`.
-fn emit_amount_subnode_expression(node: &crate::SyntaxNode, out: &mut String) {
+fn emit_amount_subnode_expression(node: &crate::SyntaxNode, group: bool, out: &mut String) {
     let mut tokens: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
@@ -2112,7 +2184,7 @@ fn emit_amount_subnode_expression(node: &crate::SyntaxNode, out: &mut String) {
     {
         tokens.pop();
     }
-    write_canonical_token_sequence(&tokens, out);
+    write_canonical_token_sequence(&tokens, group, out);
 }
 
 /// Single dispatcher for the canonical spacing rules used by EVERY
@@ -2138,7 +2210,7 @@ fn emit_amount_subnode_expression(node: &crate::SyntaxNode, out: &mut String) {
 /// its own rule. The corpus-level idempotence test
 /// (`idempotence_corpus_sweep`) is the safety net that catches
 /// drifts.
-fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], out: &mut String) {
+fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], group: bool, out: &mut String) {
     let is_op = |k: crate::SyntaxKind| {
         matches!(
             k,
@@ -2170,7 +2242,7 @@ fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], out: &mut Strin
             out.push(' ');
         }
         if kind == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text()));
+            out.push_str(&canonical_number(t.text(), group));
         } else {
             out.push_str(t.text());
         }
@@ -2182,7 +2254,7 @@ fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], out: &mut Strin
 /// Extract a balance directive's optional tolerance — the
 /// `NUMBER` after the first `TILDE`, plus an optional trailing
 /// `CURRENCY` at paren-depth 0.
-fn balance_tolerance(node: &crate::SyntaxNode) -> Option<(String, Option<String>)> {
+fn balance_tolerance(node: &crate::SyntaxNode, group: bool) -> Option<(String, Option<String>)> {
     let mut past_tilde = false;
     let mut number: Option<String> = None;
     let mut currency: Option<String> = None;
@@ -2198,7 +2270,7 @@ fn balance_tolerance(node: &crate::SyntaxNode) -> Option<(String, Option<String>
         }
         match t.kind() {
             crate::SyntaxKind::NUMBER if number.is_none() => {
-                number = Some(canonical_number(t.text()));
+                number = Some(canonical_number(t.text(), group));
             }
             crate::SyntaxKind::CURRENCY if number.is_some() && currency.is_none() => {
                 currency = Some(t.text().to_string());
@@ -2216,7 +2288,7 @@ fn balance_tolerance(node: &crate::SyntaxNode) -> Option<(String, Option<String>
 /// value\n`). Most directive types don't have a `.meta_entries()`
 /// accessor on their typed wrapper; we walk the syntax node
 /// directly to stay uniform.
-fn emit_meta_entries_of(node: &crate::SyntaxNode, out: &mut String) {
+fn emit_meta_entries_of(node: &crate::SyntaxNode, group: bool, out: &mut String) {
     // Source-order walk so body-internal COMMENT lines are preserved
     // alongside the metadata entries (#1332). The header region (up to and
     // including the header-terminating NEWLINE) is skipped so the
@@ -2229,7 +2301,7 @@ fn emit_meta_entries_of(node: &crate::SyntaxNode, out: &mut String) {
             rowan::NodeOrToken::Node(n) => {
                 past_header = true;
                 if let Some(entry) = MetaEntry::cast(n) {
-                    emit_meta_entry(&entry, INDENT, out);
+                    emit_meta_entry(&entry, INDENT, group, out);
                 }
             }
             rowan::NodeOrToken::Token(t) => {
@@ -2264,7 +2336,7 @@ fn emit_meta_entries_of(node: &crate::SyntaxNode, out: &mut String) {
 /// Two semantically-equivalent inputs (e.g. `foo: "bar"` and
 /// `foo:    "bar"`) produce byte-identical output — the
 /// gofmt-style invariant the file rustdoc promises.
-fn emit_meta_entry(m: &MetaEntry, indent: &str, out: &mut String) {
+fn emit_meta_entry(m: &MetaEntry, indent: &str, group: bool, out: &mut String) {
     out.push_str(indent);
     // Split the META_ENTRY's non-trivia tokens into [META_KEY,
     // value*]. The META_KEY token already includes the trailing
@@ -2290,7 +2362,7 @@ fn emit_meta_entry(m: &MetaEntry, indent: &str, out: &mut String) {
     let value_tokens: Vec<crate::SyntaxToken> = iter.cloned().collect();
     if !value_tokens.is_empty() {
         out.push(' ');
-        write_canonical_token_sequence(&value_tokens, out);
+        write_canonical_token_sequence(&value_tokens, group, out);
     }
     out.push('\n');
 }
@@ -3467,9 +3539,15 @@ mod tests {
         };
         let out = canonicalize_directives(parsed.directives.iter().map(|d| &d.value), &config)
             .expect("comma-grouped canonical text must survive the reparse");
+        // REVERSED from "precision pads, no separators". The shim's second
+        // pass now carries the grouping rule, so a context that asks for
+        // separators gets them in ledger text — matching beancount, whose
+        // `render_commas` is documented to affect its PRINT command. The
+        // machine boundary is the parser, and the grammar admits grouped
+        // numerals; csv/json (whose consumers have no grammar) are unaffected.
         assert!(
-            out.contains("1234.50 USD"),
-            "precision pads through the shim, no separators: {out}"
+            out.contains("1,234.50 USD"),
+            "precision AND grouping both flow through the shim: {out}"
         );
 
         // And the default config stays byte-faithful to the value's scale.
@@ -4456,7 +4534,7 @@ mod tests {
         for (label, source) in fixtures {
             let (node, _src) = parse_for_range(source);
             let source_file = SourceFile::cast(node.clone()).unwrap();
-            let alignment = compute_alignment(&source_file);
+            let alignment = compute_alignment(&source_file, false);
             assert_eq!(
                 format_node(&node),
                 format_node_with_alignment(&node, alignment),
@@ -4480,7 +4558,7 @@ mod tests {
 ";
         let (node, src) = parse_for_range(source);
         let source_file = SourceFile::cast(node.clone()).unwrap();
-        let alignment = compute_alignment(&source_file);
+        let alignment = compute_alignment(&source_file, false);
         // Pin the equivalence on three ranges: whole file,
         // cursor inside the first transaction, cursor inside the
         // second.
@@ -4627,5 +4705,104 @@ mod tests {
         let parse_result = crate::parse("2024-01-01 open Assets:Bank USD\n");
         // Different length — debug_assert fires.
         let _ = format_source_with_parsed(&parse_result, "different");
+    }
+
+    /// `format_source_grouped(_, true)` imposes grouping, and the alignment
+    /// pre-pass measures the GROUPED width — so the currency column still lines
+    /// up. They agree because both read `PostingAlignment::group_digits`; a
+    /// separate parameter is how #1290's non-convergence happened.
+    #[test]
+    fn grouped_formatting_aligns_and_is_idempotent() {
+        let src = "\
+2020-01-02 * \"mixed magnitudes\"
+  Assets:Bank                        1234567.89 USD
+  Assets:VeryLongAccountName:Nested       12.00 USD
+  Income:Sales                      -1234579.89 USD
+";
+        let grouped = format_source_grouped(src, true);
+        assert!(
+            grouped.contains("1,234,567.89") && grouped.contains("-1,234,579.89"),
+            "grouping must be imposed regardless of the source form:\n{grouped}"
+        );
+        // Currency column uniform => every ` USD` starts at the same column.
+        let cols: Vec<usize> = grouped
+            .lines()
+            .filter(|l| l.contains(" USD"))
+            .map(|l| l.find("USD").expect("USD"))
+            .collect();
+        assert!(
+            cols.windows(2).all(|w| w[0] == w[1]),
+            "currency column must stay uniform under grouping: {cols:?}\n{grouped}"
+        );
+        assert_eq!(
+            format_source_grouped(&grouped, true),
+            grouped,
+            "grouped formatting must be idempotent"
+        );
+    }
+
+    /// Grouping is a TOTAL rewrite, not a preserve: it converges from either
+    /// direction, so a file whose numerals are inconsistent still normalizes.
+    /// That is the property `preserve` would have given up.
+    #[test]
+    fn grouping_converges_from_either_direction() {
+        let mixed = "\
+2020-01-02 * \"inconsistent source\"
+  Assets:A  1,234,567.89 USD
+  Assets:B     -1234567.89 USD
+";
+        let on = format_source_grouped(mixed, true);
+        assert_eq!(on.matches(',').count(), 4, "both numerals grouped:\n{on}");
+        let off = format_source_grouped(mixed, false);
+        assert!(!off.contains(','), "both numerals bare:\n{off}");
+        // And each is a fixed point of its own rule.
+        assert_eq!(format_source_grouped(&on, true), on);
+        assert_eq!(format_source_grouped(&off, false), off);
+    }
+
+    /// The default entry point is untouched: every existing caller, and every
+    /// ledger that has not opted in, gets byte-identical output.
+    #[test]
+    fn default_formatting_still_strips_separators() {
+        let src = "2020-01-02 balance Assets:A  1,234.50 USD\n";
+        assert_eq!(
+            format_source(src),
+            "2020-01-02 balance Assets:A 1234.50 USD\n"
+        );
+        assert_eq!(format_source(src), format_source_grouped(src, false));
+    }
+
+    /// Grouped output must re-parse to the SAME values — the formatter may not
+    /// emit text its own lexer rejects. Groups are three digits because that is
+    /// all `(\d{1,3}(,\d{3})*|\d+)` admits.
+    #[test]
+    fn grouped_output_reparses_to_the_same_values() {
+        for n in [
+            "1",
+            "12",
+            "123",
+            "1234",
+            "1234567",
+            "1234567.891",
+            "0.5",
+            "1000000",
+        ] {
+            let src = format!("2020-01-02 balance Assets:A  {n} USD\n");
+            let grouped = format_source_grouped(&src, true);
+            let reparsed = crate::parse(&grouped);
+            assert!(
+                reparsed.errors.is_empty(),
+                "grouped `{n}` -> `{}` must re-parse: {:?}",
+                grouped.trim(),
+                reparsed.errors
+            );
+            // And round-trips to the identical value.
+            let before = crate::parse(&src);
+            let val = |r: &crate::ParseResult| match &r.directives[0].value {
+                rustledger_core::Directive::Balance(b) => b.amount.number,
+                _ => panic!("balance"),
+            };
+            assert_eq!(val(&before), val(&reparsed), "value changed for `{n}`");
+        }
     }
 }

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -106,7 +106,7 @@ pub struct PostingAlignment {
 /// NOT a field of `PostingAlignment`: that type is `pub`, `Eq` and cached on
 /// `ParseResult`, so it cannot carry a lifetime. The invariant that pairs a
 /// cached alignment with the style it was measured under is stated on
-/// [`format_node_with_style`].
+/// `format_node_with_style` (crate-internal).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GroupingStyle<'a> {
     ctx: Option<&'a rustledger_core::DisplayContext>,
@@ -241,6 +241,11 @@ pub fn format_source_grouped(source: &str, style: GroupingStyle<'_>) -> String {
 /// different lengths) in debug builds; release builds skip the
 /// check. Identical-length mismatches still pass silently —
 /// the rustdoc-level contract remains the source of truth.
+///
+/// Formats under the DEFAULT grouping style, always: it reuses
+/// `ParseResult::alignment`, which is measured ungrouped, and the two
+/// must agree. A caller that needs a ledger's separators wants
+/// [`format_node_grouped`], which measures its own alignment.
 ///
 /// # Panics
 ///
@@ -749,6 +754,13 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
 
 /// [`format_node_with_alignment`] with an explicit grouping style.
 ///
+/// Deliberately NOT public. It is the one shape that can be called wrongly —
+/// see the invariant below — and every public entry point either measures the
+/// alignment itself (`format_node_grouped`) or is fixed to the default style,
+/// which is what `ParseResult::alignment` is measured under. Keeping this
+/// private makes the mismatch unstatable from outside the crate rather than
+/// merely documented.
+///
 /// INVARIANT: `alignment` must have been produced by [`compute_alignment`] with
 /// this same `style`. Grouping changes a numeral's width, so an alignment
 /// measured under a different style puts the currency column in the wrong place
@@ -757,7 +769,7 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
 /// `ParseResult::alignment` (computed at parse time, before any options are
 /// known) must pass `GroupingStyle::default()`.
 #[must_use]
-pub fn format_node_with_style(
+fn format_node_with_style(
     node: &crate::SyntaxNode,
     alignment: PostingAlignment,
     group: GroupingStyle<'_>,
@@ -972,7 +984,7 @@ pub fn format_node_range_with_alignment(
 /// [`format_node_range`] under an explicit grouping style, measuring the
 /// alignment itself.
 ///
-/// Prefer this over pairing [`format_node_range_with_style`] with a cached
+/// Prefer this over pairing a caller-supplied alignment with a
 /// alignment: the alignment MUST have been measured under the same style, and
 /// doing both here makes that unfalsifiable. Costs one `compute_alignment`
 /// walk, which is why the ungrouped hot path still uses the cached alignment.
@@ -989,11 +1001,11 @@ pub fn format_node_range_grouped(
 /// [`format_node_range_with_alignment`] with an explicit grouping style.
 ///
 /// Same `alignment`/`style` agreement invariant as
-/// [`format_node_with_style`]: `alignment` must have been measured by
+/// `format_node_with_style`: `alignment` must have been measured by
 /// `compute_alignment` under this same `style`, or the currency column will be
 /// off by the separators' width. The cached `ParseResult::alignment` is
 /// measured UNGROUPED, so it may only be paired with the default style.
-pub fn format_node_range_with_style(
+fn format_node_range_with_style(
     node: &crate::SyntaxNode,
     range: rowan::TextRange,
     alignment: PostingAlignment,

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -96,14 +96,42 @@ pub struct PostingAlignment {
     /// Width of the number field; shorter numbers are left-padded
     /// with spaces so the currency column stays uniform.
     pub number_width: usize,
-    /// Whether numerals carry thousands separators.
+}
+
+/// How numerals are grouped, resolved per currency.
+///
+/// `Copy` on purpose: it rides [`PostingAlignment`], which the width pre-pass
+/// and the emitters both read. Handing them the style separately is how they
+/// could disagree about a numeral's width — the #1290 failure — so it travels
+/// with the layout it determines.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GroupingStyle<'a> {
+    ctx: Option<&'a rustledger_core::DisplayContext>,
+}
+
+impl<'a> GroupingStyle<'a> {
+    /// Grouping as declared by a ledger's display context.
     ///
-    /// Lives HERE rather than in a separate parameter because grouping changes
-    /// a numeral's width: the width pre-pass and the emitter must agree, and
-    /// they agree by construction if both read it off the same struct. Getting
-    /// that wrong is what made `rledger format` and `bean-format` fail to
-    /// converge in #1290.
-    pub group_digits: bool,
+    /// Returns the no-grouping style when the context groups nothing, so the
+    /// overwhelmingly common case costs no per-numeral lookups.
+    #[must_use]
+    pub fn from_context(ctx: &'a rustledger_core::DisplayContext) -> Self {
+        Self {
+            ctx: ctx.renders_any_commas().then_some(ctx),
+        }
+    }
+
+    /// Whether a numeral in `currency` is grouped. `None` for numerals with no
+    /// currency in scope (metadata values, `custom` values), which take the
+    /// ledger-wide default.
+    #[must_use]
+    pub fn groups(self, currency: Option<&str>) -> bool {
+        match (self.ctx, currency) {
+            (None, _) => false,
+            (Some(c), Some(cur)) => c.render_commas_for(cur),
+            (Some(c), None) => c.render_commas(),
+        }
+    }
 }
 
 /// Two-space indent for directive bodies (postings, metadata).
@@ -127,7 +155,7 @@ const INDENT: &str = "  ";
 /// promise that line endings are LF-only on output.
 #[must_use]
 pub fn format_source(source: &str) -> String {
-    format_source_grouped(source, false)
+    format_source_grouped(source, GroupingStyle::default())
 }
 
 /// [`format_source`], with the thousands-separator rule supplied by the caller.
@@ -141,11 +169,11 @@ pub fn format_source(source: &str) -> String {
 /// `format_source` passes `false`, so every existing caller and every ledger
 /// that has not opted in is byte-for-byte unaffected.
 #[must_use]
-pub fn format_source_grouped(source: &str, group_digits: bool) -> String {
+pub fn format_source_grouped(source: &str, style: GroupingStyle<'_>) -> String {
     let (stripped, _had_bom) = crate::bom::strip_leading(source);
     let normalized = crlf_to_lf_outside_strings(stripped);
     let parsed = SourceFile::parse(&normalized);
-    format_node_grouped(parsed.syntax(), group_digits)
+    format_node_grouped(parsed.syntax(), style)
 }
 
 /// Like [`format_source`] but reuses the caller's
@@ -418,11 +446,11 @@ where
     // It must carry the same grouping rule, or it would strip the separators
     // the first pass just wrote — which is exactly why this shim used to
     // preserve precision but not grouping.
-    let group = config
+    let style = config
         .number_display
         .as_ref()
-        .is_some_and(rustledger_core::DisplayContext::render_commas);
-    Ok(format_source_grouped(&raw, group))
+        .map_or_else(GroupingStyle::default, GroupingStyle::from_context);
+    Ok(format_source_grouped(&raw, style))
 }
 
 /// Error returned by [`canonicalize_directives`].
@@ -654,18 +682,18 @@ const fn advance_source_state(
 #[must_use]
 pub fn format_node(node: &crate::SyntaxNode) -> String {
     // The SOURCE_FILE precondition is asserted by `format_node_grouped`.
-    format_node_grouped(node, false)
+    format_node_grouped(node, GroupingStyle::default())
 }
 
 /// [`format_node`], with the thousands-separator rule supplied by the caller.
 #[must_use]
-pub fn format_node_grouped(node: &crate::SyntaxNode, group_digits: bool) -> String {
+pub fn format_node_grouped(node: &crate::SyntaxNode, style: GroupingStyle<'_>) -> String {
     // Precondition as in `format_node`.
     #[allow(clippy::expect_used)]
     let source_file =
         SourceFile::cast(node.clone()).expect("format_node_grouped called on non-SOURCE_FILE node");
-    let alignment = compute_alignment(&source_file, group_digits);
-    format_node_with_alignment(node, alignment)
+    let alignment = compute_alignment(&source_file, style);
+    format_node_with_style(node, alignment, style)
 }
 
 /// Like [`format_node`] but skips the per-call
@@ -689,6 +717,24 @@ pub fn format_node_grouped(node: &crate::SyntaxNode, group_digits: bool) -> Stri
 /// Panics if `node`'s kind is not `SOURCE_FILE`.
 #[must_use]
 pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAlignment) -> String {
+    format_node_with_style(node, alignment, GroupingStyle::default())
+}
+
+/// [`format_node_with_alignment`] with an explicit grouping style.
+///
+/// INVARIANT: `alignment` must have been produced by [`compute_alignment`] with
+/// this same `style`. Grouping changes a numeral's width, so an alignment
+/// measured under a different style puts the currency column in the wrong place
+/// — the #1290 non-convergence, reintroduced. The `_grouped` entry points
+/// derive both from one value and cannot mismatch; a caller reusing a cached
+/// `ParseResult::alignment` (computed at parse time, before any options are
+/// known) must pass `GroupingStyle::default()`.
+#[must_use]
+pub fn format_node_with_style(
+    node: &crate::SyntaxNode,
+    alignment: PostingAlignment,
+    group: GroupingStyle<'_>,
+) -> String {
     // Precondition check (debug-only). The bare `format_node`
     // delegate already validated the kind via the
     // `SourceFile::cast` it performs for `compute_alignment`, so
@@ -739,7 +785,7 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
                             out.push('\n');
                         }
                     }
-                    emit_directive(&directive, alignment, &mut out);
+                    emit_directive(&directive, alignment, group, &mut out);
                     prev_was_directive = true;
                 } else if n.kind() == crate::SyntaxKind::ERROR_NODE {
                     // Preserve unparsable content verbatim (#1335): `format`
@@ -864,7 +910,7 @@ pub fn format_node_range(
     // rationale. The selected subset always uses the full file's
     // alignment columns. Hot paths with a precomputed `PostingAlignment`
     // should call `format_node_range_with_alignment` instead.
-    let alignment = compute_alignment(&source_file, false);
+    let alignment = compute_alignment(&source_file, GroupingStyle::default());
     format_node_range_with_alignment(node, range, alignment)
 }
 
@@ -1035,7 +1081,7 @@ pub fn format_node_range_with_alignment(
                         out.push('\n');
                     }
                 }
-                emit_directive(&directive, alignment, &mut out);
+                emit_directive(&directive, alignment, GroupingStyle::default(), &mut out);
                 prev_was_directive = true;
             }
             rowan::NodeOrToken::Token(t) => {
@@ -1106,7 +1152,7 @@ fn range_intersects(child: rowan::TextRange, sel: rowan::TextRange) -> bool {
 /// `parse_result_alignment_cache::*` regression tests (7 fixtures) in
 /// this module.
 #[must_use]
-pub fn compute_alignment(sf: &SourceFile, group_digits: bool) -> PostingAlignment {
+pub fn compute_alignment(sf: &SourceFile, style: GroupingStyle<'_>) -> PostingAlignment {
     let mut max_lhs: usize = 0;
     let mut max_num: usize = 0;
     // Tracks postings that actually render a number — the only ones that
@@ -1142,7 +1188,7 @@ pub fn compute_alignment(sf: &SourceFile, group_digits: bool) -> PostingAlignmen
             // `amount_number_text` is the shared predicate that keeps
             // this pre-pass in lockstep with `emit_posting`.
             if let Some(amt) = p.amount()
-                && let Some(text) = amount_number_text(&amt, group_digits)
+                && let Some(text) = amount_number_text(&amt, style)
             {
                 any_aligned_posting = true;
                 max_lhs = max_lhs.max(lhs);
@@ -1151,17 +1197,13 @@ pub fn compute_alignment(sf: &SourceFile, group_digits: bool) -> PostingAlignmen
         }
     }
     if !any_aligned_posting {
-        return PostingAlignment {
-            group_digits,
-            ..PostingAlignment::default()
-        };
+        return PostingAlignment::default();
     }
     // 2 spaces between the longest account end and the number field,
     // matching the conventional Beancount layout.
     PostingAlignment {
         number_col: INDENT.len() + max_lhs + 2,
         number_width: max_num,
-        group_digits,
     }
 }
 
@@ -1176,7 +1218,7 @@ pub fn compute_alignment(sf: &SourceFile, group_digits: bool) -> PostingAlignmen
 /// disagree about which postings participate in alignment — the bug
 /// class behind #1290 (amount-less postings) and its currency-only
 /// sibling.
-fn amount_number_text(amt: &ast::Amount, group: bool) -> Option<String> {
+fn amount_number_text(amt: &ast::Amount, group: GroupingStyle<'_>) -> Option<String> {
     let text = amount_value_text(amt, group);
     (!text.is_empty()).then_some(text)
 }
@@ -1184,7 +1226,7 @@ fn amount_number_text(amt: &ast::Amount, group: bool) -> Option<String> {
 /// Render an amount's value portion (number or arithmetic
 /// expression) as a string, EXCLUDING the trailing currency.
 /// Mirrors the value half of [`format_amount`].
-fn amount_value_text(amt: &ast::Amount, group: bool) -> String {
+fn amount_value_text(amt: &ast::Amount, group: GroupingStyle<'_>) -> String {
     let mut buf = String::new();
     if amt.is_arithmetic() {
         emit_amount_subnode_expression(amt.syntax(), group, &mut buf);
@@ -1196,12 +1238,20 @@ fn amount_value_text(amt: &ast::Amount, group: bool) -> String {
         buf.push('-');
     }
     if let Some(n) = amt.number() {
-        buf.push_str(&canonical_number(n.text(), group));
+        buf.push_str(&canonical_number(
+            n.text(),
+            group.groups(amt.currency().as_ref().map(ast::CurrencyName::text)),
+        ));
     }
     buf
 }
 
-fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String) {
+fn emit_directive(
+    d: &ast::Directive,
+    align: PostingAlignment,
+    group: GroupingStyle<'_>,
+    out: &mut String,
+) {
     // Leading inter-directive trivia: COMMENT tokens that sit
     // BEFORE the directive's first content token. Per phase-2.0
     // trivia attachment, these live inside the directive's syntax
@@ -1217,25 +1267,25 @@ fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String)
 
     let len_before = out.len();
     match d {
-        ast::Directive::Open(d) => emit_open(d, align.group_digits, out),
-        ast::Directive::Close(d) => emit_close(d, align.group_digits, out),
-        ast::Directive::Commodity(d) => emit_commodity(d, align.group_digits, out),
-        ast::Directive::Note(d) => emit_note(d, align.group_digits, out),
-        ast::Directive::Event(d) => emit_event(d, align.group_digits, out),
-        ast::Directive::Query(d) => emit_query(d, align.group_digits, out),
-        ast::Directive::Pad(d) => emit_pad(d, align.group_digits, out),
-        ast::Directive::Document(d) => emit_document(d, align.group_digits, out),
-        ast::Directive::Price(d) => emit_price(d, align.group_digits, out),
-        ast::Directive::Balance(d) => emit_balance(d, align.group_digits, out),
-        ast::Directive::Custom(d) => emit_custom(d, align.group_digits, out),
+        ast::Directive::Open(d) => emit_open(d, group, out),
+        ast::Directive::Close(d) => emit_close(d, group, out),
+        ast::Directive::Commodity(d) => emit_commodity(d, group, out),
+        ast::Directive::Note(d) => emit_note(d, group, out),
+        ast::Directive::Event(d) => emit_event(d, group, out),
+        ast::Directive::Query(d) => emit_query(d, group, out),
+        ast::Directive::Pad(d) => emit_pad(d, group, out),
+        ast::Directive::Document(d) => emit_document(d, group, out),
+        ast::Directive::Price(d) => emit_price(d, group, out),
+        ast::Directive::Balance(d) => emit_balance(d, group, out),
+        ast::Directive::Custom(d) => emit_custom(d, group, out),
         ast::Directive::Option(d) => emit_option(d, out),
         ast::Directive::Include(d) => emit_include(d, out),
         ast::Directive::Plugin(d) => emit_plugin(d, out),
         ast::Directive::Pushtag(d) => emit_pushtag(d, out),
         ast::Directive::Poptag(d) => emit_poptag(d, out),
-        ast::Directive::Pushmeta(d) => emit_pushmeta(d, align.group_digits, out),
+        ast::Directive::Pushmeta(d) => emit_pushmeta(d, group, out),
         ast::Directive::Popmeta(d) => emit_popmeta(d, out),
-        ast::Directive::Transaction(d) => emit_transaction(d, align, out),
+        ast::Directive::Transaction(d) => emit_transaction(d, align, group, out),
     }
     // Splice the same-line trailing comment in: find the FIRST '\n'
     // after `len_before` (= end of the directive's header line in
@@ -1383,7 +1433,7 @@ fn collect_trailing_comment(node: &crate::SyntaxNode) -> Option<String> {
 
 // ---- Single-line directives ------------------------------------
 
-fn emit_open(d: &ast::OpenDirective, group: bool, out: &mut String) {
+fn emit_open(d: &ast::OpenDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1407,7 +1457,7 @@ fn emit_open(d: &ast::OpenDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_close(d: &ast::CloseDirective, group: bool, out: &mut String) {
+fn emit_close(d: &ast::CloseDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1420,7 +1470,7 @@ fn emit_close(d: &ast::CloseDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_commodity(d: &ast::CommodityDirective, group: bool, out: &mut String) {
+fn emit_commodity(d: &ast::CommodityDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let currency = d
         .currency()
@@ -1433,7 +1483,7 @@ fn emit_commodity(d: &ast::CommodityDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_note(d: &ast::NoteDirective, group: bool, out: &mut String) {
+fn emit_note(d: &ast::NoteDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1449,7 +1499,7 @@ fn emit_note(d: &ast::NoteDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_event(d: &ast::EventDirective, group: bool, out: &mut String) {
+fn emit_event(d: &ast::EventDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let event_type = d
         .event_type()
@@ -1465,7 +1515,7 @@ fn emit_event(d: &ast::EventDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_query(d: &ast::QueryDirective, group: bool, out: &mut String) {
+fn emit_query(d: &ast::QueryDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let name = d.name().map(|s| s.text().to_string()).unwrap_or_default();
     let query = d.query().map(|s| s.text().to_string()).unwrap_or_default();
@@ -1478,7 +1528,7 @@ fn emit_query(d: &ast::QueryDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_pad(d: &ast::PadDirective, group: bool, out: &mut String) {
+fn emit_pad(d: &ast::PadDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let target = d
         .target_account()
@@ -1497,7 +1547,7 @@ fn emit_pad(d: &ast::PadDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_document(d: &ast::DocumentDirective, group: bool, out: &mut String) {
+fn emit_document(d: &ast::DocumentDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1542,7 +1592,7 @@ fn emit_document(d: &ast::DocumentDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_price(d: &ast::PriceDirective, group: bool, out: &mut String) {
+fn emit_price(d: &ast::PriceDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let base = d
         .base_currency()
@@ -1563,7 +1613,7 @@ fn emit_price(d: &ast::PriceDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_balance(d: &ast::BalanceDirective, group: bool, out: &mut String) {
+fn emit_balance(d: &ast::BalanceDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let account = d
         .account()
@@ -1593,7 +1643,7 @@ fn emit_balance(d: &ast::BalanceDirective, group: bool, out: &mut String) {
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
-fn emit_custom(d: &ast::CustomDirective, group: bool, out: &mut String) {
+fn emit_custom(d: &ast::CustomDirective, group: GroupingStyle<'_>, out: &mut String) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let custom_type = d
         .custom_type()
@@ -1637,7 +1687,7 @@ fn emit_custom(d: &ast::CustomDirective, group: bool, out: &mut String) {
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group));
+            out.push_str(&canonical_number(t.text(), group.groups(None)));
             if matches!(
                 tokens.get(i + 1).map(rowan::SyntaxToken::kind),
                 Some(crate::SyntaxKind::CURRENCY)
@@ -1702,7 +1752,7 @@ fn emit_poptag(d: &ast::PoptagDirective, out: &mut String) {
     out.push('\n');
 }
 
-fn emit_pushmeta(d: &ast::PushmetaDirective, group: bool, out: &mut String) {
+fn emit_pushmeta(d: &ast::PushmetaDirective, group: GroupingStyle<'_>, out: &mut String) {
     let key = d.key().map(|t| t.text().to_string()).unwrap_or_default();
     out.push_str("pushmeta ");
     out.push_str(&key);
@@ -1723,7 +1773,7 @@ fn emit_pushmeta(d: &ast::PushmetaDirective, group: bool, out: &mut String) {
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group));
+            out.push_str(&canonical_number(t.text(), group.groups(None)));
         } else {
             out.push_str(t.text());
         }
@@ -1740,7 +1790,12 @@ fn emit_popmeta(d: &ast::PopmetaDirective, out: &mut String) {
 
 // ---- Transaction + Posting --------------------------------------
 
-fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut String) {
+fn emit_transaction(
+    d: &ast::Transaction,
+    align: PostingAlignment,
+    group: GroupingStyle<'_>,
+    out: &mut String,
+) {
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     out.push_str(&date);
     out.push(' ');
@@ -1809,9 +1864,9 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
                 // A POSTING / META_ENTRY node is definitively past the header.
                 past_header = true;
                 if let Some(p) = ast::Posting::cast(n.clone()) {
-                    emit_posting(&p, align, out);
+                    emit_posting(&p, align, group, out);
                 } else if let Some(m) = ast::MetaEntry::cast(n) {
-                    emit_meta_entry(&m, INDENT, align.group_digits, out);
+                    emit_meta_entry(&m, INDENT, group, out);
                 }
             }
             rowan::NodeOrToken::Token(t) => {
@@ -1859,7 +1914,12 @@ fn transaction_flag_string(d: &ast::Transaction) -> String {
     }
 }
 
-fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
+fn emit_posting(
+    p: &ast::Posting,
+    align: PostingAlignment,
+    group: GroupingStyle<'_>,
+    out: &mut String,
+) {
     // Posting-trailing comment (same-line, before the posting-line
     // NEWLINE) — capture upfront so we can splice it back in just
     // before that NEWLINE, preserving the user's attachment intent.
@@ -1884,7 +1944,7 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
         // `amount_number_text` is the shared "does this render a number?"
         // predicate (see `compute_alignment`); a currency-only amount
         // returns `None` and prints no number.
-        if let Some(value) = amount_number_text(&amt, align.group_digits) {
+        if let Some(value) = amount_number_text(&amt, group) {
             // Two stages of padding:
             //   1) Account end → start of number field (`number_col`).
             //      Fall back to 2 spaces when the LHS already exceeds
@@ -1905,11 +1965,11 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
             }
             if let Some(cs) = p.cost_spec() {
                 out.push(' ');
-                out.push_str(&format_cost_spec(&cs, align.group_digits));
+                out.push_str(&format_cost_spec(&cs, group));
             }
             if let Some(pa) = p.price_annotation() {
                 out.push(' ');
-                out.push_str(&format_price_annotation(&pa, align.group_digits));
+                out.push_str(&format_price_annotation(&pa, group));
             }
         }
     }
@@ -1943,7 +2003,7 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
                 // re-emitted here as a body comment. META_ENTRY nodes only
                 // appear in the body, after `past_header` is already set.
                 if let Some(m) = ast::MetaEntry::cast(n) {
-                    emit_meta_entry(&m, "    ", align.group_digits, out);
+                    emit_meta_entry(&m, "    ", group, out);
                 }
             }
             rowan::NodeOrToken::Token(t) => {
@@ -1972,7 +2032,7 @@ fn emit_posting(p: &ast::Posting, align: PostingAlignment, out: &mut String) {
 /// arithmetic shapes, emits the expression with single-space
 /// separators (parens tight); for plain shapes, emits
 /// `NUMBER CURRENCY` with thousands separators stripped.
-fn format_amount(amt: &ast::Amount, group: bool) -> String {
+fn format_amount(amt: &ast::Amount, group: GroupingStyle<'_>) -> String {
     let mut out = String::new();
     if amt.is_arithmetic() {
         emit_amount_subnode_expression(amt.syntax(), group, &mut out);
@@ -1990,7 +2050,10 @@ fn format_amount(amt: &ast::Amount, group: bool) -> String {
         out.push('-');
     }
     if let Some(n) = amt.number() {
-        out.push_str(&canonical_number(n.text(), group));
+        out.push_str(&canonical_number(
+            n.text(),
+            group.groups(amt.currency().as_ref().map(ast::CurrencyName::text)),
+        ));
     }
     if let Some(c) = amt.currency() {
         if !out.is_empty() && !out.ends_with('-') {
@@ -2009,7 +2072,7 @@ fn format_amount(amt: &ast::Amount, group: bool) -> String {
 /// Commas separating cost components (`{N CCY, DATE, "label"}`)
 /// stay tight against the preceding token; every other adjacent
 /// token pair is joined with a single space.
-fn format_cost_spec(cs: &ast::CostSpec, group: bool) -> String {
+fn format_cost_spec(cs: &ast::CostSpec, group: GroupingStyle<'_>) -> String {
     let (open, close) = if cs.is_total() {
         ("{{", "}}")
     } else if cs.is_per_unit_plus_total() {
@@ -2054,7 +2117,7 @@ fn format_cost_spec(cs: &ast::CostSpec, group: bool) -> String {
 
 /// Canonical price annotation: `@ amount` (per-unit) or
 /// `@@ amount` (total).
-fn format_price_annotation(pa: &ast::PriceAnnotation, group: bool) -> String {
+fn format_price_annotation(pa: &ast::PriceAnnotation, group: GroupingStyle<'_>) -> String {
     let op = if pa.is_total() { "@@" } else { "@" };
     match pa.amount() {
         Some(a) => format!("{op} {}", format_amount(&a, group)),
@@ -2138,7 +2201,7 @@ fn canonical_number(text: &str, group: bool) -> String {
 /// `1 + 2) USD USD`). Sign drift in BALANCE / PRICE is silent data
 /// corruption — a balance assertion that previously asserted a
 /// debit would assert a credit after a round-trip.
-fn emit_amount_expression(node: &crate::SyntaxNode, group: bool, out: &mut String) {
+fn emit_amount_expression(node: &crate::SyntaxNode, group: GroupingStyle<'_>, out: &mut String) {
     let raw: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
@@ -2173,7 +2236,11 @@ fn emit_amount_expression(node: &crate::SyntaxNode, group: bool, out: &mut Strin
 /// token minus the trailing `CURRENCY` (caller re-emits the
 /// currency itself). Used by [`format_amount`] for arithmetic
 /// posting amounts like `-(1.00 + 2.00) USD`.
-fn emit_amount_subnode_expression(node: &crate::SyntaxNode, group: bool, out: &mut String) {
+fn emit_amount_subnode_expression(
+    node: &crate::SyntaxNode,
+    group: GroupingStyle<'_>,
+    out: &mut String,
+) {
     let mut tokens: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
@@ -2210,7 +2277,11 @@ fn emit_amount_subnode_expression(node: &crate::SyntaxNode, group: bool, out: &m
 /// its own rule. The corpus-level idempotence test
 /// (`idempotence_corpus_sweep`) is the safety net that catches
 /// drifts.
-fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], group: bool, out: &mut String) {
+fn write_canonical_token_sequence(
+    tokens: &[crate::SyntaxToken],
+    group: GroupingStyle<'_>,
+    out: &mut String,
+) {
     let is_op = |k: crate::SyntaxKind| {
         matches!(
             k,
@@ -2242,7 +2313,7 @@ fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], group: bool, ou
             out.push(' ');
         }
         if kind == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group));
+            out.push_str(&canonical_number(t.text(), group.groups(None)));
         } else {
             out.push_str(t.text());
         }
@@ -2254,7 +2325,10 @@ fn write_canonical_token_sequence(tokens: &[crate::SyntaxToken], group: bool, ou
 /// Extract a balance directive's optional tolerance — the
 /// `NUMBER` after the first `TILDE`, plus an optional trailing
 /// `CURRENCY` at paren-depth 0.
-fn balance_tolerance(node: &crate::SyntaxNode, group: bool) -> Option<(String, Option<String>)> {
+fn balance_tolerance(
+    node: &crate::SyntaxNode,
+    group: GroupingStyle<'_>,
+) -> Option<(String, Option<String>)> {
     let mut past_tilde = false;
     let mut number: Option<String> = None;
     let mut currency: Option<String> = None;
@@ -2270,7 +2344,7 @@ fn balance_tolerance(node: &crate::SyntaxNode, group: bool) -> Option<(String, O
         }
         match t.kind() {
             crate::SyntaxKind::NUMBER if number.is_none() => {
-                number = Some(canonical_number(t.text(), group));
+                number = Some(canonical_number(t.text(), group.groups(None)));
             }
             crate::SyntaxKind::CURRENCY if number.is_some() && currency.is_none() => {
                 currency = Some(t.text().to_string());
@@ -2288,7 +2362,7 @@ fn balance_tolerance(node: &crate::SyntaxNode, group: bool) -> Option<(String, O
 /// value\n`). Most directive types don't have a `.meta_entries()`
 /// accessor on their typed wrapper; we walk the syntax node
 /// directly to stay uniform.
-fn emit_meta_entries_of(node: &crate::SyntaxNode, group: bool, out: &mut String) {
+fn emit_meta_entries_of(node: &crate::SyntaxNode, group: GroupingStyle<'_>, out: &mut String) {
     // Source-order walk so body-internal COMMENT lines are preserved
     // alongside the metadata entries (#1332). The header region (up to and
     // including the header-terminating NEWLINE) is skipped so the
@@ -2336,7 +2410,7 @@ fn emit_meta_entries_of(node: &crate::SyntaxNode, group: bool, out: &mut String)
 /// Two semantically-equivalent inputs (e.g. `foo: "bar"` and
 /// `foo:    "bar"`) produce byte-identical output — the
 /// gofmt-style invariant the file rustdoc promises.
-fn emit_meta_entry(m: &MetaEntry, indent: &str, group: bool, out: &mut String) {
+fn emit_meta_entry(m: &MetaEntry, indent: &str, group: GroupingStyle<'_>, out: &mut String) {
     out.push_str(indent);
     // Split the META_ENTRY's non-trivia tokens into [META_KEY,
     // value*]. The META_KEY token already includes the trailing
@@ -4534,7 +4608,7 @@ mod tests {
         for (label, source) in fixtures {
             let (node, _src) = parse_for_range(source);
             let source_file = SourceFile::cast(node.clone()).unwrap();
-            let alignment = compute_alignment(&source_file, false);
+            let alignment = compute_alignment(&source_file, GroupingStyle::default());
             assert_eq!(
                 format_node(&node),
                 format_node_with_alignment(&node, alignment),
@@ -4558,7 +4632,7 @@ mod tests {
 ";
         let (node, src) = parse_for_range(source);
         let source_file = SourceFile::cast(node.clone()).unwrap();
-        let alignment = compute_alignment(&source_file, false);
+        let alignment = compute_alignment(&source_file, GroupingStyle::default());
         // Pin the equivalence on three ranges: whole file,
         // cursor inside the first transaction, cursor inside the
         // second.
@@ -4719,7 +4793,7 @@ mod tests {
   Assets:VeryLongAccountName:Nested       12.00 USD
   Income:Sales                      -1234579.89 USD
 ";
-        let grouped = format_source_grouped(src, true);
+        let grouped = format_source_grouped(src, grouped_style(&all_commas()));
         assert!(
             grouped.contains("1,234,567.89") && grouped.contains("-1,234,579.89"),
             "grouping must be imposed regardless of the source form:\n{grouped}"
@@ -4735,7 +4809,7 @@ mod tests {
             "currency column must stay uniform under grouping: {cols:?}\n{grouped}"
         );
         assert_eq!(
-            format_source_grouped(&grouped, true),
+            format_source_grouped(&grouped, grouped_style(&all_commas())),
             grouped,
             "grouped formatting must be idempotent"
         );
@@ -4751,13 +4825,13 @@ mod tests {
   Assets:A  1,234,567.89 USD
   Assets:B     -1234567.89 USD
 ";
-        let on = format_source_grouped(mixed, true);
+        let on = format_source_grouped(mixed, grouped_style(&all_commas()));
         assert_eq!(on.matches(',').count(), 4, "both numerals grouped:\n{on}");
-        let off = format_source_grouped(mixed, false);
+        let off = format_source_grouped(mixed, GroupingStyle::default());
         assert!(!off.contains(','), "both numerals bare:\n{off}");
         // And each is a fixed point of its own rule.
-        assert_eq!(format_source_grouped(&on, true), on);
-        assert_eq!(format_source_grouped(&off, false), off);
+        assert_eq!(format_source_grouped(&on, grouped_style(&all_commas())), on);
+        assert_eq!(format_source_grouped(&off, GroupingStyle::default()), off);
     }
 
     /// The default entry point is untouched: every existing caller, and every
@@ -4769,7 +4843,10 @@ mod tests {
             format_source(src),
             "2020-01-02 balance Assets:A 1234.50 USD\n"
         );
-        assert_eq!(format_source(src), format_source_grouped(src, false));
+        assert_eq!(
+            format_source(src),
+            format_source_grouped(src, GroupingStyle::default())
+        );
     }
 
     /// Grouped output must re-parse to the SAME values — the formatter may not
@@ -4788,7 +4865,7 @@ mod tests {
             "1000000",
         ] {
             let src = format!("2020-01-02 balance Assets:A  {n} USD\n");
-            let grouped = format_source_grouped(&src, true);
+            let grouped = format_source_grouped(&src, grouped_style(&all_commas()));
             let reparsed = crate::parse(&grouped);
             assert!(
                 reparsed.errors.is_empty(),
@@ -4804,5 +4881,78 @@ mod tests {
             };
             assert_eq!(val(&before), val(&reparsed), "value changed for `{n}`");
         }
+    }
+
+    /// A ledger-wide context used by the grouping tests.
+    fn all_commas() -> rustledger_core::DisplayContext {
+        let mut c = rustledger_core::DisplayContext::new();
+        c.set_render_commas(true);
+        c
+    }
+
+    fn grouped_style(ctx: &rustledger_core::DisplayContext) -> GroupingStyle<'_> {
+        GroupingStyle::from_context(ctx)
+    }
+
+    /// A commodity may opt OUT of the ledger-wide default, so a 4000:1 currency
+    /// can be grouped without also grouping two-digit USD amounts — the reason
+    /// a single global boolean was not enough (#1892).
+    #[test]
+    fn grouping_is_resolved_per_commodity() {
+        let mut ctx = rustledger_core::DisplayContext::new();
+        ctx.set_render_commas(true);
+        ctx.set_render_commas_for("USD", false);
+
+        let src = "\
+2020-01-02 * \"two currencies\"
+  Assets:Local   1234567.89 IQD
+  Assets:Dollars 1234567.89 USD
+";
+        let out = format_source_grouped(src, GroupingStyle::from_context(&ctx));
+        assert!(
+            out.contains("1,234,567.89 IQD"),
+            "the ledger default applies to IQD:\n{out}"
+        );
+        assert!(
+            out.contains("1234567.89 USD") && !out.contains("1,234,567.89 USD"),
+            "USD opted out and must stay bare:\n{out}"
+        );
+    }
+
+    /// The inverse: grouping declared on ONE commodity while the ledger default
+    /// is off. This is the shape a user with a single hyperinflated currency
+    /// actually wants.
+    #[test]
+    fn a_single_commodity_can_opt_in() {
+        let mut ctx = rustledger_core::DisplayContext::new();
+        ctx.set_render_commas_for("IQD", true);
+
+        let src = "\
+2020-01-02 * \"two currencies\"
+  Assets:Local   1234567.89 IQD
+  Assets:Dollars 1234567.89 USD
+";
+        let out = format_source_grouped(src, GroupingStyle::from_context(&ctx));
+        assert!(out.contains("1,234,567.89 IQD"), "IQD opted in:\n{out}");
+        assert!(
+            out.contains("1234567.89 USD") && !out.contains("1,234,567.89 USD"),
+            "USD keeps the (off) default:\n{out}"
+        );
+    }
+
+    /// A context that groups nothing must produce the no-lookup style, so the
+    /// overwhelming majority of ledgers pay nothing per numeral.
+    #[test]
+    fn a_context_that_groups_nothing_yields_the_default_style() {
+        let mut ctx = rustledger_core::DisplayContext::new();
+        ctx.set_fixed_precision("USD", 2);
+        ctx.set_render_commas_for("USD", false);
+        assert!(!ctx.renders_any_commas());
+        let src = "2020-01-02 balance Assets:A  1234.50 USD\n";
+        assert_eq!(
+            format_source_grouped(src, GroupingStyle::from_context(&ctx)),
+            format_source(src),
+            "no declared grouping must be byte-identical to the default path"
+        );
     }
 }

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -966,6 +966,39 @@ pub fn format_node_range_with_alignment(
     range: rowan::TextRange,
     alignment: PostingAlignment,
 ) -> Option<(rowan::TextRange, String)> {
+    format_node_range_with_style(node, range, alignment, GroupingStyle::default())
+}
+
+/// [`format_node_range`] under an explicit grouping style, measuring the
+/// alignment itself.
+///
+/// Prefer this over pairing [`format_node_range_with_style`] with a cached
+/// alignment: the alignment MUST have been measured under the same style, and
+/// doing both here makes that unfalsifiable. Costs one `compute_alignment`
+/// walk, which is why the ungrouped hot path still uses the cached alignment.
+pub fn format_node_range_grouped(
+    node: &crate::SyntaxNode,
+    range: rowan::TextRange,
+    style: GroupingStyle<'_>,
+) -> Option<(rowan::TextRange, String)> {
+    let source_file = SourceFile::cast(node.clone())?;
+    let alignment = compute_alignment(&source_file, style);
+    format_node_range_with_style(node, range, alignment, style)
+}
+
+/// [`format_node_range_with_alignment`] with an explicit grouping style.
+///
+/// Same `alignment`/`style` agreement invariant as
+/// [`format_node_with_style`]: `alignment` must have been measured by
+/// `compute_alignment` under this same `style`, or the currency column will be
+/// off by the separators' width. The cached `ParseResult::alignment` is
+/// measured UNGROUPED, so it may only be paired with the default style.
+pub fn format_node_range_with_style(
+    node: &crate::SyntaxNode,
+    range: rowan::TextRange,
+    alignment: PostingAlignment,
+    style: GroupingStyle<'_>,
+) -> Option<(rowan::TextRange, String)> {
     // Precondition check (debug-only). Same rationale as
     // `format_node_with_alignment`: the bare delegate already
     // validated the kind, so the most common call path (bare →
@@ -1108,7 +1141,7 @@ pub fn format_node_range_with_alignment(
                         out.push('\n');
                     }
                 }
-                emit_directive(&directive, alignment, GroupingStyle::default(), &mut out);
+                emit_directive(&directive, alignment, style, &mut out);
                 prev_was_directive = true;
             }
             rowan::NodeOrToken::Token(t) => {

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -172,14 +172,15 @@ pub fn format_source(source: &str) -> String {
 
 /// [`format_source`], with the thousands-separator rule supplied by the caller.
 ///
-/// `group_digits` comes from the LEDGER, not from the tool: `option
-/// "render_commas"`, resolved by whoever holds the options (the CLI after a
-/// load, the LSP from its ledger state, the FFI session from its own). That is
-/// what keeps this a canonical form rather than a knob — the output is still a
-/// function of the input, the option simply travels with it.
+/// The style comes from the LEDGER, not from the tool: `option
+/// "render_commas"` and per-commodity `render_commas:`, resolved by whoever
+/// holds the options (the CLI after a load, the LSP from its ledger state, the
+/// FFI session from its own). That is what keeps this a canonical form rather
+/// than a knob — the output is still a function of the input, the declaration
+/// simply travels with it.
 ///
-/// `format_source` passes `false`, so every existing caller and every ledger
-/// that has not opted in is byte-for-byte unaffected.
+/// `format_source` passes [`GroupingStyle::default`], so every existing caller
+/// and every ledger that has not opted in is byte-for-byte unaffected.
 #[must_use]
 pub fn format_source_grouped(source: &str, style: GroupingStyle<'_>) -> String {
     let (stripped, _had_bom) = crate::bom::strip_leading(source);
@@ -4910,10 +4911,14 @@ mod tests {
         let _ = format_source_with_parsed(&parse_result, "different");
     }
 
-    /// `format_source_grouped(_, true)` imposes grouping, and the alignment
-    /// pre-pass measures the GROUPED width — so the currency column still lines
-    /// up. They agree because both read `PostingAlignment::group_digits`; a
-    /// separate parameter is how #1290's non-convergence happened.
+    /// A grouping style imposes separators, and the alignment pre-pass measures
+    /// the GROUPED width — so the currency column still lines up.
+    ///
+    /// They agree because `compute_alignment` and the emitters are handed the
+    /// SAME `GroupingStyle`. Measuring under one style and emitting under
+    /// another is the mismatch that would reproduce #1290, which is why the two
+    /// entry points that could express it are crate-private and every public
+    /// one either measures its own alignment or is fixed to the default style.
     #[test]
     fn grouped_formatting_aligns_and_is_idempotent() {
         let src = "\

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -2322,12 +2322,12 @@ fn emit_amount_subnode_expression(
 /// the ledger default instead is how `{1,234,567.89 USD}` came out grouped
 /// while a plain `1234567.89 USD` posting in the same file stayed bare — USD
 /// had declared `render_commas: FALSE` and only one of the two honored it.
-fn run_currency(tokens: &[crate::SyntaxToken]) -> Option<String> {
+fn run_currency(tokens: &[crate::SyntaxToken]) -> Option<&str> {
     tokens
         .iter()
         .rev()
         .find(|t| t.kind() == crate::SyntaxKind::CURRENCY)
-        .map(|t| t.text().to_string())
+        .map(rowan::SyntaxToken::text)
 }
 
 fn write_canonical_token_sequence(
@@ -2335,7 +2335,10 @@ fn write_canonical_token_sequence(
     group: GroupingStyle<'_>,
     out: &mut String,
 ) {
-    let run_group = group.groups(run_currency(tokens).as_deref());
+    // `&&` short-circuits, so a ledger that declares no grouping never pays
+    // for the currency scan. `format` walks whole ledgers; see the
+    // `profile_format` example.
+    let run_group = group.groups_anything() && group.groups(run_currency(tokens));
     let is_op = |k: crate::SyntaxKind| {
         matches!(
             k,
@@ -2386,12 +2389,13 @@ fn balance_tolerance(
     // `balance Assets:A 100.00 ~ 0.05 USD` — one currency covers the asserted
     // amount and the tolerance, and it trails both, so resolve it up front
     // rather than mid-walk.
-    let run_group = {
+    let run_group = group.groups_anything() && {
+        // Only materialized when something groups — see above.
         let toks: Vec<crate::SyntaxToken> = node
             .children_with_tokens()
             .filter_map(rowan::NodeOrToken::into_token)
             .collect();
-        group.groups(run_currency(&toks).as_deref())
+        group.groups(run_currency(&toks))
     };
     let mut past_tilde = false;
     let mut number: Option<String> = None;

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -1652,22 +1652,24 @@ fn emit_balance(d: &ast::BalanceDirective, group: GroupingStyle<'_>, out: &mut S
     out.push_str(&account);
     out.push(' ');
     emit_amount_expression(d.syntax(), group, out);
-    out.push(' ');
-    out.push_str(&currency);
-    // Optional `~ tolerance [CCY]` — walk raw tokens.
-    if let Some((tolerance, tol_currency)) = balance_tolerance(d.syntax(), group) {
+    // `balance ACCOUNT AMOUNT [~ TOLERANCE] CURRENCY` — ONE currency, trailing,
+    // covering both numbers. The tolerance's own `CURRENCY` token (if the source
+    // repeated it) is deliberately dropped: emitting it as well produced
+    // `0.00 USD ~ 1234.5 USD`, which is not the beancount form.
+    if let Some((tolerance, _tol_currency)) = balance_tolerance(d.syntax(), group) {
         out.push_str(" ~ ");
         out.push_str(&tolerance);
-        if let Some(c) = tol_currency {
-            out.push(' ');
-            out.push_str(&c);
-        }
     }
+    out.push(' ');
+    out.push_str(&currency);
     out.push('\n');
     emit_meta_entries_of(d.syntax(), group, out);
 }
 
 fn emit_custom(d: &ast::CustomDirective, group: GroupingStyle<'_>, out: &mut String) {
+    // `custom` / `pushmeta` values are not denominated in anything, so
+    // they take the ledger-wide default.
+    let run_group = group.groups(None);
     let date = d.date().map(|t| t.text().to_string()).unwrap_or_default();
     let custom_type = d
         .custom_type()
@@ -1711,7 +1713,7 @@ fn emit_custom(d: &ast::CustomDirective, group: GroupingStyle<'_>, out: &mut Str
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group.groups(None)));
+            out.push_str(&canonical_number(t.text(), run_group));
             if matches!(
                 tokens.get(i + 1).map(rowan::SyntaxToken::kind),
                 Some(crate::SyntaxKind::CURRENCY)
@@ -1777,6 +1779,9 @@ fn emit_poptag(d: &ast::PoptagDirective, out: &mut String) {
 }
 
 fn emit_pushmeta(d: &ast::PushmetaDirective, group: GroupingStyle<'_>, out: &mut String) {
+    // `custom` / `pushmeta` values are not denominated in anything, so
+    // they take the ledger-wide default.
+    let run_group = group.groups(None);
     let key = d.key().map(|t| t.text().to_string()).unwrap_or_default();
     out.push_str("pushmeta ");
     out.push_str(&key);
@@ -1797,7 +1802,7 @@ fn emit_pushmeta(d: &ast::PushmetaDirective, group: GroupingStyle<'_>, out: &mut
         }
         out.push(' ');
         if t.kind() == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group.groups(None)));
+            out.push_str(&canonical_number(t.text(), run_group));
         } else {
             out.push_str(t.text());
         }
@@ -2246,6 +2251,15 @@ fn emit_amount_expression(node: &crate::SyntaxNode, group: GroupingStyle<'_>, ou
         match t.kind() {
             crate::SyntaxKind::L_PAREN => depth += 1,
             crate::SyntaxKind::R_PAREN => depth -= 1,
+            // A `~ tolerance` clause ENDS the asserted amount. `emit_balance`
+            // emits it separately via `balance_tolerance`, so running past the
+            // tilde here emitted it twice: `0.00 ~ 1234.5 USD` came out as
+            // `0.00 ~ 1234.5 USD ~ 1234.5 USD`. Stable but wrong, and very
+            // likely not valid beancount — its balance grammar takes at most
+            // one tolerance.
+            crate::SyntaxKind::TILDE if depth == 0 && first_currency_idx.is_none() => {
+                first_currency_idx = Some(i);
+            }
             crate::SyntaxKind::CURRENCY if depth == 0 && first_currency_idx.is_none() => {
                 first_currency_idx = Some(i);
             }
@@ -2301,11 +2315,27 @@ fn emit_amount_subnode_expression(
 /// its own rule. The corpus-level idempotence test
 /// (`idempotence_corpus_sweep`) is the safety net that catches
 /// drifts.
+/// The currency a token run is denominated in: the LAST `CURRENCY` token in it.
+///
+/// A cost spec (`{1234.56 USD}`) and a balance tolerance carry their own
+/// currency, and it is the one whose declaration governs their numerals. Taking
+/// the ledger default instead is how `{1,234,567.89 USD}` came out grouped
+/// while a plain `1234567.89 USD` posting in the same file stayed bare — USD
+/// had declared `render_commas: FALSE` and only one of the two honored it.
+fn run_currency(tokens: &[crate::SyntaxToken]) -> Option<String> {
+    tokens
+        .iter()
+        .rev()
+        .find(|t| t.kind() == crate::SyntaxKind::CURRENCY)
+        .map(|t| t.text().to_string())
+}
+
 fn write_canonical_token_sequence(
     tokens: &[crate::SyntaxToken],
     group: GroupingStyle<'_>,
     out: &mut String,
 ) {
+    let run_group = group.groups(run_currency(tokens).as_deref());
     let is_op = |k: crate::SyntaxKind| {
         matches!(
             k,
@@ -2337,7 +2367,7 @@ fn write_canonical_token_sequence(
             out.push(' ');
         }
         if kind == crate::SyntaxKind::NUMBER {
-            out.push_str(&canonical_number(t.text(), group.groups(None)));
+            out.push_str(&canonical_number(t.text(), run_group));
         } else {
             out.push_str(t.text());
         }
@@ -2353,6 +2383,16 @@ fn balance_tolerance(
     node: &crate::SyntaxNode,
     group: GroupingStyle<'_>,
 ) -> Option<(String, Option<String>)> {
+    // `balance Assets:A 100.00 ~ 0.05 USD` — one currency covers the asserted
+    // amount and the tolerance, and it trails both, so resolve it up front
+    // rather than mid-walk.
+    let run_group = {
+        let toks: Vec<crate::SyntaxToken> = node
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .collect();
+        group.groups(run_currency(&toks).as_deref())
+    };
     let mut past_tilde = false;
     let mut number: Option<String> = None;
     let mut currency: Option<String> = None;
@@ -2368,7 +2408,7 @@ fn balance_tolerance(
         }
         match t.kind() {
             crate::SyntaxKind::NUMBER if number.is_none() => {
-                number = Some(canonical_number(t.text(), group.groups(None)));
+                number = Some(canonical_number(t.text(), run_group));
             }
             crate::SyntaxKind::CURRENCY if number.is_some() && currency.is_none() => {
                 currency = Some(t.text().to_string());
@@ -2839,10 +2879,17 @@ mod tests {
 
     #[test]
     fn balance_with_tolerance_canonical() {
+        // Beancount's form is `AMOUNT ~ TOLERANCE CURRENCY` — ONE trailing
+        // currency covering both numbers, per its Precision & Tolerances docs
+        // (`319.020 ~ 0.002 RGAGX`). This test previously asserted
+        // `100.00 USD ~ 0.01 USD`, repeating the currency; that is not the
+        // beancount form, and the emitter produced it by running the amount
+        // expression past the tilde and then emitting the tolerance again.
+        // Input that repeats the currency now normalizes to the canonical form.
         let src = "2024-01-15 balance Assets:Cash 100.00 USD ~ 0.01 USD\n";
         assert_eq!(
             format_source(src),
-            "2024-01-15 balance Assets:Cash 100.00 USD ~ 0.01 USD\n"
+            "2024-01-15 balance Assets:Cash 100.00 ~ 0.01 USD\n"
         );
     }
 
@@ -4978,5 +5025,53 @@ mod tests {
             format_source(src),
             "no declared grouping must be byte-identical to the default path"
         );
+    }
+
+    /// `format` must not duplicate a balance tolerance.
+    ///
+    /// `emit_amount_expression` ran from the first NUMBER to the first
+    /// CURRENCY, which SWALLOWED the `~ tolerance` clause; `emit_balance` then
+    /// emitted it again via `balance_tolerance`. So
+    /// `balance Assets:A 0.00 ~ 1234.5 USD` was rewritten as
+    /// `... 0.00 ~ 1234.5 USD ~ 1234.5 USD` — stable across reformats, but
+    /// almost certainly not valid beancount, whose balance grammar takes at
+    /// most one tolerance. `--check` reported the ORIGINAL as unformatted, so a
+    /// CI gate pushed users into the corrupted form.
+    ///
+    /// Pre-existing on main; unrelated to grouping.
+    #[test]
+    fn balance_tolerance_is_emitted_exactly_once() {
+        for (src, want) in [
+            (
+                "2020-01-04 balance Assets:A 0.00 ~ 1234.5 USD\n",
+                "2020-01-04 balance Assets:A 0.00 ~ 1234.5 USD\n",
+            ),
+            // A source that repeats the currency collapses to the one-currency
+            // beancount form rather than keeping both.
+            (
+                "2020-01-04 balance Assets:A 0.00 USD ~ 0.05 USD\n",
+                "2020-01-04 balance Assets:A 0.00 ~ 0.05 USD\n",
+            ),
+            // No tolerance: unchanged.
+            (
+                "2020-01-04 balance Assets:A 1234.50 USD\n",
+                "2020-01-04 balance Assets:A 1234.50 USD\n",
+            ),
+            // Arithmetic still terminates at the currency, not the tilde.
+            (
+                "2020-01-04 balance Assets:A (1 + 5) / 2 USD\n",
+                "2020-01-04 balance Assets:A (1 + 5) / 2 USD\n",
+            ),
+        ] {
+            let out = format_source(src);
+            assert_eq!(out, want, "formatting {src:?}");
+            assert_eq!(format_source(&out), out, "not idempotent for {src:?}");
+            // And the output must still parse — a formatter may not emit text
+            // its own parser rejects.
+            assert!(
+                crate::parse(&out).errors.is_empty(),
+                "output must re-parse: {out}"
+            );
+        }
     }
 }

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -100,10 +100,13 @@ pub struct PostingAlignment {
 
 /// How numerals are grouped, resolved per currency.
 ///
-/// `Copy` on purpose: it rides [`PostingAlignment`], which the width pre-pass
-/// and the emitters both read. Handing them the style separately is how they
-/// could disagree about a numeral's width — the #1290 failure — so it travels
-/// with the layout it determines.
+/// `Copy` on purpose: it is threaded as a sibling of [`PostingAlignment`]
+/// through the width pre-pass and the emitters, which must agree about a
+/// numeral's width or the currency column drifts — the #1290 failure. It is
+/// NOT a field of `PostingAlignment`: that type is `pub`, `Eq` and cached on
+/// `ParseResult`, so it cannot carry a lifetime. The invariant that pairs a
+/// cached alignment with the style it was measured under is stated on
+/// [`format_node_with_style`].
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GroupingStyle<'a> {
     ctx: Option<&'a rustledger_core::DisplayContext>,
@@ -329,7 +332,7 @@ pub fn try_format_source_grouped(
     // letting `format_source_grouped` re-parse. The alignment cached on
     // `ParseResult` is computed WITHOUT grouping, so it can only be reused for
     // the default style — see `format_node_with_style`'s invariant.
-    if style.groups(None) || style.groups_anything() {
+    if style.groups_anything() {
         return Ok(format_node_grouped(&result.syntax_node(), style));
     }
     Ok(format_source_with_parsed(&result, source))
@@ -2185,10 +2188,16 @@ const fn is_trivia_kind(kind: crate::SyntaxKind) -> bool {
 /// accepts (`(\d{1,3}(,\d{3})*|\d+)(\.\d*)?`). Anything else — Indian lakh
 /// grouping, say — would emit text this parser then REJECTS, so widening this
 /// needs a lexer change first, not just a formatter one.
-fn canonical_number(text: &str, group: bool) -> String {
+fn canonical_number(text: &str, group: bool) -> std::borrow::Cow<'_, str> {
+    // The overwhelmingly common numeral is already canonical: no separators to
+    // strip and no grouping requested. Borrow it rather than allocating a copy
+    // per numeral on the default formatter path.
+    if !group && !text.contains(',') {
+        return std::borrow::Cow::Borrowed(text);
+    }
     let bare = text.replace(',', "");
     if !group {
-        return bare;
+        return std::borrow::Cow::Owned(bare);
     }
     let (int_part, frac) = match bare.split_once('.') {
         Some((i, f)) => (i, Some(f)),
@@ -2197,7 +2206,7 @@ fn canonical_number(text: &str, group: bool) -> String {
     // Defensive: a non-digit integer part is not ours to regroup. Unreachable
     // for a lexed NUMBER, whose sign is a separate token.
     if int_part.is_empty() || !int_part.bytes().all(|b| b.is_ascii_digit()) {
-        return bare;
+        return std::borrow::Cow::Owned(bare);
     }
     let n = int_part.len();
     let mut out = String::with_capacity(bare.len() + n / 3);
@@ -2211,7 +2220,7 @@ fn canonical_number(text: &str, group: bool) -> String {
         out.push('.');
         out.push_str(f);
     }
-    out
+    std::borrow::Cow::Owned(out)
 }
 
 /// Emit the arithmetic expression of a `PRICE` / `BALANCE`
@@ -2412,7 +2421,7 @@ fn balance_tolerance(
         }
         match t.kind() {
             crate::SyntaxKind::NUMBER if number.is_none() => {
-                number = Some(canonical_number(t.text(), run_group));
+                number = Some(canonical_number(t.text(), run_group).into_owned());
             }
             crate::SyntaxKind::CURRENCY if number.is_some() && currency.is_none() => {
                 currency = Some(t.text().to_string());

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -121,6 +121,15 @@ impl<'a> GroupingStyle<'a> {
         }
     }
 
+    /// Whether this style groups anything at all.
+    ///
+    /// Lets a caller keep the fast precomputed-alignment path when nothing is
+    /// declared, which is the overwhelming majority of ledgers.
+    #[must_use]
+    pub const fn groups_anything(self) -> bool {
+        self.ctx.is_some()
+    }
+
     /// Whether a numeral in `currency` is grouped. `None` for numerals with no
     /// currency in scope (metadata values, `custom` values), which take the
     /// ledger-wide default.
@@ -300,14 +309,29 @@ pub fn format_source_with_parsed(parse_result: &crate::ParseResult, source: &str
 /// `source`. The caller decides whether to abort, render the
 /// errors, or fall back to a non-canonical pass.
 pub fn try_format_source(source: &str) -> Result<String, Vec<crate::ParseError>> {
+    try_format_source_grouped(source, GroupingStyle::default())
+}
+
+/// [`try_format_source`], with the grouping style supplied by the caller.
+///
+/// # Errors
+///
+/// As [`try_format_source`].
+pub fn try_format_source_grouped(
+    source: &str,
+    style: GroupingStyle<'_>,
+) -> Result<String, Vec<crate::ParseError>> {
     let result = crate::parse(source);
     if !result.errors.is_empty() {
         return Err(result.errors);
     }
-    // Reuse the parse + alignment we already produced for the
-    // error gate instead of letting `format_source` re-parse +
-    // re-walk every posting. Byte-identical output pinned by
-    // `format_source_with_parsed_matches_format_source`.
+    // Reuse the parse we already produced for the error gate rather than
+    // letting `format_source_grouped` re-parse. The alignment cached on
+    // `ParseResult` is computed WITHOUT grouping, so it can only be reused for
+    // the default style — see `format_node_with_style`'s invariant.
+    if style.groups(None) || style.groups_anything() {
+        return Ok(format_node_grouped(&result.syntax_node(), style));
+    }
     Ok(format_source_with_parsed(&result, source))
 }
 

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -62,10 +62,10 @@ pub mod format {
     pub use crate::cst::format::{
         CanonicalizeError, GroupingStyle, PostingAlignment, canonicalize_directives,
         compute_alignment, cr_outside_strings_present, crlf_to_lf_outside_strings, format_node,
-        format_node_grouped, format_node_range, format_node_range_with_alignment,
-        format_node_with_alignment, format_node_with_style, format_source, format_source_grouped,
-        format_source_with_parsed, lf_to_crlf_outside_strings, try_format_source,
-        try_format_source_grouped,
+        format_node_grouped, format_node_range, format_node_range_grouped,
+        format_node_range_with_alignment, format_node_range_with_style, format_node_with_alignment,
+        format_node_with_style, format_source, format_source_grouped, format_source_with_parsed,
+        lf_to_crlf_outside_strings, try_format_source, try_format_source_grouped,
     };
 }
 

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -65,6 +65,7 @@ pub mod format {
         format_node_grouped, format_node_range, format_node_range_with_alignment,
         format_node_with_alignment, format_node_with_style, format_source, format_source_grouped,
         format_source_with_parsed, lf_to_crlf_outside_strings, try_format_source,
+        try_format_source_grouped,
     };
 }
 

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -60,11 +60,11 @@ pub mod logos_lexer;
 /// exactly one site.
 pub mod format {
     pub use crate::cst::format::{
-        CanonicalizeError, PostingAlignment, canonicalize_directives, compute_alignment,
-        cr_outside_strings_present, crlf_to_lf_outside_strings, format_node, format_node_grouped,
-        format_node_range, format_node_range_with_alignment, format_node_with_alignment,
-        format_source, format_source_grouped, format_source_with_parsed,
-        lf_to_crlf_outside_strings, try_format_source,
+        CanonicalizeError, GroupingStyle, PostingAlignment, canonicalize_directives,
+        compute_alignment, cr_outside_strings_present, crlf_to_lf_outside_strings, format_node,
+        format_node_grouped, format_node_range, format_node_range_with_alignment,
+        format_node_with_alignment, format_node_with_style, format_source, format_source_grouped,
+        format_source_with_parsed, lf_to_crlf_outside_strings, try_format_source,
     };
 }
 
@@ -719,7 +719,6 @@ mod canonical_payload_excludes_alignment {
         // by 100. Real-world alignment would never be this wide
         // for the fixture, so we get a guaranteed-different cache.
         mutated.alignment = PostingAlignment {
-            group_digits: false,
             number_col: parsed.alignment.number_col + 100,
             number_width: parsed.alignment.number_width + 7,
         };
@@ -755,7 +754,7 @@ mod parse_result_alignment_cache {
         let result = parse(source);
         let source_file = SourceFile::cast(result.syntax_node())
             .expect("ParseResult::syntax_node() must be a SOURCE_FILE");
-        let fresh = compute_alignment(&source_file, false);
+        let fresh = compute_alignment(&source_file, crate::cst::format::GroupingStyle::default());
         assert_eq!(
             result.alignment, fresh,
             "ParseResult::alignment cache diverged from a fresh \

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -61,9 +61,10 @@ pub mod logos_lexer;
 pub mod format {
     pub use crate::cst::format::{
         CanonicalizeError, PostingAlignment, canonicalize_directives, compute_alignment,
-        cr_outside_strings_present, crlf_to_lf_outside_strings, format_node, format_node_range,
-        format_node_range_with_alignment, format_node_with_alignment, format_source,
-        format_source_with_parsed, lf_to_crlf_outside_strings, try_format_source,
+        cr_outside_strings_present, crlf_to_lf_outside_strings, format_node, format_node_grouped,
+        format_node_range, format_node_range_with_alignment, format_node_with_alignment,
+        format_source, format_source_grouped, format_source_with_parsed,
+        lf_to_crlf_outside_strings, try_format_source,
     };
 }
 
@@ -718,6 +719,7 @@ mod canonical_payload_excludes_alignment {
         // by 100. Real-world alignment would never be this wide
         // for the fixture, so we get a guaranteed-different cache.
         mutated.alignment = PostingAlignment {
+            group_digits: false,
             number_col: parsed.alignment.number_col + 100,
             number_width: parsed.alignment.number_width + 7,
         };
@@ -753,7 +755,7 @@ mod parse_result_alignment_cache {
         let result = parse(source);
         let source_file = SourceFile::cast(result.syntax_node())
             .expect("ParseResult::syntax_node() must be a SOURCE_FILE");
-        let fresh = compute_alignment(&source_file);
+        let fresh = compute_alignment(&source_file, false);
         assert_eq!(
             result.alignment, fresh,
             "ParseResult::alignment cache diverged from a fresh \

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -63,9 +63,9 @@ pub mod format {
         CanonicalizeError, GroupingStyle, PostingAlignment, canonicalize_directives,
         compute_alignment, cr_outside_strings_present, crlf_to_lf_outside_strings, format_node,
         format_node_grouped, format_node_range, format_node_range_grouped,
-        format_node_range_with_alignment, format_node_range_with_style, format_node_with_alignment,
-        format_node_with_style, format_source, format_source_grouped, format_source_with_parsed,
-        lf_to_crlf_outside_strings, try_format_source, try_format_source_grouped,
+        format_node_range_with_alignment, format_node_with_alignment, format_source,
+        format_source_grouped, format_source_with_parsed, lf_to_crlf_outside_strings,
+        try_format_source, try_format_source_grouped,
     };
 }
 

--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -163,7 +163,7 @@ fn format_command(name: &'static str, description: &'static str) -> Command {
     Command::new(name, description)
         .usage(
             "ag-rledger format [<file>...] [--output <file>] [--in-place] [-i] [--check] [--diff] \
-             [--verbose] [-v]",
+             [--ledger <root>] [--verbose] [-v]",
         )
         .allow_unknown_flags()
         .allow_extra_args()
@@ -533,6 +533,7 @@ fn build_format_args(
         in_place: bool_flag(req, "in-place", Some("i")),
         check: bool_flag(req, "check", None),
         diff: bool_flag(req, "diff", None),
+        ledger: path_flag(req, "ledger", None),
         verbose: bool_flag(req, "verbose", Some("v")),
     })
 }

--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -163,7 +163,7 @@ fn format_command(name: &'static str, description: &'static str) -> Command {
     Command::new(name, description)
         .usage(
             "ag-rledger format [<file>...] [--output <file>] [--in-place] [-i] [--check] [--diff] \
-             [--ledger <root>] [--verbose] [-v]",
+             [--ledger <root>] [--no-ledger] [--verbose] [-v]",
         )
         .allow_unknown_flags()
         .allow_extra_args()
@@ -534,6 +534,7 @@ fn build_format_args(
         check: bool_flag(req, "check", None),
         diff: bool_flag(req, "diff", None),
         ledger: path_flag(req, "ledger", None),
+        no_ledger: bool_flag(req, "no-ledger", None),
         verbose: bool_flag(req, "verbose", Some("v")),
     })
 }

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -101,7 +101,7 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
     let display_context = args
         .ledger
         .as_deref()
-        .map(load_display_context)
+        .map(|root| load_display_context(root, args.verbose))
         .transpose()?;
     let style = display_context
         .as_ref()
@@ -125,19 +125,28 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
 
 /// Load `root` purely to obtain its resolved display declarations.
 ///
-/// Validation findings are ignored on purpose: `format` must keep working on a
-/// ledger that does not yet `check` clean — that is often exactly when you
-/// reach for it. A missing `include`, an unbalanced transaction or a failed
-/// assertion all still yield a usable display context, and only that context is
-/// taken from the load.
+/// Takes the RAW load and stops there — no booking, no plugins. `process`
+/// forwards `display_context` from the raw result untouched, so the extra work
+/// cannot change the answer, and skipping it means a ledger that fails to book
+/// still formats. That is the point: `format` must keep working on a ledger
+/// that does not yet `check` clean, which is often exactly when you reach for
+/// it. A missing `include`, an unbalanced transaction or a failed assertion all
+/// still yield a usable display context.
+///
+/// Goes through the shared cached loader for the same reason every other
+/// command does — a pre-commit hook invoking `format --ledger` should not
+/// re-parse the whole ledger on each run.
 ///
 /// A root that cannot be READ is a different matter and fails: the user named a
 /// file to take declarations from, so silently substituting defaults would
 /// format their ledger the wrong way and say nothing.
-fn load_display_context(root: &std::path::Path) -> Result<rustledger_core::DisplayContext> {
-    let loaded = rustledger_loader::load(root, &rustledger_loader::LoadOptions::default())
+fn load_display_context(
+    root: &std::path::Path,
+    verbose: bool,
+) -> Result<rustledger_core::DisplayContext> {
+    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(root, false, verbose)
         .with_context(|| format!("failed to read ledger root {}", root.display()))?;
-    Ok(loaded.display_context)
+    Ok(raw.display_context)
 }
 
 fn format_file<W: Write>(

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -125,10 +125,15 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
 
 /// Load `root` purely to obtain its resolved display declarations.
 ///
-/// Load ERRORS are ignored on purpose: `format` must keep working on a ledger
-/// that does not yet `check` clean — that is often exactly when you reach for
-/// it. Only the display context is taken; whatever the loader reports about
-/// balances or bookings is irrelevant here.
+/// Validation findings are ignored on purpose: `format` must keep working on a
+/// ledger that does not yet `check` clean — that is often exactly when you
+/// reach for it. A missing `include`, an unbalanced transaction or a failed
+/// assertion all still yield a usable display context, and only that context is
+/// taken from the load.
+///
+/// A root that cannot be READ is a different matter and fails: the user named a
+/// file to take declarations from, so silently substituting defaults would
+/// format their ledger the wrong way and say nothing.
 fn load_display_context(root: &std::path::Path) -> Result<rustledger_core::DisplayContext> {
     let loaded = rustledger_loader::load(root, &rustledger_loader::LoadOptions::default())
         .with_context(|| format!("failed to read ledger root {}", root.display()))?;

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -8,7 +8,9 @@
 use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result};
 use clap::Parser;
-use rustledger_parser::format::{cr_outside_strings_present, try_format_source};
+use rustledger_parser::format::{
+    GroupingStyle, cr_outside_strings_present, try_format_source_grouped,
+};
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -41,6 +43,20 @@ pub struct Args {
     /// Show diff when using --check
     #[arg(long, requires = "check")]
     pub diff: bool,
+
+    /// Ledger root to read display declarations from (`option
+    /// "render_commas"`, per-commodity `render_commas:`).
+    ///
+    /// `format` is otherwise a per-file text transform: it never loads a
+    /// ledger, so it cannot see declarations that live in the root while the
+    /// postings live in an `include`d file. Naming the root explicitly is
+    /// deterministic regardless of which files are listed or in what order —
+    /// which matters because pre-commit hooks pass whichever files changed.
+    ///
+    /// This locates the declarations; it does not choose a style. Without it,
+    /// output is byte-identical to a ledger that declares nothing.
+    #[arg(long, value_name = "ROOT")]
+    pub ledger: Option<PathBuf>,
 
     /// Show verbose output
     #[arg(short, long)]
@@ -79,10 +95,22 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
         anyhow::bail!("--output and --in-place cannot be used together");
     }
 
+    // Resolve the display declarations ONCE, so every file in one invocation is
+    // formatted identically. Loading per file would give the root separators
+    // and its includes none.
+    let display_context = args
+        .ledger
+        .as_deref()
+        .map(load_display_context)
+        .transpose()?;
+    let style = display_context
+        .as_ref()
+        .map_or_else(GroupingStyle::default, GroupingStyle::from_context);
+
     let mut any_needs_formatting = false;
 
     for file in &args.files {
-        let result = format_file(file, args, out)?;
+        let result = format_file(file, args, style, out)?;
         if result == ExitCode::from(1) {
             any_needs_formatting = true;
         }
@@ -95,7 +123,24 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
     }
 }
 
-fn format_file<W: Write>(file: &PathBuf, args: &Args, out: &mut W) -> Result<ExitCode> {
+/// Load `root` purely to obtain its resolved display declarations.
+///
+/// Load ERRORS are ignored on purpose: `format` must keep working on a ledger
+/// that does not yet `check` clean — that is often exactly when you reach for
+/// it. Only the display context is taken; whatever the loader reports about
+/// balances or bookings is irrelevant here.
+fn load_display_context(root: &std::path::Path) -> Result<rustledger_core::DisplayContext> {
+    let loaded = rustledger_loader::load(root, &rustledger_loader::LoadOptions::default())
+        .with_context(|| format!("failed to read ledger root {}", root.display()))?;
+    Ok(loaded.display_context)
+}
+
+fn format_file<W: Write>(
+    file: &PathBuf,
+    args: &Args,
+    style: GroupingStyle<'_>,
+    out: &mut W,
+) -> Result<ExitCode> {
     if !file.exists() {
         anyhow::bail!("file not found: {}", file.display());
     }
@@ -112,7 +157,7 @@ fn format_file<W: Write>(file: &PathBuf, args: &Args, out: &mut W) -> Result<Exi
     let had_invalid_utf8 = std::str::from_utf8(&bytes).is_err();
     let original_content = String::from_utf8_lossy(&bytes).into_owned();
 
-    let formatted = match try_format_source(&original_content) {
+    let formatted = match try_format_source_grouped(&original_content, style) {
         Ok(out) => out,
         Err(errors) => {
             for err in &errors {

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -11,9 +11,10 @@ use clap::Parser;
 use rustledger_parser::format::{
     GroupingStyle, cr_outside_strings_present, try_format_source_grouped,
 };
+use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 /// Format beancount files in the canonical opinionated form.
@@ -55,8 +56,17 @@ pub struct Args {
     ///
     /// This locates the declarations; it does not choose a style. Without it,
     /// output is byte-identical to a ledger that declares nothing.
-    #[arg(long, value_name = "ROOT")]
+    #[arg(long, value_name = "ROOT", conflicts_with = "no_ledger")]
     pub ledger: Option<PathBuf>,
+
+    /// Do not look for a ledger root; format as a standalone text transform.
+    ///
+    /// Without this, `format` finds the nearest root journal at or above each
+    /// file and honors its declarations, matching what the editor does on
+    /// save. Pass this where output must depend only on the file's own bytes —
+    /// a hook that must behave identically whatever surrounds a checkout.
+    #[arg(long)]
+    pub no_ledger: bool,
 
     /// Show verbose output
     #[arg(short, long)]
@@ -95,21 +105,36 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
         anyhow::bail!("--output and --in-place cannot be used together");
     }
 
-    // Resolve the display declarations ONCE, so every file in one invocation is
-    // formatted identically. Loading per file would give the root separators
-    // and its includes none.
-    let display_context = args
-        .ledger
-        .as_deref()
-        .map(|root| load_display_context(root, args.verbose))
-        .transpose()?;
-    let style = display_context
-        .as_ref()
-        .map_or_else(GroupingStyle::default, GroupingStyle::from_context);
+    // Which ledger's declarations govern each file. Resolved before any
+    // loading so the roots can be de-duplicated: formatting twenty files of
+    // one ledger loads it once.
+    let roots: Vec<Option<PathBuf>> = args
+        .files
+        .iter()
+        .map(|file| resolve_root(file, args))
+        .collect();
+
+    let explicit = args.ledger.is_some();
+    let mut ledgers: HashMap<PathBuf, Option<Ledger>> = HashMap::new();
+    for root in roots.iter().flatten() {
+        if !ledgers.contains_key(root) {
+            let ledger = load_ledger_declarations(root, explicit, args.verbose)?;
+            ledgers.insert(root.clone(), ledger);
+        }
+    }
 
     let mut any_needs_formatting = false;
 
-    for file in &args.files {
+    for (file, root) in args.files.iter().zip(&roots) {
+        let ledger = root
+            .as_ref()
+            .and_then(|r| ledgers.get(r))
+            .and_then(Option::as_ref);
+        let style = ledger
+            .filter(|l| l.governs(file))
+            .map_or_else(GroupingStyle::default, |l| {
+                GroupingStyle::from_context(&l.display_context)
+            });
         let result = format_file(file, args, style, out)?;
         if result == ExitCode::from(1) {
             any_needs_formatting = true;
@@ -123,6 +148,64 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
     }
 }
 
+/// A ledger root's display declarations, plus which files it actually spans.
+struct Ledger {
+    display_context: rustledger_core::DisplayContext,
+    /// Canonicalized paths of the root and everything it includes.
+    files: std::collections::HashSet<PathBuf>,
+    /// Whether the user named this root explicitly.
+    explicit: bool,
+}
+
+impl Ledger {
+    /// Whether this ledger's declarations govern `file`.
+    ///
+    /// An explicitly named root always governs: the user pointed at it, and
+    /// obeying that is not our call to second-guess even for a file the ledger
+    /// does not include.
+    ///
+    /// A DISCOVERED root has to earn it. Discovery is a guess made from
+    /// directory layout, so it is confirmed against the files the ledger really
+    /// spans. Without that check, a stray `.beancount` sitting beside someone's
+    /// journal — a scratch file, a vendor export, a fixture — would be
+    /// reformatted to a ledger that has never heard of it.
+    fn governs(&self, file: &Path) -> bool {
+        if self.explicit {
+            return true;
+        }
+        canonical(file).is_some_and(|c| self.files.contains(&c))
+    }
+}
+
+/// Canonicalize for comparison, matching how the ledger's own files were
+/// recorded. Falls back to the path as given when the file cannot be resolved.
+fn canonical(path: &Path) -> Option<PathBuf> {
+    path.canonicalize()
+        .ok()
+        .or_else(|| Some(path.to_path_buf()))
+}
+
+/// Which ledger root, if any, should supply `file`'s display declarations.
+///
+/// `--ledger` wins outright; `--no-ledger` disables the search. Otherwise the
+/// nearest root journal at or above the file, which is the same rule the
+/// language server uses — so a file formats the same on save as it does in a
+/// pre-commit hook.
+fn resolve_root(file: &Path, args: &Args) -> Option<PathBuf> {
+    if args.no_ledger {
+        return None;
+    }
+    if let Some(explicit) = &args.ledger {
+        return Some(explicit.clone());
+    }
+    let dir = file.parent().filter(|p| !p.as_os_str().is_empty());
+    let start = match dir {
+        Some(d) => d.to_path_buf(),
+        None => std::env::current_dir().ok()?,
+    };
+    rustledger_loader::discover_journal_upward(&start)
+}
+
 /// Load `root` purely to obtain its resolved display declarations.
 ///
 /// Takes the RAW load and stops there — no booking, no plugins. `process`
@@ -134,19 +217,42 @@ pub fn run_with_writer<W: Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
 /// still yield a usable display context.
 ///
 /// Goes through the shared cached loader for the same reason every other
-/// command does — a pre-commit hook invoking `format --ledger` should not
-/// re-parse the whole ledger on each run.
+/// command does — a pre-commit hook invoking `format` should not re-parse the
+/// whole ledger on each run.
 ///
-/// A root that cannot be READ is a different matter and fails: the user named a
-/// file to take declarations from, so silently substituting defaults would
-/// format their ledger the wrong way and say nothing.
-fn load_display_context(
-    root: &std::path::Path,
-    verbose: bool,
-) -> Result<rustledger_core::DisplayContext> {
-    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(root, false, verbose)
-        .with_context(|| format!("failed to read ledger root {}", root.display()))?;
-    Ok(raw.display_context)
+/// A root that cannot be READ fails only when the user NAMED it: they pointed
+/// at a file to take declarations from, so silently substituting defaults would
+/// format their ledger the wrong way and say nothing. A DISCOVERED root that
+/// will not load is not an error — nobody asked for it — so it degrades to no
+/// declarations, exactly as if none had been found.
+fn load_ledger_declarations(root: &Path, explicit: bool, verbose: bool) -> Result<Option<Ledger>> {
+    match crate::cmd::loadcache::load_result_cached(root, false, verbose) {
+        Ok((raw, _from_cache)) => {
+            let files = raw
+                .source_map
+                .files()
+                .iter()
+                .filter_map(|f| canonical(&f.path))
+                .collect();
+            Ok(Some(Ledger {
+                display_context: raw.display_context,
+                files,
+                explicit,
+            }))
+        }
+        Err(e) if explicit => {
+            Err(e.context(format!("failed to read ledger root {}", root.display())))
+        }
+        Err(e) => {
+            if verbose {
+                eprintln!(
+                    "note: ignoring discovered ledger {} ({e}); formatting without declarations",
+                    root.display()
+                );
+            }
+            Ok(None)
+        }
+    }
 }
 
 fn format_file<W: Write>(

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -74,9 +74,11 @@ fn write_text<W: Write>(
     // it holds. It used to arrive only as a side effect of the Number-column
     // `update_from` below, which meant `SUM(number)` printed `1,234,567.89`
     // while `SUM(position)` in the same query printed `1234567.89 USD`
-    // (issue #1892).
+    // (issue #1892). Adopt the policy WHOLE — the ledger-wide flag plus every
+    // per-commodity override — rather than copying the global bit, which left
+    // a commodity's own `render_commas:` declaration unreadable here (#1896).
     for col in &mut col_contexts {
-        col.set_render_commas(ctx.render_commas());
+        col.adopt_grouping_from(ctx);
     }
     let mut col_inherited: Vec<bool> = vec![false; result.columns.len()];
     for row in &result.rows {
@@ -1885,6 +1887,46 @@ mod tests {
             text.matches("1,234,567.89").count(),
             2,
             "both the Number and the Position column must carry separators:\n{text}"
+        );
+    }
+
+    /// A commodity's own `render_commas:` declaration reaches the query
+    /// writer, on every column kind.
+    ///
+    /// The per-column contexts are built fresh and used to inherit only the
+    /// ledger-wide flag, so a commodity opting out was grouped anyway (#1896).
+    /// `Value::Number` has no currency in scope and necessarily takes the
+    /// ledger-wide default — that is why the opted-out commodity is asserted
+    /// through the columns that DO carry a currency.
+    #[test]
+    fn a_commoditys_own_grouping_declaration_reaches_the_query_writer() {
+        use rustledger_core::{Amount, Position};
+        use rustledger_query::QueryResult;
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+        ctx.set_render_commas_for("USD", false);
+        ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
+        ctx.update(rust_decimal_macros::dec!(1234567.89), "IQD");
+
+        let mut result = QueryResult::new(vec!["amt".into(), "pos".into()]);
+        result.add_row(vec![
+            Value::Amount(Amount::new(rust_decimal_macros::dec!(1234567.89), "USD")),
+            Value::Position(Box::new(Position::simple(Amount::new(
+                rust_decimal_macros::dec!(1234567.89),
+                "IQD",
+            )))),
+        ]);
+
+        let mut out = Vec::new();
+        write_text(&result, &mut out, false, &ctx).expect("write");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains("1234567.89 USD"),
+            "USD declared render_commas: FALSE and must not be grouped:\n{text}"
+        );
+        assert!(
+            text.contains("1,234,567.89 IQD"),
+            "IQD declared nothing and takes the ledger-wide TRUE:\n{text}"
         );
     }
 

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -1890,6 +1890,62 @@ mod tests {
         );
     }
 
+    /// `query --format beancount` honors `render_commas`, agreeing with
+    /// `rledger format --ledger` on the same ledger (#1896).
+    ///
+    /// Both emit ledger text, whose reader has a grammar that admits grouped
+    /// numerals, so a ledger asking for separators gets them from both. This
+    /// arm used to suppress them, which was right while `format` stripped
+    /// unconditionally and wrong the moment `format --ledger` learned to
+    /// group. Asserted through the SAME surface resolution the dispatcher
+    /// performs, so the wiring is covered and not just the writer.
+    #[test]
+    fn beancount_output_honors_render_commas_like_format() {
+        use rustledger_core::OutputSurface;
+        use rustledger_query::QueryResult;
+
+        let surface: OutputSurface = super::super::OutputFormat::Beancount.into();
+        assert!(
+            surface.renders_thousands_separators(),
+            "ledger text has a grammar for separators"
+        );
+
+        let mut ledger_ctx = DisplayContext::new();
+        ledger_ctx.set_render_commas(true);
+        ledger_ctx.update(rust_decimal_macros::dec!(1234567.89), "USD");
+        let ctx = ledger_ctx.for_surface(surface);
+
+        let mut result = QueryResult::new(vec!["pos".into()]);
+        result.add_row(vec![Value::Position(Box::new(
+            rustledger_core::Position::simple(rustledger_core::Amount::new(
+                rust_decimal_macros::dec!(1234567.89),
+                "USD",
+            )),
+        ))]);
+
+        let mut out = Vec::new();
+        write_beancount(&result, &mut out, &ctx).expect("write");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains("1,234,567.89 USD"),
+            "must group, like `format --ledger` does: {text}"
+        );
+
+        // ...and a commodity opting out is still honored on this surface.
+        let mut opted_out = DisplayContext::new();
+        opted_out.set_render_commas(true);
+        opted_out.set_render_commas_for("USD", false);
+        opted_out.update(rust_decimal_macros::dec!(1234567.89), "USD");
+        let ctx = opted_out.for_surface(surface);
+        let mut out = Vec::new();
+        write_beancount(&result, &mut out, &ctx).expect("write");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains("1234567.89 USD") && !text.contains(','),
+            "USD declared render_commas: FALSE: {text}"
+        );
+    }
+
     /// A commodity's own `render_commas:` declaration reaches the query
     /// writer, on every column kind.
     ///
@@ -1948,10 +2004,12 @@ mod tests {
         let mut result = QueryResult::new(vec!["sum".into()]);
         result.add_row(vec![Value::Number(rust_decimal_macros::dec!(1234567.89))]);
 
+        // Beancount is deliberately absent: it is ledger text, whose reader
+        // has a grammar for separators, and it groups (#1896). See
+        // `beancount_output_honors_render_commas_like_format`.
         for format in [
             super::super::OutputFormat::Csv,
             super::super::OutputFormat::Json,
-            super::super::OutputFormat::Beancount,
         ] {
             let surface: OutputSurface = format.into();
             assert!(

--- a/crates/rustledger/tests/format_render_commas_test.rs
+++ b/crates/rustledger/tests/format_render_commas_test.rs
@@ -1,0 +1,122 @@
+//! `rledger format --ledger` reads display declarations from a ledger root and
+//! applies them to the files it formats (#1892).
+//!
+//! The declarations live in the root while the postings usually live in an
+//! `include`d file, so a per-file formatter cannot see them. Naming the root is
+//! deterministic regardless of which files are listed or in what order — which
+//! matters because pre-commit hooks pass whichever files changed.
+
+mod common;
+
+use std::io::Write;
+use std::process::Command;
+
+/// Write a two-file ledger: a root carrying the declarations, and an included
+/// file carrying the postings. Returns (dir, root, included).
+fn ledger() -> (tempfile::TempDir, String, String) {
+    let dir = tempfile::Builder::new()
+        .prefix("fmt-commas-")
+        .tempdir()
+        .expect("tempdir");
+    let root = dir.path().join("main.beancount");
+    let inc = dir.path().join("postings.beancount");
+    let mut f = std::fs::File::create(&root).expect("create root");
+    f.write_all(
+        b"option \"operating_currency\" \"USD\"\n\
+          option \"render_commas\" \"TRUE\"\n\
+          \n\
+          2020-01-01 commodity USD\n\
+          \x20 render_commas: FALSE\n\
+          2020-01-01 commodity IQD\n\
+          \n\
+          2020-01-01 open Assets:Local\n\
+          2020-01-01 open Assets:Dollars\n\
+          include \"postings.beancount\"\n",
+    )
+    .expect("write root");
+    let mut g = std::fs::File::create(&inc).expect("create include");
+    g.write_all(
+        b"2020-01-02 * \"local\"\n\
+          \x20 Assets:Local    1234567.89 IQD\n\
+          \x20 Assets:Local   -1234567.89 IQD\n\
+          2020-01-03 * \"dollars\"\n\
+          \x20 Assets:Dollars  1234567.89 USD\n\
+          \x20 Assets:Dollars -1234567.89 USD\n",
+    )
+    .expect("write include");
+    (
+        dir,
+        root.to_str().expect("utf8").to_owned(),
+        inc.to_str().expect("utf8").to_owned(),
+    )
+}
+
+fn run(bin: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new(bin).args(args).output().expect("run rledger");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Without `--ledger`, output is exactly what it has always been. Every
+/// existing invocation and CI gate is unaffected.
+#[test]
+fn without_the_flag_output_is_unchanged() {
+    let bin = require_rledger!();
+    let (_d, _root, inc) = ledger();
+    let out = run(bin.as_ref(), &["format", &inc]);
+    assert!(
+        !out.contains(','),
+        "no declarations in scope means no separators: {out}"
+    );
+}
+
+/// With `--ledger`, the ROOT's declarations reach the INCLUDED file — the case
+/// a per-file formatter fundamentally cannot serve. And the per-commodity
+/// override wins over the ledger-wide default.
+#[test]
+fn the_root_declarations_reach_an_included_file() {
+    let bin = require_rledger!();
+    let (_d, root, inc) = ledger();
+    let out = run(bin.as_ref(), &["format", "--ledger", &root, &inc]);
+    assert!(
+        out.contains("1,234,567.89 IQD"),
+        "IQD takes the ledger-wide default: {out}"
+    );
+    assert!(
+        out.contains("1234567.89 USD") && !out.contains("1,234,567.89 USD"),
+        "USD declared `render_commas: FALSE` and must stay bare: {out}"
+    );
+}
+
+/// The grouped file is CANONICAL for that ledger: formatting is idempotent and
+/// `--check` accepts it. Without this the option would leave every file
+/// permanently "unformatted" — the trap the reporter identified.
+#[test]
+fn grouped_output_is_canonical_and_check_accepts_it() {
+    let bin = require_rledger!();
+    let (_d, root, inc) = ledger();
+
+    let once = run(bin.as_ref(), &["format", "--ledger", &root, &inc]);
+    std::fs::write(&inc, once.as_bytes()).expect("rewrite include");
+    let twice = run(bin.as_ref(), &["format", "--ledger", &root, &inc]);
+    assert_eq!(once, twice, "grouped formatting must be idempotent");
+
+    let status = Command::new(&bin)
+        .args(["format", "--check", "--ledger", &root, &inc])
+        .status()
+        .expect("run --check");
+    assert!(
+        status.success(),
+        "a grouped file must be canonical for a ledger that asked for grouping"
+    );
+
+    // And the grouped source still loads: the formatter may not emit text its
+    // own parser rejects.
+    let status = Command::new(&bin)
+        .args(["check", "--no-cache", &root])
+        .status()
+        .expect("run check");
+    assert!(
+        status.success(),
+        "grouped source must still parse and check"
+    );
+}

--- a/crates/rustledger/tests/format_render_commas_test.rs
+++ b/crates/rustledger/tests/format_render_commas_test.rs
@@ -53,6 +53,11 @@ fn ledger() -> (tempfile::TempDir, String, String) {
 
 fn run(bin: &std::path::Path, args: &[&str]) -> String {
     let out = Command::new(bin).args(args).output().expect("run rledger");
+    assert!(
+        out.status.success(),
+        "rledger {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
@@ -118,5 +123,152 @@ fn grouped_output_is_canonical_and_check_accepts_it() {
     assert!(
         status.success(),
         "grouped source must still parse and check"
+    );
+}
+
+/// The reporter's actual shape: ONE hyperinflated commodity declares grouping,
+/// with no global option, so everything else is untouched (#1892).
+///
+/// Also exercises the metadata path for `TRUE`. An uppercase bare word's token
+/// classification depends on context, so all the spellings a ledger author
+/// might write are accepted — silently ignoring the declaration is the failure
+/// mode that makes a display option look broken.
+#[test]
+fn a_single_commodity_can_opt_in_via_metadata() {
+    let bin = require_rledger!();
+    for spelling in ["TRUE", "\"TRUE\"", "true"] {
+        let dir = tempfile::Builder::new()
+            .prefix("fmt-opt-in-")
+            .tempdir()
+            .expect("tempdir");
+        let root = dir.path().join("main.beancount");
+        let inc = dir.path().join("p.beancount");
+
+        // Built line-by-line on purpose: a multi-line literal with `\`
+        // continuations silently bakes the source indentation into the fixture,
+        // which indents the DATE lines and makes the file a parse error.
+        let root_text = [
+            "2020-01-01 commodity IQD".to_string(),
+            format!("  render_commas: {spelling}"),
+            "2020-01-01 open Assets:Local".to_string(),
+            "2020-01-01 open Assets:Dollars".to_string(),
+            "include \"p.beancount\"".to_string(),
+        ]
+        .join("\n")
+            + "\n";
+        let inc_text = [
+            "2020-01-02 * \"local\"",
+            "  Assets:Local     1234567.89 IQD",
+            "  Assets:Local    -1234567.89 IQD",
+            "2020-01-03 * \"dollars\"",
+            "  Assets:Dollars   1234567.89 USD",
+            "  Assets:Dollars  -1234567.89 USD",
+        ]
+        .join("\n")
+            + "\n";
+        std::fs::write(&root, root_text).expect("write root");
+        std::fs::write(&inc, inc_text).expect("write include");
+
+        let out = run(
+            bin.as_ref(),
+            &[
+                "format",
+                "--ledger",
+                root.to_str().expect("utf8"),
+                inc.to_str().expect("utf8"),
+            ],
+        );
+        assert!(
+            out.contains("1,234,567.89 IQD"),
+            "`render_commas: {spelling}` must opt IQD in: {out}"
+        );
+        assert!(
+            out.contains("1234567.89 USD") && !out.contains("1,234,567.89 USD"),
+            "USD declared nothing and the global default is off: {out}"
+        );
+    }
+}
+
+/// Grouping must not change a single VALUE.
+///
+/// Formatting with grouping and then formatting the result WITHOUT it must
+/// reproduce the plain-formatted original byte for byte. That is a much
+/// stronger check than "the output still parses": it catches a grouped numeral
+/// that re-reads as a different number, which is the one way this feature could
+/// corrupt a ledger.
+#[test]
+fn grouping_round_trips_without_changing_any_value() {
+    let bin = require_rledger!();
+    let dir = tempfile::Builder::new()
+        .prefix("fmt-roundtrip-")
+        .tempdir()
+        .expect("tempdir");
+    let root = dir.path().join("main.beancount");
+    let inc = dir.path().join("p.beancount");
+
+    // Magnitudes and shapes chosen to straddle every group boundary, plus a
+    // trailing decimal point and a 28-digit value at the `Decimal` ceiling.
+    let vals = [
+        "0",
+        "1",
+        "12",
+        "123",
+        "1234",
+        "12345",
+        "123456",
+        "1234567",
+        "1000",
+        "1000000",
+        "0.5",
+        "0.05",
+        "1.0",
+        "1.",
+        "123456789.123456789",
+        "1234567890123456789012345678",
+        "999",
+        "1000.001",
+        "10.10",
+        "100000000",
+    ];
+    let mut body = String::new();
+    for (i, v) in vals.iter().enumerate() {
+        let day = (i % 27) + 2;
+        body.push_str(&format!(
+            "2020-01-{day:02} * \"v{i}\"\n  Assets:A   {v} USD\n  Assets:B  -{v} USD\n"
+        ));
+        body.push_str(&format!(
+            "2020-02-{day:02} balance Assets:A 0.00 ~ {v} USD\n"
+        ));
+        body.push_str(&format!("2020-03-{day:02} custom \"c\" {v} USD\n"));
+    }
+    std::fs::write(&inc, &body).expect("write include");
+    std::fs::write(
+        &root,
+        "option \"render_commas\" \"TRUE\"\n         2020-01-01 open Assets:A\n         2020-01-01 open Assets:B\n         include \"p.beancount\"\n",
+    )
+    .expect("write root");
+
+    let plain = run(bin.as_ref(), &["format", inc.to_str().expect("utf8")]);
+    let grouped = run(
+        bin.as_ref(),
+        &[
+            "format",
+            "--ledger",
+            root.to_str().expect("utf8"),
+            inc.to_str().expect("utf8"),
+        ],
+    );
+    assert!(
+        grouped.contains(','),
+        "the fixture must actually exercise grouping"
+    );
+
+    // Ungroup the grouped output and compare to the plain baseline.
+    let regrouped = dir.path().join("grouped.beancount");
+    std::fs::write(&regrouped, grouped.as_bytes()).expect("write grouped");
+    let ungrouped = run(bin.as_ref(), &["format", regrouped.to_str().expect("utf8")]);
+    assert_eq!(
+        ungrouped, plain,
+        "group-then-ungroup must reproduce the original values exactly"
     );
 }

--- a/crates/rustledger/tests/format_render_commas_test.rs
+++ b/crates/rustledger/tests/format_render_commas_test.rs
@@ -272,3 +272,64 @@ fn grouping_round_trips_without_changing_any_value() {
         "group-then-ungroup must reproduce the original values exactly"
     );
 }
+
+/// `--ledger` works on a root that does NOT `check` clean.
+///
+/// That is often exactly when you reach for a formatter — mid-edit, with an
+/// unbalanced transaction or a failing assertion still in the file. Only the
+/// display declarations are taken from the root, and resolving them is a raw
+/// load: no booking, no plugins, so nothing downstream of parsing can refuse.
+#[test]
+fn a_root_that_does_not_check_clean_still_supplies_declarations() {
+    let dir = tempfile::Builder::new()
+        .prefix("fmt-commas-broken-")
+        .tempdir()
+        .expect("tempdir");
+    let root = dir.path().join("main.beancount");
+    let inc = dir.path().join("postings.beancount");
+
+    std::fs::write(
+        &root,
+        "option \"render_commas\" \"TRUE\"\n\
+         2020-01-01 open Assets:Local\n\
+         2020-01-02 * \"does not balance\"\n\
+        \x20 Assets:Local  1234567.89 IQD\n\
+        \x20 Assets:Local        -1.00 IQD\n\
+         2020-01-03 balance Assets:Local  999.00 IQD\n",
+    )
+    .expect("write root");
+    std::fs::write(
+        &inc,
+        "2020-01-02 * \"x\"\n\
+        \x20 Assets:Local  1234567.89 IQD\n\
+        \x20 Equity:Opening\n",
+    )
+    .expect("write include");
+
+    let bin = require_rledger!();
+
+    // Precondition: the root really is broken, so this test cannot pass
+    // vacuously on a ledger that happens to be fine.
+    let check = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
+        .args(["check", root.to_str().expect("utf8")])
+        .output()
+        .expect("run check");
+    assert!(
+        !check.status.success(),
+        "fixture must NOT check clean, or this proves nothing"
+    );
+
+    let out = run(
+        bin.as_ref(),
+        &[
+            "format",
+            "--ledger",
+            root.to_str().expect("utf8"),
+            inc.to_str().expect("utf8"),
+        ],
+    );
+    assert!(
+        out.contains("1,234,567.89 IQD"),
+        "declarations must still be read from an unbalanced root: {out}"
+    );
+}

--- a/crates/rustledger/tests/format_render_commas_test.rs
+++ b/crates/rustledger/tests/format_render_commas_test.rs
@@ -61,16 +61,29 @@ fn run(bin: &std::path::Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
-/// Without `--ledger`, output is exactly what it has always been. Every
-/// existing invocation and CI gate is unaffected.
+/// A file with no ledger above it formats exactly as it always has.
+///
+/// This used to assert that omitting `--ledger` was enough. It is not any
+/// more: `format` now discovers the nearest root, which is the point of doing
+/// so — see `format_discovers_the_nearest_root_journal`. What is unchanged is
+/// the case where there is nothing to discover, plus `--no-ledger`.
 #[test]
-fn without_the_flag_output_is_unchanged() {
+fn a_file_with_no_ledger_above_it_is_unchanged() {
     let bin = require_rledger!();
-    let (_d, _root, inc) = ledger();
-    let out = run(bin.as_ref(), &["format", &inc]);
+    let dir = tempfile::Builder::new()
+        .prefix("fmt-commas-lonely-")
+        .tempdir()
+        .expect("tempdir");
+    let lone = dir.path().join("scratch.beancount");
+    std::fs::write(
+        &lone,
+        "2020-01-02 * \"x\"\n\x20 Assets:Local  1234567.89 IQD\n\x20 Equity:Opening\n",
+    )
+    .expect("write");
+    let out = run(bin.as_ref(), &["format", lone.to_str().expect("utf8")]);
     assert!(
         !out.contains(','),
-        "no declarations in scope means no separators: {out}"
+        "nothing to discover means no separators: {out}"
     );
 }
 
@@ -248,7 +261,12 @@ fn grouping_round_trips_without_changing_any_value() {
     )
     .expect("write root");
 
-    let plain = run(bin.as_ref(), &["format", inc.to_str().expect("utf8")]);
+    // Both ungrouped renderings pass `--no-ledger`: the fixture's root is in
+    // this directory, so plain `format` would discover it and group.
+    let plain = run(
+        bin.as_ref(),
+        &["format", "--no-ledger", inc.to_str().expect("utf8")],
+    );
     let grouped = run(
         bin.as_ref(),
         &[
@@ -266,7 +284,12 @@ fn grouping_round_trips_without_changing_any_value() {
     // Ungroup the grouped output and compare to the plain baseline.
     let regrouped = dir.path().join("grouped.beancount");
     std::fs::write(&regrouped, grouped.as_bytes()).expect("write grouped");
-    let ungrouped = run(bin.as_ref(), &["format", regrouped.to_str().expect("utf8")]);
+    // `--no-ledger` is required: the fixture's root sits in this same
+    // directory, so plain `format` would discover it and group right back.
+    let ungrouped = run(
+        bin.as_ref(),
+        &["format", "--no-ledger", regrouped.to_str().expect("utf8")],
+    );
     assert_eq!(
         ungrouped, plain,
         "group-then-ungroup must reproduce the original values exactly"
@@ -331,5 +354,76 @@ fn a_root_that_does_not_check_clean_still_supplies_declarations() {
     assert!(
         out.contains("1,234,567.89 IQD"),
         "declarations must still be read from an unbalanced root: {out}"
+    );
+}
+
+/// With no flag at all, `format` finds the nearest root journal above the file
+/// and honors it — the same rule the language server applies on save.
+///
+/// Without this, a pre-commit `rledger format` strips the separators that
+/// format-on-save just wrote, and the two fight on every save.
+#[test]
+fn format_discovers_the_nearest_root_journal() {
+    let (_d, _root, inc) = ledger();
+    let bin = require_rledger!();
+    let out = run(bin.as_ref(), &["format", &inc]);
+    assert!(
+        out.contains("1,234,567.89 IQD"),
+        "the discovered root declares render_commas: {out}"
+    );
+    assert!(
+        out.contains("1234567.89 USD"),
+        "and its per-commodity opt-out is honored too: {out}"
+    );
+}
+
+/// Discovery is a guess, so it is confirmed against the files the ledger
+/// actually spans.
+///
+/// A scratch file, vendor export or fixture sitting beside someone's journal
+/// must not be reformatted to a ledger that has never heard of it. An
+/// explicitly named `--ledger` is different: the user pointed at it.
+#[test]
+fn a_file_outside_the_discovered_ledger_is_not_governed() {
+    let (dir, root, _inc) = ledger();
+    let stray = std::path::Path::new(&root)
+        .parent()
+        .expect("parent")
+        .join("stray.beancount");
+    std::fs::write(
+        &stray,
+        "2020-01-02 * \"not included anywhere\"\n\
+        \x20 Assets:Local  1234567.89 IQD\n\
+        \x20 Equity:Opening\n",
+    )
+    .expect("write stray");
+    let stray = stray.to_str().expect("utf8").to_owned();
+    let bin = require_rledger!();
+
+    let discovered = run(bin.as_ref(), &["format", &stray]);
+    assert!(
+        !discovered.contains(','),
+        "a stray file must not inherit the neighboring ledger: {discovered}"
+    );
+
+    // Naming the root explicitly is an instruction, not a guess.
+    let explicit = run(bin.as_ref(), &["format", "--ledger", &root, &stray]);
+    assert!(
+        explicit.contains("1,234,567.89 IQD"),
+        "an explicit --ledger governs whatever it is pointed at: {explicit}"
+    );
+    drop(dir);
+}
+
+/// `--no-ledger` restores the pure text transform, for a hook that must behave
+/// identically whatever surrounds a checkout.
+#[test]
+fn no_ledger_opts_out_of_discovery() {
+    let (_d, _root, inc) = ledger();
+    let bin = require_rledger!();
+    let out = run(bin.as_ref(), &["format", "--no-ledger", &inc]);
+    assert!(
+        !out.contains(','),
+        "--no-ledger means the file's own bytes decide: {out}"
     );
 }

--- a/docs/reference/adr/0008-presentation-is-ledger-declared.md
+++ b/docs/reference/adr/0008-presentation-is-ledger-declared.md
@@ -1,0 +1,144 @@
+# ADR-0008: Presentation is declared by the ledger, resolved per surface
+
+## Status
+
+Accepted
+
+## Context
+
+`rledger format` produces a canonical form. The question this record settles is
+what "canonical" ranges over, because two different things were being called by
+that name:
+
+- **Canonical value** — what the numbers mean. `1,234.50` and `1234.50` are the
+  same amount. The parser guarantees this, and nothing in this decision touches
+  it.
+- **Canonical text** — the bytes on disk. This is what a formatter actually
+  produces and what `format --check` compares.
+
+The original position was gofmt's: there is exactly one canonical text for any
+given content, no knobs, because a formatter exists to end the argument.
+ADR-adjacent code said so explicitly — `OutputSurface`'s first implementation
+carried the comment *"ledger text has one canonical form"* — and stripping
+thousands separators followed from it. A file with separators and one without
+mean the same thing, so pick the simpler and normalize to it.
+
+Issue #1892 pressed on that. A ledger denominated in a currency where amounts
+run to ten digits is materially harder to read unseparated, Beancount's own
+`option "render_commas"` exists precisely for this, and Beancount's printer
+honors it (`grammar.py` calls `dcontext.set_commas(options["render_commas"])`
+during the parse; `printer.py` renders through that same context). rledger
+stripped the separators such a ledger had asked for.
+
+The observation that resolved it: **the Beancount grammar admits both
+spellings.** A formatter that strips separators is therefore not enforcing a
+truth, it is making a style choice while presenting it as a canonical form.
+Refusing to let the ledger choose is not more principled than letting it — it
+just moves the choice from the ledger's author to us.
+
+## Decision
+
+**Canonical text is a function of `(content, the ledger's own declarations)`.**
+Not one universal normal form, but one per ledger.
+
+Four rules follow.
+
+### 1. A surface renders separators iff its consumer has a grammar for them
+
+Not "iff a human reads it". The question is whether the receiving parser can
+absorb the variation:
+
+| Consumer | Separators | Why |
+|----------|-----------|-----|
+| Beancount readers (`format`, `query --format beancount`, the LSP) | as declared | the grammar admits them; every conforming reader accepts them |
+| Rendered tables (`report`, `query` text) | as declared | read by a person |
+| CSV / JSON | **never** | no grammar — a separator forces quoting and then breaks `Decimal(field)` |
+
+The CSV/JSON suppression is **absolute**: it outranks the ledger-wide option and
+any per-commodity declaration. That asymmetry is the whole point of the rule —
+those consumers cannot express the preference, so the preference does not reach
+them. This lives in exactly one place, `OutputSurface::renders_thousands_separators`.
+
+### 2. The declaration lives in the ledger, never in the invocation
+
+This is what keeps the decision from being "we added a formatting flag", which
+is the thing gofmt exists to prevent.
+
+`option "render_commas"` and per-commodity `render_commas:` are data in the
+ledger. `rledger format --ledger <root>` names *where those declarations live*;
+it cannot choose a style. So within any one ledger there is still exactly one
+canonical text, `--check` still means something, and every tool that reads that
+ledger agrees on it.
+
+### 3. Only presentation that cannot change meaning is the ledger's to choose
+
+Grouping qualifies: inserting or removing separators cannot change a value, and
+the parser strips them before anything sees a number.
+
+Precision does not. `DisplayContext` knows a commodity's tracked precision and
+`report`/`query` render through it, but **`format` deliberately does not
+re-quantize** — a `1234567.5` in a file whose commodity declares `precision: 2`
+is written back as `1,234,567.5`, not `1,234,567.50`. Beancount infers a
+transaction's balance tolerance from the decimal places actually written, so
+padding would change whether the ledger balances. A formatter may exercise the
+freedom the grammar allows; it may not use that freedom to alter meaning.
+
+This is the boundary of the ADR, and it is narrower than "presentation is the
+ledger's business".
+
+### 4. A ledger-relative canonical form obliges tools to find the ledger
+
+If canonical text depends on the ledger, a tool that cannot see the ledger
+cannot produce it. Both the language server and `rledger format` therefore
+locate the root journal themselves (shared name list and walk in
+`rustledger_loader::discover`), so a file formats identically on save and in a
+pre-commit hook.
+
+Discovery is a **guess**, so it is verified: a discovered ledger governs a file
+only if that ledger actually includes it. An explicitly named `--ledger` skips
+the check, because a guess must be confirmed while an instruction is followed.
+
+## Consequences
+
+### Positive
+
+- A ledger that asks for separators gets them everywhere it is safe to give
+  them, matching Beancount.
+- One rule, stated once, covers every output surface. Before this, the surfaces
+  had already drifted: `query --format beancount` emitted separators while
+  `format` stripped them, and CSV emitted them while JSON did not.
+- `format --check` and idempotence survive, because the style is fixed by the
+  ledger rather than by the caller.
+- Editor and CLI agree by construction, since they share the discovery rule.
+
+### Negative, and accepted
+
+- **A file has no canonical form in isolation.** Taken out of its ledger, the
+  same bytes canonicalize differently. This is inherent to the decision, not an
+  implementation gap. `--no-ledger` is the escape hatch for pipelines that need
+  output to depend only on the file's own content.
+- **Discovery reads the filesystem**, so `format`'s output depends on something
+  other than its input. Bounded three ways: only ledgers that *declare*
+  `render_commas` are affected at all (one that declares nothing is
+  byte-identical to before), a discovered ledger must actually include the file,
+  and `--no-ledger` opts out entirely.
+- **A naked number has no commodity**, so a `Value::Number` column in a query
+  (`SUM(number)`) can only take the ledger-wide default, never a per-commodity
+  declaration. Unavoidable: there is nothing to resolve against.
+- **Groups are three digits**, which is all the lexer accepts
+  (`\d{1,3}(,\d{3})*`). Other conventions, such as Indian lakh grouping, would
+  need a grammar change first — the formatter must never emit text its own
+  parser rejects.
+
+## Prior art
+
+- **gofmt / black** — one canonical form, no configuration. The position this
+  ADR departs from, and the reason rule 2 exists.
+- **rustfmt (`rustfmt.toml`), clang-format (`.clang-format`), EditorConfig
+  (`.editorconfig`)** — style declared in-tree and discovered by walking up from
+  the file. The closest analogue: the project, not the invocation, owns the
+  style, and every tool that touches the project finds the same answer. Rule 4
+  is the same mechanism.
+- **Beancount** — `grammar.py` sets the display context's `commas` flag from
+  `options["render_commas"]` while parsing; `printer.py` renders through that
+  context. Beancount already treats presentation as ledger-declared data.

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -17,6 +17,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0005](0005-cst-conversion-performance.md) | CST Conversion Performance (parse cache; green-tree declined) | Accepted |
 | [ADR-0006](0006-wit-component-model-embedding.md) | WIT / Component-Model embedding contract | Proposed |
 | [ADR-0007](0007-average-booking-realization.md) | AVERAGE booking realizes a single weighted-average pool | Accepted |
+| [ADR-0008](0008-presentation-is-ledger-declared.md) | Presentation is declared by the ledger, resolved per surface | Accepted |
 
 ## About ADRs
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -112,26 +112,59 @@ Use commas as thousand separators.
 option "render_commas" "TRUE"
 ```
 
-Separators are a **display** concern, so they appear in rendered output
-(`report`, `query` text) and never in ledger text or machine-readable output:
+Where separators appear depends on whether the consumer has a **grammar**. A
+Beancount reader does — grouped numerals are part of the syntax, so every
+conforming reader accepts them. A CSV or JSON consumer does not: a separator
+forces the field to be quoted and is then rejected by ordinary decimal parsers.
 
 | Surface | Separators? |
 |---------|-------------|
 | `report`, `query` — text | yes, when the option is set |
-| `report`, `query` — `--format csv` / `json` | **no** — machine interchange, and a separator breaks ordinary decimal parsers |
-| `query --format beancount` | **no** — it is ledger text, so it follows the same rule as `format` |
-| `format` (the file on disk) | **no** — see below |
+| `report`, `query` — `--format csv` / `json` | **never** — machine interchange with no grammar |
+| `query --format beancount` | **never** currently — a known inconsistency with `format`, since Beancount's own `print` does honor the option |
+| `format` (the file on disk) | only with `--ledger` — see below |
 
-`rledger format` deliberately writes numbers without separators even when this
-option is set: the formatter's job is one canonical on-disk representation, and
-`,` is locale-ambiguous. This differs from Beancount's `bean-format`, which
-leaves numerals untouched, though Beancount's own `printer` also drops them.
+### Separators in the ledger file itself
 
-The practical consequence: a file containing `1,234,567.89` will always be
-reported as unformatted by `format --check` (exit 1), which fails a CI
-formatting gate. Run `rledger format` once to canonicalize the file; it is
-stable from then on. The parser accepts separators on input either way, so
-existing files keep loading.
+`rledger format` writes numbers without separators by default. Pass
+`--ledger <root>` to have it read the declarations above and apply them:
+
+```console
+$ rledger format --ledger main.beancount postings.beancount
+  Assets:Local    1,234,567.89 IQD
+```
+
+The flag names where the declarations live, not what style to use. `format` is
+otherwise a per-file text transform that never loads a ledger, so it cannot see
+an `option` or `commodity` directive that sits in the root while the postings
+sit in an `include`d file. Naming the root is deterministic no matter which
+files are listed or in what order — which matters when a pre-commit hook passes
+whichever files happened to change.
+
+A grouped file is *canonical* for a ledger that asked for grouping, so
+`format --check` accepts it and formatting stays idempotent. Without
+`--ledger`, output is byte-identical to a ledger that declares nothing.
+
+### Per-commodity declarations
+
+`render_commas` is the ledger-wide default; a commodity can override it:
+
+```beancount
+option "render_commas" "TRUE"
+
+2020-01-01 commodity IQD          ; grouped: amounts run to 10 digits
+2020-01-01 commodity USD
+  render_commas: FALSE            ; not grouped: amounts are 2-4 digits
+```
+
+This is the same metadata mechanism as `precision:`, resolved by the same
+tiers — amount-scan inference, then the global option, then commodity
+metadata. Beancount ignores metadata keys it does not recognize, so a ledger
+carrying this still round-trips through Beancount and Fava.
+
+Groups are three digits, which is all the parser accepts. Other conventions
+(Indian lakh grouping, for instance) would need a grammar change first — the
+formatter must never emit text its own parser rejects.
 
 ### inferred_tolerance_default
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -121,8 +121,13 @@ forces the field to be quoted and is then rejected by ordinary decimal parsers.
 |---------|-------------|
 | `report`, `query` — text | yes, when the option is set |
 | `report`, `query` — `--format csv` / `json` | **never** — machine interchange with no grammar |
-| `query --format beancount` | **never** currently — a known inconsistency with `format`, since Beancount's own `print` does honor the option |
+| `query --format beancount` | yes — ledger text, same as `format` (matches Beancount's `print`) |
 | `format` (the file on disk) | only with `--ledger` — see below |
+| Editor format-on-save (LSP) | yes, when the open file belongs to a loaded ledger that asks for them |
+
+The CSV/JSON row is absolute: it outranks both the option and any per-commodity
+declaration, because the reason there is the consumer's missing grammar rather
+than the ledger's preference.
 
 ### Separators in the ledger file itself
 
@@ -144,6 +149,15 @@ whichever files happened to change.
 A grouped file is *canonical* for a ledger that asked for grouping, so
 `format --check` accepts it and formatting stays idempotent. Without
 `--ledger`, output is byte-identical to a ledger that declares nothing.
+
+**In an editor**, the language server needs no flag — it already knows the
+journal root, so format-on-save, range formatting, and the *Align Amounts*
+command all group when the ledger asks. The options come from the root, which
+is what makes this work on an `include`d file that has no `option` lines of its
+own. Two cases deliberately fall back to ungrouped: a file no journal includes
+(editing a stray `.beancount` must not inherit an unrelated ledger's style),
+and a ledger that has not finished loading (formatting still works rather than
+blocking on it).
 
 ### Per-commodity declarations
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -122,8 +122,8 @@ forces the field to be quoted and is then rejected by ordinary decimal parsers.
 | `report`, `query` — text | yes, when the option is set |
 | `report`, `query` — `--format csv` / `json` | **never** — machine interchange with no grammar |
 | `query --format beancount` | yes — ledger text, same as `format` (matches Beancount's `print`) |
-| `format` (the file on disk) | only with `--ledger` — see below |
-| Editor format-on-save (LSP) | yes, when the open file belongs to a loaded ledger that asks for them |
+| `format` (the file on disk) | when the file's ledger declares them, see below |
+| Editor format-on-save (LSP) | same rule as `format` |
 
 The CSV/JSON row is absolute: it outranks both the option and any per-commodity
 declaration, because the reason there is the consumer's missing grammar rather
@@ -131,33 +131,50 @@ than the ledger's preference.
 
 ### Separators in the ledger file itself
 
-`rledger format` writes numbers without separators by default. Pass
-`--ledger <root>` to have it read the declarations above and apply them:
+`rledger format` finds the ledger a file belongs to and honors its
+declarations:
 
 ```console
-$ rledger format --ledger main.beancount postings.beancount
+$ rledger format postings.beancount
   Assets:Local    1,234,567.89 IQD
 ```
 
-The flag names where the declarations live, not what style to use. `format` is
-otherwise a per-file text transform that never loads a ledger, so it cannot see
+It looks for the nearest root journal at or above the file — `main.beancount`,
+`ledger.beancount`, `journal.beancount`, `index.beancount` and their `.bean`
+spellings, nearest first — which is the same rule the language server uses. A
+file therefore formats the same on save as it does in a pre-commit hook. This
+matters because `format` is otherwise a per-file text transform: it cannot see
 an `option` or `commodity` directive that sits in the root while the postings
-sit in an `include`d file. Naming the root is deterministic no matter which
-files are listed or in what order — which matters when a pre-commit hook passes
-whichever files happened to change.
+sit in an `include`d file.
+
+Discovery is a guess, so it is checked: a discovered ledger governs a file only
+if it actually `include`s it. A scratch file or vendor export sitting beside
+your journal is left alone.
+
+| Flag | Effect |
+|------|--------|
+| *(none)* | Use the nearest root journal that includes this file |
+| `--ledger <ROOT>` | Use exactly this root, and apply it to every file listed |
+| `--no-ledger` | Do not look for a ledger; format from the file's bytes alone |
+
+`--ledger` names *where the declarations live*, not what style to use, and it
+is obeyed without the containment check — you pointed at it. Use it when the
+root is somewhere discovery will not look, or to be explicit in CI. Use
+`--no-ledger` where output must depend only on the file's own content, whatever
+surrounds a checkout.
 
 A grouped file is *canonical* for a ledger that asked for grouping, so
-`format --check` accepts it and formatting stays idempotent. Without
-`--ledger`, output is byte-identical to a ledger that declares nothing.
+`format --check` accepts it and formatting stays idempotent. A ledger that
+declares nothing is unaffected by any of this, which bounds the blast radius of
+discovery: only a ledger that asked for separators can get them.
 
-**In an editor**, the language server needs no flag — it already knows the
-journal root, so format-on-save, range formatting, and the *Align Amounts*
-command all group when the ledger asks. The options come from the root, which
-is what makes this work on an `include`d file that has no `option` lines of its
-own. Two cases deliberately fall back to ungrouped: a file no journal includes
-(editing a stray `.beancount` must not inherit an unrelated ledger's style),
-and a ledger that has not finished loading (formatting still works rather than
-blocking on it).
+**In an editor**, the language server applies the same rule without any flag:
+format-on-save, range formatting, and the *Align Amounts* command all group
+when the ledger asks. It resolves the root from its own configuration or
+workspace rather than by walking up from the file, but the fallbacks match — a
+buffer no journal includes is left alone, and so is anything formatted before
+the ledger has finished loading (formatting still works rather than blocking on
+it).
 
 ### Per-commodity declarations
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -162,6 +162,12 @@ tiers — amount-scan inference, then the global option, then commodity
 metadata. Beancount ignores metadata keys it does not recognize, so a ledger
 carrying this still round-trips through Beancount and Fava.
 
+A commodity's declaration reaches every surface the global option does —
+`report` and `query` text as well as `format`. It does **not** override the
+surface rules in the table above: a commodity declaring `render_commas: TRUE`
+is still written unseparated to CSV and JSON, because suppression there is
+about the consumer's lack of a grammar, not about the ledger's preference.
+
 Groups are three digits, which is all the parser accepts. Other conventions
 (Indian lakh grouping, for instance) would need a grammar change first — the
 formatter must never emit text its own parser rejects.

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -129,6 +129,9 @@ The CSV/JSON row is absolute: it outranks both the option and any per-commodity
 declaration, because the reason there is the consumer's missing grammar rather
 than the ledger's preference.
 
+Why presentation is the ledger's to declare at all, and where that stops, is
+recorded in [ADR-0008](adr/0008-presentation-is-ledger-declared.md).
+
 ### Separators in the ledger file itself
 
 `rledger format` finds the ledger a file belongs to and honors its


### PR DESCRIPTION
Closes the loop on #1892: a ledger can declare that its numerals carry thousands separators, and `rledger format` will write them.

Three commits, each independently reviewable. **Default behaviour is byte-identical** — a ledger that declares nothing is unaffected.

## Why this is a canonical form, not a knob

The objection to formatter knobs is that output stops being a function of the input. A declaration *in the ledger* doesn't have that property: `canonical(ledger)` stays total and deterministic.

And the surface rule from #1893 turned out to be drawn in the wrong place. That change split on machine-vs-human; the real split is **whether the consumer has a grammar**:

- **CSV/JSON** consumers don't — the consumer is someone's `Decimal(field)`, and a separator forces quoting and then breaks it. Those stay separator-free unconditionally.
- **A `.beancount` reader does** — grouped numerals are part of the syntax, so every conforming reader already accepts them, and downstream consumers receive `Decimal`s, not text. **The machine boundary is the parser, not the file.**

Beancount reached the same split independently. From its CHANGES (issue #106): `render_commas` affects *"the web interface, the reports, and the PRINT command"* — and explicitly **not** its SQL query output.

Worth noting the original decision here cited gofmt's no-knobs philosophy — but gofmt doesn't normalize digit separators either. Verified locally: it realigns a `var` block and leaves both `1000000` and `1_000_000` exactly as written.

## The three tiers

Grouping now resolves exactly like `precision:` already did — inference → global option → commodity metadata:

```beancount
option "render_commas" "TRUE"

2020-01-01 commodity IQD          ; grouped: amounts run to 10 digits
2020-01-01 commodity USD
  render_commas: FALSE            ; not grouped: amounts are 2-4 digits
```

A single global boolean wasn't enough: the reporter's currency runs ~4000:1, so they want grouping there and not on their 2-4 digit USD. Grouping previously had only the global tier — that asymmetry with `precision:` is what this closes. Beancount ignores unknown metadata keys, so files carrying this still round-trip through Beancount and Fava.

## `--ledger`, and why a flag

`format` is a per-file text transform that never loads a ledger, so it can't see declarations in the root while the postings are in an `include`d file. Three sourcing options were considered; only one is deterministic under the invocation pattern that matters (pre-commit hooks pass whichever files changed, in whatever order):

```console
$ rledger format --ledger main.beancount postings.beancount
  Assets:Local    1,234,567.89 IQD
  Assets:Dollars   -1234567.89 USD
```

The flag locates the declarations; it doesn't choose a style.

## Verification

**Grouped output is canonical for that ledger** — `--check` accepts it and formatting is idempotent. Without that, setting the option would leave every file permanently "unformatted", which is the trap the reporter identified. The grouped source also still `check`s clean: a formatter must never emit text its own parser rejects.

Groups are three digits, because that's all the lexer accepts. Indian lakh grouping would need a *grammar* change first.

**Sabotage-verified, and one is worth calling out**: making the width pre-pass measure ungrouped text puts the currency column at `[50, 49, 51]` instead of uniform — #1290's non-convergence, reproduced on demand. That's the property the alignment test actually guards.

## Design note for review

`GroupingStyle` travels as a sibling parameter, not as a field on `PostingAlignment`. Putting it there was my first attempt — grouping changes width, so I wanted the pre-pass and the emitter reading one struct. But `PostingAlignment` is `pub`, `Copy`, `Eq` and lives in `ParseResult`; a borrowed context forces a lifetime through public API. The entry points derive both from one value instead, and the residual hazard is documented on `format_node_with_style`: an alignment measured under a different style misplaces the column, so callers reusing the parse-time `ParseResult::alignment` must pass the default style.

## Surfaces

| Surface | Separators |
|---------|-----------|
| `report`, `query` — text | when declared |
| `report`, `query` — csv / json | **never** — no grammar; outranks every declaration |
| `query --format beancount` | when declared (matches Beancount's `print`) |
| `format` | when declared, with `--ledger <root>` |
| Editor format-on-save (LSP) | when declared, if the buffer belongs to a loaded ledger |

Both items originally filed here as known gaps — `query --format beancount`
never grouping, and the LSP formatter not grouping — are now implemented
rather than recorded.

## Behavior change outside `render_commas`

`option "infer_tolerance_from_cost" "1"` previously warned and evaluated
FALSE; it is now TRUE. Every boolean option in ledger source now shares one
vocabulary (`parse_bool_word`: TRUE/FALSE/1/0, case-insensitive), which the
E7002 message now names accurately. Python beancount accepts `1`/`true`/`yes`
as true for every boolean option, so this narrows a divergence.

4391 tests · clippy clean at the CI-pinned 1.97.0 · `cargo doc -D warnings`
clean · fmt clean.

Refs #1892

