### PR TITLE
test(parser): close the convert.rs mutation gaps, and unify the merge rule

### DIFF
--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -1153,21 +1153,16 @@ impl CostSpec {
     /// matters.
     #[must_use]
     pub fn is_merge(&self) -> bool {
-        let mut past_opener = false;
+        // Delegates rather than re-deriving: this used to be a hand-mirrored
+        // copy of the machine in `cost_spec_from_tokens`, and the 2026-08-01
+        // mutation run showed the copy was the only one under test.
+        let mut flag = super::convert::MergeFlag::default();
         for el in self.syntax().children_with_tokens() {
             if let rowan::NodeOrToken::Token(t) = el {
-                match t.kind() {
-                    SyntaxKind::L_BRACE | SyntaxKind::L_DOUBLE_BRACE | SyntaxKind::L_BRACE_HASH => {
-                        past_opener = true;
-                    }
-                    SyntaxKind::WHITESPACE if past_opener => {}
-                    SyntaxKind::STAR if past_opener => return true,
-                    _ if past_opener => return false,
-                    _ => {}
-                }
+                flag.feed(t.kind());
             }
         }
-        false
+        flag.is_merge()
     }
 }
 

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -3066,6 +3066,16 @@ fn fixup_directive_spans(
 mod tests {
     use super::*;
 
+    /// Match a `SyntaxError` by message prefix rather than by `Debug` output.
+    /// The `Debug` rendering of `ParseErrorKind` can change without any
+    /// semantic change, and an assertion that reads it would fail for no
+    /// reason; the variant plus the message prefix is the real contract.
+    fn has_syntax_error(result: &ParseResult, prefix: &str) -> bool {
+        result.errors.iter().any(
+            |e| matches!(&e.kind, crate::ParseErrorKind::SyntaxError(m) if m.starts_with(prefix)),
+        )
+    }
+
     fn assert_directive_count(result: &ParseResult, expected: usize) {
         assert_eq!(
             result.directives.len(),
@@ -4756,10 +4766,7 @@ mod tests {
         // Two numbers still must be rejected.
         let result = parse_via_cst("2024-01-15 price HOOL 1 2 USD\n");
         assert!(
-            result
-                .errors
-                .iter()
-                .any(|e| format!("{:?}", e.kind).contains("malformed amount")),
+            has_syntax_error(&result, "malformed amount"),
             "two numbers must still be refused: {:?}",
             result.errors
         );
@@ -4772,10 +4779,7 @@ mod tests {
     fn a_posting_flag_is_not_an_orphaned_amount_prefix() {
         let result = parse_via_cst("2024-01-15 *\n  ! Assets:A 5 USD\n  Assets:B\n");
         assert!(
-            !result
-                .errors
-                .iter()
-                .any(|e| format!("{:?}", e.kind).contains("unexpected token before posting amount")),
+            !has_syntax_error(&result, "unexpected token before posting amount"),
             "a posting flag is not an orphan: {:?}",
             result.errors
         );
@@ -4841,10 +4845,7 @@ mod tests {
     fn a_trailing_currency_closes_the_value_scan() {
         let result = parse_via_cst("2024-01-15 price HOOL 1.50 USD 2\n");
         assert!(
-            !result
-                .errors
-                .iter()
-                .any(|e| format!("{:?}", e.kind).contains("malformed amount")),
+            !has_syntax_error(&result, "malformed amount"),
             "the scan must stop at the closing currency, so the stray `2` is not \
              a second number of the VALUE: {:?}",
             result.errors
@@ -4857,10 +4858,10 @@ mod tests {
     #[test]
     fn orphan_detection_ignores_pre_account_and_non_sign_tokens() {
         let orphan_reported = |src: &str| {
-            parse_via_cst(src)
-                .errors
-                .iter()
-                .any(|e| format!("{:?}", e.kind).contains("unexpected token before posting amount"))
+            has_syntax_error(
+                &parse_via_cst(src),
+                "unexpected token before posting amount",
+            )
         };
 
         assert!(
@@ -4973,12 +4974,7 @@ mod tests {
 
         // Orphan detection, through the red converter: a comma after the
         // account is one, a comma before it and a non-sign token are not.
-        let orphan_reported = |src: &str| {
-            parse_red_only(src)
-                .errors
-                .iter()
-                .any(|e| format!("{:?}", e.kind).contains(orphan_msg))
-        };
+        let orphan_reported = |src: &str| has_syntax_error(&parse_red_only(src), orphan_msg);
         assert!(
             orphan_reported("2024-01-15 *\n  Assets:A , 1 USD\n  Assets:B\n"),
             "red: a comma after the account IS an orphan"

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -1567,6 +1567,53 @@ impl TokenView for &rowan::GreenTokenData {
         (*self).text()
     }
 }
+/// The `{*}` merge-flag state machine.
+///
+/// ONE implementation, driven by both token walkers: [`cost_spec_from_tokens`]
+/// feeds it inside its single pass, and [`super::ast::CostSpec::is_merge`]
+/// feeds it while walking the red tree. The rule was hand-mirrored in those two
+/// places until the 2026-08-01 mutation run showed EVERY mutant in this machine
+/// surviving on the `convert.rs` side: the only tests exercising the rule went
+/// through the `ast.rs` copy, so the canonical could have been broken outright
+/// without one test failing. That is the drift this module's `TokenView` doc
+/// says it exists to prevent, in the one place it had not been applied.
+///
+/// The rule: the flag is decided by the first non-whitespace, non-opener token
+/// after an opener (`*` means merge, anything else means not). A `*` elsewhere
+/// is the multiplication operator, as in `{500 * 2 USD}`, and a pass that
+/// re-arms on later openers flips the flag on malformed input where it must not.
+#[derive(Default)]
+pub(in crate::cst) struct MergeFlag {
+    past_opener: bool,
+    decided: bool,
+    merge: bool,
+}
+
+impl MergeFlag {
+    /// Feed the next token kind, in source order. Ignores everything once the
+    /// flag is decided.
+    pub(in crate::cst) const fn feed(&mut self, kind: crate::SyntaxKind) {
+        use crate::SyntaxKind as K;
+        if self.decided {
+            return;
+        }
+        match kind {
+            K::L_BRACE | K::L_DOUBLE_BRACE | K::L_BRACE_HASH => self.past_opener = true,
+            K::WHITESPACE => {}
+            K::STAR if self.past_opener => {
+                self.merge = true;
+                self.decided = true;
+            }
+            _ if self.past_opener => self.decided = true,
+            _ => {}
+        }
+    }
+
+    /// Whether the tokens fed so far describe a `{*}` merge cost.
+    pub(in crate::cst) const fn is_merge(&self) -> bool {
+        self.merge
+    }
+}
 
 /// Convert the direct child tokens of a `COST_SPEC` node into a [`CostSpec`]
 /// (forms `{N CCY}`, `{{T CCY}}`, `{N # T CCY}`, `{*}` merge, plus optional
@@ -1612,26 +1659,11 @@ pub(super) fn cost_spec_from_tokens(tokens: impl Iterator<Item = impl TokenView>
     let mut date_seen = false;
     let mut label: Option<String> = None;
     let mut label_seen = false;
-    let mut merge = false;
-    let mut merge_decided = false;
-    let mut past_opener = false;
+    let mut merge_flag = MergeFlag::default();
     for t in tokens {
         let kind = t.kind();
-        // Merge-flag machine (runs alongside the value machine below; openers
-        // and whitespace never decide, the first other token after an opener
-        // does).
-        if !merge_decided {
-            match kind {
-                K::L_BRACE | K::L_DOUBLE_BRACE | K::L_BRACE_HASH => past_opener = true,
-                K::WHITESPACE => {}
-                K::STAR if past_opener => {
-                    merge = true;
-                    merge_decided = true;
-                }
-                _ if past_opener => merge_decided = true,
-                _ => {}
-            }
-        }
+        // Runs alongside the value machine below; see `MergeFlag`.
+        merge_flag.feed(kind);
         match kind {
             K::L_DOUBLE_BRACE => is_total = true,
             K::NUMBER => {
@@ -1679,7 +1711,7 @@ pub(super) fn cost_spec_from_tokens(tokens: impl Iterator<Item = impl TokenView>
         currency,
         date,
         label,
-        merge,
+        merge: merge_flag.is_merge(),
     }
 }
 
@@ -4440,6 +4472,524 @@ mod tests {
              account_occurrences (got {:?}); rename should not hit garbled \
              mid-edit syntax",
             r.account_occurrences,
+        );
+    }
+
+    // ---- cost-spec token latches and the `{*}` merge machine ----
+    //
+    // Added after the 2026-08-01 mutation run: every mutant in these two
+    // machines survived. The merge rule was tested only through the `ast.rs`
+    // copy (now deleted, it delegates here), and nothing at all exercised the
+    // first-token latches, so a cost spec carrying a duplicate date, label or
+    // currency was untested in either tree walker.
+
+    /// Parse one posting's cost spec, or panic with the source for context.
+    fn cost_of(src: &str) -> CostSpec {
+        let result = parse_via_cst(src);
+        let Some(Directive::Transaction(txn)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected a transaction from {src:?}");
+        };
+        txn.postings
+            .first()
+            .and_then(|p| p.cost.clone())
+            .unwrap_or_else(|| panic!("expected a cost spec from {src:?}"))
+    }
+
+    fn posting_with_cost(spec: &str) -> String {
+        format!("2020-01-01 * \"t\"\n  Assets:A 1 HOOL {spec}\n  Assets:B\n")
+    }
+
+    /// A repeated DATE, STRING or CURRENCY keeps the FIRST occurrence. Malformed
+    /// input is the only way to get here, and "first wins" is what keeps the
+    /// green and red walkers agreeing on it.
+    #[test]
+    fn cost_spec_latches_the_first_date_label_and_currency() {
+        let cost = cost_of(&posting_with_cost(
+            "{2 USD, 2020-06-01, 2021-02-02, \"first\", \"second\"}",
+        ));
+        assert_eq!(cost.date, naive_date(2020, 6, 1), "the FIRST date wins");
+        assert_eq!(cost.label.as_deref(), Some("first"), "the FIRST label wins");
+        assert_eq!(
+            cost.currency
+                .as_ref()
+                .map(rustledger_core::Currency::as_str),
+            Some("USD"),
+            "the FIRST currency wins"
+        );
+
+        // Currency specifically, with nothing else competing.
+        let cost = cost_of(&posting_with_cost("{2 USD, EUR}"));
+        assert_eq!(
+            cost.currency
+                .as_ref()
+                .map(rustledger_core::Currency::as_str),
+            Some("USD")
+        );
+    }
+
+    /// The latch is on the first token of a KIND, not the first that parses.
+    ///
+    /// `9999-99-99` lexes as a DATE and fails to parse. The latch must still
+    /// close, leaving the date empty — falling through to a later, valid DATE
+    /// would make the two walkers disagree on malformed input, which is the
+    /// divergence class this design exists to prevent.
+    #[test]
+    fn cost_spec_latch_closes_on_an_unparsable_first_token() {
+        let cost = cost_of(&posting_with_cost("{2 USD, 9999-99-99, 2021-02-02}"));
+        assert_eq!(
+            cost.date, None,
+            "an unparsable first DATE must not let a later one through"
+        );
+    }
+
+    /// The merge flag is decided by the first non-whitespace, non-opener token
+    /// after an opener. Each row pins one arm of that machine.
+    #[test]
+    fn cost_spec_merge_flag_is_decided_by_the_first_token_after_an_opener() {
+        for (spec, expected, why) in [
+            ("{*}", true, "bare star directly after the opener"),
+            (
+                "{ * }",
+                true,
+                "whitespace never decides, so the star still does",
+            ),
+            ("{{*}}", true, "`{{` is an opener too"),
+            (
+                "{2 USD, *}",
+                false,
+                "the number decided it first; a later star cannot re-arm",
+            ),
+            (
+                "{500 * 2 USD}",
+                false,
+                "a star past the first token is multiplication",
+            ),
+        ] {
+            assert_eq!(
+                cost_of(&posting_with_cost(spec)).merge,
+                expected,
+                "{spec}: {why}"
+            );
+        }
+    }
+
+    /// The red-tree accessor and the token-level canonical must agree, since
+    /// they are now one machine fed by two walkers. Asserts on the exact pair
+    /// rather than on either alone, so deleting the delegation is caught.
+    #[test]
+    fn ast_is_merge_agrees_with_the_converted_cost_spec() {
+        for spec in [
+            "{*}",
+            "{ * }",
+            "{{*}}",
+            "{2 USD, *}",
+            "{500 * 2 USD}",
+            "{2 USD}",
+        ] {
+            let src = posting_with_cost(spec);
+            let converted = cost_of(&src).merge;
+
+            let parsed = crate::parse(&src);
+            let root = ast::SourceFile::cast(parsed.syntax_node()).expect("source file");
+            let from_ast = root
+                .syntax()
+                .descendants()
+                .find_map(ast::CostSpec::cast)
+                .map_or_else(|| panic!("no CostSpec node in {src:?}"), |cs| cs.is_merge());
+
+            assert_eq!(
+                from_ast, converted,
+                "{spec}: ast::CostSpec::is_merge disagrees with the converted CostSpec"
+            );
+        }
+    }
+
+    /// `MergeFlag` guards `past_opener` because a token stream may begin before
+    /// the opener. Both tree walkers happen to start AT the opener, so this is
+    /// unreachable through them and only a direct feed can pin it -- but the
+    /// guard is what stops a leading `*` (or any leading token) from deciding
+    /// the flag, and it costs nothing to keep it honest.
+    #[test]
+    fn merge_flag_ignores_tokens_before_the_opener() {
+        use crate::SyntaxKind as K;
+
+        // A star BEFORE any opener is not a merge marker: nothing has opened
+        // yet, so it cannot be the first token after an opener.
+        let mut flag = MergeFlag::default();
+        for kind in [K::STAR, K::L_BRACE, K::R_BRACE] {
+            flag.feed(kind);
+        }
+        assert!(
+            !flag.is_merge(),
+            "a star before the opener must not decide the flag"
+        );
+
+        // And a non-star before the opener must not close the machine early,
+        // or the real `{*}` that follows would be missed.
+        let mut flag = MergeFlag::default();
+        for kind in [K::NUMBER, K::L_BRACE, K::STAR, K::R_BRACE] {
+            flag.feed(kind);
+        }
+        assert!(
+            flag.is_merge(),
+            "a token before the opener must not consume the decision"
+        );
+    }
+
+    /// Every diagnostic span in this module is built as `offset + bom_offset`,
+    /// and a wrong offset puts the editor's squiggle on the wrong text.
+    ///
+    /// The error paths were already exercised, but only for the PRESENCE of an
+    /// error, so the 2026-08-01 mutation run could flip `+` to `-` or `*` in
+    /// five different span computations without a single failure. Each row
+    /// below drives one of them and asserts the exact range, once with no BOM
+    /// and once with one, so the addition itself is pinned rather than merely
+    /// the arithmetic happening to agree at zero.
+    #[test]
+    fn diagnostic_spans_point_at_the_offending_text_with_and_without_a_bom() {
+        // (label, source, the substring the span must cover)
+        let cases = [
+            (
+                "price with two numbers",
+                "2024-01-15 price HOOL 1 2 USD\n",
+                "1 2",
+            ),
+            (
+                "balance with two numbers",
+                "2024-01-15 balance Assets:Cash 1 2 USD\n",
+                "1 2",
+            ),
+            (
+                "posting with a second amount",
+                "2024-01-15 *\n  Assets:A 5 USD + 3 USD\n  Assets:B\n",
+                // Underlined from the END of the first amount on purpose, so
+                // the reader sees `5 USD + 3 USD` and not just the tail.
+                " + 3 USD",
+            ),
+            (
+                // A `+`/`-` binds to the amount as its sign, so the orphan that
+                // actually reaches this path is a stray comma - someone writing
+                // `1,234` with the separator outside the number.
+                "orphaned comma before a posting amount",
+                "2024-01-15 *\n  Assets:A , 1,234.00 USD\n  Assets:B\n",
+                ",",
+            ),
+        ];
+
+        for (label, src, needle) in cases {
+            for bom in [false, true] {
+                let full = if bom {
+                    format!("\u{FEFF}{src}")
+                } else {
+                    src.to_string()
+                };
+                let result = parse_via_cst(&full);
+                let bom_len = if bom { "\u{FEFF}".len() } else { 0 };
+
+                let expected_start = src
+                    .find(needle)
+                    .unwrap_or_else(|| panic!("{label}: {needle:?} not in the fixture"))
+                    + bom_len;
+                let expected_end = expected_start + needle.len();
+
+                let hit = result
+                    .errors
+                    .iter()
+                    .find(|e| e.span.start == expected_start && e.span.end == expected_end);
+                assert!(
+                    hit.is_some(),
+                    "{label} (bom={bom}): expected an error spanning {expected_start}..{expected_end} \
+                     (the {needle:?}), got {:?}",
+                    result
+                        .errors
+                        .iter()
+                        .map(|e| (e.span.start, e.span.end))
+                        .collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+
+    /// A leading `-` on a `price`/`balance` number is a separate MINUS token,
+    /// so the converter has to re-apply the sign the AST accessor drops. Both
+    /// the negation and the scanner that finds it were untested.
+    #[test]
+    fn negative_numbers_in_price_and_balance_keep_their_sign() {
+        // SPACED, so the sign is its own MINUS token and the AST accessor
+        // hands back an unsigned number. `-1.50` written closed up lexes as a
+        // single signed NUMBER and never reaches the scanner at all.
+        let result = parse_via_cst("2024-01-15 price HOOL - 1.50 USD\n");
+        let Some(Directive::Price(p)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected a Price, got {:?}", result.directives);
+        };
+        assert_eq!(p.amount.number, rust_decimal_macros::dec!(-1.50));
+
+        let result = parse_via_cst("2024-01-15 balance Assets:Cash - 1.50 USD\n");
+        let Some(Directive::Balance(b)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected a Balance, got {:?}", result.directives);
+        };
+        assert_eq!(b.amount.number, rust_decimal_macros::dec!(-1.50));
+
+        // And the positive case must stay positive: a scanner that reports
+        // "minus" for everything would pass the assertions above alone.
+        let result = parse_via_cst("2024-01-15 price HOOL 1.50 USD\n");
+        let Some(Directive::Price(p)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected a Price");
+        };
+        assert_eq!(p.amount.number, rust_decimal_macros::dec!(1.50));
+    }
+
+    /// `price` puts the BASE currency BEFORE the number, so the scan that
+    /// rejects a two-number value may only stop at a currency once a number has
+    /// been seen. Getting that guard wrong makes every `price` directive look
+    /// malformed, or stops rejecting the thing it exists to reject.
+    #[test]
+    fn price_base_currency_before_the_number_is_not_a_malformed_value() {
+        let result = parse_via_cst("2024-01-15 price HOOL 1.50 USD\n");
+        assert!(
+            result.errors.is_empty(),
+            "a well-formed price must not be reported as malformed: {:?}",
+            result.errors
+        );
+        assert_eq!(result.directives.len(), 1);
+
+        // Two numbers still must be rejected.
+        let result = parse_via_cst("2024-01-15 price HOOL 1 2 USD\n");
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| format!("{:?}", e.kind).contains("malformed amount")),
+            "two numbers must still be refused: {:?}",
+            result.errors
+        );
+    }
+
+    /// Only `+`, `-` and `,` are orphanable. A posting FLAG sits between the
+    /// account and the amount too, and treating it as an orphan would reject
+    /// perfectly ordinary input.
+    #[test]
+    fn a_posting_flag_is_not_an_orphaned_amount_prefix() {
+        let result = parse_via_cst("2024-01-15 *\n  ! Assets:A 5 USD\n  Assets:B\n");
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| format!("{:?}", e.kind).contains("unexpected token before posting amount")),
+            "a posting flag is not an orphan: {:?}",
+            result.errors
+        );
+    }
+
+    /// Both diagnostics inside posting-amount conversion carry spans built with
+    /// the BOM offset, and neither was pinned. An arithmetic expression that
+    /// cannot be evaluated and a number past the Decimal ceiling are the two
+    /// ways in.
+    #[test]
+    fn posting_amount_diagnostics_point_at_the_offending_amount() {
+        // 30 digits: past `rust_decimal`'s ~28-digit ceiling.
+        let huge = "1".repeat(30);
+        let cases = [
+            (
+                // The span covers the whole AMOUNT node, currency included:
+                // the expression is what is wrong, but the amount is what the
+                // reader has to replace.
+                "unevaluatable arithmetic",
+                "2024-01-15 *\n  Assets:A (1/0) USD\n  Assets:B\n".to_string(),
+                "(1/0) USD".to_string(),
+            ),
+            (
+                "number past the Decimal ceiling",
+                format!("2024-01-15 *\n  Assets:A {huge} USD\n  Assets:B\n"),
+                huge,
+            ),
+        ];
+
+        for (label, src, needle) in cases {
+            for bom in [false, true] {
+                let full = if bom {
+                    format!("\u{FEFF}{src}")
+                } else {
+                    src.clone()
+                };
+                let bom_len = if bom { "\u{FEFF}".len() } else { 0 };
+                let result = parse_via_cst(&full);
+
+                let start = src.find(&needle).expect("needle present") + bom_len;
+                let end = start + needle.len();
+                assert!(
+                    result
+                        .errors
+                        .iter()
+                        .any(|e| e.span.start == start && e.span.end == end),
+                    "{label} (bom={bom}): expected a span {start}..{end}, got {:?}",
+                    result
+                        .errors
+                        .iter()
+                        .map(|e| (e.span.start, e.span.end))
+                        .collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+
+    /// The trailing currency closes a directive value, and it must only do so
+    /// once a number has been seen (a `price` names its base currency first).
+    /// Without the break, a stray number after the currency would be counted
+    /// and a well-formed directive rejected.
+    #[test]
+    fn a_trailing_currency_closes_the_value_scan() {
+        let result = parse_via_cst("2024-01-15 price HOOL 1.50 USD 2\n");
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| format!("{:?}", e.kind).contains("malformed amount")),
+            "the scan must stop at the closing currency, so the stray `2` is not \
+             a second number of the VALUE: {:?}",
+            result.errors
+        );
+    }
+
+    /// Only tokens AFTER the account can be orphans, and only `+`, `-` and `,`
+    /// qualify. Both halves of that were untested, so each row here would be
+    /// reported as an orphan by a slightly wrong predicate.
+    #[test]
+    fn orphan_detection_ignores_pre_account_and_non_sign_tokens() {
+        let orphan_reported = |src: &str| {
+            parse_via_cst(src)
+                .errors
+                .iter()
+                .any(|e| format!("{:?}", e.kind).contains("unexpected token before posting amount"))
+        };
+
+        assert!(
+            !orphan_reported("2024-01-15 *\n  , Assets:A 1 USD\n  Assets:B\n"),
+            "a comma BEFORE the account is not an orphaned amount prefix"
+        );
+        assert!(
+            !orphan_reported("2024-01-15 *\n  Assets:A \"note\" 1 USD\n  Assets:B\n"),
+            "a non-sign token between account and amount is not an orphan"
+        );
+        // The genuine orphan still is one, so the assertions above cannot pass
+        // by the detector simply never firing.
+        assert!(
+            orphan_reported("2024-01-15 *\n  Assets:A , 1 USD\n  Assets:B\n"),
+            "a comma after the account IS an orphan"
+        );
+    }
+
+    /// A posting's trailing comment is collected up to the newline. Stopping on
+    /// the wrong condition silently drops every one of them.
+    #[test]
+    fn posting_trailing_comment_is_captured() {
+        let result = parse_via_cst("2024-01-15 *\n  Assets:A 1 USD ; why\n  Assets:B\n");
+        let Some(Directive::Transaction(txn)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected a transaction");
+        };
+        let first = &txn.postings[0];
+        assert!(
+            first.trailing_comments.iter().any(|c| c.contains("why")),
+            "expected the trailing comment on the posting, got {:?}",
+            first.trailing_comments
+        );
+    }
+
+    /// The sign scanner behind `price`/`balance` fallback conversion.
+    ///
+    /// Reaching it takes work: `directive_arithmetic_value` runs first and
+    /// handles ordinary unary minus, so `- 1.50` never gets here. The fallback
+    /// only runs when the arithmetic parse declines, and `- 1.50 - USD` is one
+    /// such shape -- error recovery tolerates the trailing operator, the
+    /// arithmetic parse gives up, and the AST accessor then hands back an
+    /// UNSIGNED number that this scanner has to re-sign.
+    ///
+    /// Probed for rather than assumed: the whole test suite and all 995 corpus
+    /// files leave this branch cold, so it looked like dead code until an
+    /// adversarial sweep found the inputs. Worth stating, because deleting it
+    /// on that first impression would have been wrong.
+    #[test]
+    fn price_and_balance_fallback_re_signs_a_leading_minus() {
+        let number_of = |src: &str| -> Decimal {
+            let r = parse_via_cst(src);
+            match r.directives.first().map(|d| &d.value) {
+                Some(Directive::Price(p)) => p.amount.number,
+                Some(Directive::Balance(b)) => b.amount.number,
+                other => panic!("expected price/balance from {src:?}, got {other:?}"),
+            }
+        };
+
+        // MINUS before the number: re-signed.
+        assert_eq!(
+            number_of("2024-01-15 price HOOL - 1.50 - USD\n"),
+            rust_decimal_macros::dec!(-1.50)
+        );
+        assert_eq!(
+            number_of("2024-01-15 balance Assets:C - 1.50 - USD\n"),
+            rust_decimal_macros::dec!(-1.50)
+        );
+
+        // NUMBER first: the scan stops there, so a LATER minus must not flip
+        // the sign. Without this the "stop at the number" arm is free to vanish.
+        assert_eq!(
+            number_of("2024-01-15 price HOOL 1.50 - USD\n"),
+            rust_decimal_macros::dec!(1.50)
+        );
+        assert_eq!(
+            number_of("2024-01-15 balance Assets:C 1.50 - USD\n"),
+            rust_decimal_macros::dec!(1.50)
+        );
+    }
+
+    /// The red conversion path is a mirror of the green one, kept for the
+    /// `green_eq_red` differential fuzz target. Production parses via green, so
+    /// a test written against `parse_via_cst` exercises the mirror only where
+    /// the two SHARE a helper -- which is why the 2026-08-01 mutation run
+    /// showed red-only code uncovered even though its green twin was tested.
+    ///
+    /// These drive `parse_red_only` directly, and assert the two paths agree,
+    /// so the mirror cannot rot silently.
+    #[test]
+    fn red_path_matches_green_on_posting_comments_and_orphan_detection() {
+        let orphan_msg = "unexpected token before posting amount";
+
+        // Trailing comment on a posting line, collected by the red converter's
+        // own scan up to the terminating NEWLINE.
+        let src = "2024-01-15 *\n  Assets:A 1 USD ; why\n  Assets:B\n";
+        for (label, result) in [("green", parse_via_cst(src)), ("red", parse_red_only(src))] {
+            let Some(Directive::Transaction(txn)) = result.directives.first().map(|d| &d.value)
+            else {
+                panic!("{label}: expected a transaction");
+            };
+            assert!(
+                txn.postings[0]
+                    .trailing_comments
+                    .iter()
+                    .any(|c| c.contains("why")),
+                "{label}: trailing comment lost, got {:?}",
+                txn.postings[0].trailing_comments
+            );
+        }
+
+        // Orphan detection, through the red converter: a comma after the
+        // account is one, a comma before it and a non-sign token are not.
+        let orphan_reported = |src: &str| {
+            parse_red_only(src)
+                .errors
+                .iter()
+                .any(|e| format!("{:?}", e.kind).contains(orphan_msg))
+        };
+        assert!(
+            orphan_reported("2024-01-15 *\n  Assets:A , 1 USD\n  Assets:B\n"),
+            "red: a comma after the account IS an orphan"
+        );
+        assert!(
+            !orphan_reported("2024-01-15 *\n  , Assets:A 1 USD\n  Assets:B\n"),
+            "red: a comma BEFORE the account is not"
+        );
+        assert!(
+            !orphan_reported("2024-01-15 *\n  Assets:A \"note\" 1 USD\n  Assets:B\n"),
+            "red: a non-sign token between account and amount is not"
         );
     }
 }

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -807,7 +807,26 @@ fn extract_custom_values(node: &crate::SyntaxNode) -> Vec<MetaValue> {
         // `NUMBER CURRENCY` → Amount handling as metadata entries.
         if let Some((value, next)) = value_tokens_to_meta(&raw, i) {
             values.push(value);
-            i = next;
+            // `value_tokens_to_meta` must return the index PAST what it
+            // consumed. Both halves of this line matter and they do different
+            // jobs:
+            //
+            // The assert makes a violated contract fail loudly under test.
+            // Clamping alone would silently repair it — the loop would step one
+            // token at a time, re-discriminate, and usually produce the same
+            // values, so a genuinely broken advance would look fine. Measured:
+            // clamping without this turned seventeen index mutants from
+            // detected-by-timeout into simply undetected.
+            //
+            // The clamp keeps release builds from hanging on a violation, which
+            // is what the same seventeen mutants did before either existed. A
+            // parser that spins forever on malformed input is worse than one
+            // that errors, and a hang is invisible in review.
+            debug_assert!(
+                next > i,
+                "value_tokens_to_meta must advance: returned {next} at {i}"
+            );
+            i = next.max(i + 1);
         } else {
             i += 1;
         }
@@ -1970,6 +1989,15 @@ pub(super) fn meta_value_from_tokens(tokens: impl Iterator<Item = impl TokenView
                 _ => {}
             }
         }
+        // Gates the sign machine so a MINUS in or before the key position is
+        // not read as a value's sign. No input reachable through the parser
+        // exercises it: the key is always the first meaningful token, and the
+        // malformed shapes that would put a MINUS ahead of it (`- key: 42`,
+        // `-key: 42`, `key- : 42`) yield no metadata entry at all. Kept as a
+        // guard on the token contract rather than deleted, since this helper
+        // is shared with the green walker and takes whatever tokens it is
+        // handed. Flipping this comparison survives mutation testing for the
+        // same reason -- recorded so the next reader does not hunt for a test.
         if kind == K::META_KEY {
             past_key = true;
         }
@@ -4986,6 +5014,229 @@ mod tests {
         assert!(
             !orphan_reported("2024-01-15 *\n  Assets:A \"note\" 1 USD\n  Assets:B\n"),
             "red: a non-sign token between account and amount is not"
+        );
+    }
+
+    // ---- metadata and custom values: the other token-level canonical ----
+    //
+    // `meta_value_from_tokens` is the twin of `cost_spec_from_tokens` and had
+    // the same shape of gap: first-of-kind latches and a sign machine that no
+    // test touched. `value_tokens_to_meta` is the sibling used by custom
+    // directives and the red path.
+
+    fn meta_of(entries: &str) -> rustledger_core::Metadata {
+        let src = format!("2024-01-15 open Assets:A\n{entries}");
+        let result = parse_via_cst(&src);
+        let Some(Directive::Open(open)) = result.directives.first().map(|d| &d.value) else {
+            panic!("expected an Open from {src:?}, errors {:?}", result.errors);
+        };
+        open.meta.clone()
+    }
+
+    fn custom_values(line: &str) -> Vec<MetaValue> {
+        let result = parse_via_cst(line);
+        let Some(Directive::Custom(c)) = result.directives.first().map(|d| &d.value) else {
+            panic!(
+                "expected a Custom from {line:?}, errors {:?}",
+                result.errors
+            );
+        };
+        c.values.clone()
+    }
+
+    /// Every value kind a metadata entry can carry. Deleting any one arm made
+    /// that kind silently fall through to the next candidate in the priority
+    /// order, which is invisible unless the kind is asserted directly.
+    #[test]
+    fn metadata_values_cover_every_kind() {
+        let meta = meta_of(
+            "  str: \"hello\"\n  num: 42\n  amt: 42 USD\n  dt: 2024-06-01\n  \
+             acct: Assets:B\n  cur: USD\n  yes: TRUE\n  no: FALSE\n  \
+             tg: #mytag\n  lk: ^mylink\n",
+        );
+        let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
+
+        assert_eq!(got("str"), MetaValue::String("hello".into()));
+        assert_eq!(got("num"), MetaValue::Int(42));
+        assert_eq!(
+            got("amt"),
+            MetaValue::Amount(Amount::new(rust_decimal_macros::dec!(42), "USD"))
+        );
+        assert_eq!(got("dt"), MetaValue::Date(naive_date(2024, 6, 1).unwrap()));
+        assert_eq!(got("acct"), MetaValue::Account(Account::new("Assets:B")));
+        assert_eq!(got("cur"), MetaValue::Currency(Currency::new("USD")));
+        assert_eq!(got("yes"), MetaValue::Bool(true));
+        assert_eq!(got("no"), MetaValue::Bool(false));
+        assert_eq!(got("tg"), MetaValue::Tag(Tag::new("mytag")));
+        assert_eq!(got("lk"), MetaValue::Link(Link::new("mylink")));
+    }
+
+    /// First-of-kind latching, the same rule `cost_spec_from_tokens` uses. A
+    /// repeated token of any kind keeps the FIRST, and nothing exercised that
+    /// for metadata, so every latch guard could be flipped freely.
+    #[test]
+    fn metadata_latches_the_first_token_of_each_kind() {
+        let meta = meta_of(
+            "  s: \"one\" \"two\"\n  n: 1 2\n  c: USD EUR\n  d: 2024-06-01 2025-07-02\n  \
+             a: Assets:First Assets:Second\n  b: TRUE FALSE\n  t: #first #second\n",
+        );
+        let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
+
+        assert_eq!(got("s"), MetaValue::String("one".into()));
+        assert_eq!(got("n"), MetaValue::Int(1));
+        assert_eq!(got("d"), MetaValue::Date(naive_date(2024, 6, 1).unwrap()));
+        assert_eq!(got("a"), MetaValue::Account(Account::new("Assets:First")));
+        assert_eq!(got("b"), MetaValue::Bool(true), "TRUE came first");
+        assert_eq!(got("t"), MetaValue::Tag(Tag::new("first")));
+        // `c` pairs a number-less currency run: the FIRST currency wins.
+        assert_eq!(got("c"), MetaValue::Currency(Currency::new("USD")));
+    }
+
+    /// The sign machine: a MINUS after the key negates the number, and one
+    /// AFTER the number does not, because the first NUMBER closes the decision.
+    #[test]
+    fn metadata_minus_applies_only_before_the_number() {
+        let meta = meta_of("  neg: -42\n  negamt: -42 USD\n  after: 42 - 1\n");
+        let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
+
+        assert_eq!(got("neg"), MetaValue::Int(-42));
+        assert_eq!(
+            got("negamt"),
+            MetaValue::Amount(Amount::new(rust_decimal_macros::dec!(-42), "USD")),
+            "the sign applies to the amount too"
+        );
+        assert_eq!(
+            got("after"),
+            MetaValue::Int(42),
+            "a minus past the number is not a sign; the first NUMBER closes it"
+        );
+    }
+
+    /// `value_tokens_to_meta` walks a token run and returns the NEXT index, so
+    /// a wrong advance either drops values or repeats them. Custom directives
+    /// are the surface that reads several values in a row, which makes the
+    /// advance observable.
+    #[test]
+    fn custom_directive_values_advance_one_value_at_a_time() {
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" FALSE TRUE FALSE\n"),
+            vec![
+                MetaValue::Bool(false),
+                MetaValue::Bool(true),
+                MetaValue::Bool(false)
+            ],
+            "each bool consumes exactly one token"
+        );
+
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" 42 USD TRUE\n"),
+            vec![
+                MetaValue::Amount(Amount::new(rust_decimal_macros::dec!(42), "USD")),
+                MetaValue::Bool(true)
+            ],
+            "NUMBER + CURRENCY consumes TWO tokens and the next value still lands"
+        );
+
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" USD TRUE\n"),
+            vec![
+                MetaValue::Currency(Currency::new("USD")),
+                MetaValue::Bool(true)
+            ],
+            "a lone CURRENCY is a value in its own right, not an amount fragment"
+        );
+
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" -42 #tag ^link 2024-06-01 Assets:B\n"),
+            vec![
+                MetaValue::Int(-42),
+                MetaValue::Tag(Tag::new("tag")),
+                MetaValue::Link(Link::new("link")),
+                MetaValue::Date(naive_date(2024, 6, 1).unwrap()),
+                MetaValue::Account(Account::new("Assets:B")),
+            ],
+            "MINUS + NUMBER consumes two tokens; the rest follow in order"
+        );
+    }
+
+    /// The bool and tag/link latches, in the order that actually exercises the
+    /// SECOND arm of each pair. `TRUE FALSE` only proves the first arm latches;
+    /// reversing it is what pins the guard on the other one.
+    #[test]
+    fn metadata_latches_bool_and_taglink_in_either_order() {
+        let meta = meta_of("  b: FALSE TRUE\n  tl: #tag ^link\n  lt: ^link #tag\n");
+        let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
+
+        assert_eq!(
+            got("b"),
+            MetaValue::Bool(false),
+            "FALSE came first, so the later TRUE must not overwrite it"
+        );
+        assert_eq!(
+            got("tl"),
+            MetaValue::Tag(Tag::new("tag")),
+            "tag and link share one slot; the tag came first"
+        );
+        assert_eq!(
+            got("lt"),
+            MetaValue::Link(Link::new("link")),
+            "and the link wins when it comes first"
+        );
+    }
+
+    /// `extract_custom_values` advances by the index the discriminator returns.
+    /// A helper that failed to advance would spin the loop forever, so the
+    /// caller clamps. This pins that a long run of values terminates and is
+    /// read in order -- a hang here would let malformed input stall the parser.
+    #[test]
+    fn custom_values_terminate_on_a_long_run() {
+        let values = custom_values(
+            "2024-01-15 custom \"b\" 1 USD 2 EUR TRUE FALSE #a ^b 2024-06-01 Assets:X \"s\"\n",
+        );
+        assert_eq!(
+            values.len(),
+            9,
+            "every value consumed exactly once, got {values:?}"
+        );
+        assert_eq!(
+            values.first(),
+            Some(&MetaValue::Amount(Amount::new(
+                rust_decimal_macros::dec!(1),
+                "USD"
+            )))
+        );
+        assert_eq!(values.last(), Some(&MetaValue::String("s".into())));
+    }
+
+    /// The scan skips the directive header (date, keyword, and the type-name
+    /// string) before reading values, steps past tokens that are not values,
+    /// and terminates when there are none. Each of those is a separate step in
+    /// the loop and none had a test.
+    #[test]
+    fn custom_directive_scan_skips_the_header_and_non_values() {
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\"\n"),
+            vec![],
+            "the type name is the header, not a value, and no values is valid"
+        );
+
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" \"x\" 42\n"),
+            vec![MetaValue::String("x".into()), MetaValue::Int(42)],
+            "the FIRST string is the type name; a later one IS a value"
+        );
+
+        // A `*` is not a value, so the scan must step over it rather than
+        // stall. Both positions matter: before any value, and between two.
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" * 42\n"),
+            vec![MetaValue::Int(42)],
+            "a non-value token before the first value is stepped over"
+        );
+        assert_eq!(
+            custom_values("2024-01-15 custom \"b\" 42 * 7\n"),
+            vec![MetaValue::Int(42), MetaValue::Int(7)],
+            "and between two values"
         );
     }
 }

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -1034,3 +1034,200 @@ fn balance_number(r: &rustledger_parser::ParseResult) -> rustledger_core::Decima
         })
         .expect("a balance directive")
 }
