### PR TITLE
fix(ci): give miri a real timeout and scope it away from proptest

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -6,11 +6,15 @@
 # are miri-compatible; WASM/FFI crates and fs/wasmtime-heavy crates are
 # excluded because miri can't run their targets.
 #
-# Memory model: Stacked Borrows (miri's default). The job is scoped to the
-# rowan-free crates because rowan's `ThinArc` green tree trips miri under BOTH
-# Stacked Borrows AND Tree Borrows (a known, open aliasing-model question, not a
-# rowan bug), so no memory-model flag fixes it. See the "Run Miri on rowan-free
-# crates" step below for the full rationale and upstream references.
+# Memory model: Stacked Borrows (miri's default). Scoped to the rowan-free
+# crates because rowan's `ThinArc` green tree trips miri under BOTH Stacked
+# Borrows AND Tree Borrows (a known, open aliasing-model question, not a rowan
+# bug), so no memory-model flag fixes it. See the run step below for the full
+# rationale and upstream references.
+#
+# One crate per matrix job, each with its own timeout, and proptest targets
+# skipped — see the job and run step for why both were necessary to make this
+# fit at all.
 name: Miri
 on:
   schedule:
@@ -24,13 +28,23 @@ env:
   RUST_MIN_STACK: 8388608
 jobs:
   miri:
-    name: Miri
+    name: Miri (${{ matrix.crate }})
     runs-on: ubuntu-latest
     # Explicit, because the default is GitHub's 6-hour job cap. Without this the
     # job silently burned all six hours every Sunday and reported `cancelled`
     # (four consecutive weeks, 2026-07-05 through 07-26) — a red X that looks
     # like an infrastructure hiccup rather than "this job no longer fits".
+    #
+    # One crate per job, so the budget is PER CRATE rather than shared. Run
+    # sequentially they contend for a single ceiling, and whichever runs second
+    # is starved by whatever the first spent — so a slowdown in `core` reads as
+    # a `booking` failure. Splitting also halves wall clock, since the two are
+    # independent.
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [rustledger-core, rustledger-booking]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # nightly
@@ -89,24 +103,22 @@ jobs:
       # lives (imbl, smallvec, rust_decimal) — all still run. Properties keep
       # their full case counts in the normal test suite; what Miri wants is the
       # UB check, not the input exploration.
-      - name: Run Miri on rowan-free crates
+      - name: Run Miri on ${{ matrix.crate }}
         run: |
           set -euo pipefail
-          for crate in rustledger-core rustledger-booking; do
-            targets=(--lib)
-            for f in "crates/$crate/tests/"*.rs; do
-              [ -e "$f" ] || continue
-              name="$(basename "$f" .rs)"
-              if grep -q 'proptest!' "$f"; then
-                echo "skipping $crate/$name (proptest: too slow under Miri)"
-              else
-                targets+=(--test "$name")
-              fi
-            done
-            echo "::group::$crate ${targets[*]}"
-            cargo +nightly miri test --package "$crate" --all-features "${targets[@]}"
-            echo "::endgroup::"
+          crate="${{ matrix.crate }}"
+          targets=(--lib)
+          for f in "crates/$crate/tests/"*.rs; do
+            [ -e "$f" ] || continue
+            name="$(basename "$f" .rs)"
+            if grep -q 'proptest!' "$f"; then
+              echo "skipping $crate/$name (proptest: too slow under Miri)"
+            else
+              targets+=(--test "$name")
+            fi
           done
+          echo "running: cargo miri test -p $crate ${targets[*]}"
+          cargo +nightly miri test --package "$crate" --all-features "${targets[@]}"
         env:
           # -Zmiri-disable-isolation: some tests read the realtime clock
           # (e.g. "today"-based date helpers), which miri rejects under its
@@ -117,16 +129,12 @@ jobs:
           MIRIFLAGS: -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-disable-isolation
       - name: Summary
         run: |
-          echo "## Miri Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Miri checks for undefined behavior in unsafe Rust code." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Memory model: Stacked Borrows (miri default)." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Checked crates (rowan-free):" >> $GITHUB_STEP_SUMMARY
-          echo "- rustledger-core" >> $GITHUB_STEP_SUMMARY
-          echo "- rustledger-booking" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Excluded — rowan's ThinArc is miri-incompatible under Stacked AND Tree Borrows: rustledger-parser, rustledger-query." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Proptest targets are skipped here (see the run step): at 256+ cases under Miri they took hours. They run at full case counts in the normal test suite; neither crate has a \`proptest!\` in \`src/\`, so the unit tests still run." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Miri: ${{ matrix.crate }}"
+            echo ""
+            echo "Memory model: Stacked Borrows (miri default)."
+            echo ""
+            echo "Excluded crates — rowan's ThinArc is miri-incompatible under Stacked AND Tree Borrows: rustledger-parser, rustledger-query."
+            echo ""
+            echo "Proptest targets are skipped (see the run step): at 256+ cases under Miri they took hours. They run at full case counts in the normal test suite, and neither crate has a \`proptest!\` in \`src/\`, so the unit tests still run here."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -26,6 +26,11 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    # Explicit, because the default is GitHub's 6-hour job cap. Without this the
+    # job silently burned all six hours every Sunday and reported `cancelled`
+    # (four consecutive weeks, 2026-07-05 through 07-26) — a red X that looks
+    # like an infrastructure hiccup rather than "this job no longer fits".
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # nightly
@@ -58,15 +63,50 @@ jobs:
       # Miri-incompatible dependency applies: scope Miri away from it. We still
       # catch transitive-`unsafe` UB in our own logic via core + booking (+ their
       # deps: rust_decimal, bigdecimal, imbl, smallvec, ...).
