### PR TITLE
fix(compat): compare balances as money, not as raw Decimals

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -715,9 +715,9 @@ jobs:
       # wrong numbers in them passes it silently. For an accounting tool that
       # is the failure that matters most.
       #
-      # Advisory, not gating: the first run surfaced two genuine divergences
-      # (#1909) and they need triage before this can block a merge. Flip
-      # `continue-on-error` off once the known set is at zero.
+      # Advisory, not gating. One known divergence remains once #1913 lands:
+      # issue-520.beancount, a tracked regression fixture. Flip
+      # `continue-on-error` off once that set is at zero.
       - name: Compare booked values against beancount
         continue-on-error: true
         run: |

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import argparse, csv, io, subprocess, sys
 from collections import defaultdict
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 QUERY = ("SELECT account, currency, sum(number) AS n "
@@ -87,8 +87,29 @@ def rledger_totals(binary: str, path: Path):
 
 
 def compare(a: dict, b: dict):
-    """Numeric comparison. Display SCALE differences are a documented, separate
-    divergence (#1112), so `-1966.700` and `-1966.70` must not be reported."""
+    """Do the two ledgers agree AS MONEY?
+
+    Compared at the precision beancount used, not on raw Decimals. The two
+    tools legitimately carry different precision for the same balance, because
+    they quantize at different layers: beancount rounds when it books, rledger
+    books what the arithmetic implies and rounds when it displays. Neither is
+    wrong — see #1909, closed after this comparison reported two false
+    divergences by asking the wrong question.
+
+    Concretely, `0.035 SPY @ 137.142857143 USD` against an explicit `4.80`
+    leaves 5e-12. beancount books `0.00`, losing it; rledger books
+    `0.000000000005`, keeping the postings summing to exactly zero and
+    rendering `0.03` on every surface that knows the currency. A raw Decimal
+    comparison calls that a value bug. It is a representation difference.
+
+    So each side is quantized to beancount's own exponent before comparing:
+    beancount has already rounded to the currency's precision at booking, so
+    its exponent IS the precision at which these figures are money.
+
+    The cost, stated plainly: a genuine divergence smaller than one display
+    unit is invisible here. That is the deliberate trade — it is also, by
+    definition, a difference no user could observe in a balance.
+    """
     diffs = []
     for key in sorted(set(a) | set(b), key=lambda k: (k[0], k[1])):
         x, y = a.get(key), b.get(key)
@@ -97,7 +118,15 @@ def compare(a: dict, b: dict):
             other = y if x is None else x
             if other != 0:
                 diffs.append((key, x, y))
-        elif x != y:
+            continue
+        try:
+            y_at_bc_precision = y.quantize(x)
+        except (InvalidOperation, ValueError):
+            # Cannot express rledger's value at beancount's precision at all
+            # (wildly different magnitude) — that is a real disagreement.
+            diffs.append((key, x, y))
+            continue
+        if x != y_at_bc_precision:
             diffs.append((key, x, y))
     return diffs
 


### PR DESCRIPTION
Re-lands the correction from #1910. That PR auto-merged at 15:18 yesterday with head `8b2342e82`; I pushed this commit afterwards, so it was stranded on the branch and never reached main. Same content, plus a comment correction.

## What

The value oracle compared raw `Decimal`s, which is the one question guaranteed to expose a *representation* difference rather than a value disagreement. Each side is now quantized to beancount's own exponent before comparing.

The two tools legitimately carry different precision for the same balance because they quantize at different layers: **beancount rounds when it books; rledger books what the arithmetic implies and rounds when it displays.**

`0.035 SPY @ 137.142857143 USD` against an explicit `4.80` leaves 5e-12. beancount books `0.00` and loses it. rledger books `0.000000000005`, keeps the postings summing to exactly zero, and renders `0.03` on every surface that knows the currency. Only `sum(number)` — a deliberately currency-less projection, which is what this harness asks for — shows the residue, and there the exact sum is the correct answer.

That is why #1909 was closed as working-as-intended: rledger preserving the value is the better behavior, since beancount silently discards a tenth of a cent someone deliberately typed.

Quantizing to beancount's exponent is principled rather than a fudge: beancount has already rounded to the currency's precision at booking, so **its exponent is the precision at which these figures are money.**

## Stated cost

A genuine divergence smaller than one display unit is now invisible. That is the deliberate trade, and it is written into the docstring — it is also, by definition, a difference no user could observe in a balance.

## Verification

The harness was shown able to report dirty, not just clean:

| case | reported |
|---|---|
| #1909 repr: `0.03` vs `0.030000000005` | silent |
| #1909 repr: `0.00` vs `-0.0003183` | silent |
| one cent wrong | **reported** |
| sign flip | **reported** |
| missing posting | **reported** |
| magnitude blowup | **reported** |

Corpus, with #1913 also applied: **4 divergences to 1**, the survivor being `issue-520.beancount`, a tracked regression fixture.

## Also

The workflow comment listed #1911 as a known divergence. #1913 fixes it, so the comment now names only `issue-520`.
