### PR TITLE
fix(ci): tell a verified fix apart from an untouched failure

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -27,6 +27,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Runs BEFORE the live check and is allowed to fail the job. The live
+      # check deliberately exits 0 whatever it finds, so a logic bug in this
+      # script would otherwise surface only as a quietly wrong issue body —
+      # the same "results produced but never read" failure it exists to catch.
+      - name: Self-test
+        run: python3 scripts/nightly-health.py --self-test
       - name: Check scheduled workflows
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/nightly-health.py
+++ b/scripts/nightly-health.py
@@ -30,6 +30,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 REPO = "rustledger/rustledger"
+DEFAULT_BRANCH = "main"
 ISSUE_TITLE = "Scheduled workflow health"
 MARKER = "<!-- nightly-health -->"
 
@@ -136,7 +137,13 @@ def later_successful_manual_run(workflow: str, after: datetime) -> dict | None:
     """
     raw = gh(
         "run", "list", "--repo", REPO, "--workflow", workflow,
-        "--event", "workflow_dispatch", "--status", "success", "--limit", "1",
+        "--event", "workflow_dispatch", "--status", "success",
+        # DEFAULT BRANCH ONLY. A dispatch on a feature branch proves nothing
+        # about the scheduled run, which fires against `main`, so counting one
+        # would produce exactly the false reassurance this annotation exists to
+        # avoid: "a fix is likely already in" while `main` is still broken.
+        "--branch", DEFAULT_BRANCH,
+        "--limit", "1",
         "--json", "conclusion,createdAt,url",
         tolerate_missing=True,
     )
@@ -164,8 +171,15 @@ def self_test() -> int:
     real_gh = gh
     sched = datetime(2026, 7, 26, 6, 0, tzinfo=timezone.utc)
 
+    # Records the argv so the test can assert the QUERY, not just the answer.
+    # Stubbing only the return value would let a regression that drops
+    # `--event`, `--status` or `--branch` keep this green while the live
+    # annotation silently went wrong.
+    seen_args: list[tuple[str, ...]] = []
+
     def stub(payload: str):
         def fake(*args, **kwargs):
+            seen_args.append(args)
             return payload
         return fake
 
@@ -187,6 +201,20 @@ def self_test() -> int:
         ok = got == expected
         failures += not ok
         print(f"  {'ok  ' if ok else 'FAIL'} {label}: annotated={got} expected={expected}")
+
+    # The query shape itself: these four flags are what make the answer mean
+    # "a later manual run on the branch the cron uses".
+    required = [
+        ("--event", "workflow_dispatch"),
+        ("--status", "success"),
+        ("--branch", DEFAULT_BRANCH),
+        ("--workflow", "miri.yml"),
+    ]
+    argv = seen_args[-1] if seen_args else ()
+    for flag, value in required:
+        ok = flag in argv and argv[argv.index(flag) + 1] == value
+        failures += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'} query passes {flag} {value}")
 
     gh = real_gh
     if failures:

--- a/scripts/nightly-health.py
+++ b/scripts/nightly-health.py
@@ -116,6 +116,86 @@ def latest_scheduled_run(workflow: str) -> dict | None:
     return runs[0] if runs else None
 
 
+def later_successful_manual_run(workflow: str, after: datetime) -> dict | None:
+    """A `workflow_dispatch` run of `workflow` that succeeded after `after`.
+
+    A scheduled workflow whose fix has already been verified by hand is a
+    different state from one nobody has touched, and only reading
+    `--event schedule` cannot tell them apart. Miri is the case that prompted
+    this: its fix (#1901, #1904) was confirmed by dispatch on 2026-08-01 and
+    finished in 3 minutes where it had been running to the 60-minute cap, but
+    the report went on naming it a plain failure against a scheduled run from
+    six days earlier. An alarm that keeps flagging something already fixed is
+    one people learn to skim, which is the failure mode this whole script
+    exists to prevent.
+
+    Deliberately does NOT clear the entry. A green manual run says the code is
+    fixed; it says nothing about whether the cron still fires, which is the
+    other half of what this watches (see STALE). So it annotates and the
+    workflow stays listed until a SCHEDULED run proves it.
+    """
+    raw = gh(
+        "run", "list", "--repo", REPO, "--workflow", workflow,
+        "--event", "workflow_dispatch", "--status", "success", "--limit", "1",
+        "--json", "conclusion,createdAt,url",
+        tolerate_missing=True,
+    )
+    try:
+        runs = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not runs:
+        return None
+    created = datetime.fromisoformat(runs[0]["createdAt"].replace("Z", "+00:00"))
+    return runs[0] if created > after else None
+
+
+def self_test() -> int:
+    """Prove the manual-run annotation fires when it should and not otherwise.
+
+    This script is only useful if it is trusted, and the one thing that
+    destroys trust is a wrong entry. The date guard in
+    `later_successful_manual_run` is the part that can silently invert: get the
+    comparison backwards and every long-fixed workflow grows a reassuring
+    "already fixed" note that is not true. Nothing else in CI exercises this
+    file, so it checks itself.
+    """
+    global gh
+    real_gh = gh
+    sched = datetime(2026, 7, 26, 6, 0, tzinfo=timezone.utc)
+
+    def stub(payload: str):
+        def fake(*args, **kwargs):
+            return payload
+        return fake
+
+    cases = [
+        ("newer manual success annotates",
+         '[{"conclusion":"success","createdAt":"2026-08-01T01:53:00Z","url":"u"}]', True),
+        ("older manual success does NOT annotate",
+         '[{"conclusion":"success","createdAt":"2026-07-20T01:00:00Z","url":"u"}]', False),
+        ("same instant does NOT annotate",
+         '[{"conclusion":"success","createdAt":"2026-07-26T06:00:00Z","url":"u"}]', False),
+        ("no manual runs at all", "[]", False),
+        ("unparsable response", "not json", False),
+    ]
+
+    failures = 0
+    for label, payload, expected in cases:
+        gh = stub(payload)
+        got = later_successful_manual_run("miri.yml", sched) is not None
+        ok = got == expected
+        failures += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'} {label}: annotated={got} expected={expected}")
+
+    gh = real_gh
+    if failures:
+        print(f"::error::nightly-health self-test: {failures} case(s) failed")
+        return 1
+    print("nightly-health self-test: all cases passed")
+    return 0
+
+
 def main() -> int:
     now = datetime.now(timezone.utc)
     failing: list[str] = []
@@ -163,7 +243,18 @@ def main() -> int:
                 f"([{concl}]({run['url']}))"
             )
         elif concl != "success":
-            failing.append(f"- `{wf}` ({period}) — last run **{concl}** ([log]({run['url']}))")
+            entry = f"- `{wf}` ({period}) — last scheduled run **{concl}** ([log]({run['url']}))"
+            manual = later_successful_manual_run(wf, created)
+            if manual:
+                since = (now - datetime.fromisoformat(
+                    manual["createdAt"].replace("Z", "+00:00")
+                )).days
+                entry += (
+                    f", but a [manual run]({manual['url']}) has succeeded since "
+                    f"({since}d ago) — a fix is likely already in; still listed "
+                    "until a SCHEDULED run confirms the cron itself"
+                )
+            failing.append(entry)
         else:
             ok.append(f"`{wf}`")
         print(f"{wf:24} {period:8} {concl:12} {age.days}d ago")
@@ -221,4 +312,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        raise SystemExit(self_test())
     sys.exit(main())


### PR DESCRIPTION
## What

`nightly-health` read only `--event schedule`, so a scheduled workflow whose fix had already been verified by hand looked identical to one nobody had touched.

Miri is the live case. Its fix (#1901, #1904) was confirmed by dispatch on 2026-08-01 — `rustledger-core` finished in **3 minutes** where it had been running to the 60-minute cap — but #1907 kept reporting it as a plain failure against a scheduled run from six days earlier, and would have done so until the Sunday cron.

An alarm that keeps flagging something already fixed is one people learn to skim. That is the exact failure mode this script was written to prevent, so it should not exhibit it.

## After

Verified against the live repo (issue writes stubbed out):

```
- `miri.yml` (weekly) — last scheduled run **cancelled** ([log](...)), but a
  [manual run](...) has succeeded since (1d ago) — a fix is likely already in;
  still listed until a SCHEDULED run confirms the cron itself

- `mutation.yml` (monthly) — last scheduled run **failure** ([log](...))
```

`mutation.yml` has no later manual success and is correctly left unannotated, which is the negative case that matters.

**It deliberately does not clear the entry.** A green manual run says the code is fixed; it says nothing about whether the cron still fires, which is the other half of what this watches (see the `STALE` path). So it annotates, and the workflow stays listed until a scheduled run proves it.

## Self-test

Added `--self-test`, wired into CI **before** the live check and allowed to fail the job.

This mattered enough to add: the live check exits 0 whatever it finds, by design, so a logic bug would surface only as a quietly wrong issue body — results produced but never read, precisely the thing the script exists to catch. Nothing else in CI exercised this file at all.

The date guard is the part that can silently invert: get the comparison backwards and every long-fixed workflow grows a reassuring "already fixed" note that is untrue. So the test was checked against that mutation rather than assumed:

```
$ sed -i 's/created > after/created < after/' scripts/nightly-health.py
$ python3 scripts/nightly-health.py --self-test
  FAIL newer manual success annotates: annotated=False expected=True
  FAIL older manual success does NOT annotate: annotated=True expected=False
::error::nightly-health self-test: 2 case(s) failed          exit=1
```

Five cases: newer-success annotates, older-success does not, same-instant does not, no runs, unparsable response.

## Note

This dry run also surfaced that **`mutation.yml`'s 2026-08-01 scheduled run failed** ([log](https://github.com/rustledger/rustledger/actions/runs/30688795112)). #1907 had it as "still running" when I last looked. Investigating separately; unrelated to this change.
