### PR TITLE
fix(booking): answer a bare price sigil instead of ignoring it

### DIFF
--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -77,6 +77,34 @@ pub enum InterpolationError {
         reason: &'static str,
     },
 
+    /// A bare price sigil (`@` / `@@` with no amount) asks for the price to be
+    /// computed, but no single currency stands out to compute it in (#1915).
+    #[error(
+        "cannot tell which currency the bare price on the {account} posting should be \
+         computed in; write the price currency (e.g. `@ 1.20 USD`)"
+    )]
+    AmbiguousBarePriceCurrency {
+        /// The account of the posting carrying the bare sigil.
+        account: rustledger_core::Account,
+    },
+
+    /// Solving a bare price sigil from the residual gives a negative price
+    /// (#1915). Refused for the same reason as [`Self::NegativeInferredCost`]:
+    /// the balance is asking for something that is not a price.
+    #[error(
+        "the price of the {account} posting would have to be {price} {currency} to \
+         balance this transaction, and a negative price is not meaningful; check the \
+         signs of the other postings"
+    )]
+    NegativeInferredPrice {
+        /// The account of the posting carrying the bare sigil.
+        account: rustledger_core::Account,
+        /// The currency the price was solved in.
+        currency: Currency,
+        /// The (negative) solved price.
+        price: Decimal,
+    },
+
     /// Cannot infer currency for a posting.
     #[error("cannot infer currency for posting to account {account}")]
     CannotInferCurrency {
@@ -271,9 +299,16 @@ fn units_weight(
         };
     }
 
