### PR TITLE
perf(booking): snapshot in apply() only when overflow is possible

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -668,6 +668,49 @@ impl BookingEngine {
         Ok(())
     }
 
+    /// Whether any `Inventory::add` this transaction performs could overflow.
+    ///
+    /// Conservative: `true` means "cannot prove otherwise", never "will". A
+    /// `false` lets [`Self::apply`] skip the rollback snapshot, which is pure
+    /// cost for the overwhelming majority of transactions (#1897).
+    ///
+    /// Sound because `add` is the ONLY operation whose failure `apply` rolls
+    /// back — `reduce` reports a missing lot, a caller precondition violation
+    /// that is deliberately non-fatal, never `Overflow`.
+    ///
+    /// The headroom offered to each account is the absolute magnitude of the
+    /// WHOLE transaction, not of that account's own postings. That over-states
+    /// what any one account can consume, which is the safe direction, and it
+    /// avoids grouping postings by account and currency — an allocation, which
+    /// is the thing being removed.
+    fn overflow_is_possible(&self, txn: &Transaction) -> bool {
+        let mut sum_abs = rustledger_core::Decimal::ZERO;
+        for posting in &txn.postings {
+            let Some(units) = posting.amount() else {
+                // An unfilled posting means booking did not complete; do not
+                // reason about arithmetic that has not been determined yet.
+                return true;
+            };
+            match sum_abs.checked_add(units.number.abs()) {
+                Some(next) => sum_abs = next,
+                // The magnitudes alone exceed the range — exactly the case the
+                // snapshot exists for.
+                None => return true,
+            }
+        }
+
+        !txn.postings.iter().all(|posting| {
+            let Some(units) = posting.amount() else {
+                return false;
+            };
+            // An account with no inventory yet starts from zero, so only the
+            // transaction's own magnitudes matter, and `sum_abs` is in range.
+            self.inventories
+                .get(&posting.account)
+                .is_none_or(|inv| inv.add_headroom_for(&units.currency, sum_abs))
+        })
+    }
+
     /// Apply a transaction's postings to the running inventories (update
     /// balances).
     ///
@@ -708,13 +751,23 @@ impl BookingEngine {
         // REMOVED rather than restored to an empty inventory: `apply` is the
         // only thing that creates entries here, and leaving a phantom empty
         // one changes `into_inventories`' output.
-        let mut snapshot: FxHashMap<rustledger_core::Account, Option<Inventory>> =
-            FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
-        for posting in &txn.postings {
-            snapshot
-                .entry(posting.account.clone())
-                .or_insert_with(|| self.inventories.get(&posting.account).cloned());
-        }
+        // ...but only when overflow is actually possible. `imbl::Vector`'s clone
+        // is O(1), yet it leaves the chunks SHARED, so the next `Inventory::add`
+        // pays `Arc::make_mut` and copies a 64-`Position` chunk. Snapshotting
+        // every transaction cost 2.4x heap churn and 6% CPU on the nightly
+        // profile to guard a case needing values near 7.9e28 (#1897).
+        let snapshot: Option<FxHashMap<rustledger_core::Account, Option<Inventory>>> =
+            if self.overflow_is_possible(txn) {
+                let mut snap =
+                    FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
+                for posting in &txn.postings {
+                    snap.entry(posting.account.clone())
+                        .or_insert_with(|| self.inventories.get(&posting.account).cloned());
+                }
+                Some(snap)
+            } else {
+                None
+            };
         let rollback =
             |engine: &mut Self,
              snapshot: FxHashMap<rustledger_core::Account, Option<Inventory>>| {
@@ -741,7 +794,20 @@ impl BookingEngine {
                     }
                 ))
             ) {
-                rollback(self, snapshot);
+                // `snapshot` is `Some` whenever this arm is reachable: the
+                // guard only returns false when no add can overflow, and
+                // overflow is the sole error that reaches here. Restoring
+                // nothing would be silent corruption, so a violated guard must
+                // be loud rather than quiet.
+                assert!(
+                    snapshot.is_some(),
+                    "overflow_is_possible() returned false but an overflow \
+                     occurred: the guard is unsound and the earlier postings \
+                     of this transaction cannot be rolled back"
+                );
+                if let Some(snapshot) = snapshot {
+                    rollback(self, snapshot);
+                }
                 return reduced;
             }
             debug_assert!(
@@ -2307,6 +2373,66 @@ mod tests {
                 Directive::Transaction(t) if t.narration.as_ref() == "Sell at phantom cost basis"
             )),
             "failed sell must not appear in booked"
