### PR TITLE
feat(compat): compare booked values against beancount, not just shapes

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -721,6 +721,11 @@ jobs:
       - name: Compare booked values against beancount
         continue-on-error: true
         run: |
+          # `pipefail` because the pipe into `tee` would otherwise mask the
+          # script's exit status: a crashed comparison would leave an empty
+          # compat-values.txt and a green step, which is exactly the
+          # vacuous-pass shape this comparison exists to catch.
+          set -o pipefail
           python3 scripts/compat-values.py \
             --rledger ./target/release/rledger \
             --corpus tests/compatibility/files tests/regressions \

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -707,6 +707,32 @@ jobs:
           # the fixtures fail to fetch. The live stale-mask gate runs inside the
           # main BQL step.
           python3 scripts/compat-bql-test.py --self-test
+      # Compare booked VALUES, not just shapes. The comprehensive test above
+      # compares `check_match`, `accounts_match`, `posting_count_match` and
+      # `error_presence_match` — how MANY postings there are and WHETHER there
+      # was an error. It never compares an amount, so a booking or
+      # interpolation bug that yields the right number of postings with the
+      # wrong numbers in them passes it silently. For an accounting tool that
+      # is the failure that matters most.
+      #
+      # Advisory, not gating: the first run surfaced two genuine divergences
+      # (#1909) and they need triage before this can block a merge. Flip
+      # `continue-on-error` off once the known set is at zero.
+      - name: Compare booked values against beancount
+        continue-on-error: true
+        run: |
+          python3 scripts/compat-values.py \
+            --rledger ./target/release/rledger \
+            --corpus tests/compatibility/files tests/regressions \
+            | tee compat-values.txt
+          {
+            echo "## Booked-value comparison"
+            echo ""
+            echo '```'
+            head -40 compat-values.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Run BQL compatibility test
         id: bql_compat
         run: |

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Compare BOOKED VALUES against Python beancount, not just shapes.
+
+The existing comprehensive compat test compares `check_match`,
+`accounts_match`, `posting_count_match` and `error_presence_match` — whether
+the two tools agree on how MANY postings there are and WHETHER there was an
+error. It never compares an amount. A booking or interpolation bug that
+produces the right number of postings with the wrong numbers in them passes
+silently, which for an accounting tool is the failure that matters most.
+
+This compares the sum of booked units per (account, currency) over a whole
+file. That is sensitive to interpolation (an elided amount filled wrongly),
+booking (a reduction matched against the wrong lot), and sign handling, while
+being insensitive to directive ORDER and to display scale — which is a known,
+documented divergence and not what this is hunting.
+"""
+from __future__ import annotations
+
+import argparse, csv, io, subprocess, sys
+from collections import defaultdict
+from decimal import Decimal
+from pathlib import Path
+
+QUERY = ("SELECT account, currency, sum(number) AS n "
+         "GROUP BY account, currency ORDER BY account, currency")
+
+
+def beancount_totals(path: Path):
+    """(account, currency) -> summed units, per Python beancount."""
+    from beancount import loader
+    entries, errors, _ = loader.load_file(str(path))
+    if errors:
+        return None
+    from beancount.core import data
+    totals = defaultdict(Decimal)
+    for e in entries:
+        if not isinstance(e, data.Transaction):
+            continue
+        for p in e.postings:
+            if p.units is None or p.units.number is None:
+                return None          # unbooked; nothing meaningful to compare
+            totals[(p.account, p.units.currency)] += p.units.number
+    return dict(totals)
+
+
+def rledger_totals(binary: str, path: Path):
+    proc = subprocess.run(
+        [binary, "query", "--format", "csv", str(path), QUERY],
+        capture_output=True, text=True, timeout=120,
+    )
+    if proc.returncode != 0:
+        return None
+    totals = {}
+    for row in csv.DictReader(io.StringIO(proc.stdout)):
+        acct, cur, n = row.get("account"), row.get("currency"), row.get("n")
+        if not acct or not cur or n in (None, ""):
+            continue
+        try:
+            totals[(acct, cur)] = Decimal(n)
+        except Exception:
+            return None
+    return totals
+
+
+def compare(a: dict, b: dict):
+    """Numeric comparison. Display SCALE differences are a documented, separate
+    divergence (#1112), so `-1966.700` and `-1966.70` must not be reported."""
+    diffs = []
+    for key in sorted(set(a) | set(b), key=lambda k: (k[0], k[1])):
+        x, y = a.get(key), b.get(key)
+        if x is None or y is None:
+            # A zero-sum bucket may legitimately be absent on one side.
+            other = y if x is None else x
+            if other != 0:
+                diffs.append((key, x, y))
+        elif x != y:
+            diffs.append((key, x, y))
+    return diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rledger", default="./target/release/rledger")
+    ap.add_argument("--corpus", nargs="+", required=True)
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    files = sorted(p for d in args.corpus for p in Path(d).rglob("*.beancount"))
+    if args.limit:
+        files = files[: args.limit]
+
+    compared = skipped = 0
+    divergent = []
+    for path in files:
+        try:
+            bc = beancount_totals(path)
+        except Exception:
+            bc = None
+        if bc is None:
+            skipped += 1
+            continue
+        rl = rledger_totals(args.rledger, path)
+        if rl is None:
+            skipped += 1
+            continue
+        compared += 1
+        diffs = compare(bc, rl)
+        if diffs:
+            divergent.append((path, diffs))
+
+    print(f"compared {compared} files, skipped {skipped} "
+          f"(errors in either tool, or unbooked postings)")
+    print(f"files with a VALUE divergence: {len(divergent)}\n")
+    for path, diffs in divergent[:25]:
+        print(f"  {path}")
+        for (acct, cur), x, y in diffs[:6]:
+            print(f"      {acct} {cur}:  beancount={x}  rledger={y}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -25,11 +25,23 @@ QUERY = ("SELECT account, currency, sum(number) AS n "
          "GROUP BY account, currency ORDER BY account, currency")
 
 
+# Error classes that do NOT stop beancount booking the transactions it parsed.
+# A file missing an `open` directive still books its postings correctly, and its
+# amounts are just as comparable as a clean file's. Anything lexer/parser/load
+# shaped is different: the entry stream is then incomplete, and comparing it
+# would be comparing two different ledgers rather than two readings of one.
+#
+# This distinction is what the comparison lives or dies by. Skipping every file
+# with any error at all left 499 of 758 unexamined, and 302 of those are fully
+# booked — more files than were being compared.
+NON_FATAL_ERRORS = {"ValidationError", "BalanceError", "DocumentError", "PadError"}
+
+
 def beancount_totals(path: Path):
     """(account, currency) -> summed units, per Python beancount."""
     from beancount import loader
     entries, errors, _ = loader.load_file(str(path))
-    if errors:
+    if errors and not {type(e).__name__ for e in errors} <= NON_FATAL_ERRORS:
         return None
     from beancount.core import data
     totals = defaultdict(Decimal)
@@ -49,6 +61,12 @@ def rledger_totals(binary: str, path: Path):
         capture_output=True, text=True, timeout=120,
     )
     if proc.returncode != 0:
+        return None
+    # `query` exits 0 even when the file failed to PARSE, emitting data from
+    # the partial parse (#1908). Until that is fixed, treat a parse complaint
+    # on stderr as "not comparable" — otherwise this compares beancount's
+    # ledger against a truncated one and reports the difference as a value bug.
+    if "parse errors" in proc.stderr:
         return None
     totals = {}
     for row in csv.DictReader(io.StringIO(proc.stdout)):

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -56,10 +56,16 @@ def beancount_totals(path: Path):
 
 
 def rledger_totals(binary: str, path: Path):
-    proc = subprocess.run(
-        [binary, "query", "--format", "csv", str(path), QUERY],
-        capture_output=True, text=True, timeout=120,
-    )
+    try:
+        proc = subprocess.run(
+            [binary, "query", "--format", "csv", str(path), QUERY],
+            capture_output=True, text=True, timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        # One pathological file must not abort the sweep. Counting it as
+        # not-comparable keeps the other 700-odd results, which is the whole
+        # value of a corpus run.
+        return None
     if proc.returncode != 0:
         return None
     # `query` exits 0 even when the file failed to PARSE, emitting data from


### PR DESCRIPTION
Item 1 of the bug-hunt plan. It found real bugs on the first run.

## The gap

The comprehensive compat test compares:

```
check_match           did check pass/fail agree
accounts_match        same set of account names
posting_count_match   same NUMBER of postings
error_presence_match  did either report any error
```

**No amount is ever compared.** A booking or interpolation bug that produces the right number of postings with the wrong numbers in them passes silently — for an accounting tool, the failure that matters most.

## What this adds

Sums booked units per `(account, currency)` per file and compares against Python beancount. Sensitive to interpolation, booking and sign handling; insensitive to directive order and to display scale, since scale is a separate documented divergence (#1112) and not what this is hunting — so the comparison is numeric, not textual.

## First run: 259 files compared, 4 divergences, all real

**#1908 — `query` and `report` exit 0 on a file that failed to parse**, emitting data from the partial parse. `check` correctly exits non-zero on the same file, so the two commands disagree about whether a file is usable. Any automation piping `query --format csv` gets plausible-looking wrong numbers with a success status.

Surfaced because a unicode account name beancount accepts (`Assets:CORP✨`) is truncated to `Assets:CORP` and still reaches a result set — where it would collide with a real `Assets:CORP`.

**#1909 — interpolated postings book the exact residual where beancount quantizes.**

| file | beancount | rledger |
|---|---|---|
| fidelity, 2012-08-01 | `0.00 USD` | `0.000000000005 USD` |
| vanguard, 2013-09-05 | `-0.00 USD` | `-0.0003183 USD` |

Both transactions balance in both tools. The damage is downstream: capital-gains accounts carry sub-cent noise, and a file total reads `0.030000000005` instead of `0.03`. Both corpus instances share this one root cause.

## Advisory, not gating

`continue-on-error: true` until the known set is triaged to zero. Flip it off then. Shipping it as a gate today would just mean a permanently red job, which is how the miri situation started.

## Verification

Two things checked before trusting any of it:

- **Sabotage-tested** with a deliberate `0.01` perturbation on the beancount side, to confirm the harness can report a divergence at all.
- **Caught a near-vacuous first run** — it compared 36 files and reported clean. The corpus is CI-fetched, so a fresh worktree holds 21 files rather than 732. The real run is 259 comparable files out of 758.

## Reproducing locally

```
uv run --with beancount python3 scripts/compat-values.py \
  --corpus tests/compatibility/files tests/regressions
```
