### PR TITLE
fix(validate): apply the E3002 rule per currency group, not to the total

### DIFF
--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -62,7 +62,9 @@ pub enum InterpolationError {
 
     /// A posting's units number is missing and cannot be recovered from the
     /// balance, because the posting's weight does not vary with that number
-    /// (#1911). See [`UnitsWeight::Undetermined`] for the cases.
+    /// (#1911). The cases are enumerated on the private `UnitsWeight` classifier
+    /// in this module: a total cost or price, a zero factor, an empty `{}` spec,
+    /// a compound cost, and a cost with no units currency to write into.
     ///
     /// Reported rather than left unfilled: `validate_transaction_balance` skips
     /// a transaction that still has an unfilled posting, so staying silent here

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -60,6 +60,21 @@ pub enum InterpolationError {
         candidates: String,
     },
 
+    /// A posting's units number is missing and cannot be recovered from the
+    /// balance, because the posting's weight does not vary with that number
+    /// (#1911). See [`UnitsWeight::Undetermined`] for the cases.
+    ///
+    /// Reported rather than left unfilled: `validate_transaction_balance` skips
+    /// a transaction that still has an unfilled posting, so staying silent here
+    /// would accept an unbalanced transaction.
+    #[error("cannot interpolate the units number for the {account} posting: {reason}")]
+    UnsolvableUnits {
+        /// The account of the posting whose units could not be solved.
+        account: rustledger_core::Account,
+        /// Why the balance does not determine the number.
+        reason: &'static str,
+    },
+
     /// Cannot infer currency for a posting.
     #[error("cannot infer currency for posting to account {account}")]
     CannotInferCurrency {
@@ -151,6 +166,132 @@ fn round_interpolated(residual: Decimal, existing_scale: Option<u32>) -> Decimal
     } else {
         interpolated
     }
+}
+
+/// How a units-missing posting's balance weight depends on the number we are
+/// about to solve for.
+///
+/// The number is recovered from a residual, so the question is always "which
+/// currency's residual, and scaled by what?". For a plain posting the weight
+/// IS the units, and the answer is the units currency's residual unchanged.
+/// For a posting carrying a cost or price the weight is `units × multiplier`
+/// denominated in the cost/price currency, so the number is that currency's
+/// residual DIVIDED by the multiplier, written back in the posting's own units
+/// currency (#1911).
+///
+/// This mirrors the weight ladder in [`crate::cost_weight`] /
+/// [`crate::cost_number_weight_generic`] — inverted. A new `CostNumber` variant
+/// must be classified here as well as given a weight there; the `_ =>` arm
+/// below fails closed (refuse to solve) rather than guessing a multiplier.
+enum UnitsWeight {
+    /// `weight = units`, in the posting's own units currency: a plain posting,
+    /// or one whose price annotation is too incomplete to convert (matching the
+    /// "fall back to units" arm of the complete-units branch).
+    Units,
+    /// `weight = units × multiplier`, in `currency`. Only ever constructed with
+    /// a NON-ZERO multiplier, which is what makes the inverting division safe.
+    Scaled {
+        /// The currency the weight lands in, whose residual we solve from.
+        currency: Currency,
+        /// The non-zero per-unit factor.
+        multiplier: Decimal,
+    },
+    /// The weight does not depend on the units number, so no number can be
+    /// recovered from any residual. Carries the user-facing explanation.
+    ///
+    /// A total cost (`{{600 USD}}`) or total price (`@@ 600 USD`) contributes a
+    /// CONSTANT weight — every units number balances equally, so the input is
+    /// genuinely ambiguous rather than merely hard. A zero per-unit factor
+    /// collapses the weight to zero for the same reason. An empty `{}` spec has
+    /// no number to divide by, and a compound `{a # b}` weight
+    /// (`units×a + b×signum(units)`) admits two roots; we refuse rather than
+    /// pick one.
+    ///
+    /// Python beancount does not diagnose these — it crashes: `TypeError: bad
+    /// operand type for abs(): 'type'` on a total or zero cost, and
+    /// `AssertionError: Internal error; residual currency different than
+    /// missing currency` on a zero price. We report
+    /// [`InterpolationError::UnsolvableUnits`] instead.
+    ///
+    /// This MUST be an error and not a silent skip: `validate_transaction_balance`
+    /// deliberately returns without checking a transaction that still has an
+    /// unfilled posting, on the documented assumption that interpolation already
+    /// reported the real failure. Leaving one unfilled and quiet would accept an
+    /// unbalanced transaction outright.
+    Undetermined {
+        /// Why no number can be recovered, phrased for the ledger author.
+        reason: &'static str,
+    },
+}
+
+/// Classify how `posting`'s weight scales with its (missing) units number.
+fn units_weight(
+    posting: &rustledger_core::Posting,
+    infer_currency: impl FnOnce() -> Option<Currency>,
+) -> UnitsWeight {
+    // Cost beats price, exactly as in `cost_weight`: a posting with both
+    // annotations weighs at cost, so the price is not what we invert.
+    if let Some(cost_spec) = posting.cost.as_ref() {
+        return match cost_spec.number {
+            Some(CostNumber::PerUnit { value }) if !value.is_zero() => {
+                match crate::cost_currency_of(posting, infer_currency) {
+                    Some(currency) => UnitsWeight::Scaled {
+                        currency,
+                        multiplier: value,
+                    },
+                    // A per-unit cost whose currency we cannot name gives us a
+                    // multiplier but no residual to apply it to.
+                    None => UnitsWeight::Undetermined {
+                        reason: "the cost currency cannot be determined, so there is no \
+                                 residual to solve from; name it explicitly (e.g. `{300.00 USD}`)",
+                    },
+                }
+            }
+            Some(CostNumber::PerUnit { .. }) => UnitsWeight::Undetermined {
+                reason: "a zero per-unit cost makes every units number weigh zero, \
+                         so the balance cannot single one out",
+            },
+            Some(CostNumber::Total { .. } | CostNumber::PerUnitFromTotal(_)) => {
+                UnitsWeight::Undetermined {
+                    reason: "a total cost `{{...}}` contributes the same weight whatever the \
+                             units are, so the balance cannot single one out; write the cost \
+                             per unit (`{...}`) or state the units",
+                }
+            }
+            Some(CostNumber::Compound { .. }) => UnitsWeight::Undetermined {
+                reason: "a compound cost `{a # b}` can balance at two different \
+                         units numbers, one positive and one negative",
+            },
+            None => UnitsWeight::Undetermined {
+                reason: "an empty cost spec `{}` has no cost number to solve against, \
+                         and its own value is not known until lot matching",
+            },
+        };
+    }
+
+    if let Some(price) = posting.price.as_ref()
+        && let Some(price_amt) = price.amount.as_ref().and_then(IncompleteAmount::as_amount)
+    {
+        return match price.kind {
+            rustledger_core::PriceKind::Unit if !price_amt.number.is_zero() => {
+                UnitsWeight::Scaled {
+                    currency: price_amt.currency.clone(),
+                    multiplier: price_amt.number,
+                }
+            }
+            rustledger_core::PriceKind::Unit => UnitsWeight::Undetermined {
+                reason: "a zero per-unit price makes every units number weigh zero, \
+                         so the balance cannot single one out",
+            },
+            rustledger_core::PriceKind::Total => UnitsWeight::Undetermined {
+                reason: "a total price `@@ ...` contributes the same weight whatever the \
+                         units are, so the balance cannot single one out; write the price \
+                         per unit (`@ ...`) or state the units",
+            },
+        };
+    }
+
+    UnitsWeight::Units
 }
 
 /// Interpolate missing amounts in a transaction.