+
+/// Every transaction-flag form, checked against `classify()` AND the whole
+/// predicate vector.
+///
+/// The existing tests above assert one variant via `classify()` alone, which
+/// leaves each `is_*` free to return a constant and each `cast` arm free to
+/// vanish: the 2026-08-01 mutation run replaced all six predicates with `true`
+/// or `false` and deleted cast arms without a failure. Asserting the FULL
+/// vector per input is what pins them, because exactly one predicate may hold.
+#[test]
+fn transaction_flag_classifies_every_form_and_its_predicates() {
+    use rustledger_parser::cst::ast::TransactionFlagKind as K;
+
+    // (source flag, expected kind)
+    let cases = [
+        ("*", K::Star),
+        ("!", K::Pending),
+        ("#", K::Hash),
+        ("txn", K::Txn),
+        // A one-character CURRENCY is a flag; see `cast`'s length guard.
+        ("P", K::CurrencyLetter),
+        // `?` and `&` are the only characters in the lexer's flag regex that
+        // are NOT also valid one-letter currencies, so they are the only ones
+        // that reach `Letter`. `P S T C U R M` all lex as CURRENCY and land on
+        // `CurrencyLetter` instead, despite the regex listing them.
+        ("?", K::Letter),
+    ];
+
+    for (text, want) in cases {
+        let src = format!("2024-01-15 {text} \"x\"\n  Assets:Cash  -5 USD\n");
+        let f = parse(&src);
+        let Directive::Transaction(t) = single_directive(&f) else {
+            panic!("{text}: expected a transaction");
+        };
+        let flag = t.flag().unwrap_or_else(|| panic!("{text}: no flag"));
+
+        assert_eq!(
+            std::mem::discriminant(&flag.classify()),
+            std::mem::discriminant(&want),
+            "{text}: classify"
+        );
+        // Exactly one predicate holds, and it is the one matching `want`.
+        let got = [
+            ("star", flag.is_star(), matches!(want, K::Star)),
+            ("pending", flag.is_pending(), matches!(want, K::Pending)),
+            ("hash", flag.is_hash(), matches!(want, K::Hash)),
+            ("txn", flag.is_txn(), matches!(want, K::Txn)),
+            ("letter", flag.is_letter_flag(), matches!(want, K::Letter)),
+            (
+                "currency_letter",
+                flag.is_currency_letter(),
+                matches!(want, K::CurrencyLetter),
+            ),
+        ];
+        for (name, actual, expected) in got {
+            assert_eq!(actual, expected, "{text}: is_{name}");
+        }
+        assert_eq!(
+            got.iter().filter(|(_, a, _)| *a).count(),
+            1,
+            "{text}: exactly one predicate must hold"
+        );
+    }
+}
+
+/// A multi-character CURRENCY is NOT a flag. Without this the length guard can
+/// be replaced with `true` and `2024-01-15 USD "x"` starts parsing as a flagged
+/// transaction.
+#[test]
+fn multi_character_currency_is_not_a_transaction_flag() {
+    // Not routed through `single_directive`: with no valid flag this is not a
+    // transaction at all, so the directive list is empty. Asserting on the
+    // typed tree keeps the test about the flag rather than about how far
+    // recovery got.
+    let f = parse("2024-01-15 USD \"x\"\n  Assets:Cash  -5 USD\n");
+    let flagged = f
+        .directives()
+        .filter_map(|d| match d {
+            Directive::Transaction(t) => Some(t),
+            _ => None,
+        })
+        .any(|t| t.flag().is_some());
+    assert!(
+        !flagged,
+        "a 3-letter currency must not classify as a transaction flag"
+    );
+
+    // The single-letter form still does, so the assertion above cannot pass
+    // merely because nothing parsed.
+    let f = parse("2024-01-15 P \"x\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected a transaction for the single-letter flag");
+    };
+    assert!(t.flag().is_some(), "a 1-letter currency IS a flag");
+}
+
+/// The same for posting flags, which share the machinery minus `Txn`.
+#[test]
+fn posting_flag_classifies_every_form_and_its_predicates() {
+    use rustledger_parser::cst::ast::PostingFlagKind as K;
+
+    let cases = [
+        ("*", K::Star),
+        ("!", K::Pending),
+        ("#", K::Hash),
+        ("?", K::Letter),
+        ("P", K::CurrencyLetter),
+    ];
+
+    for (text, want) in cases {
+        let src = format!("2024-01-15 * \"x\"\n  {text} Assets:Cash  -5 USD\n");
+        let f = parse(&src);
+        let Directive::Transaction(t) = single_directive(&f) else {
+            panic!("{text}: expected a transaction");
+        };
+        let p = t
+            .postings()
+            .next()
+            .unwrap_or_else(|| panic!("{text}: no posting"));
+        let flag = p.flag().unwrap_or_else(|| panic!("{text}: no flag"));
+
+        assert_eq!(
+            std::mem::discriminant(&flag.classify()),
+            std::mem::discriminant(&want),
+            "{text}: classify"
+        );
+        let got = [
+            ("star", flag.is_star(), matches!(want, K::Star)),
+            ("pending", flag.is_pending(), matches!(want, K::Pending)),
+            ("hash", flag.is_hash(), matches!(want, K::Hash)),
+            ("letter", flag.is_letter_flag(), matches!(want, K::Letter)),
+            (
+                "currency_letter",
+                flag.is_currency_letter(),
+                matches!(want, K::CurrencyLetter),
+            ),
+        ];
+        for (name, actual, expected) in got {
+            assert_eq!(actual, expected, "{text}: is_{name}");
+        }
+        assert_eq!(
+            got.iter().filter(|(_, a, _)| *a).count(),
+            1,
+            "{text}: exactly one predicate must hold"
+        );
+    }
+}
+
+/// `TransactionFlag::cast` / `PostingFlag::cast` accept a CURRENCY token only
+/// when it is one character long.
+///
+/// Driven directly rather than through a parse, because the parser filters
+/// multi-character currencies out of the flag position before the AST layer
+/// ever sees them — so no source text can reach this guard. `cast` is public
+/// API though, and a caller holding an arbitrary token (the LSP walks tokens
+/// this way) can reach it, which is exactly what the guard is for.
+#[test]
+fn cast_rejects_a_multi_character_currency_token() {
+    use rustledger_parser::SyntaxKind;
+    use rustledger_parser::cst::ast::{PostingFlag, TransactionFlag};
+
+    let f = parse("2024-01-15 open Assets:Cash USD\n2024-01-15 open Assets:B C\n");
+    let currencies: Vec<_> = f
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(rustledger_parser::NodeOrToken::into_token)
+        .filter(|t| t.kind() == SyntaxKind::CURRENCY)
+        .collect();
+
+    let multi = currencies
+        .iter()
+        .find(|t| t.text() == "USD")
+        .expect("a 3-letter CURRENCY token");
+    let single = currencies
+        .iter()
+        .find(|t| t.text() == "C")
+        .expect("a 1-letter CURRENCY token");
+
+    assert!(
+        TransactionFlag::cast(multi.clone()).is_none(),
+        "a 3-letter currency is not a transaction flag"
+    );
+    assert!(
+        PostingFlag::cast(multi.clone()).is_none(),
+        "a 3-letter currency is not a posting flag"
+    );
+    // The single-character form still casts, so the assertions above cannot
+    // pass merely because `cast` rejects every CURRENCY.
+    assert!(
+        TransactionFlag::cast(single.clone()).is_some(),
+        "a 1-letter currency IS a transaction flag"
+    );
+    assert!(
+        PostingFlag::cast(single.clone()).is_some(),
+        "a 1-letter currency IS a posting flag"
+    );
+}


