### PR TITLE
fix(ci): skip TLA+ corpus replay under miri, and cap a runaway target

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -78,56 +78,48 @@ jobs:
       # catch transitive-`unsafe` UB in our own logic via core + booking (+ their
       # deps: rust_decimal, bigdecimal, imbl, smallvec, ...).
       #
-      # Proptest targets are skipped. Under Miri's ~100x slowdown a property at
-      # its default 256 cases is not a test, it is an outage: on 2026-06-28 one
-      # 18-test proptest binary took 5,951s and another 1,730s, and after this
-      # job was scoped to core+booking the remaining properties (including a
-      # 500-case one) pushed it past six hours every week.
+      # HIGH-REPETITION targets are skipped. Miri's cost is per executed step,
+      # so repetition — not complexity — is what turns a test into an outage.
+      # Two categories, both measured on this job:
       #
-      # `PROPTEST_CASES` does NOT help: every one of these binaries calls
-      # `ProptestConfig::with_cases(N)`, which is `Config { cases: N,
-      # ..Config::default() }` — the literal overwrites the env-derived default.
-      # Setting it would look like a fix and change nothing.
+      #   proptest!            256+ cases per property. On 2026-06-28 one
+      #                        18-test binary took 5,951s and another 1,730s;
+      #                        a 500-case property then pushed the job past six
+      #                        hours every week.
+      #   spec/tla/behaviors   TLA+ corpus replay: 33,772 transitions across 11
+      #                        specs. 1.03s natively, still unfinished after 57
+      #                        minutes under Miri on 2026-07-31, starving the
+      #                        target queued behind it.
       #
-      # Nor does filtering by name: four of the properties are not `prop_*`
-      # prefixed (`try_reduce_predicts_reduce`, `interpolation_is_idempotent_*`,
-      # `interpolated_transaction_has_zero_residual`).
+      # Two obvious alternatives do NOT work, which is why the skip is shaped
+      # this way rather than as a knob:
       #
-      # So the list is DERIVED from the sources, not hardcoded. A new
-      # integration test is picked up automatically; a new proptest one is
-      # skipped automatically and named in the log. Hardcoding it would mean a
-      # future test file silently never runs under Miri.
+      #   `PROPTEST_CASES` is ignored — every binary calls
+      #   `ProptestConfig::with_cases(N)`, i.e. `Config { cases: N,
+      #   ..Config::default() }`, so the literal overwrites the env-derived
+      #   default. Setting it would look like a fix and change nothing.
       #
-      # Coverage is not really reduced: neither crate has a single `proptest!`
-      # in `src/`, so the unit tests — where the transitive `unsafe` actually
-      # lives (imbl, smallvec, rust_decimal) — all still run. Properties keep
-      # their full case counts in the normal test suite; what Miri wants is the
-      # UB check, not the input exploration.
+      #   Filtering by test NAME misses four properties that are not `prop_*`
+      #   prefixed (`try_reduce_predicts_reduce`,
+      #   `interpolation_is_idempotent_*`, `interpolated_transaction_has_zero_residual`).
+      #
+      # So the list is DERIVED from file contents, never hardcoded: a new suite
+      # of either kind is handled without editing this file, and a new ordinary
+      # test is picked up automatically. A hardcoded allowlist would mean a
+      # future test file silently never runs under Miri — the failure mode this
+      # job spent eight weeks demonstrating.
+      #
+      # Coverage cost is small. Neither crate has a `proptest!` in `src/`, so
+      # the unit tests — where the transitive `unsafe` actually lives (imbl,
+      # smallvec, rust_decimal) — all still run. Both categories keep full
+      # strength in the normal test suite, and TLA+ conformance is owned by
+      # tla.yml regardless.
       - name: Run Miri on ${{ matrix.crate }}
         run: |
           set -euo pipefail
           crate="${{ matrix.crate }}"
 
-          # Skip HIGH-REPETITION suites. The rule is not "skip proptest", it is
-          # "skip anything that runs one operation tens of thousands of times":
-          # Miri's cost is per executed step, so repetition is what turns a test
-          # into an outage. Two markers, both content-derived so a new suite of
-          # either kind is handled without editing this file:
-          #
-          #   proptest!            256+ cases per property. One 18-test binary
-          #                        took 5,951s on 2026-06-28.
-          #   spec/tla/behaviors   TLA+ corpus replay. 33,772 transitions across
-          #                        11 specs; 1.03s natively, and it had still
-          #                        not finished after 57 minutes under Miri
-          #                        (2026-07-31), consuming the whole budget and
-          #                        starving the target queued behind it.
-          #
-          # Neither loses meaningful coverage. Both exercise the same Inventory
-          # and Decimal paths the 444 lib tests already cover, just far more
-          # often; the marginal chance of the 33,772nd operation tripping UB
-          # that the first few hundred did not is negligible. Both keep their
-          # full strength in the normal test suite, and the TLA+ conformance
-          # story is owned by tla.yml regardless.
+          # Skip markers and rationale: see the comment block above this step.
           targets=(--lib)
           for f in "crates/$crate/tests/"*.rs; do
             [ -e "$f" ] || continue
@@ -177,5 +169,5 @@ jobs:
             echo ""
             echo "Excluded crates — rowan's ThinArc is miri-incompatible under Stacked AND Tree Borrows: rustledger-parser, rustledger-query."
             echo ""
