### PR TITLE
ci(mutation): halve the parser's cargo jobs, and name truncated shards

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -87,6 +87,21 @@ jobs:
             esac
           }
 
+          # PARALLEL CARGO JOBS PER SHARD. `rustledger-parser` gets fewer.
+          # Measured on run 30765289550: three of its four shards were
+          # SIGTERMed by the runner at 32-47 minutes (exit 143, "runner has
+          # received a shutdown signal") while all four `core` shards of the
+          # same duration finished. The parser's suite is the heavy one
+          # (proptest, fuzz-corpus replay, insta snapshots), so four concurrent
+          # test binaries is the likelier cause than runner flakiness. Halving
+          # it spends wall-clock that sharding has freed up.
+          jobs_for() {
+            case "$1" in
+              rustledger-parser) echo 2 ;;
+              *) echo 4 ;;
+            esac
+          }
+
           # SHARD INDICES ARE ZERO-BASED: `--shard k/n` wants k in 0..n-1.
           # cargo-mutants' own `--help` says "specify as e.g. 1/4", which reads
           # as one-based and is not. Verified against cargo-mutants 27.1.0 on a
@@ -101,7 +116,7 @@ jobs:
             n=$(shards_for "$pkg")
             i=0
             while [ "$i" -lt "$n" ]; do
-              ENTRIES="$ENTRIES{\"package\":\"$pkg\",\"shard\":$i,\"shards\":$n},"
+              ENTRIES="$ENTRIES{\"package\":\"$pkg\",\"shard\":$i,\"shards\":$n,\"jobs\":$(jobs_for "$pkg")},"
               i=$((i + 1))
             done
           done
@@ -134,6 +149,7 @@ jobs:
           TIMEOUT="${{ github.event.inputs.timeout || '300' }}"
           echo "Mutating package: ${{ matrix.package }}"
           echo "Shard: ${{ matrix.shard }} of ${{ matrix.shards }}"
+          echo "Parallel cargo jobs: ${{ matrix.jobs }}"
           echo "Timeout per mutant: ${TIMEOUT}s"
           echo ""
 
@@ -142,7 +158,7 @@ jobs:
           # for jobs that actually finish.
           cargo mutants \
             --timeout "$TIMEOUT" \
-            --jobs 4 \
+            --jobs "${{ matrix.jobs }}" \
             --package "${{ matrix.package }}" \
             --shard "${{ matrix.shard }}/${{ matrix.shards }}" \
             -- --all-features \
@@ -279,3 +295,68 @@ jobs:
           GITHUB_ANNOTATIONS: '1'
           MUTATION_FLOOR: '10'
         run: scripts/per-plugin-mutation-report.sh