### PR DESCRIPTION
Closes the surviving mutants in `cst/convert.rs` that the 2026-08-01 mutation run reported (74 of the crate's 128). Reading them turned up three separate problems, none of which a passing test suite could have shown.

## 1. The `{*}` merge rule was tested through a copy

It was implemented **twice**: inside `cost_spec_from_tokens`, and again in `ast::CostSpec::is_merge`. The only tests went through the `ast.rs` copy, so **every mutant in the canonical survived** — the shared helper could have been broken outright without a single failure.

That is precisely the drift this module's own `TokenView` doc says it exists to prevent:

> Every historical green/red fuzz divergence (#1704, #1713, **the `{*}` merge flag**) landed in a hand-mirrored copy of these semantics; with one implementation the class is gone.

…in the one place it had not been applied. Extracted as `MergeFlag`, a state machine fed by both walkers; `is_merge` now delegates rather than re-derives, so its existing tests exercise the canonical.

## 2. The first-token latches were untested

Nothing exercised a cost spec with a duplicate date, label or currency, so `!date_seen`, `!label_seen` and `currency.is_none()` could all be flipped freely. Now pinned, including the subtle part:

```beancount
{2 USD, 9999-99-99, 2021-02-02}    →  date: None
```

The latch is on the first token of a **kind**, not the first that **parses** — so an unparsable first `DATE` closes it and the later valid one does not sneak through. That is what keeps the green and red walkers agreeing on malformed input.

## 3. Diagnostic spans were never asserted

Five computations of the form `offset + bom_offset` were exercised only for the *presence* of an error, never its *position*, so `+` could silently become `-` or `*`. A wrong offset puts the editor's squiggle on the wrong text. Each is now driven with and without a BOM, so the addition is pinned rather than merely agreeing at zero.

## Two findings worth recording

**`node_has_minus_before_number` looked like dead code.** The entire test suite and all 995 corpus files leave it cold, because `directive_arithmetic_value` runs first and handles ordinary unary minus. An adversarial sweep found the inputs that *do* reach it — `- .5 USD`, `- 1.50 - USD`, where the arithmetic parse declines and the AST accessor hands back an unsigned number. **Deleting it on the first impression would have removed live code.**

**`convert.rs` is the RED path; `parse_via_cst` parses via GREEN.** Tests written against the public entry point therefore only cover the mirror where the two *share* a helper, which is why red-only code sat uncovered while its green twin was tested. The last test drives `parse_red_only` directly and asserts the two agree.

## Verification

Re-ran `cargo-mutants` over the affected functions rather than inspecting:

| cluster | before | after |
|---|---:|---:|
| `cost_spec_from_tokens` + `MergeFlag` | 14 surviving | **0** (22/22 caught) |
| converters, spans, orphan detection | 19 surviving | **2** |

The two that remain are `\|\|` → `&&` on a guard whose `continue` is indistinguishable from the following check's `continue` for every reachable token kind. They look equivalent, and I have left them rather than paper over them with a test that would assert nothing.

Parser suite 590 passed / 0 failed; clippy clean at the CI pin with `-D warnings`. **No production behaviour changes** — `is_merge` delegates to an identical machine, everything else is tests.

Refs #1902 (Phase 1: the coverage inversion, with names attached).


---

## Second cluster: `meta_value_from_tokens` (added after review)

The twin canonical of `cost_spec_from_tokens`, with the same shape of gap. **37 surviving → 4**, and the four remaining are explained rather than left unknown.

Tests for all ten metadata value kinds, first-of-kind latching in **both orders** (`TRUE FALSE` only proves one arm; `FALSE TRUE` and `^link #tag` pin the others), the sign machine, and the custom-directive scan.

### A robustness fix that first made things worse

Seventeen index mutants were detected only by **timing out**: `extract_custom_values` does `i = next`, so a helper returning a non-advancing index spins the loop forever. A parser that hangs on malformed input is worse than one that errors, so I clamped the advance.

On its own that was measurably the **wrong** fix. Clamping silently *repairs* a violated contract — the loop steps one token at a time, re-discriminates, and usually produces the same values. All seventeen went from detected-by-timeout to simply undetected: the run went from **3 missed to 22**.

Both halves are now present, doing different jobs:

```rust
debug_assert!(next > i, "value_tokens_to_meta must advance: returned {next} at {i}");
i = next.max(i + 1);
```

The assert makes a violated contract fail loudly under test — that is what catches the seventeen. The clamp keeps release builds from hanging. Confirmed the assert fires, naming the offending indices.

### The four that remain

| | why |
|---|---|
| `i + 1` inside `next.max(i + 1)` (×2) | the assert guarantees `next > i`, so `max` returns `next` regardless |
| `while i < raw.len()` → `<=` | helper returns `None` at `i == len`; the one out-of-bounds path needs a custom directive with no type string, which does not parse as a Custom |
| `kind == K::META_KEY` → `!=` | probed six malformed shapes, none yields a metadata entry, so nothing reaches it — documented at the source |

Parser suite **597 passed / 0 failed**; clippy and rustdoc clean.
