### PR TITLE
fix(compat): report queried files, not eligible ones, and widen the budget

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -714,12 +714,25 @@ jobs:
           # --baseline makes this step EXIT NON-ZERO (fail the job) if any
           # (file, query) pair that matched on main now fails — i.e. a BQL
           # regression. This is what blocks a JOURNAL-style drop from merging.
+          # Nightly sweeps the WHOLE eligible corpus; PRs keep a budget.
+          # Same split as the fuzz workflow, for the same reason: the BQL step
+          # runs ~17 file×query pairs per second, so a full sweep costs about
+          # eleven minutes — free on a schedule, not free on every PR. A
+          # divergence that only a rarely-selected file exposes is then found
+          # within a day instead of never.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            MAX_FILES=100000   # effectively uncapped; the corpus is ~673
+          else
+            MAX_FILES=150
+          fi
+          echo "querying up to $MAX_FILES files (event: ${{ github.event_name }})"
           python3 scripts/compat-bql-test.py \
             --corpus tests/compatibility/bql-queries.toml \
             --files-from compat-check-results.jsonl \
             --rledger ./target/release/rledger \
             --output compat-bql-results.jsonl \
             --baseline .github/badges/previous-bql-results.jsonl \
+            --max-files "$MAX_FILES" \
             --github-output
       # `report budget` is arithmetic over generated data, so it is checked by
       # generation rather than by examples: the budgeted figure against a

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -59,8 +59,6 @@ DEFAULT_TEST_DIRS = [
 # fewer queries than this.
 MIN_CORPUS_SIZE = 15
 
-# Files we test against. 30 is enough breadth for representative coverage
-# without being slow; tune up if the corpus grows substantially.
 # Files queried per run, unless --max-files says otherwise.
 #
 # Raised from 30 after measuring the real cost: the BQL step ran 510 runs in

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -61,7 +61,15 @@ MIN_CORPUS_SIZE = 15
 
 # Files we test against. 30 is enough breadth for representative coverage
 # without being slow; tune up if the corpus grows substantially.
-MAX_FILES = 30
+# Files queried per run, unless --max-files says otherwise.
+#
+# Raised from 30 after measuring the real cost: the BQL step ran 510 runs in
+# about 30 seconds (~17 runs/sec), so the old cap was saving seconds while
+# exercising 4% of the eligible corpus. 150 costs roughly two minutes and
+# covers ~22%; the nightly passes a cap high enough to take everything (see
+# compat.yml), which is the same gate-on-PR / full-sweep-nightly split the
+# fuzz workflow uses.
+MAX_FILES = 150
 
 # A query that returns 0 rows on more than this fraction of files isn't
 # really being tested by the corpus — flag it loudly so we know to add
@@ -854,7 +862,16 @@ def main() -> int:
     # step downstream consumes those names.
     print()
     print(f"Corpus queries:      {len(queries)}")
-    print(f"Files tested:        {len(valid)}")
+    # `valid` is every file BOTH tools parse with postings; `selected_pairs` is
+    # what this run actually queried, capped by --max-files. Reporting the
+    # former as "Files tested" overstated coverage by 22x at the old default
+    # (673 eligible, 30 queried) — and it is the one number a reader quotes.
+    _covered = 100 * len(selected_pairs) / len(valid) if valid else 0.0
+    print(f"Corpus files eligible: {len(valid)}")
+    print(
+        f"Files queried:       {len(selected_pairs)} "
+        f"({_covered:.0f}% of eligible; --max-files={args.max_files})"
+    )
     print(f"Runs tested:         {total}  (file × query)")
     print(f"Runs matching:       {matching}")
     print(f"Known Python diffs:  {known_py}")


### PR DESCRIPTION
Phase 0 of #1902 — "confirm the compat pass rate is a real number."

It mostly is. The finding is narrower than I expected, and it's a label.

## The label

The suite printed **`Files tested: 673`**. That is the count of files *both tools parse with postings* — the **eligible** corpus. What it actually queried was capped by `--max-files`, defaulting to **30**.

```
eligible files : 673
files queried  :  30      ← MAX_FILES
coverage       : 4.5%
runs = 30 × 17 queries = 510   ← matches the reported "Runs tested"
```

A 22x overstatement, on the one number a reader quotes. Now reports both:

```
Corpus files eligible: 673
Files queried:       150 (22% of eligible; --max-files=150)
```

## What was already right

Worth saying, because it shaped how small this fix is. The metric was honestly *constructed*:

- raw `Runs matching: 475` is printed alongside `Effective match: 510/510 (100%)`, so masking is visible rather than buried
- the Rust-side masks are **3 surgically pinned `(file, query)` pairs** — not wildcards — each with rationale and a tracker (#1112)
- there is already a vacuity guard: `EMPTY_RESULT_WARNING_FRACTION = 0.5` warns when a query returns 0 rows on more than half the files

The design anticipated exactly the failure modes I went looking for. Only the label lagged the budget.

## The budget

It was buying almost nothing. From the last nightly, the BQL step ran 510 pairs in ~30 seconds — about **17/sec**. The cap saved seconds while skipping 96% of the corpus.

| max-files | runs | ~time | coverage |
|---:|---:|---:|---:|
| 30 (old) | 510 | 30s | 4% |
| **150 (new default)** | 2,550 | ~2.5 min | 22% |
| uncapped (nightly) | 11,441 | ~11 min | 100% |

Nightly now sweeps everything; PRs keep a budget. Same gate-on-PR / full-sweep-nightly split as the fuzz workflow (#1899), for the same reason: eleven minutes is free on a schedule and not free on every PR. A divergence only a rarely-selected file exposes is now found within a day instead of never.

## Verification

`--self-test` passes, but it only covers divergence detection, so I exercised the changed reporting block directly against the normal, uncapped, tiny-corpus and empty-corpus cases. The last would divide by zero without the guard.

## Known, not addressed here

`prices-from-plugin-by-date` returns 0 rows on >50% of files and the WARN has been firing unaddressed. Widening the corpus may fix it on its own — worth re-checking after this lands rather than guessing now.
