### PR TITLE
fix(cli): refuse to report on a file that failed to parse

### DIFF
--- a/crates/rustledger/src/cmd/loadcache.rs
+++ b/crates/rustledger/src/cmd/loadcache.rs
@@ -115,3 +115,52 @@ pub fn load_result_cached(
 
     Ok((result, false))
 }
+
+/// Refuse to report numbers derived from a file that failed to PARSE.
+///
+/// # Deliberate deviation from Python beancount
+///
+/// bean-query does NOT do this. Given a file with a lexer error it prints the
+/// rows it could recover and exits 0, and beancount's loader likewise returns
+/// the transactions it managed to parse. rledger matched that faithfully until
+/// #1908.
+///
+/// We deviate because the output is not merely incomplete, it is *plausible*:
+/// a truncated ledger yields numbers that look like an answer, with a success
+/// status, on stdout that another program is probably consuming. For a tool
+/// whose entire job is producing figures people rely on, confidently wrong is
+/// worse than loudly broken. `rledger check` already refuses the same file, so
+/// tolerating it here also made the CLI contradict itself: one command calls a
+/// file unusable while another reports on it and claims success.
+///
+/// Scoped deliberately to PARSE errors. Validation errors — an account never
+/// opened, a failed balance assertion — leave the entry stream complete and
+/// the arithmetic sound, so those still report exactly as beancount does. That
+/// is the common messy-ledger case and breaking it would be a real
+/// compatibility loss for no safety gain.
+///
+/// Deliberately NOT registered under `KNOWN_RUST_DIVERGENCES`: the BQL compat
+/// suite's `load_valid_files` already requires `python_ok AND rust_ok`, so a
+/// file neither tool can parse never reaches that comparison. Adding an entry
+/// would imply a divergence the metric can never observe.
+///
+/// # Errors
+///
+/// Returns an error naming the file when the load reported any
+/// [`rustledger_loader::LoadError::ParseErrors`].
+pub fn bail_on_parse_errors(raw: &rustledger_loader::LoadResult, file: &Path) -> Result<()> {
+    let parse_failures = raw
+        .errors
+        .iter()
+        .filter(|e| matches!(e, rustledger_loader::LoadError::ParseErrors { .. }))
+        .count();
+    if parse_failures > 0 {
+        anyhow::bail!(
+            "{}: {parse_failures} parse error(s); refusing to report on a file that \
+             did not parse. Run `rledger check {}` to see them.",
+            file.display(),
+            file.display(),
+        );
+    }
+    Ok(())
+}