-    if let Some(price) = posting.price.as_ref()
-        && let Some(price_amt) = price.amount.as_ref().and_then(IncompleteAmount::as_amount)
-    {
+    if let Some(price) = posting.price.as_ref() {
+        let Some(price_amt) = price.amount.as_ref().and_then(IncompleteAmount::as_amount) else {
+            // A bare `@` sigil is itself a request to compute the price
+            // (#1915). Together with a missing units number that is two
+            // unknowns on one posting, and one residual cannot determine both.
+            return UnitsWeight::Undetermined {
+                reason: "the units number and the price are both missing, and a single \
+                         residual cannot determine two unknowns; write one of them",
+            };
+        };
         return match price.kind {
             rustledger_core::PriceKind::Unit if !price_amt.number.is_zero() => {
                 UnitsWeight::Scaled {
@@ -294,6 +329,64 @@ fn units_weight(
     }
 
     UnitsWeight::Units
+}
+
+/// The currency a bare price sigil (`@` / `@@` with no amount) resolves in.
+///
+/// The sigil means "compute this price", and the only thing that determines it
+/// is the residual the posting has to cancel — so the answer is the currency
+/// the transaction is out of balance in.
+///
+/// When nothing is known yet (every other posting is itself an unknown, so all
+/// residuals are zero) fall back to the currencies the other postings are
+/// denominated in. That is what lets the count rule name a group and say
+/// "two unknowns in USD" rather than failing with something vaguer.
+///
+/// `None` when no single currency stands out, in either pass.
+fn bare_price_currency(
+    txn: &Transaction,
+    self_index: usize,
+    residuals: &HashMap<Currency, Decimal>,
+) -> Option<Currency> {
+    let candidates: Vec<&Currency> = residuals
+        .iter()
+        .filter(|(_, value)| !value.is_zero())
+        .map(|(currency, _)| currency)
+        .collect();
+
+    if candidates.is_empty() {
+        // The other postings' WEIGHT currencies, not their units currencies:
+        // this posting has to cancel what they contribute to the balance, and
+        // a price annotation redenominates that. `? CAD @ 1.2 USD` weighs in
+        // USD, so a bare sigil facing it resolves in USD too — reading CAD off
+        // its units would put the two unknowns in different groups and hide a
+        // genuine ambiguity.
+        let mut weights: Vec<Currency> = Vec::new();
+        for (i, posting) in txn.postings.iter().enumerate() {
+            if i == self_index {
+                continue;
+            }
+            let currency = crate::price_currency_of(posting).or_else(|| match &posting.units {
+                Some(IncompleteAmount::Complete(amount)) => Some(amount.currency.clone()),
+                Some(IncompleteAmount::CurrencyOnly(currency)) => Some(currency.clone()),
+                _ => None,
+            });
+            if let Some(currency) = currency
+                && !weights.contains(&currency)
+            {
+                weights.push(currency);
+            }
+        }
+        return match weights.as_slice() {
+            [only] => Some(only.clone()),
+            _ => None,
+        };
+    }
+
+    match candidates.as_slice() {
+        [only] => Some((*only).clone()),
+        _ => None,
+    }
 }
 
 /// The currency a `NumberOnly` posting (`10 {300.00 USD}`) is denominated in:
@@ -346,6 +439,13 @@ pub enum UnknownGroup {
 /// [`interpolate`] refuses outright ([`InterpolationError::UnsolvableUnits`]):
 /// those get a precise message naming the offending annotation, which a
 /// generic "too many unknowns" would only obscure.
+///
+/// Bare price sigils (`@` / `@@` with no amount) are also omitted, even though
+/// they ARE unknowns for the same one-per-group rule (#1915). Which group they
+/// fall in depends on the residuals, which this function deliberately does not
+/// compute — reproducing that here would be a second implementation of the
+/// grouping, the drift this function exists to prevent. `interpolate` reports
+/// them instead, one phase later.
 #[must_use]
 pub fn elided_unknown_groups(txn: &Transaction) -> Vec<(usize, UnknownGroup)> {
     let mut inferred_cost_currency: Option<Option<Currency>> = None;
@@ -482,15 +582,19 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     //   per_unit precision.
     let mut max_scale_by_currency: HashMap<Currency, u32> = HashMap::with_capacity(4);
 
-    // Track per-currency count of postings whose weight contribution is unknown
-    // because the cost spec is empty (e.g., `{}`) and resolution is deferred to
-    // the booking pass (lot matching). Each such posting is one unknown for
-    // interpolation accounting and gets added to the per-currency unknowns
-    // total alongside missing-amount postings (issue #1026). Without this,
-    // rledger would silently use a fallback weight (price annotation, if
-    // present) and accept transactions with more unknowns than the
-    // interpolation rule allows.
-    let mut cost_unknowns_by_currency: HashMap<Currency, usize> = HashMap::with_capacity(2);
+    // Per-currency count of postings whose WEIGHT contribution is unknown even
+    // though their units are written out. Two shapes qualify:
+    //
+    // - an empty cost spec (`{}`), whose cost basis is not known until booking
+    //   resolves the lot match (issue #1026). Without counting these, rledger
+    //   would silently fall back to the price annotation and accept
+    //   transactions with more unknowns than the interpolation rule allows.
+    // - a bare price sigil (`@` / `@@` with no amount), whose price is solved
+    //   from the residual further down (#1915).
+    //
+    // Each is one unknown for interpolation accounting, added to the
+    // per-currency total alongside missing-amount postings.
+    let mut weight_unknowns_by_currency: HashMap<Currency, usize> = HashMap::with_capacity(2);
 
     // Augmenting `{}` postings whose per-unit cost beancount infers from the
     // balance residual (issue #1705): `(posting index, cost currency, units)`.
@@ -500,6 +604,12 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Each is solved post-loop, but only when it is the SOLE unknown in its
     // cost currency group (else the group already errored on the count rule).
     let mut inferable_cost: Vec<(usize, Currency, Decimal)> = Vec::new();
+
+    // Postings carrying a bare price sigil (`@` / `@@` with no amount), whose
+    // price is solved from the residual once the currency is known (#1915):
+    // `(posting index, units, sigil kind)`. Cost-bearing postings never appear
+    // here — cost beats price, so their sigil does not affect the balance.
+    let mut bare_price: Vec<(usize, Amount, rustledger_core::PriceKind)> = Vec::new();
 
     // Units-missing postings whose weight is `units × multiplier` in some other
     // currency (a per-unit cost or price): `index -> (units currency, factor)`.
@@ -577,7 +687,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         get_inferred_currency(&mut inferred_cost_currency)
                     });
                     if let Some(curr) = cost_currency {
-                        *cost_unknowns_by_currency.entry(curr.clone()).or_default() += 1;
+                        *weight_unknowns_by_currency.entry(curr.clone()).or_default() += 1;
                         // An empty `{}` reaching here is an augmentation (a
                         // reduction's `{}` is filled by the booking pass
                         // first). Beancount infers its per-unit cost from the
@@ -697,13 +807,17 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         };
                         accumulate_residual(&mut residuals, &mut unrepresentable, &curr, signed);
                     } else {
-                        // Incomplete/empty price annotation — fall back to units
-                        accumulate_residual(
-                            &mut residuals,
-                            &mut unrepresentable,
-                            &amount.currency,
-                            amount.number,
-                        );
+                        // A bare `@` / `@@` sigil with no amount is a REQUEST to
+                        // compute the price, so this posting's weight is unknown
+                        // rather than "the units" (#1915). Contributing the units
+                        // here would both answer the request with silence and let
+                        // an unbalanced transaction look balanced.
+                        //
+                        // Reached only when the posting has no cost spec (the cost
+                        // branches come first), which is right: cost beats price,
+                        // so alongside a cost the sigil is inert — it feeds implicit
+                        // price directives and never the balance.
+                        bare_price.push((i, amount.clone(), price.kind));
                     }
                 } else {
                     // Simple posting: weight is just the units
@@ -790,7 +904,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // failing here, and what Python beancount prints.
     if !unrepresentable.is_empty()
         && (!missing_by_currency.is_empty()
-            || !cost_unknowns_by_currency.is_empty()
+            || !weight_unknowns_by_currency.is_empty()
             || !unassigned_missing.is_empty())
     {
         // Deterministic choice of currency for the message.
@@ -807,11 +921,30 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
         residuals.remove(currency);
     }
 
+    // Resolve which currency each bare price sigil answers in, and register it
+    // as an unknown there BEFORE the count rule below — a posting whose price
+    // is still to be computed contributes an unknown weight to that currency
+    // exactly as an empty `{}` cost spec does (#1915).
+    let mut bare_price_solved: Vec<(usize, Amount, rustledger_core::PriceKind, Currency)> =
+        Vec::with_capacity(bare_price.len());
+    for (idx, units, kind) in bare_price {
+        let Some(currency) = bare_price_currency(transaction, idx, &residuals) else {
+            return Err(InterpolationError::AmbiguousBarePriceCurrency {
+                account: transaction.postings[idx].account.clone(),
+            });
+        };
+        *weight_unknowns_by_currency
+            .entry(currency.clone())
+            .or_default() += 1;
+        bare_price_solved.push((idx, units, kind, currency));
+    }
+
     // Check for multiple unknowns in the same currency group. An "unknown"
-    // is either a missing-amount posting or a posting with an empty cost
-    // spec (whose cost-basis weight contribution is unknown until booking
-    // resolves the lot match). Bean-check enforces "at most one unknown
-    // per currency group" — see issue #1026.
+    // is a missing-amount posting, a posting with an empty cost spec (whose
+    // cost-basis weight is unknown until booking resolves the lot match), or
+    // a posting whose price is still to be computed from a bare sigil.
+    // Bean-check enforces "at most one unknown per currency group" — see
+    // issue #1026.
     //
     // Iterate currencies in sorted order so the error message is
     // deterministic for the same input. HashMap iteration order is
@@ -819,7 +952,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // sorting would produce non-reproducible test output.
     let mut currencies_with_unknowns: Vec<&Currency> = missing_by_currency
         .keys()
-        .chain(cost_unknowns_by_currency.keys())
+        .chain(weight_unknowns_by_currency.keys())
         .collect();
     currencies_with_unknowns.sort_by(|a, b| a.as_str().cmp(b.as_str()));
     currencies_with_unknowns.dedup();
@@ -827,11 +960,11 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
         let missing_count = missing_by_currency
             .get(currency)
             .map_or(0, std::vec::Vec::len);
-        let cost_unknown_count = cost_unknowns_by_currency
+        let weight_unknown_count = weight_unknowns_by_currency
             .get(currency)
             .copied()
             .unwrap_or(0);
-        let total = missing_count + cost_unknown_count;
+        let total = missing_count + weight_unknown_count;
         if total > 1 {
             return Err(InterpolationError::MultipleMissing {
                 currency: currency.clone(),
@@ -857,10 +990,10 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Pick the lexicographically-smallest cost-unknown currency for the
     // error so the message is reproducible across runs.
     if !unassigned_missing.is_empty() {
-        let mut cost_unknown_keys: Vec<&Currency> = cost_unknowns_by_currency.keys().collect();
-        cost_unknown_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-        if let Some(curr) = cost_unknown_keys.first() {
-            let count = cost_unknowns_by_currency.get(*curr).copied().unwrap_or(0);
+        let mut weight_unknown_keys: Vec<&Currency> = weight_unknowns_by_currency.keys().collect();
+        weight_unknown_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        if let Some(curr) = weight_unknown_keys.first() {
+            let count = weight_unknowns_by_currency.get(*curr).copied().unwrap_or(0);
             return Err(InterpolationError::MultipleMissing {
                 currency: (*curr).clone(),
                 count: count + unassigned_missing.len(),
@@ -916,6 +1049,72 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
         // Fold the now-known cost weight into the residual so downstream
         // missing-amount solving sees a balanced cost currency.
         *residuals.entry(currency).or_default() += total * signum;
+    }
+
+    // Answer each bare price sigil from the residual it has to cancel (#1915).
+    //
+    // Runs beside the `{}` cost inference above and for the same reason: the
+    // solved weight has to land in the residual before any elided amount
+    // absorbs that currency. Each entry is guaranteed the sole unknown in its
+    // currency — the count rule rejected any group with more.
+    //
+    // `@` weighs `units × price` and `@@` weighs `total × signum(units)`, so
+    // invert each accordingly. NOT what Python beancount computes: it solves
+    // the MAGNITUDE, `|residual| / |units|`, which happens to balance only when
+    // the other side is opposite-signed. On `IncompleteInputs.PriceMissing`
+    // (`100.00 USD @` against a POSITIVE `120.00 CAD`) it fills `@1.2 CAD` and
+    // then reports the 240 CAD imbalance it just created. The value that would
+    // balance there is -1.2, and a negative price is not a price, so the honest
+    // answer is to refuse and say why.
+    for (idx, units, kind, currency) in bare_price_solved {
+        let residual = residuals.get(&currency).copied().unwrap_or(Decimal::ZERO);
+
+        if units.number.is_zero() {
+            // Zero units weigh nothing at any price, so the balance says
+            // nothing about this price. Harmless when the books already
+            // balance; otherwise the sigil cannot be the thing that fixes them.
+            if residual.is_zero() {
+                continue;
+            }
+            return Err(InterpolationError::AmbiguousBarePriceCurrency {
+                account: transaction.postings[idx].account.clone(),
+            });
+        }
+
+        let (solved, weight) = match kind {
+            rustledger_core::PriceKind::Unit => {
+                let Some(price) = (-residual).checked_div(units.number) else {
+                    return Err(InterpolationError::Unrepresentable { currency });
+                };
+                let Some(weight) = crate::price_weight(units.number, price, kind) else {
+                    return Err(InterpolationError::Unrepresentable { currency });
+                };
+                (price, weight)
+            }
+            rustledger_core::PriceKind::Total => {
+                // `weight = total × signum(units)`, and signum is ±1 here, so
+                // multiplying inverts it exactly.
+                let total = -residual * units.number.signum();
+                let Some(weight) = crate::price_weight(units.number, total, kind) else {
+                    return Err(InterpolationError::Unrepresentable { currency });
+                };
+                (total, weight)
+            }
+        };
+
+        if solved < Decimal::ZERO {
+            return Err(InterpolationError::NegativeInferredPrice {
+                account: transaction.postings[idx].account.clone(),
+                currency,
+                price: solved,
+            });
+        }
+
+        result.postings[idx].price = Some(rustledger_core::PriceAnnotation {
+            kind,
+            amount: Some(IncompleteAmount::Complete(Amount::new(solved, &currency))),
+        });
+        *residuals.entry(currency).or_default() += weight;
     }
 
     // Fill in known-currency missing postings
@@ -2881,5 +3080,183 @@ mod tests {
             get_amount(&result.transaction.postings[1]).map(|a| a.number),
             Some(dec!(50.00))
         );
+    }
+
+    // ---- #1915: a bare price sigil (`@` / `@@`) is a request to COMPUTE the
+    // price, not an absent price ----
+
+    fn bare_unit_price(account: &str, number: Decimal, currency: &str) -> Posting {
+        Posting::new(account, Amount::new(number, currency))
+            .with_price(rustledger_core::PriceAnnotation::unit_empty())
+    }
+
+    fn solved_price(posting: &Posting) -> Option<(Decimal, Currency, rustledger_core::PriceKind)> {
+        let price = posting.price.as_ref()?;
+        let amount = price
+            .amount
+            .as_ref()
+            .and_then(IncompleteAmount::as_amount)?;
+        Some((amount.number, amount.currency.clone(), price.kind))
+    }
+
+    /// `100.00 USD @` against `-50.00 EUR` has exactly one answer: 0.5 EUR.
+    #[test]
+    fn solves_a_bare_unit_price_from_the_residual() {
+        let txn = Transaction::new(date(2010, 5, 28), "Convert")
+            .with_synthesized_posting(bare_unit_price("Assets:A", dec!(100.00), "USD"))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-50.00), "EUR")));
+
+        let result = interpolate(&txn).expect("solvable");
+        let (number, currency, kind) =
+            solved_price(&result.transaction.postings[0]).expect("price filled");
+        assert_eq!(number, dec!(0.5));
+        assert_eq!(currency, Currency::from("EUR"));
+        assert_eq!(
+            kind,
+            rustledger_core::PriceKind::Unit,
+            "stays a per-unit `@`"
+        );
+        assert_eq!(
+            result.residuals.get("EUR").copied(),
+            Some(Decimal::ZERO),
+            "the solved price must make the transaction balance"
+        );
+    }
+
+    /// A `@@` sigil is answered with a TOTAL, and stays a `@@`. Python
+    /// beancount normalizes this to a per-unit price; keeping the form the
+    /// author chose is the ADR-0008 position, and the weight is identical.
+    #[test]
+    fn solves_a_bare_total_price_and_keeps_the_total_form() {
+        let txn = Transaction::new(date(2010, 5, 28), "Convert")
+            .with_synthesized_posting(
+                Posting::new("Assets:A", Amount::new(dec!(100.00), "USD"))
+                    .with_price(rustledger_core::PriceAnnotation::total_empty()),
+            )
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-50.00), "EUR")));
+
+        let result = interpolate(&txn).expect("solvable");
+        let (number, currency, kind) =
+            solved_price(&result.transaction.postings[0]).expect("price filled");
+        assert_eq!(number, dec!(50.00), "the TOTAL, not the 0.5 per-unit rate");
+        assert_eq!(currency, Currency::from("EUR"));
+        assert_eq!(kind, rustledger_core::PriceKind::Total);
+        assert_eq!(result.residuals.get("EUR").copied(), Some(Decimal::ZERO));
+    }
+
+    /// The sign convention, which is where Python beancount goes wrong. It
+    /// solves the MAGNITUDE (`|residual| / |units|`), so on
+    /// `IncompleteInputs.PriceMissing` it fills `@1.2 CAD` against a POSITIVE
+    /// `120.00 CAD` and then reports the 240 CAD imbalance it just created.
+    /// The value that balances is -1.2, and a negative price is not a price,
+    /// so refuse and say so.
+    #[test]
+    fn refuses_a_bare_price_that_would_have_to_be_negative() {
+        let txn = Transaction::new(date(2010, 5, 28), "PriceMissing vector")
+            .with_synthesized_posting(bare_unit_price("Assets:Account1", dec!(100.00), "USD"))
+            .with_synthesized_posting(Posting::new(
+                "Assets:Account2",
+                Amount::new(dec!(120.00), "CAD"),
+            ));
+
+        match interpolate(&txn) {
+            Err(InterpolationError::NegativeInferredPrice {
+                account,
+                currency,
+                price,
+            }) => {
+                assert_eq!(account.as_str(), "Assets:Account1");
+                assert_eq!(currency, Currency::from("CAD"));
+                assert_eq!(price, dec!(-1.2));
+            }
+            other => panic!("expected NegativeInferredPrice, got {other:?}"),
+        }
+    }
+
+    /// The sigil competes for a residual, so it is an unknown for the
+    /// one-per-currency-group rule — the whole point of #1915.
+    #[test]
+    fn a_bare_price_counts_as_an_unknown_in_its_group() {
+        let mut elided = Posting::auto("Assets:Cash");
+        elided.units = Some(IncompleteAmount::CurrencyOnly("USD".into()));
+
+        let txn = Transaction::new(date(2010, 5, 28), "Two unknowns in USD")
+            .with_synthesized_posting(bare_unit_price("Assets:A", dec!(100.00), "USD"))
+            .with_synthesized_posting(elided);
+
+        match interpolate(&txn) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(currency, Currency::from("USD"));
+                assert_eq!(count, 2, "the elided posting AND the bare price");
+            }
+            other => panic!("expected MultipleMissing in USD, got {other:?}"),
+        }
+    }
+
+    /// The group is the other postings' WEIGHT currency, not their units
+    /// currency: `? CAD @ 1.2 USD` weighs in USD, so a bare sigil facing it
+    /// resolves in USD and collides there. Reading CAD off the units would put
+    /// the two unknowns in different groups and hide the ambiguity — which is
+    /// exactly what an earlier draft of this fix did.
+    #[test]
+    fn a_bare_price_resolves_against_weight_currencies_not_units_currencies() {
+        let mut priced_elided = Posting::auto("Assets:Account2");
+        priced_elided.units = Some(IncompleteAmount::CurrencyOnly("CAD".into()));
+        let priced_elided = priced_elided.with_price(rustledger_core::PriceAnnotation::unit(
+            Amount::new(dec!(1.2), "USD"),
+        ));
+
+        let txn = Transaction::new(date(2010, 5, 28), "UnitsMissingNumberWithPrice vector")
+            .with_synthesized_posting(priced_elided)
+            .with_synthesized_posting(bare_unit_price("Assets:Account1", dec!(100.00), "USD"));
+
+        match interpolate(&txn) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(currency, Currency::from("USD"), "not CAD");
+                assert_eq!(count, 2);
+            }
+            other => panic!("expected MultipleMissing in USD, got {other:?}"),
+        }
+    }
+
+    /// Cost beats price, so alongside a cost the sigil never touches the
+    /// balance — it feeds implicit price directives only. Treating it as a
+    /// weight unknown there would reject transactions that are perfectly
+    /// determined by their cost basis.
+    #[test]
+    fn a_bare_price_beside_a_cost_is_inert() {
+        let txn = Transaction::new(date(2010, 5, 28), "Buy with a bare price")
+            .with_synthesized_posting(
+                Posting::new("Assets:Stock", Amount::new(dec!(2), "HOOL"))
+                    .with_cost(per_unit_cost(dec!(300.00), "USD"))
+                    .with_price(rustledger_core::PriceAnnotation::unit_empty()),
+            )
+            .with_synthesized_posting(Posting::new(
+                "Assets:Cash",
+                Amount::new(dec!(-600.00), "USD"),
+            ));
+
+        let result = interpolate(&txn).expect("the cost determines the weight");
+        assert_eq!(result.residuals.get("USD").copied(), Some(Decimal::ZERO));
+    }
+
+    /// Both the units number and the price missing is two unknowns on one
+    /// posting; one residual cannot determine both.
+    #[test]
+    fn refuses_a_bare_price_on_a_units_missing_posting() {
+        let mut both_missing = Posting::auto("Assets:A");
+        both_missing.units = Some(IncompleteAmount::CurrencyOnly("USD".into()));
+        let both_missing = both_missing.with_price(rustledger_core::PriceAnnotation::unit_empty());
+
+        let txn = Transaction::new(date(2010, 5, 28), "Two unknowns, one posting")
+            .with_synthesized_posting(both_missing)
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-100.00), "USD")));
+
+        match interpolate(&txn) {
+            Err(InterpolationError::UnsolvableUnits { account, .. }) => {
+                assert_eq!(account.as_str(), "Assets:A");
+            }
+            other => panic!("expected UnsolvableUnits, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -387,11 +387,23 @@ fn bare_price_currency(
             if i == self_index {
                 continue;
             }
-            let currency = crate::price_currency_of(posting).or_else(|| match &posting.units {
-                Some(IncompleteAmount::Complete(amount)) => Some(amount.currency.clone()),
-                Some(IncompleteAmount::CurrencyOnly(currency)) => Some(currency.clone()),
-                _ => None,
-            });
+            // Cost beats price beats units, the same ladder the residual scan
+            // walks. A cost-bearing posting weighs in its COST currency, so
+            // `HOOL {300.00 USD}` offers USD and never HOOL; reading the
+            // commodity off its units would put this sigil in a different
+            // group from a posting it actually competes with, and downgrade a
+            // "too many unknowns in USD" into a bare imbalance report. When a
+            // `{}` spec names no currency there is no candidate to offer, so
+            // contribute none rather than guess.
+            let currency = if posting.cost.is_some() {
+                crate::cost_currency_of(posting, || None)
+            } else {
+                crate::price_currency_of(posting).or_else(|| match &posting.units {
+                    Some(IncompleteAmount::Complete(amount)) => Some(amount.currency.clone()),
+                    Some(IncompleteAmount::CurrencyOnly(currency)) => Some(currency.clone()),
+                    _ => None,
+                })
+            };
             if let Some(currency) = currency
                 && !weights.contains(&currency)
             {
@@ -3335,5 +3347,34 @@ mod tests {
             Some(dec!(-50.00)),
             "the real imbalance survives to be reported"
         );
+    }
+
+    /// The fallback candidate list must use each posting's WEIGHT currency,
+    /// which for a cost-bearing posting is the COST currency. `HOOL {300.00
+    /// USD}` offers USD, never HOOL.
+    ///
+    /// Reading the commodity off its units instead put this sigil in a HOOL
+    /// group and the cost posting in a USD one, so two unknowns that genuinely
+    /// compete looked disjoint and the transaction was reported as a bare
+    /// imbalance rather than as over-constrained. Caught in review of #1919.
+    #[test]
+    fn bare_price_fallback_uses_cost_currency_not_units_currency() {
+        let mut elided_at_cost = Posting::auto("Assets:B");
+        elided_at_cost.units = Some(IncompleteAmount::CurrencyOnly("HOOL".into()));
+        let elided_at_cost = elided_at_cost.with_cost(per_unit_cost(dec!(300.00), "USD"));
+
+        // Every other posting is itself an unknown, so all residuals are zero
+        // and the fallback path is the one that runs.
+        let txn = Transaction::new(date(2010, 5, 28), "Both weigh in USD")
+            .with_synthesized_posting(bare_unit_price("Assets:A", dec!(100.00), "USD"))
+            .with_synthesized_posting(elided_at_cost);
+
+        match interpolate(&txn) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(currency, Currency::from("USD"), "not HOOL");
+                assert_eq!(count, 2, "the bare sigil AND the cost posting's units");
+            }
+            other => panic!("expected MultipleMissing in USD, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -331,11 +331,19 @@ fn units_weight(
     UnitsWeight::Units
 }
 
-/// The currency a bare price sigil (`@` / `@@` with no amount) resolves in.
+/// The currency a bare price sigil resolves in.
 ///
-/// The sigil means "compute this price", and the only thing that determines it
-/// is the residual the posting has to cancel — so the answer is the currency
-/// the transaction is out of balance in.
+/// **A declared currency always wins.** `@ USD` (the form beancount's own
+/// parser docs call "recommended") states the answer's currency and leaves only
+/// the number to compute, so there is nothing to infer and nothing we are
+/// entitled to override. Inferring anyway would let `100.00 USD @ CAD` against
+/// `-50.00 EUR` be written back as `@ 0.50 EUR` — substituting a currency the
+/// author did not write, which is the same fabrication this module refuses
+/// everywhere else.
+///
+/// Only a fully bare `@` / `@@` needs inference, and then the answer is the
+/// currency the transaction is out of balance in: that is the residual the
+/// posting has to cancel.
 ///
 /// When nothing is known yet (every other posting is itself an unknown, so all
 /// residuals are zero) fall back to the currencies the other postings are
@@ -348,6 +356,19 @@ fn bare_price_currency(
     self_index: usize,
     residuals: &HashMap<Currency, Decimal>,
 ) -> Option<Currency> {
+    if let Some(declared) = txn.postings[self_index]
+        .price
+        .as_ref()
+        .and_then(|p| p.amount.as_ref())
+        .and_then(|a| match a {
+            IncompleteAmount::CurrencyOnly(currency) => Some(currency.clone()),
+            IncompleteAmount::Complete(amount) => Some(amount.currency.clone()),
+            IncompleteAmount::NumberOnly(_) => None,
+        })
+    {
+        return Some(declared);
+    }
+
     let candidates: Vec<&Currency> = residuals
         .iter()
         .filter(|(_, value)| !value.is_zero())
@@ -1079,6 +1100,17 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
             return Err(InterpolationError::AmbiguousBarePriceCurrency {
                 account: transaction.postings[idx].account.clone(),
             });
+        }
+
+        // Nothing to cancel in this currency, so the balance determines nothing
+        // and the honest answer is to leave the sigil unanswered. Reachable when
+        // the author DECLARED a price currency (`@ CAD`) that no other posting
+        // touches: writing the `@ 0 CAD` the arithmetic implies would put a
+        // fabricated rate in the ledger, and the real problem — the currency
+        // that actually fails to balance — is reported by the balance validator,
+        // which still runs because the units here are complete.
+        if residual.is_zero() {
+            continue;
         }
 
         let (solved, weight) = match kind {
@@ -3258,5 +3290,50 @@ mod tests {
             }
             other => panic!("expected UnsolvableUnits, got {other:?}"),
         }
+    }
+
+    /// `@ USD` — the form beancount's own parser docs call "recommended" —
+    /// states the answer's currency and leaves only the number to compute. The
+    /// declared currency must WIN over inference: `100.00 USD @ CAD` against
+    /// `-50.00 EUR` must not be written back as `@ 0.50 EUR`, substituting a
+    /// currency the author never wrote.
+    #[test]
+    fn a_declared_price_currency_is_not_overridden_by_inference() {
+        let declared = |currency: &str| {
+            Posting::new("Assets:A", Amount::new(dec!(100.00), "USD")).with_price(
+                rustledger_core::PriceAnnotation {
+                    kind: rustledger_core::PriceKind::Unit,
+                    amount: Some(IncompleteAmount::CurrencyOnly(currency.into())),
+                },
+            )
+        };
+
+        // Declared currency agrees with the residual: solve the number in it.
+        let agrees = Transaction::new(date(2010, 5, 28), "Declared EUR")
+            .with_synthesized_posting(declared("EUR"))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-50.00), "EUR")));
+        let result = interpolate(&agrees).expect("solvable");
+        let (number, currency, _) =
+            solved_price(&result.transaction.postings[0]).expect("price filled");
+        assert_eq!(number, dec!(0.5));
+        assert_eq!(currency, Currency::from("EUR"));
+
+        // Declared currency has nothing to cancel. The arithmetic would give
+        // `@ 0 CAD`; writing that would put a rate in the ledger that the author
+        // never chose and the balance never implied, so leave it unanswered and
+        // let the balance validator report the currency that actually fails.
+        let conflicts = Transaction::new(date(2010, 5, 28), "Declared CAD")
+            .with_synthesized_posting(declared("CAD"))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-50.00), "EUR")));
+        let result = interpolate(&conflicts).expect("no interpolation error");
+        assert!(
+            solved_price(&result.transaction.postings[0]).is_none(),
+            "must not invent a rate in a currency the balance says nothing about"
+        );
+        assert_eq!(
+            result.residuals.get("EUR").copied(),
+            Some(dec!(-50.00)),
+            "the real imbalance survives to be reported"
+        );
     }
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -88,6 +88,16 @@ pub enum InterpolationError {
         account: rustledger_core::Account,
     },
 