@@ -263,6 +404,14 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Each is solved post-loop, but only when it is the SOLE unknown in its
     // cost currency group (else the group already errored on the count rule).
     let mut inferable_cost: Vec<(usize, Currency, Decimal)> = Vec::new();
+
+    // Units-missing postings whose weight is `units × multiplier` in some other
+    // currency (a per-unit cost or price): `index -> (units currency, factor)`.
+    // Their entry in `missing_by_currency` is keyed by the WEIGHT currency, so
+    // the fill step needs this to divide back out and to name the commodity it
+    // writes (#1911). Empty for every posting that weighs at its own units,
+    // which is the overwhelming majority — `HashMap::new` does not allocate.
+    let mut scaled_missing: HashMap<usize, (Currency, Decimal)> = HashMap::new();
 
     for (i, posting) in transaction.postings.iter().enumerate() {
         match &posting.units {
@@ -470,12 +619,38 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                     );
                 }
             }
-            Some(IncompleteAmount::CurrencyOnly(currency)) => {
-                // Currency known, number to be interpolated
-                missing_by_currency
-                    .entry(currency.clone())
-                    .or_default()
-                    .push(i);
+            Some(IncompleteAmount::CurrencyOnly(units_currency)) => {
+                // Currency known, number to be interpolated. The number comes
+                // from the residual of whichever currency this posting's WEIGHT
+                // lands in — the units currency only when no cost or price
+                // redenominates it (#1911).
+                match units_weight(posting, || {
+                    get_inferred_currency(&mut inferred_cost_currency)
+                }) {
+                    UnitsWeight::Units => {
+                        missing_by_currency
+                            .entry(units_currency.clone())
+                            .or_default()
+                            .push(i);
+                    }
+                    UnitsWeight::Scaled {
+                        currency,
+                        multiplier,
+                    } => {
+                        scaled_missing.insert(i, (units_currency.clone(), multiplier));
+                        missing_by_currency.entry(currency).or_default().push(i);
+                    }
+                    UnitsWeight::Undetermined { reason } => {
+                        // Unconditionally unsolvable: the multiplier is a
+                        // property of this posting alone, so no other posting
+                        // can rescue it and there is nothing to gain by
+                        // deferring the report.
+                        return Err(InterpolationError::UnsolvableUnits {
+                            account: posting.account.clone(),
+                            reason,
+                        });
+                    }
+                }
             }
             Some(IncompleteAmount::NumberOnly(number)) => {
                 // Number known, currency to be inferred
@@ -505,15 +680,21 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 }
             }
             None => {
-                // Missing amount - try to determine currency from cost
-                if let Some(cost_spec) = &posting.cost
-                    && let Some(currency) = &cost_spec.currency
-                {
-                    missing_by_currency
-                        .entry(currency.clone())
-                        .or_default()
-                        .push(i);
-                    continue;
+                // No units at all. A cost spec names the COST currency, never
+                // the commodity being bought, so there is nothing to denominate
+                // a solved number in. Filling the cost currency here fabricated
+                // a lot: a bare `{300.00 USD}` became `600.00 USD {300.00 USD}`
+                // and the resulting imbalance was reported as an invented
+                // `179400.0000 USD`. Python beancount refuses the shape
+                // ("CategorizationError"); we count it as an unsolvable unknown
+                // so the user gets a balance error instead of fiction.
+                if posting.cost.is_some() {
+                    return Err(InterpolationError::UnsolvableUnits {
+                        account: posting.account.clone(),
+                        reason: "a cost spec names the cost currency, not the commodity being \
+                                 bought, so there is no currency to write the solved number in; \
+                                 state the commodity (e.g. `HOOL {300.00 USD}`)",
+                    });
                 }
                 // Can't determine currency yet
                 unassigned_missing.push(i);
@@ -659,21 +840,61 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     }
 
     // Fill in known-currency missing postings
-    for (currency, indices) in missing_by_currency {
+    for (weight_currency, indices) in missing_by_currency {
         let idx = indices[0];
-        let residual = residuals.get(&currency).copied().unwrap_or(Decimal::ZERO);
+        let residual = residuals
+            .get(&weight_currency)
+            .copied()
+            .unwrap_or(Decimal::ZERO);
 
-        let interpolated =
-            round_interpolated(residual, max_scale_by_currency.get(&currency).copied());
+        // `scaled_missing` is empty unless a cost or price redenominates this
+        // posting's weight, so the common path below is the original one: the
+        // residual is the number, in the currency it was keyed under.
+        let Some((units_currency, multiplier)) = scaled_missing.remove(&idx) else {
+            let interpolated = round_interpolated(
+                residual,
+                max_scale_by_currency.get(&weight_currency).copied(),
+            );
+            result.postings[idx].units = Some(IncompleteAmount::Complete(Amount::new(
+                interpolated,
+                &weight_currency,
+            )));
+            filled_indices.push(idx);
+            // Reflect the actual interpolated amount (rounding may have moved it).
+            *residuals.entry(weight_currency).or_default() += interpolated;
+            continue;
+        };
+
+        // `weight = units × multiplier`, so invert: the number is the weight
+        // currency's residual divided by the factor, but quantized against the
+        // UNITS currency's observed scale — that is the currency it is written
+        // in. Beancount agrees on both halves: `HOOL {300.00 USD}` against
+        // `-600.00 USD` yields a bare `2 HOOL`, and gains a `.00` only once
+        // some other posting establishes a HOOL scale.
+        let Some(quotient) = residual.checked_div(multiplier) else {
+            return Err(InterpolationError::Unrepresentable {
+                currency: weight_currency,
+            });
+        };
+        let interpolated = round_interpolated(
+            quotient,
+            max_scale_by_currency.get(&units_currency).copied(),
+        );
 
         result.postings[idx].units = Some(IncompleteAmount::Complete(Amount::new(
             interpolated,
-            &currency,
+            &units_currency,
         )));
         filled_indices.push(idx);
 
-        // Update residual to reflect actual interpolated amount (may have rounding difference)
-        *residuals.entry(currency).or_default() += interpolated;
+        // Fold back the WEIGHT the posting now contributes — the solved number
+        // scaled back up, not the number itself.
+        let Some(weight) = interpolated.checked_mul(multiplier) else {
+            return Err(InterpolationError::Unrepresentable {
+                currency: weight_currency,
+            });
+        };
+        *residuals.entry(weight_currency).or_default() += weight;
     }
 
     // Handle unassigned missing postings
@@ -2182,5 +2403,293 @@ mod tests {
             Some(dec!(0)),
             "NumberOnly leg's number must net the residual to zero"
         );
+    }
+
+    // ---- #1911: solving a missing units NUMBER when the units CURRENCY is
+    // known but a cost or price redenominates the posting's weight ----
+
+    /// `Assets:A  HOOL {300.00 USD}` — units currency written, number elided.
+    fn units_currency_only(account: &str, currency: &str) -> Posting {
+        Posting {
+            units: Some(IncompleteAmount::CurrencyOnly(currency.into())),
+            ..Posting::auto(account)
+        }
+    }
+
+    fn per_unit_cost(value: Decimal, currency: &str) -> CostSpec {
+        CostSpec::empty()
+            .with_number(CostNumber::PerUnit { value })
+            .with_currency(currency)
+    }
+
+    /// The `IncompleteInputs.UnitsMissingNumberWithCost` vector: the number is
+    /// `residual / cost_per_unit`, written in the UNITS currency.
+    #[test]
+    fn interpolates_units_number_from_per_unit_cost() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Account1", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(Posting::new(
+                "Assets:Account2",
+                Amount::new(dec!(-600.00), "USD"),
+            ));
+
+        let result = interpolate(&txn).expect("solvable: 600.00 / 300.00");
+
+        assert_eq!(result.filled_indices, vec![0]);
+        let filled = get_amount(&result.transaction.postings[0]).expect("filled");
+        assert_eq!(filled.number, dec!(2), "600.00 / 300.00");
+        assert_eq!(
+            filled.currency, "HOOL",
+            "denominated in the posting's own commodity, NOT the cost currency"
+        );
+        assert_eq!(
+            result.residuals.get("USD").copied(),
+            Some(Decimal::ZERO),
+            "the solved units must weigh 600.00 USD and cancel the cash leg"
+        );
+    }
+
+    /// The inverse must actually invert the canonical forward weight function.
+    /// This is the drift guard: if `cost_number_weight` changes how a per-unit
+    /// cost weighs, solving by division silently stops agreeing with it, and
+    /// nothing else in the suite would notice.
+    #[test]
+    fn solved_units_reproduce_the_canonical_cost_weight() {
+        for (per_unit, cash) in [
+            (dec!(300.00), dec!(-600.00)),
+            (dec!(1.25), dec!(-100.00)),
+            // Negative cash: solved to negative units.
+            (dec!(300.00), dec!(600.00)),
+        ] {
+            let txn = Transaction::new(date(2010, 5, 28), "Buy")
+                .with_synthesized_posting(
+                    units_currency_only("Assets:Stock", "HOOL")
+                        .with_cost(per_unit_cost(per_unit, "USD")),
+                )
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(cash, "USD")));
+
+            let result = interpolate(&txn).expect("solvable");
+            let solved = get_amount(&result.transaction.postings[0]).expect("filled");
+            let cost = result.transaction.postings[0]
+                .cost
+                .as_ref()
+                .and_then(|c| c.number.as_ref())
+                .expect("cost number");
+
+            let weight = crate::cost_number_weight(solved.number, cost).expect("in range");
+            assert_eq!(
+                weight, -cash,
+                "canonical weight of the solved units must cancel the cash leg \
+                 (per_unit={per_unit}, cash={cash})"
+            );
+        }
+    }
+
+    /// A per-unit PRICE scales the weight the same way a per-unit cost does,
+    /// so the same inversion applies.
+    #[test]
+    fn interpolates_units_number_from_per_unit_price() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(units_currency_only("Assets:Account1", "HOOL").with_price(
+                rustledger_core::PriceAnnotation::unit(Amount::new(dec!(300.00), "USD")),
+            ))
+            .with_synthesized_posting(Posting::new(
+                "Assets:Account2",
+                Amount::new(dec!(-600.00), "USD"),
+            ));
+
+        let result = interpolate(&txn).expect("solvable: 600.00 / 300.00");
+        let filled = get_amount(&result.transaction.postings[0]).expect("filled");
+        assert_eq!(filled.number, dec!(2));
+        assert_eq!(filled.currency, "HOOL");
+        assert_eq!(result.residuals.get("USD").copied(), Some(Decimal::ZERO));
+    }
+
+    /// The quotient is quantized against the UNITS currency's observed scale,
+    /// not the cost currency's — the currency it is actually written in.
+    ///
+    /// Only the VALUE is asserted. Python beancount stores a scale here (`2.00`
+    /// where it stores a bare `2` without the extra HOOL posting) because it
+    /// quantizes at booking time; rledger stores the value and pads at render
+    /// via `DisplayContext`, so `rledger` also SHOWS `2.00` while holding `2`.
+    /// That is the presentation-versus-value split of ADR-0008 and #1909, not a
+    /// divergence: `2 == 2.00` as a quantity.
+    #[test]
+    fn solved_units_quantize_to_the_units_currency_scale() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Account1", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(Posting::new(
+                "Assets:Account2",
+                Amount::new(dec!(-600.00), "USD"),
+            ))
+            .with_synthesized_posting(Posting::new(
+                "Assets:Other",
+                Amount::new(dec!(5.00), "HOOL"),
+            ));
+
+        let result = interpolate(&txn).expect("solvable");
+        let filled = get_amount(&result.transaction.postings[0]).expect("filled");
+        assert_eq!(filled.number, dec!(2), "600.00 / 300.00, written in HOOL");
+        assert_eq!(filled.currency, "HOOL");
+        assert_eq!(
+            result.residuals.get("USD").copied(),
+            Some(Decimal::ZERO),
+            "USD still cancels"
+        );
+        assert_eq!(
+            result.residuals.get("HOOL").copied(),
+            Some(dec!(5.00)),
+            "the cost-carrying posting must NOT absorb the HOOL residual: it \
+             weighs in USD only. Before #1911 it solved to -5.00 HOOL here — \
+             a lot with the wrong sign AND magnitude."
+        );
+    }
+
+    /// A cost-carrying posting weighs in the cost currency, so a residual in
+    /// its own units currency is none of its business. Previously this filled
+    /// `-10.00 HOOL {300.00 USD}`, fabricating a 3000 USD lot from thin air.
+    #[test]
+    fn cost_posting_does_not_absorb_its_units_currency_residual() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(Posting::new(
+                "Assets:Account1",
+                Amount::new(dec!(10.00), "HOOL"),
+            ))
+            .with_synthesized_posting(
+                units_currency_only("Assets:Account2", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            );
+
+        let result = interpolate(&txn).expect("solves to zero, then fails to balance later");
+        assert_eq!(
+            result.transaction.postings.len(),
+            1,
+            "no USD residual to solve from, so the posting solves to zero units \
+             and is pruned by the zero-prune step — beancount drops it too"
+        );
+        assert_eq!(
+            result.residuals.get("HOOL").copied(),
+            Some(dec!(10.00)),
+            "the 10.00 HOOL imbalance survives to be reported"
+        );
+    }
+
+    /// Every shape whose weight does not vary with the units number must be
+    /// REFUSED, never silently left unfilled: `validate_transaction_balance`
+    /// skips a transaction containing an unfilled posting, so a silent skip
+    /// would accept an unbalanced transaction outright.
+    #[test]
+    fn refuses_units_whose_weight_does_not_vary_with_them() {
+        let cash = Posting::new("Assets:Cash", Amount::new(dec!(-600.00), "USD"));
+
+        let total_cost = CostSpec::empty()
+            .with_number(CostNumber::Total {
+                value: dec!(600.00),
+            })
+            .with_currency("USD");
+        let zero_cost = per_unit_cost(dec!(0.00), "USD");
+        let compound = CostSpec::empty()
+            .with_number(CostNumber::Compound {
+                per_unit: dec!(300.00),
+                total: dec!(5.00),
+            })
+            .with_currency("USD");
+        let empty_spec = CostSpec::empty().with_currency("USD");
+
+        let cases: Vec<(&str, Posting)> = vec![
+            (
+                "total cost",
+                units_currency_only("Assets:S", "HOOL").with_cost(total_cost),
+            ),
+            (
+                "zero per-unit cost",
+                units_currency_only("Assets:S", "HOOL").with_cost(zero_cost),
+            ),
+            (
+                "compound cost",
+                units_currency_only("Assets:S", "HOOL").with_cost(compound),
+            ),
+            (
+                "empty cost spec",
+                units_currency_only("Assets:S", "HOOL").with_cost(empty_spec),
+            ),
+            (
+                "total price",
+                units_currency_only("Assets:S", "HOOL").with_price(
+                    rustledger_core::PriceAnnotation::total(Amount::new(dec!(600.00), "USD")),
+                ),
+            ),
+            (
+                "zero per-unit price",
+                units_currency_only("Assets:S", "HOOL").with_price(
+                    rustledger_core::PriceAnnotation::unit(Amount::new(dec!(0.00), "USD")),
+                ),
+            ),
+            (
+                "cost spec but no units currency at all",
+                Posting::auto("Assets:S").with_cost(per_unit_cost(dec!(300.00), "USD")),
+            ),
+        ];
+
+        for (label, posting) in cases {
+            let txn = Transaction::new(date(2010, 5, 28), "Buy")
+                .with_synthesized_posting(posting)
+                .with_synthesized_posting(cash.clone());
+
+            match interpolate(&txn) {
+                Err(InterpolationError::UnsolvableUnits { account, reason }) => {
+                    assert_eq!(account.as_str(), "Assets:S", "{label}");
+                    assert!(!reason.is_empty(), "{label}: reason must explain why");
+                }
+                Err(other) => panic!("{label}: expected UnsolvableUnits, got {other}"),
+                Ok(result) => panic!(
+                    "{label}: expected a refusal, but interpolation returned {:?}. \
+                     An unfilled posting that does NOT error is silently accepted \
+                     by validate_transaction_balance.",
+                    result
+                        .transaction
+                        .postings
+                        .iter()
+                        .map(|p| p.units.clone())
+                        .collect::<Vec<_>>()
+                ),
+            }
+        }
+    }
+
+    /// Two solvable unknowns landing in the SAME weight currency stay ambiguous.
+    /// The cost posting is counted against USD (where its weight lands), not
+    /// HOOL, so it collides with the plain elided USD posting exactly as
+    /// beancount's `InterpolationError` does.
+    #[test]
+    fn two_unknowns_in_the_same_weight_currency_are_ambiguous() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Stock", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(units_currency_only("Assets:Cash", "USD"))
+            .with_synthesized_posting(Posting::new(
+                "Assets:Other",
+                Amount::new(dec!(-600.00), "USD"),
+            ));
+
+        match interpolate(&txn) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(
+                    currency,
+                    Currency::from("USD"),
+                    "counted where the weights land"
+                );
+                assert_eq!(count, 2);
+            }
+            other => panic!("expected MultipleMissing in USD, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -296,6 +296,100 @@ fn units_weight(
     UnitsWeight::Units
 }
 
