### PR TITLE
perf(parser): don't resolve a currency the alignment pass will ignore

### DIFF
--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -1311,10 +1311,18 @@ fn amount_value_text(amt: &ast::Amount, group: GroupingStyle<'_>) -> String {
         buf.push('-');
     }
     if let Some(n) = amt.number() {
-        buf.push_str(&canonical_number(
-            n.text(),
-            group.groups(amt.currency().as_ref().map(ast::CurrencyName::text)),
-        ));
+        // `amt.currency()` is a CST child lookup, and `groups()` ignores the
+        // currency entirely under the default style — so resolving it first
+        // costs a tree walk to answer a question already settled. That is per
+        // posting, per PARSE, because `compute_alignment` runs on every parse
+        // (see `convert.rs`), long before anything asks to be formatted. It
+        // measured 1.35% of the load pipeline's instructions.
+        //
+        // Same short-circuit `emit_amount_expression` already applies to
+        // `run_currency`; these two sites were missed when that was added.
+        let grouped = group.groups_anything()
+            && group.groups(amt.currency().as_ref().map(ast::CurrencyName::text));
+        buf.push_str(&canonical_number(n.text(), grouped));
     }
     buf
 }
@@ -2128,10 +2136,18 @@ fn format_amount(amt: &ast::Amount, group: GroupingStyle<'_>) -> String {
         out.push('-');
     }
     if let Some(n) = amt.number() {
-        out.push_str(&canonical_number(
-            n.text(),
-            group.groups(amt.currency().as_ref().map(ast::CurrencyName::text)),
-        ));
+        // `amt.currency()` is a CST child lookup, and `groups()` ignores the
+        // currency entirely under the default style — so resolving it first
+        // costs a tree walk to answer a question already settled. That is per
+        // posting, per PARSE, because `compute_alignment` runs on every parse
+        // (see `convert.rs`), long before anything asks to be formatted. It
+        // measured 1.35% of the load pipeline's instructions.
+        //
+        // Same short-circuit `emit_amount_expression` already applies to
+        // `run_currency`; these two sites were missed when that was added.
+        let grouped = group.groups_anything()
+            && group.groups(amt.currency().as_ref().map(ast::CurrencyName::text));
+        out.push_str(&canonical_number(n.text(), grouped));
     }
     if let Some(c) = amt.currency() {
         if !out.is_empty() && !out.ends_with('-') {


### PR DESCRIPTION
`amount_value_text` resolved `amt.currency()` — a CST child lookup — purely to pass into `groups()`, which ignores the currency entirely under the default style. The walk answered a question already settled.

That is **per posting, per parse**, not per format. `compute_alignment` runs from `convert.rs` on every parse to populate `ParseResult::alignment`, long before anything asks to be formatted, so a pipeline that only ever *loads* a ledger paid for it on every posting.

## Measured

CI's profiling workload (seed 42, 10 000 txns), same toolchain for every point:

| commit | instructions | vs baseline |
|---|---:|---:|
| `b6ea6097` pre-#1891 baseline | 737,109,199 | — |
| `bf1bb0e5` main | 770,331,132 | +4.51% |
| **this branch** | **757,784,295** | **+2.81%** |

−1.63%, which is the whole cost #1896 added to the load path (it measured +1.44% when it landed).

## Why it was missed

This is the same short-circuit `emit_amount_expression` already applies to `run_currency`, added in `73a222b1` during the #1896 review. The review caught the pattern in the *emitters* and missed it in the shared width pre-pass — which is the hotter of the two, since emitters only run when someone formats and the pre-pass runs on every parse.

## Safety

Behavior is unchanged by construction: `groups()` returns `false` for every currency when nothing groups, so the guard only skips work whose result was already known. Verified identical grouped output, per-commodity opt-out, and column alignment.

4400 tests · clippy clean at the CI-pinned 1.97.0 · `cargo doc -D warnings` clean · fmt clean.

## Context

Part of #1897. Full per-PR bisection of the regression is posted there; the short version is that #1891 accounts for +6.20 of the original +6.40%, #1898 recovered −3.09, and this recovers a further −1.63, leaving ~+2.8% that is the intrinsic cost of #1891's checked arithmetic.