+    /// A bare price sigil cannot be answered from the balance for a reason
+    /// other than an ambiguous currency (#1915).
+    #[error("cannot compute the price for the {account} posting: {reason}")]
+    UnsolvablePrice {
+        /// The account of the posting carrying the bare sigil.
+        account: rustledger_core::Account,
+        /// Why the balance does not determine the price.
+        reason: &'static str,
+    },
+
     /// Solving a bare price sigil from the residual gives a negative price
     /// (#1915). Refused for the same reason as [`Self::NegativeInferredCost`]:
     /// the balance is asking for something that is not a price.
@@ -1109,8 +1119,13 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
             if residual.is_zero() {
                 continue;
             }
-            return Err(InterpolationError::AmbiguousBarePriceCurrency {
+            // The currency IS known here; what fails is the arithmetic, so do
+            // not send the user off to write a price currency they already
+            // have (or that would not help).
+            return Err(InterpolationError::UnsolvablePrice {
                 account: transaction.postings[idx].account.clone(),
+                reason: "the posting has zero units, so no price gives it any weight, \
+                         and the transaction does not balance without one",
             });
         }
 
@@ -3376,5 +3391,37 @@ mod tests {
             }
             other => panic!("expected MultipleMissing in USD, got {other:?}"),
         }
+    }
+
+    /// A zero-units posting carrying a bare sigil has a KNOWN currency; what
+    /// fails is that no price gives zero units any weight. The error must say
+    /// that, not send the author off to write a price currency they already
+    /// have. (Python beancount raises `decimal.DivisionByZero` on this input,
+    /// unguarded, where its sibling cost branch checks `units.number != ZERO`.)
+    #[test]
+    fn refuses_a_bare_price_on_zero_units_without_blaming_the_currency() {
+        let txn = Transaction::new(date(2010, 5, 28), "Zero units")
+            .with_synthesized_posting(bare_unit_price("Assets:A", dec!(0.00), "USD"))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-50.00), "EUR")));
+
+        match interpolate(&txn) {
+            Err(InterpolationError::UnsolvablePrice { account, reason }) => {
+                assert_eq!(account.as_str(), "Assets:A");
+                assert!(reason.contains("zero units"), "got: {reason}");
+            }
+            other => panic!("expected UnsolvablePrice, got {other:?}"),
+        }
+    }
+
+    /// Zero units AND a balanced book: the sigil is simply unanswerable and
+    /// harmless, so leave it rather than erroring.
+    #[test]
+    fn leaves_a_bare_price_on_zero_units_alone_when_the_books_balance() {
+        let txn = Transaction::new(date(2010, 5, 28), "Zero units, balanced")
+            .with_synthesized_posting(bare_unit_price("Assets:A", dec!(0.00), "USD"))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(0.00), "EUR")));
+
+        let result = interpolate(&txn).expect("harmless");
+        assert!(solved_price(&result.transaction.postings[0]).is_none());
     }
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -341,6 +341,27 @@ fn units_weight(
     UnitsWeight::Units
 }
 