+/// The currency a `NumberOnly` posting (`10 {300.00 USD}`) is denominated in:
+/// the cost currency, else the price currency. `None` means the number cannot
+/// be placed in a currency group yet.
+fn number_only_currency(posting: &rustledger_core::Posting) -> Option<Currency> {
+    posting
+        .cost
+        .as_ref()
+        .and_then(|c| c.currency.clone())
+        .or_else(|| {
+            // Pull currency from the price's complete amount, regardless of
+            // kind. Incomplete/empty prices contribute nothing here.
+            posting
+                .price
+                .as_ref()
+                .and_then(|p| p.amount.as_ref())
+                .and_then(IncompleteAmount::as_amount)
+                .map(|a| a.currency.clone())
+        })
+}
+
+/// Which residual an elided posting's unknown will be solved from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnknownGroup {
+    /// Solved from this currency's residual. For a posting carrying a per-unit
+    /// cost or price this is the COST/PRICE currency, not the units currency
+    /// (#1911) — that is the whole reason this cannot be eyeballed from the
+    /// posting's units.
+    Currency(Currency),
+    /// A fully-elided posting (`Assets:Cash` with no amount at all). Which
+    /// currency it absorbs is not knowable until the residuals are, so
+    /// interpolation assigns it late — and may split it across several
+    /// currencies.
+    Unassigned,
+}
+
+/// The currency group each of `txn`'s elided postings will be solved in.
+///
+/// **Canonical grouping.** [`interpolate`] solves per this grouping, and
+/// `rustledger-validate`'s E3002 check enforces "at most one unknown per group"
+/// against it. Both go through the same private `units_weight` classifier in
+/// this module, so the rule cannot drift
+/// between the pre-booking diagnostic and the solver that actually runs
+/// (#1914 — the validator previously grouped by the posting's own units
+/// currency, then summed across groups anyway, and rejected two elided
+/// postings that were in different currencies entirely).
+///
+/// Postings with a complete amount are omitted, as are shapes that
+/// [`interpolate`] refuses outright ([`InterpolationError::UnsolvableUnits`]):
+/// those get a precise message naming the offending annotation, which a
+/// generic "too many unknowns" would only obscure.
+#[must_use]
+pub fn elided_unknown_groups(txn: &Transaction) -> Vec<(usize, UnknownGroup)> {
+    let mut inferred_cost_currency: Option<Option<Currency>> = None;
+    let mut groups = Vec::new();
+
+    for (i, posting) in txn.postings.iter().enumerate() {
+        match &posting.units {
+            // Nothing to solve.
+            Some(IncompleteAmount::Complete(_)) => {}
+            Some(IncompleteAmount::CurrencyOnly(units_currency)) => {
+                match units_weight(posting, || {
+                    inferred_cost_currency
+                        .get_or_insert_with(|| crate::infer_cost_currency_from_postings(txn))
+                        .clone()
+                }) {
+                    UnitsWeight::Units => {
+                        groups.push((i, UnknownGroup::Currency(units_currency.clone())));
+                    }
+                    UnitsWeight::Scaled { currency, .. } => {
+                        groups.push((i, UnknownGroup::Currency(currency)));
+                    }
+                    UnitsWeight::Undetermined { .. } => {}
+                }
+            }
+            // A number with a currency in reach is not an unknown at all — it
+            // lands in that group as a known contribution.
+            Some(IncompleteAmount::NumberOnly(_)) => {
+                if number_only_currency(posting).is_none() {
+                    groups.push((i, UnknownGroup::Unassigned));
+                }
+            }
+            // A cost spec here is refused by `interpolate` (no commodity to
+            // write the solved number in), so it is not grouped.
+            None => {
+                if posting.cost.is_none() {
+                    groups.push((i, UnknownGroup::Unassigned));
+                }
+            }
+        }
+    }
+
+    groups
+}
+
 /// Interpolate missing amounts in a transaction.
 ///
 /// This function:
