### PR TITLE
fix(parser): make the custom-value scan provably terminate

### DIFF
--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -805,31 +805,32 @@ fn extract_custom_values(node: &crate::SyntaxNode) -> Vec<MetaValue> {
         // One value at a time through the shared discriminator — this is what
         // gives custom directives the same MINUS-sign, Tag/Link and
         // `NUMBER CURRENCY` → Amount handling as metadata entries.
-        if let Some((value, next)) = value_tokens_to_meta(&raw, i) {
+        // ONE advance for both branches, so the loop provably terminates.
+        //
+        // It used to advance in two places, and only the value branch was
+        // guarded. That left the `else` free to move `i` BACKWARD, which does
+        // not merely spin: stepping back re-enters the branch above, pushes
+        // another value, steps forward, and repeats — allocating without
+        // bound. Memory runs out before any per-test timeout can fire, so on
+        // CI it takes the whole runner down and surfaces as "the runner has
+        // received a shutdown signal", indistinguishable from infrastructure.
+        // Two full mutation runs lost the same three parser shards to it
+        // (runs 30765289550 and 30768895946) before the cause was found.
+        //
+        // `value_tokens_to_meta` returns the index past what it consumed, so
+        // the assert is the contract and the clamp is the belt: in release a
+        // violation costs one wasted token rather than the process.
+        let next = if let Some((value, consumed)) = value_tokens_to_meta(&raw, i) {
             values.push(value);
-            // `value_tokens_to_meta` must return the index PAST what it
-            // consumed. Both halves of this line matter and they do different
-            // jobs:
-            //
-            // The assert makes a violated contract fail loudly under test.
-            // Clamping alone would silently repair it — the loop would step one
-            // token at a time, re-discriminate, and usually produce the same
-            // values, so a genuinely broken advance would look fine. Measured:
-            // clamping without this turned seventeen index mutants from
-            // detected-by-timeout into simply undetected.
-            //
-            // The clamp keeps release builds from hanging on a violation, which
-            // is what the same seventeen mutants did before either existed. A
-            // parser that spins forever on malformed input is worse than one
-            // that errors, and a hang is invisible in review.
-            debug_assert!(
-                next > i,
-                "value_tokens_to_meta must advance: returned {next} at {i}"
-            );
-            i = next.max(i + 1);
+            consumed
         } else {
-            i += 1;
-        }
+            i + 1
+        };
+        debug_assert!(
+            next > i,
+            "value_tokens_to_meta must advance: returned {next} at {i}"
+        );
+        i = next.max(i + 1);
     }
     values
 }


### PR DESCRIPTION
Two full mutation runs lost the same three parser shards to what looked like infrastructure — exit 143, *"the runner has received a shutdown signal"*.

| run | failed shards |
|---|---|
| [30765289550](https://github.com/rustledger/rustledger/actions/runs/30765289550) | parser 1/4, 2/4, 3/4 |
| [30768895946](https://github.com/rustledger/rustledger/actions/runs/30768895946) | parser 1/4, 2/4, 3/4 |

Identical both times, with shard 0/4 passing. I first read that as runner flakiness, then as `--jobs` over-subscription and halved it in #1925. Neither was the cause: the second run failed exactly as the first, with `Parallel cargo jobs: 2` in the log.

**It is a mutant, and it kills the machine.**

## The bug

`extract_custom_values` advanced its cursor in **two** places and only one was guarded:

```rust
if let Some((value, next)) = value_tokens_to_meta(&raw, i) {
    values.push(value);
    debug_assert!(next > i, ...);
    i = next.max(i + 1);      // guarded
} else {
    i += 1;                   // not
}
```

That leaves the `else` free to move `i` **backward**, which does not merely spin. Stepping back re-enters the branch above, pushes another value onto `values`, steps forward, and repeats. The loop **allocates without bound**. Memory runs out long before any per-mutant timeout can fire, so `cargo-mutants` never gets to report it and the runner dies instead — indistinguishable from a preempted VM.

Reproduced locally under a 2 GB cap, with `i -= 1` applied:

```
memory allocation of 1 bytes failed
SIGABRT
```

## The fix

Both branches now compute a candidate index and pass through **one** advance, so the assert and the clamp cover the whole loop instead of half of it. The same mutation applied to the new shape fails the test in milliseconds rather than consuming the process.

## Result

The cluster now completes locally where it previously could not run at all: **14 mutants tested, 9 caught**. The three survivors are equivalent (the `<=` bound is unreachable; the `i + 1` inside `next.max(i + 1)` cannot matter while the assert holds), and the single timeout is the header-skip `i += 1`, which spins without allocating and so is detected cleanly.

## Worth stating plainly

Production never took this path. `i += 1` is literally plus one, and no input moves the cursor backward. What was actually wrong is that the loop's termination rested on two separate places both being correct with only one of them checked — so a single-character edit could turn a parser into an OOM.

The mutation runner found it by being the one thing that actually makes that edit. It also means #1925's `--jobs 2` was a fix for a cause that did not exist; it is harmless and I have left it, but the real reason those shards died is here.

Refs #1902, #1907.