+        );
+    }
+
+    /// The snapshot is skipped for ordinary transactions and kept whenever
+    /// overflow cannot be ruled out (#1897).
+    ///
+    /// Both directions matter. Skipping when overflow IS possible is silent
+    /// corruption; keeping it always is the 2.4x heap churn this guard exists
+    /// to remove. The third case is the one a naive guard gets wrong: the
+    /// posting is tiny, but the account it lands in already sits at the
+    /// ceiling, so the add still overflows.
+    #[test]
+    fn the_snapshot_is_skipped_only_when_overflow_is_impossible() {
+        let mut engine = BookingEngine::new();
+
+        let ordinary = Transaction::new(date(2024, 1, 1), "groceries")
+            .with_synthesized_posting(Posting::new(
+                "Assets:Bank",
+                Amount::new(dec!(-42.50), "USD"),
+            ))
+            .with_synthesized_posting(Posting::new(
+                "Expenses:Food",
+                Amount::new(dec!(42.50), "USD"),
+            ));
+        assert!(
+            !engine.overflow_is_possible(&ordinary),
+            "a two-posting transaction of ordinary magnitudes must take the \
+             fast path, or the guard buys nothing"
+        );
+        engine.apply(&ordinary).expect("applies");
+        assert!(
+            !engine.overflow_is_possible(&ordinary),
+            "and still does once the accounts hold a balance"
+        );
+
+        // Magnitudes alone exceed the range.
+        let huge = Transaction::new(date(2024, 1, 2), "huge")
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(Decimal::MAX, "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(Decimal::MAX, "USD")));
+        assert!(engine.overflow_is_possible(&huge));
+
+        // The case that makes the guard non-trivial: a SMALL posting into an
+        // account already parked at the ceiling.
+        let park = Transaction::new(date(2024, 1, 3), "park").with_synthesized_posting(
+            Posting::new("Assets:Full", Amount::new(Decimal::MAX, "USD")),
+        );
+        engine.apply(&park).expect("one MAX position fits");
+        let small_but_doomed = Transaction::new(date(2024, 1, 4), "small")
+            .with_synthesized_posting(Posting::new("Assets:Full", Amount::new(dec!(1.00), "USD")));
+        assert!(
+            engine.overflow_is_possible(&small_but_doomed),
+            "the posting is tiny but the destination is at the ceiling — a \
+             guard that looked only at the transaction would miss this"
+        );
+        // ...and the currency it cannot reach is unaffected.
+        let other_currency = Transaction::new(date(2024, 1, 4), "eur")
+            .with_synthesized_posting(Posting::new("Assets:Full", Amount::new(dec!(1.00), "EUR")));
+        assert!(
+            !engine.overflow_is_possible(&other_currency),
+            "the ceiling is per currency; EUR has room"
         );
     }
 

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -489,6 +489,19 @@ impl Inventory {
         // transaction cannot be rolled back. Cheap insurance on a `pub` method
         // whose failure mode is silent corruption.
         let needed = needed.abs();
+
+        // `units_cache` and `simple_index` are `#[serde(skip)]`, so a
+        // deserialized inventory carries its positions with both caches empty
+        // until `rebuild_caches` runs. Reading them in that state answers
+        // "plenty of room" for an inventory sitting at the ceiling — an
+        // unsound `true`, which is the one direction this method must never
+        // fail in. Refuse to answer instead. `units()` handles the same gap by
+        // recomputing from `positions`; that is O(positions) and this is meant
+        // to be O(1), so the conservative answer is the right trade here.
+        if self.units_cache.is_empty() && !self.positions.is_empty() {
+            return false;
+        }
+
         let fits = |v: Decimal| {
             v.abs()
                 .checked_add(needed)
@@ -959,6 +972,43 @@ impl Inventory {
 
 #[cfg(test)]
 mod tests {
+
+    /// A deserialized inventory, whose caches are empty until rebuilt, must
+    /// not be reported as having headroom it does not have.
+    ///
+    /// `units_cache` and `simple_index` are `#[serde(skip)]`, so a round-trip
+    /// leaves `positions` populated and both caches empty. Reading them in that
+    /// state answers "plenty of room" for an inventory parked at the ceiling.
+    /// An unsound `true` makes `apply` skip the snapshot it needed, so this is
+    /// silent corruption rather than a wrong number (review catch on #1898).
+    #[test]
+    fn a_deserialized_inventory_refuses_to_claim_headroom() {
+        let mut inv = Inventory::new();
+        inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+            .expect("one MAX position fits");
+        assert!(!inv.add_headroom_for("USD", Decimal::ONE));
+
+        let round_tripped: Inventory =
+            serde_json::from_str(&serde_json::to_string(&inv).expect("serialize"))
+                .expect("deserialize");
+
+        // Precondition: this really is the caches-empty state, so the test
+        // cannot pass vacuously on an inventory that rebuilt them itself.
+        assert!(
+            !round_tripped.positions.is_empty(),
+            "the positions survive the round-trip"
+        );
+        assert!(
+            round_tripped.units_cache.is_empty(),
+            "...and the caches do not — that is what makes this dangerous"
+        );
+
+        assert!(
+            !round_tripped.add_headroom_for("USD", Decimal::ONE),
+            "the inventory still holds Decimal::MAX; an empty cache is \
+             'cannot prove', never 'plenty of room'"
+        );
+    }
 
     /// `add_headroom_for` treats `needed` as a magnitude, whatever sign it
     /// arrives with.

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -467,6 +467,39 @@ impl Inventory {
         })
     }
 
+    /// Whether every `add` of `currency` totaling at most `needed` in absolute
+    /// value is guaranteed not to overflow.
+    ///
+    /// `add` overflows at exactly two `checked_add`s: the per-currency running
+    /// total, and — for a cost-less position — the single merged lot that
+    /// `simple_index` points at. Both operands are bounded here against
+    /// `needed`, so a `true` answer means no sequence of adds whose magnitudes
+    /// sum to `needed` can overflow either, at any intermediate step: every
+    /// partial sum is bounded by the total.
+    ///
+    /// Conservative by construction — `false` only ever means "cannot prove
+    /// it", never "will overflow". Callers use it to skip work that exists
+    /// solely to recover from overflow (#1897).
+    #[must_use]
+    pub fn add_headroom_for(&self, currency: &str, needed: Decimal) -> bool {
+        let fits = |v: Decimal| {
+            v.abs()
+                .checked_add(needed)
+                .is_some_and(|sum| sum <= Decimal::MAX)
+        };
+
+        let cached_ok = self.units_cache.get(currency).copied().is_none_or(fits);
+        if !cached_ok {
+            return false;
+        }
+        // Only a cost-less add merges, and `simple_index` names the one lot it
+        // would merge into.
+        self.simple_index
+            .get(currency)
+            .and_then(|idx| self.positions.get(*idx))
+            .is_none_or(|lot| fits(lot.units.number))
+    }
+
     /// Get all currencies in this inventory.
     #[must_use]
     pub fn currencies(&self) -> Vec<&str> {

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -482,6 +482,13 @@ impl Inventory {
     /// solely to recover from overflow (#1897).
     #[must_use]
     pub fn add_headroom_for(&self, currency: &str, needed: Decimal) -> bool {
+        // Enforce the magnitude contract rather than trusting it. A negative
+        // `needed` would make the sums below SMALLER and hand back `true` when
+        // overflow is possible — and an unsound `true` here means `apply`
+        // skips the snapshot it needed, so earlier postings of a failing
+        // transaction cannot be rolled back. Cheap insurance on a `pub` method
+        // whose failure mode is silent corruption.
+        let needed = needed.abs();
         let fits = |v: Decimal| {
             v.abs()
                 .checked_add(needed)
@@ -952,6 +959,36 @@ impl Inventory {
 
 #[cfg(test)]
 mod tests {
+
+    /// `add_headroom_for` treats `needed` as a magnitude, whatever sign it
+    /// arrives with.
+    ///
+    /// A negative `needed` would make the internal sums smaller and return
+    /// `true` where overflow is possible. `apply` would then skip the snapshot
+    /// it needed, leaving a failing transaction's earlier postings applied —
+    /// silent corruption. Not reachable from the in-tree caller, which sums
+    /// absolute values, but this is a `pub` method (review catch on #1898).
+    #[test]
+    fn add_headroom_for_reads_needed_as_a_magnitude() {
+        let mut inv = Inventory::new();
+        inv.add(Position::simple(Amount::new(Decimal::MAX, "USD")))
+            .expect("one MAX position fits");
+
+        assert!(
+            !inv.add_headroom_for("USD", Decimal::ONE),
+            "at the ceiling, there is no room for one more unit"
+        );
+        assert!(
+            !inv.add_headroom_for("USD", -Decimal::ONE),
+            "and a negatively-signed magnitude must not manufacture room"
+        );
+        assert_eq!(
+            inv.add_headroom_for("USD", Decimal::ONE),
+            inv.add_headroom_for("USD", -Decimal::ONE),
+            "the sign of `needed` cannot change the answer"
+        );
+    }
+
     use super::*;
     use crate::Cost;
     use crate::NaiveDate;


### PR DESCRIPTION
Closes #1897.

## The regression

The nightly profile regressed on 2026-07-30 (`54e47170`): **+6.08% instructions**, **heap total 86.8 MB → 210.5 MB (+142%)**. Heap *peak* was byte-identical, so it was allocator churn, not memory pressure.

All of it is the rollback snapshot #1891 added to `apply` to make it all-or-nothing — a fix that must stay: without it, a transaction the loader then *dropped* had still moved the running balances, and every later transaction booked against the corruption.

## Why it cost so much

The snapshot's own comment says `imbl::Vector`'s clone is O(1) structural sharing. True, and beside the point: the clone leaves the chunks **shared**, so the next `Inventory::add` hits `Arc::make_mut` and copies a 64-`Position` chunk. The snapshot is cheap; what it does to every subsequent write is not.

dhat attributes the +123.7 MB to four sites, 100.0% of the delta:

| delta | blocks | site |
|------:|-------:|------|
| +112,940,512 | +18,287 | `Chunk<Position,64>` via `Arc::make_mut` |
| +5,960,000 | +10,000 | the snapshot map — one per transaction |
| +2,706,476 | +18,287 | `Inventory`'s cached totals, cloned |
| +2,121,292 | +18,287 | ditto |

Meanwhile `rollback` fires on exactly one condition, `Overflow`. Every other error path falls through to a `debug_assert` and is ignored in release. So ~1.8 inventory copies were paid on **100%** of transactions to guard a case needing values near 7.9×10²⁸.

## The guard

`apply` now snapshots only when `overflow_is_possible`. Sound because:

- `add` is the only operation whose failure is rolled back — `reduce` reports a missing lot, a caller precondition violation that is deliberately non-fatal, never `Overflow`.
- `add` overflows at exactly two `checked_add`s: the per-currency running total, and the single merged lot `simple_index` names for a cost-less position. Both are O(1) lookups, so `Inventory::add_headroom_for` bounds them without walking any lots.

Headroom offered to each account is the magnitude of the **whole transaction**, not of that account's own postings. That over-states what any one account can consume — the safe direction — and avoids grouping postings by account and currency, which would be an allocation, the thing being removed. Bounding the total also covers every intermediate step, since each partial sum is bounded by it.

Conservative in one direction only: `false` means *proved impossible*, never *unlikely*. If it were ever wrong the rollback arm would be unreachable and earlier postings unrecoverable, so that arm now **asserts** rather than silently restoring nothing.

## Measured

CI's workload (seed 42, 10,000 txns):

```
heap total   main 54e47170   210,549,215
             this branch      86,808,601      (pre-regression baseline 86,820,807)
wall clock   -1.8% median, -2.7% min   (9 interleaved runs, both built --profile profiling)
output       byte-identical
```

Heap lands 12 KB **below** the pre-regression baseline, because the snapshot map is now not allocated at all for ordinary transactions.

Instruction count is **not** measured here — no valgrind in the local shell. The nightly cachegrind slice will confirm it returns to ~808M.

## Tests

`the_snapshot_is_skipped_only_when_overflow_is_impossible` pins both directions, including the case a naive guard gets wrong: a *tiny* posting into an account already parked at the ceiling. The existing `a_failed_apply_leaves_no_partial_mutation` still exercises the snapshot path (its fixture uses `Decimal::MAX`, so the guard correctly declines to skip).

4364 tests · clippy clean at the CI-pinned 1.97.0 · `cargo doc -D warnings` clean · fmt clean.