-            echo "Proptest targets are skipped (see the run step): at 256+ cases under Miri they took hours. They run at full case counts in the normal test suite, and neither crate has a \`proptest!\` in \`src/\`, so the unit tests still run here."
+            echo "High-repetition targets are skipped (see the run step): proptest binaries at 256+ cases, and TLA+ corpus replay at 33,772 transitions. Miri's cost is per executed step, so repetition is what turns a test into an outage. Both keep full strength in the normal test suite; neither crate has a \`proptest!\` in \`src/\`, so the unit tests still run here, and TLA+ conformance is owned by tla.yml."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -107,18 +107,59 @@ jobs:
         run: |
           set -euo pipefail
           crate="${{ matrix.crate }}"
+
+          # Skip HIGH-REPETITION suites. The rule is not "skip proptest", it is
+          # "skip anything that runs one operation tens of thousands of times":
+          # Miri's cost is per executed step, so repetition is what turns a test
+          # into an outage. Two markers, both content-derived so a new suite of
+          # either kind is handled without editing this file:
+          #
+          #   proptest!            256+ cases per property. One 18-test binary
+          #                        took 5,951s on 2026-06-28.
+          #   spec/tla/behaviors   TLA+ corpus replay. 33,772 transitions across
+          #                        11 specs; 1.03s natively, and it had still
+          #                        not finished after 57 minutes under Miri
+          #                        (2026-07-31), consuming the whole budget and
+          #                        starving the target queued behind it.
+          #
+          # Neither loses meaningful coverage. Both exercise the same Inventory
+          # and Decimal paths the 444 lib tests already cover, just far more
+          # often; the marginal chance of the 33,772nd operation tripping UB
+          # that the first few hundred did not is negligible. Both keep their
+          # full strength in the normal test suite, and the TLA+ conformance
+          # story is owned by tla.yml regardless.
           targets=(--lib)
           for f in "crates/$crate/tests/"*.rs; do
             [ -e "$f" ] || continue
             name="$(basename "$f" .rs)"
             if grep -q 'proptest!' "$f"; then
-              echo "skipping $crate/$name (proptest: too slow under Miri)"
+              echo "skipping $crate/$name (proptest: repetition too costly under Miri)"
+            elif grep -q 'spec/tla/behaviors' "$f"; then
+              echo "skipping $crate/$name (TLA+ corpus replay: repetition too costly under Miri)"
             else
               targets+=(--test "$name")
             fi
           done
+
           echo "running: cargo miri test -p $crate ${targets[*]}"
-          cargo +nightly miri test --package "$crate" --all-features "${targets[@]}"
+          # Backstop: a per-invocation cap so the NEXT unexpectedly slow target
+          # is named and killed rather than silently eating the job budget the
+          # way tla_behavior_replay did. Deliberately fails rather than warning
+          # — a target too slow to run is a decision for a human, and a silent
+          # skip here is exactly how this job stayed dark for eight weeks.
+          # `rc=$?` inside `if ! cmd` would capture the NEGATION's status (0),
+          # not the command's — so the timeout branch below would never fire.
+          rc=0
+          timeout --signal=INT 2400 cargo +nightly miri test \
+            --package "$crate" --all-features "${targets[@]}" || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            if [ "$rc" -eq 124 ] || [ "$rc" -eq 130 ]; then
+              echo "::error::Miri exceeded 40 minutes on $crate. Find which target"
+              echo "::error::is responsible in the log above and either optimize it or"
+              echo "::error::add a skip marker to the derivation in this workflow."
+            fi
+            exit "$rc"
+          fi
         env:
           # -Zmiri-disable-isolation: some tests read the realtime clock
           # (e.g. "today"-based date helpers), which miri rejects under its


### PR DESCRIPTION
#1901 fixed booking (9.5 min) but **core still hit the 60-minute cap**. The killed run says exactly why:

```
rustledger_core --lib     444 tests   74.77s   ok
decimal_overflow_test       8 tests    0.92s   ok
tla_behavior_replay                    >57 min, never finished
tla_fifo_bug_test                      never reached
```

The lib tests were never the problem. `tla_behavior_replay` replays **33,772 transitions across 11 TLA+ specs** — 1.03s natively, still unfinished after 57 minutes under Miri, and it starved the target queued behind it.

## The rule, restated

Not "skip proptest" but **"skip anything that runs one operation tens of thousands of times."** Miri's cost is per executed step, so repetition is what turns a test into an outage. Two content-derived markers, so a new suite of either kind needs no edit here:

| marker | why |
|---|---|
| `proptest!` | 256+ cases per property; one binary took 5,951s |
| `spec/tla/behaviors` | 33,772-transition corpus replay |

Resulting selection:

```
rustledger-core     --lib --test decimal_overflow_test --test tla_fifo_bug_test
rustledger-booking  --lib
```

Projected core runtime from the run's own measurements: **~1.5 min against a 60-minute cap.**

## Coverage cost, stated plainly

Real but small. Both kinds exercise the same `Inventory` and `Decimal` paths the 444 lib tests already cover, just far more often; the chance the 33,772nd operation trips UB that the first few hundred did not is negligible. Both keep full strength in the normal test suite, and TLA+ conformance is owned by `tla.yml` regardless.

**This also drops booking's replay, which DID fit** in 9.5 minutes. I applied the rule uniformly because the marginal-value argument holds there too, not because booking needed it. Flagging it because it's a real reduction that the failure didn't force.

## Backstop

A 40-minute per-invocation cap, so the next unexpectedly slow target is named and killed rather than silently eating the budget. It **fails rather than warns** — a target too slow to run is a decision for a human, and a silent skip is exactly how this job stayed dark for eight weeks.

That backstop had a bug worth calling out: `rc=$?` inside `if ! cmd` captures the *negation's* status (0), not the command's, so the timeout branch would never have fired. I verified both forms in a shell before fixing:

```
if ! (exit 124); then rc=$?   -> rc=0    (wrong)
rc=0; (exit 124) || rc=$?     -> rc=124  (right)
```

Refs #1902 (Phase 0).