+
+  # A shard the runner TERMINATES produces no result at all: the sweep is cut
+  # off mid-list and every later step is skipped, so nothing inside that job
+  # can report what happened. From the outside it looks identical to a shard
+  # that finished and found problems, and the run's `failure` conclusion means
+  # two completely different things -- one is "coverage is imperfect", the
+  # other is "we did not measure". Conflating them is how a scheduled job stops
+  # being read (see #1907).
+  #
+  # This runs regardless of the shards' outcome and says which happened.
+  summarize:
+    name: Mutation summary
+    needs: [select-packages, mutants]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Classify each shard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --paginate --jq '.jobs[] | select(.name | startswith("Mutate"))
+              | {name, conclusion, run: ([.steps[] | select(.name=="Run mutation testing") | .conclusion] | first)}' \
+            > jobs.jsonl
+
+          # A shard whose sweep step never reached a conclusion of its own was
+          # killed from outside; one that ran to completion measured something,
+          # whatever the verdict.
+          measured=$(jq -r 'select(.run=="success") | .name' jobs.jsonl | wc -l | tr -d ' ')
+          truncated=$(jq -r 'select(.run!="success") | .name' jobs.jsonl | wc -l | tr -d ' ')
+          total=$((measured + truncated))
+
+          {
+            echo "## Mutation run"
+            echo ""
+            echo "| shards | outcome |"
+            echo "|---:|---|"
+            echo "| $measured | measured (the sweep finished) |"
+            echo "| $truncated | **truncated** (the runner terminated the job; NOT a mutant result) |"
+            echo ""
+            if [ "$truncated" -gt 0 ]; then
+              echo "Truncated shards, which measured nothing:"
+              echo ""
+              jq -r 'select(.run!="success") | "- `\(.name)`"' jobs.jsonl
+              echo ""
+              echo "These are infrastructure, not findings. Re-run them before reading"
+              echo "the numbers as coverage: a truncated shard reports no surviving"
+              echo "mutants simply because it never got to them."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "measured=$measured truncated=$truncated of $total"
+
+          # Fail on truncation so the run's conclusion means "incomplete", which
+          # is true and actionable. Surviving mutants alone do not fail a shard,
+          # so this does not swallow that signal.
+          if [ "$truncated" -gt 0 ]; then
+            echo "::error::$truncated of $total shards were terminated by the runner and measured nothing."
+            exit 1
+          fi

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -320,17 +320,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # Into RUNNER_TEMP, not the workspace: a file called `jobs.jsonl`
+          # sitting at the repo root reads like a checked-in fixture.
+          JOBS="$RUNNER_TEMP/mutation-jobs.jsonl"
           gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
             --paginate --jq '.jobs[] | select(.name | startswith("Mutate"))
               | {name, conclusion, run: ([.steps[] | select(.name=="Run mutation testing") | .conclusion] | first)}' \
-            > jobs.jsonl
+            > "$JOBS"
 
-          # A shard whose sweep step never reached a conclusion of its own was
-          # killed from outside; one that ran to completion measured something,
-          # whatever the verdict.
-          measured=$(jq -r 'select(.run=="success") | .name' jobs.jsonl | wc -l | tr -d ' ')
-          truncated=$(jq -r 'select(.run!="success") | .name' jobs.jsonl | wc -l | tr -d ' ')
-          total=$((measured + truncated))
+          # Split on whether the sweep step SUCCEEDED. That is the honest
+          # distinction available here: a shard whose sweep did not succeed
+          # produced no numbers, whether the runner killed it (exit 143, the
+          # observed case) or cargo-mutants itself failed. Both mean "not
+          # measured"; neither means "mutants survived", because a shard that
+          # completes with survivors still exits 0. The conclusions are printed
+          # so the reader can tell which happened rather than being told.
+          measured=$(jq -r 'select(.run=="success") | .name' "$JOBS" | wc -l | tr -d ' ')
+          incomplete=$(jq -r 'select(.run!="success") | .name' "$JOBS" | wc -l | tr -d ' ')
+          total=$((measured + incomplete))
 
           {
             echo "## Mutation run"
@@ -338,25 +345,28 @@ jobs:
             echo "| shards | outcome |"
             echo "|---:|---|"
             echo "| $measured | measured (the sweep finished) |"
-            echo "| $truncated | **truncated** (the runner terminated the job; NOT a mutant result) |"
+            echo "| $incomplete | **did not complete the sweep** (no result; NOT surviving mutants) |"
             echo ""
-            if [ "$truncated" -gt 0 ]; then
-              echo "Truncated shards, which measured nothing:"
+            if [ "$incomplete" -gt 0 ]; then
+              echo "Shards that measured nothing:"
               echo ""
-              jq -r 'select(.run!="success") | "- `\(.name)`"' jobs.jsonl
+              jq -r 'select(.run!="success")
+                | "- `\(.name)` — job `\(.conclusion)`, sweep step `\(.run // "did not run")`"' "$JOBS"
               echo ""
-              echo "These are infrastructure, not findings. Re-run them before reading"
-              echo "the numbers as coverage: a truncated shard reports no surviving"
-              echo "mutants simply because it never got to them."
+              echo "Re-run these before reading the numbers as coverage: a shard"
+              echo "that stopped early reports no surviving mutants simply because"
+              echo "it never reached them. Every occurrence so far has been the"
+              echo "runner terminating the job (exit 143), which is infrastructure"
+              echo "rather than a finding."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "measured=$measured truncated=$truncated of $total"
+          echo "measured=$measured incomplete=$incomplete of $total"
 
-          # Fail on truncation so the run's conclusion means "incomplete", which
-          # is true and actionable. Surviving mutants alone do not fail a shard,
-          # so this does not swallow that signal.
-          if [ "$truncated" -gt 0 ]; then
-            echo "::error::$truncated of $total shards were terminated by the runner and measured nothing."
+          # Fail when a sweep did not complete, so the run's conclusion means
+          # "incomplete", which is true and actionable. Surviving mutants alone
+          # do not fail a shard, so this swallows nothing.
+          if [ "$incomplete" -gt 0 ]; then
+            echo "::error::$incomplete of $total shards did not complete their sweep and measured nothing."
             exit 1
           fi

--- a/jobs.jsonl
+++ b/jobs.jsonl
@@ -1,9 +1,0 @@
-{"conclusion":"success","name":"Mutate rustledger-core 1/4","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-validate 0/1","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-core 0/4","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-booking 0/1","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-core 2/4","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-core 3/4","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-parser 0/4","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-plugin 0/1","run":"success"}
-{"conclusion":"success","name":"Mutate rustledger-loader 0/1","run":"success"}

--- a/jobs.jsonl
+++ b/jobs.jsonl
@@ -1,0 +1,9 @@
+{"conclusion":"success","name":"Mutate rustledger-core 1/4","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-validate 0/1","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-core 0/4","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-booking 0/1","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-core 2/4","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-core 3/4","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-parser 0/4","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-plugin 0/1","run":"success"}
+{"conclusion":"success","name":"Mutate rustledger-loader 0/1","run":"success"}


### PR DESCRIPTION
Two follow-ups from [run 30765289550](https://github.com/rustledger/rustledger/actions/runs/30765289550) — the first sharded run, and the first that produced completed sweeps.

## What that run showed

Sharding did its job:

| | before | after |
|---|---|---|
| `core` | 162 min, one job | 4 shards: 33 / 34 / 40 / 49 min, all complete |
| `parser` | killed at 81 min, truncated | 4 shards: 32 / 39 / 43 / 47 min |

The partition was exact in production (460/460/460/459 = 1839), zero-based indices held (the empty-shard guard never fired), and 9 distinct artifacts uploaded — the collision fix was load-bearing.

But **three of four `parser` shards were still SIGTERMed** (exit 143, "runner has received a shutdown signal") while all four `core` shards of the same duration finished.

## 1. `parser` gets `--jobs 2` instead of 4

The kills concentrate on one crate rather than scattering, which argues against runner flakiness. The parser's suite is the heavy one — proptest, fuzz-corpus replay, insta snapshots — so four concurrent test binaries is the likelier cause. Sharding freed up wall-clock, so halving concurrency is affordable. `--jobs` is now per-package, the same shape as the shard count.

**Stated plainly: this is one run's evidence.** If the kills continue, item 2 is what makes that visible rather than letting it read as worsening coverage.

## 2. A killed shard no longer looks like one that found problems

A terminated shard measures **nothing** — the sweep is cut off mid-list and every later step is skipped, so nothing inside the job can report what happened. From outside it is indistinguishable from a shard that ran to completion and found survivors, and the run's `failure` means two entirely different things: *"coverage is imperfect"* versus *"we did not measure"*.

That conflation is exactly how a scheduled job stops being read, which is the point of #1907.

A `summarize` job with `if: always()` classifies each shard by whether its sweep step reached a conclusion of its own:

```
## Mutation run

| shards | outcome |
|---:|---|
| 9 | measured (the sweep finished) |
| 3 | **truncated** (the runner terminated the job; NOT a mutant result) |

Truncated shards, which measured nothing:

- `Mutate rustledger-parser 1/4`
- `Mutate rustledger-parser 2/4`
- `Mutate rustledger-parser 3/4`
```

It fails the run on truncation, so the conclusion means "incomplete" — true and actionable. Surviving mutants alone do not fail a shard, so this swallows nothing.

## Verification

Replayed the classifier against run 30765289550's **real job data**, not a mock:

- **9 measured, 3 truncated**, naming the three parser shards, exit 1.
- Same fixture with truncated shards filtered out: **0 truncated, exit 0**, no truncation section.

Matrix generation checked across all three trigger paths; `jq` expressions run locally rather than shipped untested.

## Incidental finding

The completed shards give real numbers for the first time: `core` 0/4 had **48 missed** of 258, `core` 2/4 had **72** of 258, `validate` **47** of 275. Extrapolated, `core` alone is around 240 surviving mutants — well above anything the truncated runs ever reported, and above what #1902's table implies.

Refs #1902, #1907.