+/// The price currency the author WROTE, whether or not they also wrote a
+/// number: both `@ 1.20 USD` and `@ USD` say USD.
+///
+/// Deliberately wider than [`crate::price_currency_of`], which reads only a
+/// COMPLETE price amount and so cannot see `@ USD` at all. That is the right
+/// reading where a price's numeric contribution is what matters, but here the
+/// question is "which currency does this posting's weight land in", and
+/// `@ USD` answers it perfectly well. Using the narrow one made a posting
+/// priced `@ USD` offer its UNITS currency as a candidate instead.
+fn declared_price_currency(posting: &rustledger_core::Posting) -> Option<Currency> {
+    posting
+        .price
+        .as_ref()
+        .and_then(|p| p.amount.as_ref())
+        .and_then(|amount| match amount {
+            IncompleteAmount::Complete(amount) => Some(amount.currency.clone()),
+            IncompleteAmount::CurrencyOnly(currency) => Some(currency.clone()),
+            IncompleteAmount::NumberOnly(_) => None,
+        })
+}
+
 /// The currency a bare price sigil resolves in.
 ///
 /// **A declared currency always wins.** `@ USD` (the form beancount's own
@@ -366,16 +387,7 @@ fn bare_price_currency(
     self_index: usize,
     residuals: &HashMap<Currency, Decimal>,
 ) -> Option<Currency> {
-    if let Some(declared) = txn.postings[self_index]
-        .price
-        .as_ref()
-        .and_then(|p| p.amount.as_ref())
-        .and_then(|a| match a {
-            IncompleteAmount::CurrencyOnly(currency) => Some(currency.clone()),
-            IncompleteAmount::Complete(amount) => Some(amount.currency.clone()),
-            IncompleteAmount::NumberOnly(_) => None,
-        })
-    {
+    if let Some(declared) = declared_price_currency(&txn.postings[self_index]) {
         return Some(declared);
     }
 
@@ -408,7 +420,7 @@ fn bare_price_currency(
             let currency = if posting.cost.is_some() {
                 crate::cost_currency_of(posting, || None)
             } else {
-                crate::price_currency_of(posting).or_else(|| match &posting.units {
+                declared_price_currency(posting).or_else(|| match &posting.units {
                     Some(IncompleteAmount::Complete(amount)) => Some(amount.currency.clone()),
                     Some(IncompleteAmount::CurrencyOnly(currency)) => Some(currency.clone()),
                     _ => None,
@@ -654,6 +666,12 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // here — cost beats price, so their sigil does not affect the balance.
     let mut bare_price: Vec<(usize, Amount, rustledger_core::PriceKind)> = Vec::new();
 
+    // Postings priced `@ 1.20` — price number written, price currency elided.
+    // Only the currency is inferred; the number is kept verbatim:
+    // `(posting index, units, sigil kind, price number)`.
+    let mut price_number_known: Vec<(usize, Amount, rustledger_core::PriceKind, Decimal)> =
+        Vec::new();
+
     // Units-missing postings whose weight is `units × multiplier` in some other
     // currency (a per-unit cost or price): `index -> (units currency, factor)`.
     // Their entry in `missing_by_currency` is keyed by the WEIGHT currency, so
@@ -849,12 +867,21 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                             }
                         };
                         accumulate_residual(&mut residuals, &mut unrepresentable, &curr, signed);
+                    } else if let Some(IncompleteAmount::NumberOnly(price_number)) =
+                        price.amount.as_ref()
+                    {
+                        // `@ 1.20` — the price NUMBER is written and only its
+                        // currency is elided. The number is data, so keep it and
+                        // infer just the currency, exactly as the units path does
+                        // for a bare `120.00`. Treating this as a sigil overwrote
+                        // the author's rate with whatever balanced the books.
+                        price_number_known.push((i, amount.clone(), price.kind, *price_number));
                     } else {
-                        // A bare `@` / `@@` sigil with no amount is a REQUEST to
-                        // compute the price, so this posting's weight is unknown
-                        // rather than "the units" (#1915). Contributing the units
-                        // here would both answer the request with silence and let
-                        // an unbalanced transaction look balanced.
+                        // A bare `@` / `@@` sigil, or `@ USD`: the NUMBER is to be
+                        // computed, so this posting's weight is unknown rather than
+                        // "the units" (#1915). Contributing the units here would
+                        // both answer the request with silence and let an
+                        // unbalanced transaction look balanced.
                         //
                         // Reached only when the posting has no cost spec (the cost
                         // branches come first), which is right: cost beats price,
@@ -968,6 +995,31 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // as an unknown there BEFORE the count rule below — a posting whose price
     // is still to be computed contributes an unknown weight to that currency
     // exactly as an empty `{}` cost spec does (#1915).
+    // Give each `@ 1.20` its price currency, keeping the number. Runs BEFORE the
+    // bare-sigil resolution below, because these postings contribute a KNOWN
+    // weight once denominated and a sigil should see what is actually left over.
+    for (idx, units, kind, price_number) in price_number_known {
+        let Some(currency) = bare_price_currency(transaction, idx, &residuals) else {
+            return Err(InterpolationError::AmbiguousBarePriceCurrency {
+                account: transaction.postings[idx].account.clone(),
+            });
+        };
+        let Some(weight) = crate::price_weight(units.number, price_number, kind) else {
+            return Err(InterpolationError::Unrepresentable { currency });
+        };
+        result.postings[idx].price = Some(rustledger_core::PriceAnnotation {
+            kind,
+            amount: Some(IncompleteAmount::Complete(Amount::new(
+                price_number,
+                &currency,
+            ))),
+        });
+        accumulate_residual(&mut residuals, &mut unrepresentable, &currency, weight);
+        if unrepresentable.contains(&currency) {
+            return Err(InterpolationError::Unrepresentable { currency });
+        }
+    }
+
     let mut bare_price_solved: Vec<(usize, Amount, rustledger_core::PriceKind, Currency)> =
         Vec::with_capacity(bare_price.len());
     for (idx, units, kind) in bare_price {
@@ -3423,5 +3475,78 @@ mod tests {
 
         let result = interpolate(&txn).expect("harmless");
         assert!(solved_price(&result.transaction.postings[0]).is_none());
+    }
+
+    /// `@ 1.20` writes the price NUMBER and elides only its currency. The
+    /// number is data: infer the currency, keep the number.
+    ///
+    /// Treating it as a sigil overwrote the author's rate with whatever
+    /// balanced the books (`1.20` became `1.00`), and diverged from
+    /// `calculate_residual`, which has its own test pinning that an incomplete
+    /// price with a number does NOT get re-solved. Caught in review of #1919.
+    #[test]
+    fn price_number_without_a_currency_keeps_its_number() {
+        let priced = |number: Decimal| {
+            Posting::new("Assets:A", Amount::new(dec!(100.00), "USD")).with_price(
+                rustledger_core::PriceAnnotation::unit_incomplete(IncompleteAmount::NumberOnly(
+                    number,
+                )),
+            )
+        };
+
+        // Does not balance: 100.00 x 1.20 = 120.00 against -100.00.
+        let off = Transaction::new(date(2010, 5, 28), "rate written, currency elided")
+            .with_synthesized_posting(priced(dec!(1.20)))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-100.00), "USD")));
+        let result = interpolate(&off).expect("currency is inferable");
+        let (number, currency, _) =
+            solved_price(&result.transaction.postings[0]).expect("price completed");
+        assert_eq!(number, dec!(1.20), "the author's rate, not a re-solved one");
+        assert_eq!(currency, Currency::from("USD"));
+        assert_eq!(
+            result.residuals.get("USD").copied(),
+            Some(dec!(20.0000)),
+            "the imbalance the author's own rate implies must survive to be reported"
+        );
+
+        // And when the rate does balance, it is simply accepted.
+        let ok = Transaction::new(date(2010, 5, 28), "rate written, balances")
+            .with_synthesized_posting(priced(dec!(1.20)))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-120.00), "USD")));
+        let result = interpolate(&ok).expect("currency is inferable");
+        assert_eq!(
+            solved_price(&result.transaction.postings[0]).map(|(n, _, _)| n),
+            Some(dec!(1.20))
+        );
+        assert_eq!(result.residuals.get("USD").copied(), Some(Decimal::ZERO));
+    }
+
+    /// The fallback candidate scan must see a price currency written WITHOUT a
+    /// number (`@ USD`). `crate::price_currency_of` reads only a complete price
+    /// amount, so using it made a posting priced `@ USD` offer its units
+    /// currency instead, splitting two unknowns that genuinely compete.
+    /// Caught in review of #1919.
+    #[test]
+    fn bare_price_fallback_sees_a_currency_only_price() {
+        let bare = bare_unit_price("Assets:A", dec!(100.00), "EUR");
+        let at_usd = Posting::new("Assets:B", Amount::new(dec!(200.00), "CAD")).with_price(
+            rustledger_core::PriceAnnotation::unit_incomplete(IncompleteAmount::CurrencyOnly(
+                "USD".into(),
+            )),
+        );
+
+        // Both prices are still to be computed, so every residual is zero and
+        // the fallback path is the one that runs.
+        let txn = Transaction::new(date(2010, 5, 28), "both weigh in USD")
+            .with_synthesized_posting(bare)
+            .with_synthesized_posting(at_usd);
+
+        match interpolate(&txn) {
+            Err(InterpolationError::MultipleMissing { currency, count }) => {
+                assert_eq!(currency, Currency::from("USD"), "not CAD, and not EUR");
+                assert_eq!(count, 2);
+            }
+            other => panic!("expected MultipleMissing in USD, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2224,3 +2224,61 @@ fn test_units_number_elided_with_cost_is_solved_and_booked() {
         "written in the posting's own commodity, not the cost currency"
     );
 }
+
+/// #1915 end-to-end: a bare `@` sigil asks for the price to be computed, and
+/// the whole pipeline must answer it rather than treating the posting as
+/// unpriced.
+#[test]
+fn test_bare_price_sigil_is_solved_from_the_residual() {
+    use rustledger_loader::{LoadOptions, process};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("issue1915.beancount");
+    std::fs::write(
+        &path,
+        "2010-01-01 open Assets:A\n\
+         2010-01-01 open Assets:B\n\
+         \n\
+         2010-05-28 * \"bare price sigil\"\n  \
+         Assets:A    100.00 USD @\n  \
+         Assets:B    -50.00 EUR\n",
+    )
+    .unwrap();
+
+    let raw = rustledger_loader::load_raw(&path).expect("load raw");
+    let ledger = process(raw, &LoadOptions::default()).expect("process");
+
+    assert!(
+        ledger.errors.is_empty(),
+        "should balance once the price is solved, got {:?}",
+        ledger.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+
+    let txn = ledger
+        .directives
+        .iter()
+        .find_map(|d| match &d.value {
+            rustledger_core::Directive::Transaction(t) => Some(t),
+            _ => None,
+        })
+        .expect("the transaction survived booking");
+
+    let priced = txn
+        .postings
+        .iter()
+        .find(|p| p.account.as_str() == "Assets:A")
+        .expect("posting present");
+    let price = priced
+        .price
+        .as_ref()
+        .and_then(|p| p.amount.as_ref())
+        .and_then(rustledger_core::IncompleteAmount::as_amount)
+        .expect("the bare sigil was answered");
+
+    assert_eq!(
+        price.number,
+        rust_decimal_macros::dec!(0.5),
+        "50.00 / 100.00"
+    );
+    assert_eq!(price.currency, "EUR");
+}


### PR DESCRIPTION
## What

`100.00 USD @` asks for the price to be **computed**. rledger read the bare sigil as "no price" and weighed the posting at its units, so the request went unanswered and the posting silently stopped competing for the residual it was meant to cancel.

```beancount
2010-05-28 * "convert"
  Assets:A    100.00 USD @
  Assets:B    -50.00 EUR
```

| | |
|---|---|
| before | `E3001 Transaction does not balance` |
| after | `@ 0.50 EUR`, balanced |

`@` weighs `units × price` and `@@` weighs `total × signum(units)`, so each is inverted accordingly. A `@@` is answered with a **total** and stays a `@@` — beancount normalizes it to a per-unit rate, but the weight is identical and keeping the author's chosen form is the ADR-0008 position.

## Where this deliberately departs from beancount

beancount solves the **magnitude**, `|residual| / |units|`, which balances only when the other side happens to be opposite-signed. On the canonical `IncompleteInputs.PriceMissing` vector it does this:

```beancount
  Assets:Account1     100.00 USD @        →  beancount fills @1.2 CAD
  Assets:Account2     120.00 CAD              (note: POSITIVE)
```

```
weight(Account1) = +120.000 CAD
weight(Account2) = +120.00  CAD
ValidationError: Transaction does not balance: (240.000 CAD)
```

It fills a price that **cannot** balance, then reports the imbalance it just created. The value that would balance is `-1.2`, and a negative price is not a price — so the honest answer is to refuse and name the number the balance was asking for:

```
the price of the Assets:Account1 posting would have to be -1.20 CAD to balance
this transaction, and a negative price is not meaningful; check the signs of
the other postings
```

That mirrors the existing `NegativeInferredCost` rule for `{}` cost specs, so the two inference paths now refuse for the same stated reason.

## The grouping subtlety

The sigil is also an unknown for the one-per-currency-group rule — which is what #1915 was actually filed for. Its group is resolved from the residual it has to cancel, falling back to the other postings' **weight** currencies when nothing is known yet.

Not their *units* currencies: a price redenominates the weight, so `? CAD @ 1.2 USD` weighs in USD. An earlier draft of this PR read CAD off the units, which put the two unknowns in separate groups and hid a genuine ambiguity. There is a test named for exactly that.

Alongside a cost the sigil is inert and left untouched — cost beats price, so it feeds implicit price directives and never the balance.

## Verification

**Sweep of 995 corpus files under `auto_accounts`.** Without the plugin, `E1001` masks the entire `IncompleteInputs` family on both sides and the sweep reports a vacuous "no change" — worth knowing for the next sweep. With it, exactly two files change status, both `ok → ERR`, and **beancount rejects both**:

| file | beancount |
|---|---|
| `IncompleteInputs.UnitsMissingCurrencyWithPrice` | `CategorizationError` |
| `IncompleteInputs.UnitsMissingNumberWithPrice` | `InterpolationError` |

The second is the regression #1913 introduced and #1915 recorded, so this closes it. Both were being **silently accepted** by main.

- All **eleven** hand-built shapes now match beancount's accept/reject, covering `@`/`@@`, bare-plus-elided in same and different groups, two bare sigils, cost-plus-sigil, and both-unknowns-on-one-posting.
- **Six of the seven new tests confirmed to fail** against the pre-fix logic, via two separate neuters. The seventh guards against over-reach on the cost path, which neither neuter exercises — stating that plainly rather than claiming all seven.
- Workspace **4424 passed, 0 failed**. Clippy clean at the CI pin (1.97.0) with `-D warnings`; `rustdoc -D warnings` clean.

## Incidental

`cost_unknowns_by_currency` → `weight_unknowns_by_currency`. That is what it has always counted, and it now visibly holds two shapes rather than one.

Closes #1915