--- a/crates/rustledger/src/cmd/loadcache.rs
+++ b/crates/rustledger/src/cmd/loadcache.rs
@@ -149,11 +149,18 @@ pub fn load_result_cached(
 /// Returns an error naming the file when the load reported any
 /// [`rustledger_loader::LoadError::ParseErrors`].
 pub fn bail_on_parse_errors(raw: &rustledger_loader::LoadResult, file: &Path) -> Result<()> {
-    let parse_failures = raw
+    // Sum the INNER errors, not the number of `ParseErrors` groups. There is
+    // one group per file, so counting groups would report "1 parse error" for
+    // a file with twenty, and for a tree of includes would count files rather
+    // than problems.
+    let parse_failures: usize = raw
         .errors
         .iter()
-        .filter(|e| matches!(e, rustledger_loader::LoadError::ParseErrors { .. }))
-        .count();
+        .filter_map(|e| match e {
+            rustledger_loader::LoadError::ParseErrors { errors, .. } => Some(errors.len()),
+            _ => None,
+        })
+        .sum();
     if parse_failures > 0 {
         anyhow::bail!(
             "{}: {parse_failures} parse error(s); refusing to report on a file that \

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -168,6 +168,8 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     // `BEANCOUNT_DISABLE_LOAD_CACHE`.
     let (raw, _from_cache) =
         crate::cmd::loadcache::load_result_cached(file, args.no_cache, args.verbose)?;
+    // Deliberate deviation from bean-query (#1908) — see `bail_on_parse_errors`.
+    crate::cmd::loadcache::bail_on_parse_errors(&raw, file)?;
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;
 

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -497,6 +497,8 @@ fn load(
     // stream; `process` books it exactly as the uncached `load` did.
     // Disable with `--no-cache` or `BEANCOUNT_DISABLE_LOAD_CACHE`.
     let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, no_cache, verbose)?;
+    // Deliberate deviation from bean-query (#1908) — see `bail_on_parse_errors`.
+    crate::cmd::loadcache::bail_on_parse_errors(&raw, file)?;
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;
 

--- a/crates/rustledger/tests/parse_error_refusal_test.rs
+++ b/crates/rustledger/tests/parse_error_refusal_test.rs
@@ -89,6 +89,25 @@ fn validation_errors_still_report_as_beancount_does() {
         "2020-01-02 * \"x\"\n  Assets:A  5 USD\n  Assets:A -5 USD\n",
     );
 
+    // Precondition: the fixture must ACTUALLY fail validation, or this test
+    // passes while pinning nothing. `check` refuses it; `query` must not.
+    let checked = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
+        .args(["check", &path])
+        .output()
+        .expect("run check");
+    assert!(
+        !checked.status.success(),
+        "fixture must fail validation for this test to mean anything"
+    );
+    assert!(
+        !String::from_utf8_lossy(&checked.stdout).contains("parse error")
+            && !String::from_utf8_lossy(&checked.stderr).contains("parse error"),
+        "...and must fail on VALIDATION, not parsing, or it is testing the \
+         other branch: {}{}",
+        String::from_utf8_lossy(&checked.stdout),
+        String::from_utf8_lossy(&checked.stderr)
+    );
+
     let out = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
         .args(["query", "--format", "csv", &path, QUERY])
         .output()

--- a/crates/rustledger/tests/parse_error_refusal_test.rs
+++ b/crates/rustledger/tests/parse_error_refusal_test.rs
@@ -1,0 +1,107 @@
+//! `query` and `report` must not report numbers from a file that failed to parse.
+//!
+//! A deliberate deviation from bean-query (#1908), which prints what it
+//! recovered and exits 0. The output there is not merely incomplete, it is
+//! *plausible* — a truncated ledger yields figures that look like an answer,
+//! with a success status, on stdout another program is probably consuming.
+//!
+//! The deviation is scoped to PARSE errors. Validation errors leave the entry
+//! stream complete and the arithmetic sound, so those must keep reporting
+//! exactly as beancount does; a test for that is below, because narrowing the
+//! deviation is the whole reason it is acceptable.
+
+use std::process::Command;
+
+mod common;
+
+fn write(name: &str, body: &str) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, body).expect("write");
+    let p = path.to_str().expect("utf8").to_owned();
+    (dir, p)
+}
+
+const QUERY: &str = "SELECT account, sum(number) AS n GROUP BY account";
+
+#[test]
+fn query_refuses_a_file_that_failed_to_parse() {
+    let bin = require_rledger!();
+    let (_d, path) = write(
+        "broken.beancount",
+        "2020-01-01 open Assets:A\n\
+         this is not valid beancount at all !!!\n\
+         2020-01-02 * \"x\"\n  Assets:A  5 USD\n  Assets:A -5 USD\n",
+    );
+
+    let out = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
+        .args(["query", "--format", "csv", &path, QUERY])
+        .output()
+        .expect("run");
+
+    assert!(
+        !out.status.success(),
+        "must not report success on a file that did not parse"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "must emit NO rows; bean-query prints `Assets:A 0` here, which is the \
+         plausible-but-wrong output this exists to prevent: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("parse error"),
+        "the refusal must say why: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn report_refuses_a_file_that_failed_to_parse() {
+    let bin = require_rledger!();
+    let (_d, path) = write(
+        "broken.beancount",
+        "2020-01-01 open Assets:A\nnot valid !!!\n",
+    );
+
+    let out = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
+        .args(["report", &path, "balances"])
+        .output()
+        .expect("run");
+
+    assert!(
+        !out.status.success(),
+        "report must refuse too, not just query"
+    );
+}
+
+/// The other half of the contract, and the reason the deviation is narrow
+/// enough to be acceptable: a ledger that PARSES but fails validation still
+/// reports, exactly as beancount does. Real ledgers are full of accounts
+/// missing an `open`, and refusing those would be a genuine compatibility
+/// loss for no safety gain — the entry stream is complete and the arithmetic
+/// is sound.
+#[test]
+fn validation_errors_still_report_as_beancount_does() {
+    let bin = require_rledger!();
+    let (_d, path) = write(
+        "unopened.beancount",
+        "2020-01-02 * \"x\"\n  Assets:A  5 USD\n  Assets:A -5 USD\n",
+    );
+
+    let out = Command::new(AsRef::<std::path::Path>::as_ref(&bin))
+        .args(["query", "--format", "csv", &path, QUERY])
+        .output()
+        .expect("run");
+
+    assert!(
+        out.status.success(),
+        "a parseable file with validation errors must still report: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("Assets:A"),
+        "and must emit its rows: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
Closes #1908.

`query` and `report` exited 0 on a file with parse errors and printed numbers derived from the partial parse. `check` refused the same file, so the CLI contradicted itself — one command called a file unusable while another reported on it and claimed success.

## This is a deliberate deviation, and I verified that before changing it

bean-query does exactly what rledger did:

```console
$ bean-query broken.beancount "SELECT account, sum(number) AS n GROUP BY account" ; echo "exit=$?"
account   n
--------  -
Assets:A  0
exit=0
```

Byte-identical output and exit code. beancount's loader likewise returns the transaction it managed to parse past a `LexerError`. The rledger code said so explicitly:

```rust
// Report errors to stderr (matching bean-query behavior)
// Continue with successfully parsed directives rather than bailing
```

So this was **not a bug** — it was faithful compatibility. I filed #1908 as a plain bug, corrected the record there once I checked, and asked before deviating.

We deviate because the output is not merely incomplete, it is **plausible**. `Assets:A 0` looks like an answer, carries a success status, and lands on stdout that another program is probably consuming. For a tool whose whole job is producing figures people rely on, confidently wrong is worse than loudly broken. `CLAUDE.md`'s compatibility policy has a bucket for exactly this.

## Scoped narrowly, on purpose

| file | before | after |
|---|---|---|
| parse error | exit 0, prints `Assets:A 0` | **exit 1, no output**, stderr says why |
| validation error only (unopened account) | exit 0, prints rows | **unchanged** |

Validation errors leave the entry stream complete and the arithmetic sound. Real ledgers are full of accounts missing an `open`, and refusing those would be a genuine compatibility loss for no safety gain. There is a test pinning that half of the contract, because narrowing the deviation is what makes it acceptable.

## CLAUDE.md deviation checklist

- Inline comment naming the deviation — on `bail_on_parse_errors` and both call sites
- Regression tests pinning the stricter behaviour — 3, all verified to fail without the guard
- `KNOWN_RUST_DIVERGENCES` entry — **deliberately not added.** The BQL suite's `load_valid_files` already requires `python_ok AND rust_ok`, so a file neither tool parses never reaches that comparison. An entry would imply a divergence the metric cannot observe. My first draft of the doc comment claimed it *was* registered; that was wrong and is fixed.

Single shared helper rather than duplicated logic at the two call sites.

## Provenance

Found by comparing booked **values** against beancount (#1910) — invisible to the shape-only comparison, which only checks posting *counts*.

4403 tests · clippy clean at 1.97.0 · `cargo doc -D warnings` clean · fmt clean.