+      #
+      # Proptest targets are skipped. Under Miri's ~100x slowdown a property at
+      # its default 256 cases is not a test, it is an outage: on 2026-06-28 one
+      # 18-test proptest binary took 5,951s and another 1,730s, and after this
+      # job was scoped to core+booking the remaining properties (including a
+      # 500-case one) pushed it past six hours every week.
+      #
+      # `PROPTEST_CASES` does NOT help: every one of these binaries calls
+      # `ProptestConfig::with_cases(N)`, which is `Config { cases: N,
+      # ..Config::default() }` — the literal overwrites the env-derived default.
+      # Setting it would look like a fix and change nothing.
+      #
+      # Nor does filtering by name: four of the properties are not `prop_*`
+      # prefixed (`try_reduce_predicts_reduce`, `interpolation_is_idempotent_*`,
+      # `interpolated_transaction_has_zero_residual`).
+      #
+      # So the list is DERIVED from the sources, not hardcoded. A new
+      # integration test is picked up automatically; a new proptest one is
+      # skipped automatically and named in the log. Hardcoding it would mean a
+      # future test file silently never runs under Miri.
+      #
+      # Coverage is not really reduced: neither crate has a single `proptest!`
+      # in `src/`, so the unit tests — where the transitive `unsafe` actually
+      # lives (imbl, smallvec, rust_decimal) — all still run. Properties keep
+      # their full case counts in the normal test suite; what Miri wants is the
+      # UB check, not the input exploration.
       - name: Run Miri on rowan-free crates
         run: |
-          echo "::group::rustledger-core"
-          cargo +nightly miri test --package rustledger-core --all-features
-          echo "::endgroup::"
-
-          echo "::group::rustledger-booking"
-          cargo +nightly miri test --package rustledger-booking --all-features
-          echo "::endgroup::"
+          set -euo pipefail
+          for crate in rustledger-core rustledger-booking; do
+            targets=(--lib)
+            for f in "crates/$crate/tests/"*.rs; do
+              [ -e "$f" ] || continue
+              name="$(basename "$f" .rs)"
+              if grep -q 'proptest!' "$f"; then
+                echo "skipping $crate/$name (proptest: too slow under Miri)"
+              else
+                targets+=(--test "$name")
+              fi
+            done
+            echo "::group::$crate ${targets[*]}"
+            cargo +nightly miri test --package "$crate" --all-features "${targets[@]}"
+            echo "::endgroup::"
+          done
         env:
           # -Zmiri-disable-isolation: some tests read the realtime clock
           # (e.g. "today"-based date helpers), which miri rejects under its
@@ -88,3 +128,5 @@ jobs:
           echo "- rustledger-booking" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Excluded — rowan's ThinArc is miri-incompatible under Stacked AND Tree Borrows: rustledger-parser, rustledger-query." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Proptest targets are skipped here (see the run step): at 256+ cases under Miri they took hours. They run at full case counts in the normal test suite; neither crate has a \`proptest!\` in \`src/\`, so the unit tests still run." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Miri has produced **no usable result in eight weeks**, and nobody noticed because the failure mode looked like flakiness.

| runs | outcome |
|---|---|
| 2026-06-07 → 06-28 | `failure` — rowan UB, fixed by `6386f1ea` |
| 2026-07-05 → 07-26 | `cancelled` at **exactly 360 minutes**, four weeks running |

The job set no `timeout-minutes`, so it inherited GitHub's 6-hour cap and burned all of it every Sunday. A `cancelled` badge reads as an infrastructure hiccup, not as "this job no longer fits."

## Two changes

**`timeout-minutes: 60`** so a runaway fails fast and visibly.

**Proptest targets are skipped.** Under Miri's ~100x slowdown a property at its default 256 cases is not a test, it is an outage. From the 2026-06-28 log: one 18-test proptest binary took **5,951s**, another **1,730s**. After the job was scoped to core+booking the remaining properties — including a 500-case one — push it past six hours.

## Why it is shaped this way

Two obvious fixes do not work, and I checked both before writing this:

- **`PROPTEST_CASES` is ignored here.** Every one of these binaries calls `ProptestConfig::with_cases(N)`, which is `Config { cases: N, ..Config::default() }`. The literal overwrites the env-derived default. Setting it would look like a fix and change nothing.
- **Name filtering misses four properties** that are not `prop_*` prefixed: `try_reduce_predicts_reduce` (500 cases) and booking's three `interpolation_*` / `interpolated_*` properties.

So the target list is **derived from the sources**, not hardcoded:

```
skip  rustledger-core/property_tests, synthetic_generation, tla_proptest, try_reduce_equivalence
RUN   rustledger-core --lib --test decimal_overflow_test --test tla_behavior_replay --test tla_fifo_bug_test
skip  rustledger-booking/booking_properties, pipeline_invariants, tla_proptest
RUN   rustledger-booking --lib --test tla_behavior_replay
```

A new integration test is picked up automatically; a new proptest one is skipped automatically and named in the log. A hardcoded allowlist would mean a future test file silently never runs under Miri, which is the exact failure mode this job just spent eight weeks demonstrating.

## Coverage

Barely moves. Neither crate has a single `proptest!` in `src/`, so all **582** unit and non-proptest integration tests still run, including the paths where the transitive `unsafe` actually lives (imbl, smallvec, rust_decimal). Properties keep their full case counts in the normal test suite. Miri is here for the UB check, not the input exploration.

## Verification

Target derivation simulated against the real tree (output above), and all selected targets confirmed to build and pass natively. A `workflow_dispatch` run against this branch is in flight to confirm the real Miri runtime fits the new budget — I will not merge on the assumption that it does.