@@ -655,25 +749,8 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 }
             }
             Some(IncompleteAmount::NumberOnly(number)) => {
-                // Number known, currency to be inferred
-                // Try to get currency from cost or price
-                let currency = posting
-                    .cost
-                    .as_ref()
-                    .and_then(|c| c.currency.clone())
-                    .or_else(|| {
-                        // Pull currency from the price's complete amount,
-                        // regardless of kind. Incomplete/empty prices
-                        // contribute nothing here.
-                        posting
-                            .price
-                            .as_ref()
-                            .and_then(|p| p.amount.as_ref())
-                            .and_then(IncompleteAmount::as_amount)
-                            .map(|a| a.currency.clone())
-                    });
-
-                if let Some(curr) = currency {
+                // Number known, currency to be inferred from cost or price.
+                if let Some(curr) = number_only_currency(posting) {
                     // We have currency from context, make it complete
                     *residuals.entry(curr.clone()).or_default() += *number;
                 } else {
@@ -2693,5 +2770,116 @@ mod tests {
             }
             other => panic!("expected MultipleMissing in USD, got {other:?}"),
         }
+    }
+
+    // ---- #1914: the canonical grouping the E3002 validator enforces ----
+
+    /// The grouping is not eyeballable from the posting: a per-unit cost
+    /// redenominates the weight, so `HOOL {300.00 USD}` is an unknown in USD.
+    #[test]
+    fn elided_groups_use_the_weight_currency_not_the_units_currency() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Stock", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(units_currency_only("Assets:Euro", "EUR"))
+            .with_synthesized_posting(Posting::new("Assets:C", Amount::new(dec!(-600.00), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:D", Amount::new(dec!(-50.00), "EUR")));
+
+        let groups = elided_unknown_groups(&txn);
+        assert_eq!(
+            groups,
+            vec![
+                (0, UnknownGroup::Currency("USD".into())),
+                (1, UnknownGroup::Currency("EUR".into())),
+            ],
+            "the cost posting belongs to USD (where its weight lands), not HOOL"
+        );
+    }
+
+    /// A fully-elided posting cannot be placed until the residuals are known.
+    /// A `NumberOnly` posting with a currency in reach is not an unknown at all.
+    #[test]
+    fn elided_groups_classify_bare_and_number_only_postings() {
+        let mut number_only = Posting::auto("Assets:WithCost");
+        number_only.units = Some(IncompleteAmount::NumberOnly(dec!(10)));
+        let number_only = number_only.with_cost(per_unit_cost(dec!(300.00), "USD"));
+
+        let mut naked_number = Posting::auto("Assets:Naked");
+        naked_number.units = Some(IncompleteAmount::NumberOnly(dec!(10)));
+
+        let txn = Transaction::new(date(2010, 5, 28), "Mixed")
+            .with_synthesized_posting(Posting::auto("Assets:Bare"))
+            .with_synthesized_posting(number_only)
+            .with_synthesized_posting(naked_number)
+            .with_synthesized_posting(Posting::new("Assets:C", Amount::new(dec!(-600.00), "USD")));
+
+        let groups = elided_unknown_groups(&txn);
+        assert_eq!(
+            groups,
+            vec![(0, UnknownGroup::Unassigned), (2, UnknownGroup::Unassigned)],
+            "index 1 has a cost currency to land in, so it is not an unknown; \
+             index 3 is complete"
+        );
+    }
+
+    /// Drift guard. If this grouping ever disagrees with the one `interpolate`
+    /// actually solves by, the E3002 validator starts rejecting transactions
+    /// the solver would have handled — which is exactly bug #1914. Two unknowns
+    /// the grouping calls same-currency MUST make `interpolate` say so too, and
+    /// two it calls disjoint MUST interpolate cleanly.
+    #[test]
+    fn elided_groups_agree_with_what_interpolate_solves() {
+        let same = Transaction::new(date(2010, 5, 28), "Same group")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Stock", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(units_currency_only("Assets:Cash", "USD"))
+            .with_synthesized_posting(Posting::new("Assets:C", Amount::new(dec!(-600.00), "USD")));
+
+        let groups = elided_unknown_groups(&same);
+        let usd = UnknownGroup::Currency("USD".into());
+        assert_eq!(
+            groups.iter().filter(|(_, g)| *g == usd).count(),
+            2,
+            "grouping must see both unknowns in USD"
+        );
+        match interpolate(&same) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(
+                    currency,
+                    Currency::from("USD"),
+                    "same currency the grouping named"
+                );
+                assert_eq!(count, 2);
+            }
+            other => panic!("grouping says ambiguous in USD; interpolate says {other:?}"),
+        }
+
+        let disjoint = Transaction::new(date(2010, 5, 28), "Disjoint groups")
+            .with_synthesized_posting(
+                units_currency_only("Assets:Stock", "HOOL")
+                    .with_cost(per_unit_cost(dec!(300.00), "USD")),
+            )
+            .with_synthesized_posting(units_currency_only("Assets:Euro", "EUR"))
+            .with_synthesized_posting(Posting::new("Assets:C", Amount::new(dec!(-600.00), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:D", Amount::new(dec!(-50.00), "EUR")));
+
+        let groups = elided_unknown_groups(&disjoint);
+        let mut seen: Vec<_> = groups.iter().map(|(_, g)| g.clone()).collect();
+        seen.dedup();
+        assert_eq!(seen.len(), 2, "grouping must see two distinct groups");
+        let result = interpolate(&disjoint).expect("disjoint groups interpolate cleanly");
+        assert_eq!(
+            get_amount(&result.transaction.postings[0]).map(|a| a.number),
+            Some(dec!(2)),
+            "600.00 / 300.00"
+        );
+        assert_eq!(
+            get_amount(&result.transaction.postings[1]).map(|a| a.number),
+            Some(dec!(50.00))
+        );
     }
 }

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -30,7 +30,9 @@ pub use book::{
     BookedTransaction, BookingEngine, BookingError, CapitalGain, LedgerBookResult, book,
     book_transactions,
 };
-pub use interpolate::{InterpolationError, InterpolationResult, interpolate};
+pub use interpolate::{
+    InterpolationError, InterpolationResult, UnknownGroup, elided_unknown_groups, interpolate,
+};
 pub use pad::{
     PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,
     merge_with_padding_spanned, process_pads,

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2163,3 +2163,64 @@ fn test_e1001_dedup_is_per_posting_not_account_date() {
         ledger.errors
     );
 }
+
+/// #1911 end-to-end: a units number elided next to a per-unit cost must be
+/// solved from the COST currency's residual and booked as a real lot.
+///
+/// The unit tests in `rustledger-booking` pin `interpolate` itself; this pins
+/// the whole pipeline (parse -> interpolate -> book -> validate), which is where
+/// the bug was found. Before the fix the posting was registered under HOOL,
+/// solved to `0 HOOL`, pruned, and the transaction was reported as unbalanced
+/// by the full `-600.00 USD`.
+#[test]
+fn test_units_number_elided_with_cost_is_solved_and_booked() {
+    use rustledger_loader::{LoadOptions, process};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("issue1911.beancount");
+    std::fs::write(
+        &path,
+        "2010-01-01 open Assets:Account1\n\
+         2010-01-01 open Assets:Account2\n\
+         \n\
+         2010-05-28 * \"units number elided beside a per-unit cost\"\n  \
+         Assets:Account1            HOOL {300.00 USD}\n  \
+         Assets:Account2    -600.00 USD\n",
+    )
+    .unwrap();
+
+    let raw = rustledger_loader::load_raw(&path).expect("load raw");
+    let ledger = process(raw, &LoadOptions::default()).expect("process");
+
+    assert!(
+        ledger.errors.is_empty(),
+        "should balance once the units are solved, got {:?}",
+        ledger.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+
+    let txn = ledger
+        .directives
+        .iter()
+        .find_map(|d| match &d.value {
+            rustledger_core::Directive::Transaction(t) => Some(t),
+            _ => None,
+        })
+        .expect("the transaction survived booking");
+
+    let stock = txn
+        .postings
+        .iter()
+        .find(|p| p.account.as_str() == "Assets:Account1")
+        .expect("the cost-carrying posting was not pruned");
+    let units = stock.amount().expect("units were filled in");
+
+    assert_eq!(
+        units.number,
+        rust_decimal_macros::dec!(2),
+        "600.00 / 300.00"
+    );
+    assert_eq!(
+        units.currency, "HOOL",
+        "written in the posting's own commodity, not the cost currency"
+    );
+}

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -2902,6 +2902,101 @@ mod tests {
         );
     }
 
+    /// #1914: two elided postings in DIFFERENT currency groups are fine —
+    /// interpolation solves one unknown per group, so they never compete.
+    /// This block used to build a per-currency map and then sum across it,
+    /// rejecting the pair outright.
+    #[test]
+    fn test_e3002_two_missing_in_different_currencies_ok() {
+        let elided = |account: &str, currency: &str| Posting {
+            account: account.into(),
+            units: Some(rustledger_core::IncompleteAmount::CurrencyOnly(
+                currency.into(),
+            )),
+            cost: None,
+            price: None,
+            flag: None,
+            meta: Default::default(),
+            comments: vec![],
+            trailing_comments: vec![],
+        };
+
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:A")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:B")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:C")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:D")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Two currencies")
+                    .with_synthesized_posting(elided("Assets:A", "USD"))
+                    .with_synthesized_posting(elided("Assets:B", "EUR"))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:C",
+                        Amount::new(dec!(-600.00), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:D",
+                        Amount::new(dec!(-50.00), "EUR"),
+                    )),
+            ),
+        ];
+
+        let errors = validate(&directives);
+
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.code == ErrorCode::MultipleInterpolation),
+            "USD and EUR unknowns do not compete; got: {errors:?}"
+        );
+    }
+
+    /// The same shape in ONE currency is still ambiguous, so the rule did not
+    /// simply get weaker.
+    #[test]
+    fn test_e3002_two_missing_in_same_currency_still_rejected() {
+        let elided = |account: &str, currency: &str| Posting {
+            account: account.into(),
+            units: Some(rustledger_core::IncompleteAmount::CurrencyOnly(
+                currency.into(),
+            )),
+            cost: None,
+            price: None,
+            flag: None,
+            meta: Default::default(),
+            comments: vec![],
+            trailing_comments: vec![],
+        };
+
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:A")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:B")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:C")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "One currency")
+                    .with_synthesized_posting(elided("Assets:A", "USD"))
+                    .with_synthesized_posting(elided("Assets:B", "USD"))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:C",
+                        Amount::new(dec!(-600.00), "USD"),
+                    )),
+            ),
+        ];
+
+        let errors = validate(&directives);
+
+        let e3002: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::MultipleInterpolation)
+            .collect();
+        assert_eq!(e3002.len(), 1, "still ambiguous, got: {errors:?}");
+        assert!(
+            e3002[0].message.contains("USD"),
+            "the message should name the contested currency, got: {}",
+            e3002[0].message
+        );
+    }
+
     #[test]
     fn test_e7001_unknown_option() {
         // E7001: import_option_warnings converts loader warnings to validation errors

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -161,31 +161,66 @@ pub fn validate_transaction_structure(
     }
 
     // Check for multiple missing amounts per currency (E3002).
-    // If >1 posting is missing an amount for the same currency, interpolation
-    // is ambiguous. We detect this by looking at postings where `amount()` is
-    // None AND the posting has no units at all (fully elided amount).
+    //
+    // Interpolation solves one unknown per currency group, so two elided
+    // postings are only ambiguous when they compete for the SAME residual.
+    // The grouping comes from `rustledger_booking::elided_unknown_groups` --
+    // the same function `interpolate` solves by -- rather than being re-derived
+    // here. It cannot be eyeballed from the posting: a per-unit cost or price
+    // redenominates the weight, so `HOOL {300.00 USD}` is an unknown in USD,
+    // not in HOOL (#1911).
+    //
+    // This block previously grouped by the units currency and then summed
+    // across every group, rejecting two elided postings that were in different
+    // currencies entirely (#1914). The grouping was also never populated: the
+    // hint used `as_amount()`, which is `None` for exactly the partial-units
+    // postings the rule is about, so everything landed in one bucket.
     {
-        let mut missing_count: FxHashMap<Option<&rustledger_core::Currency>, u32> =
-            FxHashMap::default();
-        for posting in &txn.postings {
-            if posting.amount().is_none() {
-                // Group by the currency hint from partial units, or None for fully elided
-                let currency = posting
-                    .units
-                    .as_ref()
-                    .and_then(|u| u.as_amount())
-                    .map(|a| &a.currency);
-                *missing_count.entry(currency).or_default() += 1;
+        let groups = rustledger_booking::elided_unknown_groups(txn);
+        let mut per_currency: FxHashMap<&rustledger_core::Currency, u32> = FxHashMap::default();
+        let mut unassigned = 0_u32;
+        for (_, group) in &groups {
+            match group {
+                rustledger_booking::UnknownGroup::Currency(c) => {
+                    *per_currency.entry(c).or_default() += 1;
+                }
+                rustledger_booking::UnknownGroup::Unassigned => unassigned += 1,
             }
         }
-        // If any group has >1 missing, or there are multiple groups of missing amounts
-        let total_missing: u32 = missing_count.values().sum();
-        if total_missing > 1 {
+
+        // A fully-elided posting has no currency of its own, so it can absorb
+        // any residual -- including one another unknown is already claiming.
+        // Beancount refuses the combination outright ("CategorizationError"),
+        // and so do we: more than one unknown in play alongside one is
+        // ambiguous no matter which currencies the others sit in.
+        let ambiguous = if unassigned > 0 {
+            groups.len() > 1
+        } else {
+            per_currency.values().any(|&n| n > 1)
+        };
+
+        if ambiguous {
+            let detail = per_currency
+                .iter()
+                .filter(|&(_, &n)| n > 1)
+                .map(|(c, n)| format!("{n} in {c}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let message = if detail.is_empty() {
+                format!(
+                    "Transaction has {} postings with missing amounts; at most one is allowed \
+                     when any of them has no currency to interpolate in",
+                    groups.len()
+                )
+            } else {
+                format!(
+                    "Transaction has multiple postings with missing amounts in the same \
+                     currency ({detail}); at most one per currency is allowed"
+                )
+            };
             errors.push(ValidationError::new(
                 ErrorCode::MultipleInterpolation,
-                format!(
-                    "Transaction has {total_missing} postings with missing amounts; at most one is allowed"
-                ),
+                message,
                 txn.date,
             ));
         }


### PR DESCRIPTION
> Stacked on #1913 — review that first; this branch contains its commits. The grouping fix depends on #1911's weight-currency rule.

## What

Interpolation solves **one unknown per currency group**, so two elided postings are only ambiguous when they compete for the *same* residual. The E3002 validator built a per-currency map and then summed across every group.

```beancount
2010-05-28 * "two elided postings, different currencies"
  Assets:A                 USD
  Assets:B                 EUR
  Assets:C   -600.00 USD
  Assets:D    -50.00 EUR
```

| | |
|---|---|
| before | `E3002 Transaction has 2 postings with missing amounts; at most one is allowed` |
| after | `A = 600.00 USD`, `B = 50.00 EUR` |

That is what beancount does, and what rledger's own `interpolate` already computed — the validator was rejecting a transaction the solver would have handled correctly.

## The grouping was never actually populated

The currency hint came from `.and_then(|u| u.as_amount())`, which returns `None` for exactly the partial-units postings this rule is about. So every unknown landed in the `None` bucket and the map had at most one meaningful key. The grouping was not merely discarded by the sum; it was never there.

## Not re-derived any more

`elided_unknown_groups` is new in `rustledger-booking` and is **the same grouping `interpolate` solves by** — both go through the same `units_weight` classifier. Per the Canonical-Function Discipline in CLAUDE.md, the pre-booking diagnostic and the solver now cannot disagree.

This matters more than usual since #1911: a per-unit cost redenominates the weight, so `HOOL {300.00 USD}` is an unknown in **USD**, not in HOOL. Nothing about the posting's units reveals that, which is precisely why a hand-rolled grouping in the validator drifts.

## What stays strict

A fully-elided posting (`Assets:Cash`, no amount at all) has no currency of its own, so it can absorb any residual — including one another unknown is claiming. beancount refuses that combination outright (`CategorizationError`) and so do we. One bare posting alone is still fine, including when it splits across several currencies.

## Verification

Checked against beancount on nine shapes — both elided kinds, bare postings, cost-carrying postings, same-group and disjoint-group pairs:

| | beancount | before | after |
|---|---|---|---|
| two elided, different ccy | ok | **E3002** | ok |
| cost + elided, disjoint | ok | **E3002** | ok |
| two elided, same ccy | error | E3002 | E3002 |
| two bare (1 or 2 ccy) | error | E3002 | E3002 |
| bare + elided | error | E3002 | E3002 |
| one elided / one bare across 2 ccy | ok | ok | ok |

All nine agree now; two disagreed before. Booked **values** also match beancount, including the multi-currency split where one bare posting becomes two.

- **No corpus movement**: across 758 files, not one changes accept/reject status, and the value oracle is unchanged at 3. The shape does not occur there — so the corpus is evidence of *no regression*, not evidence *for* the fix. The synthetic cases and unit tests carry that.
- **Both halves confirmed to fail when neutered**: restoring the total-count rule fails `test_e3002_two_missing_in_different_currencies_ok`; grouping by the units currency fails the drift guard `elided_groups_agree_with_what_interpolate_solves`.
- Workspace **4416 passed, 0 failed**. Clippy clean at the CI pin (1.97.0) with `-D warnings`. `rustdoc -D warnings` clean.

Closes #1914
