### PR TITLE
test(compat): pin the 51 verified beanquery#279 fixtures, and say so in the code

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -384,7 +384,49 @@ impl<'a> Executor<'a> {
                                 "expected 1 argument".to_string(),
                             ));
                         }
-                        // Find chronologically first posting (by transaction date)
+                        // Find chronologically first posting (by transaction date).
+                        //
+                        // Deliberately stricter than Python: see beanquery#279.
+                        // beanquery's `balance` column MUTATES a shared
+                        // accumulator each time it is evaluated
+                        // (`sources/beancount.py`), and its `FIRST.update`
+                        // evaluates the operand only on a group's first row —
+                        // so the postings after it never reach the accumulator
+                        // and every later group reads a stale balance. The
+                        // symptom is that the same `FIRST(balance)` returns
+                        // different numbers depending on what ELSE is in the
+                        // SELECT list, because adding `LAST(balance)` forces
+                        // evaluation on every row and repairs the accumulator.
+                        //
+                        // rledger cannot have that bug by construction: the
+                        // running balance is materialized onto each row during
+                        // the scan (`execution.rs`, `track_balance`), so column
+                        // reads are pure and no aggregate can change what
+                        // another aggregate sees. Evaluating the operand once,
+                        // here, is therefore safe.
+                        //
+                        // One genuine semantic difference remains, independent
+                        // of that bug: "first" here means the chronologically
+                        // earliest posting, where beanquery means the first row
+                        // it happened to scan. So reordering entries that have
+                        // DIFFERENT dates cannot change our answer, but it can
+                        // change beanquery's.
+                        //
+                        // Ties are NOT broken by this: `min_by_key` keeps the
+                        // earliest-scanned of several postings sharing the
+                        // minimum date, so a same-date reorder moves our answer
+                        // too. That is deterministic for a given input (rows
+                        // arrive in `booking_sort_key` order) and matches what
+                        // Python does with a tie, so it is left alone rather
+                        // than invented here — BQL has no defined tie-break and
+                        // picking one would be a divergence with no upstream
+                        // behavior to compare against.
+                        //
+                        // Registered in `KNOWN_PYTHON_DIVERGENCES`
+                        // (scripts/compat-bql-test.py) with the root-cause
+                        // writeup in tests/compatibility/exclusions.toml, and
+                        // re-verifiable via
+                        // scripts/verify-first-balance-divergence.py.
                         if let Some(ctx) = group.iter().min_by_key(|c| c.transaction.date) {
                             self.evaluate_expr(&func.args[0], ctx)
                         } else {

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -109,6 +109,78 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
     ("testdata_source_healthequity_test_matching_journal.beancount", "first-balance-by-month"),
     ("testdata_source_ofx_test_fidelity_ira_journal.beancount", "first-balance-by-month"),
     ("testdata_source_paypal_test_matching_journal.beancount", "first-balance-by-month"),
+    #
+    # The 51 below hit the SAME upstream bug and were pinned later, once the
+    # corpus grew past the original five. Each was VERIFIED, not assumed:
+    # `scripts/verify-first-balance-divergence.py` checks that rledger's
+    # `FIRST(balance)` equals what beanquery itself produces when `balance` is
+    # forced to evaluate on every row (by adding `LAST(balance)` to the SELECT
+    # list). Where those agree, the only difference is the accumulation
+    # beanquery skipped, so the fixture is upstream's bug and not ours.
+    #
+    # Eight further fixtures mismatch on this query and are deliberately NOT
+    # pinned. Seven load third-party plugins (beancount_reds_plugins,
+    # beancount_lazy_plugins) that the verifier could not import; beancount
+    # reports that as a load error and then EXITS 0 with a partially-loaded
+    # ledger, so the comparison silently degrades to rledger-full against
+    # beancount-partial and proves nothing — including for three of them whose
+    # rows happened to match anyway. The eighth genuinely disagrees.
+    #
+    # All eight stay surfaced. Pinning on the strength of "same query name"
+    # would be exactly the too-broad mask this registry's surgical-pin rule
+    # exists to prevent, and would bury a real regression among known-bad
+    # pairs. Install those plugins and re-run the verifier to settle them.
+    ("bc_scripts_my_accounts.beancount", "first-balance-by-month"),
+    ("contrib_examples_budgets-example.beancount", "first-balance-by-month"),
+    ("contrib_examples_example.beancount", "first-balance-by-month"),
+    ("contrib_examples_huge-example.beancount", "first-balance-by-month"),
+    ("data_sample-west.beancount", "first-balance-by-month"),
+    ("data_sample.beancount", "first-balance-by-month"),
+    ("example_alipay_example-alipay-output.beancount", "first-balance-by-month"),
+    ("example_bocom_debit_example-bocom_debit-output.beancount", "first-balance-by-month"),
+    ("example_example.beancount", "first-balance-by-month"),
+    ("example_ledger.beancount", "first-balance-by-month"),
+    ("example_multiple-files-example_example.beancount", "first-balance-by-month"),
+    ("example_portfolio.beancount", "first-balance-by-month"),
+    ("example_wechat_example-wechat-output.beancount", "first-balance-by-month"),
+    ("examples_example.beancount", "first-balance-by-month"),
+    ("examples_ledger_ledger.beancount", "first-balance-by-month"),
+    ("examples_simple_basic.beancount", "first-balance-by-month"),
+    ("examples_simple_starter.beancount", "first-balance-by-month"),
+    ("examples_vesting_vesting.beancount", "first-balance-by-month"),
+    ("fava_investor_examples_example.beancount", "first-balance-by-month"),
+    ("fava_investor_examples_huge-example.beancount", "first-balance-by-month"),
+    ("fava_investor_modules_minimizegains_example.beancount", "first-balance-by-month"),
+    ("fava_investor_modules_tlh_example.beancount", "first-balance-by-month"),
+    ("frontend_tests_dashboards__testdata.beancount", "first-balance-by-month"),
+    ("nomina_examples_example.beancount", "first-balance-by-month"),
+    ("src_fava_portfolio_returns_test_ledger_example_stock.beancount", "first-balance-by-month"),
+    ("src_fava_portfolio_returns_test_ledger_linear_growth_stock.beancount", "first-balance-by-month"),
+    ("src_fava_portfolio_returns_test_ledger_savings_plan.beancount", "first-balance-by-month"),
+    ("testdata_source_venmo_test_invalid_references_journal.beancount", "first-balance-by-month"),
+    ("testdata_source_venmo_test_matching_journal.beancount", "first-balance-by-month"),
+    ("tests_amounts-decimal-comma.beancount", "first-balance-by-month"),
+    ("tests_amounts.beancount", "first-balance-by-month"),
+    ("tests_aux-date.beancount", "first-balance-by-month"),
+    ("tests_balance-assertion.beancount", "first-balance-by-month"),
+    ("tests_code.beancount", "first-balance-by-month"),
+    ("tests_comments.beancount", "first-balance-by-month"),
+    ("tests_commodities.beancount", "first-balance-by-month"),
+    ("tests_data_extension-report-example.beancount", "first-balance-by-month"),
+    ("tests_data_long-example.beancount", "first-balance-by-month"),
+    ("tests_data_query-example.beancount", "first-balance-by-month"),
+    ("tests_dates.beancount", "first-balance-by-month"),
+    ("tests_fixated.beancount", "first-balance-by-month"),
+    ("tests_hledger.beancount", "first-balance-by-month"),
+    ("tests_lots.beancount", "first-balance-by-month"),
+    ("tests_metadata.beancount", "first-balance-by-month"),
+    ("tests_narration.beancount", "first-balance-by-month"),
+    ("tests_payee.beancount", "first-balance-by-month"),
+    ("tests_prices.beancount", "first-balance-by-month"),
+    ("tests_samples_official.beancount", "first-balance-by-month"),
+    ("tests_tags.beancount", "first-balance-by-month"),
+    ("tests_test.beancount", "first-balance-by-month"),
+    ("tests_virtual-postings.beancount", "first-balance-by-month"),
 }
 
 

--- a/scripts/verify-first-balance-divergence.py
+++ b/scripts/verify-first-balance-divergence.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Prove that a `first-balance-by-month` divergence is beanquery#279 and not ours.
+
+The registry in `compat-bql-test.py` pins fixtures per-file on purpose, so it
+falls behind whenever the corpus grows: 5 fixtures were pinned and 59 more had
+since appeared with the identical upstream bug, all counted against rledger.
+Re-run this after a corpus refresh instead of eyeballing the mismatch list.
+
+The test is beanquery's own inconsistency. `balance` mutates a shared
+accumulator when evaluated, and `FIRST.update` evaluates its operand only on a
+group's first row, so later postings never reach the accumulator. Adding
+`LAST(balance)` to the SELECT list forces evaluation on every row and repairs
+it — which is why the same query returns different numbers depending on what
+else is selected.
+
+So: if rledger's `FIRST(balance)` equals beanquery's when `balance` is forced
+to evaluate, the only difference is the skipped accumulation, and the fixture
+belongs in KNOWN_PYTHON_DIVERGENCES. If it does NOT, something else is going
+on and the fixture must stay surfaced — that is the case this script exists to
+keep honest, because a real regression hiding among dozens of known-bad pairs
+is exactly what a too-broad mask would bury.
+
+Usage:  python3 scripts/verify-first-balance-divergence.py <file-with-fixture-names>
+Writes the proven-same-cause names to /tmp/fbm_same.txt.
+
+Run it from a checkout that has the compat corpus fetched — the fixtures under
+tests/compatibility/files are downloaded, not committed, so a fresh worktree
+reports every candidate as "not found". Set RLEDGER to use a binary from a
+different worktree than the one holding the corpus.
+
+Needs the third-party plugins some fixtures load (beancount_reds_plugins,
+beancount_lazy_plugins); without them bean-query fails to load the ledger and
+the fixture is reported inconclusive rather than same-cause.
+"""
+import os, re, subprocess, sys, pathlib
+
+Q_ALONE = "SELECT year, month, FIRST(balance) WHERE account ~ '^Assets' ORDER BY year, month LIMIT 12"
+Q_FORCED = "SELECT year, month, FIRST(balance), LAST(balance) WHERE account ~ '^Assets' ORDER BY year, month LIMIT 12"
+RLEDGER = os.environ.get("RLEDGER", "./target/release/rledger")
+# beancount emits these on stderr and still exits 0, leaving the ledger short
+# of directives the fixture expects.
+LOAD_ERROR = re.compile(r"Error importing|error importing|<load>:")
+ROW = re.compile(r'^\s*(\d{4})\s+(\d{1,2})\s+(-?[\d,.]+)\s+([A-Z][A-Z0-9._-]*)')
+
+def rows(text, cols=3):
+    out = []
+    for line in text.splitlines():
+        m = ROW.match(line)
+        if m:
+            out.append((m.group(1), m.group(2), m.group(3).replace(',', ''), m.group(4)))
+    return out
+
+def run(cmd):
+    """Return (stdout, failure) — `failure` is None on success, else a reason.
+
+    Exit status alone is NOT enough here. beancount reports a failed plugin
+    import as a load error on stderr and then exits 0 with a partially-loaded
+    ledger, so the comparison silently becomes rledger-full vs beancount-
+    partial. That is not evidence of anything and must not be read as a
+    genuine disagreement.
+
+    Nothing here can cause a false pin: a fixture only gets pinned when both
+    sides produce rows and those rows match. The reason string exists so that
+    "could not import a third-party plugin" is distinguishable from "the
+    outputs genuinely disagree", which is the entire job of this script.
+    """
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    if p.returncode != 0:
+        tail = (p.stderr or p.stdout).strip().splitlines()
+        return p.stdout, f"exit {p.returncode}: {tail[-1][:90] if tail else 'no output'}"
+    for line in (p.stderr or "").splitlines():
+        if LOAD_ERROR.search(line):
+            return p.stdout, f"load error: {line.strip()[:90]}"
+    return p.stdout, None
+
+def find(name):
+    for d in ("tests/compatibility/files", "tests/regressions"):
+        hits = list(pathlib.Path(d).rglob(name))
+        if hits: return str(hits[0])
+    return None
+
+with open(sys.argv[1]) as fh:
+    files = [l.strip() for l in fh if l.strip()]
+same, differ, err = [], [], []
+for i, name in enumerate(files, 1):
+    p = find(name)
+    if not p:
+        err.append((name, "not found")); continue
+    try:
+        rl_out, rl_fail = run([RLEDGER, "query", p, Q_ALONE])
+        bq_out, bq_fail = run(["uv", "run", "--offline", "--with", "beancount", "--with", "beanquery",
+                               "bean-query", p, Q_FORCED])
+    except Exception as e:
+        err.append((name, str(e)[:90])); continue
+    if rl_fail or bq_fail:
+        # Cause unproven, so the fixture stays surfaced rather than pinned.
+        err.append((name, f"rledger {rl_fail}" if rl_fail else f"bean-query {bq_fail}"))
+        continue
+    rl, bq = rows(rl_out), rows(bq_out)
+    if rl and bq and rl == bq:
+        same.append(name)
+    else:
+        differ.append((name, len(rl), len(bq)))
+    if i % 10 == 0:
+        print(f"  ...{i}/{len(files)}", flush=True)
+
+print(f"\n  SAME cause (rledger == beanquery-with-balance-forced): {len(same)}")
+print(f"  DIFFERENT / inconclusive:                              {len(differ)}")
+print(f"  errors:                                                {len(err)}")
+for n, a, b in differ[:8]: print(f"    differ: {n}  (rl {a} rows, bq {b} rows)")
+for n, e in err[:10]: print(f"    error:  {n}  {e}")
+if differ or err:
+    print("\n  Not pinned. Prove the cause before adding these to the registry;")
+    print("  a mask applied on a shared query name would bury a real regression.")
+with open('/tmp/fbm_same.txt', 'w') as fh:
+    fh.write('\n'.join(same) + '\n')


### PR DESCRIPTION
`first-balance-by-month` accounted for **62 of the 160 mismatches** in the BQL compat run: 39% of the entire reported gap, and every one with a proven cause is the same upstream bug, filed as [beanquery#279](https://github.com/beancount/beanquery/issues/279).

The registry had five fixtures pinned. The corpus has grown to 812 files since, and newer ones hit the same bug uncounted, so the metric was attributing beanquery's defect to us.

## Why this is upstream's bug, re-established from source

beanquery's `balance` column mutates a shared accumulator every time it is evaluated (`sources/beancount.py`; the `@cache(maxsize=1)` on it is an admission the function is impure). Its `FIRST.update` evaluates the operand only on a group's first row, so later postings never reach the accumulator and every subsequent group reads a stale balance.

The symptom is decisive and needs no judgment call: **the same `FIRST(balance)` returns different numbers depending on what else is in the SELECT list**, because adding `LAST(balance)` forces evaluation on every row. No engine may let one selected column change another's value.

And when beanquery is forced to evaluate completely, it agrees with us exactly, byte-identical on every row of the fixture I drilled into.

rledger cannot have the bug by construction: the running balance is materialized onto each row during the scan (`execution.rs`, `track_balance`), so column reads are pure and no aggregate can change what another sees.

## Verified, not assumed

`scripts/verify-first-balance-divergence.py` (added) checks each candidate by that same test. **51 of 59 proved same-cause** and are pinned.

The other eight are deliberately **not** pinned. Seven load third-party plugins the verifier could not import, and beancount reports that as a load error and then **exits 0** with a partially-loaded ledger, so the comparison silently degrades to rledger-full against beancount-partial and proves nothing. Three of those seven produced matching rows anyway; matching output from a ledger missing directives is not evidence, so they are not pinned either. The eighth genuinely disagrees.

Checking only the exit status would have missed all seven, so the script greps stderr for the load-error line too. Credit to the Copilot review comment that prompted this: the first version of the registration pinned 54, three of them on a compromised comparison.

Pinning the remainder on the strength of a shared query name would be the too-broad mask this registry's surgical-pin rule exists to prevent, and would bury a real regression among dozens of known-bad pairs. Install the plugins and re-run the verifier to settle them.

The script exists because this **will** drift again: the registry pins per file and the corpus keeps growing. Re-run it after a corpus refresh instead of eyeballing the mismatch list. It needs a checkout with the corpus fetched (fixtures are downloaded, not committed); set `RLEDGER` to point at a binary built elsewhere.

## Also: the inline comment CLAUDE.md asks for

The deviation checklist requires a code comment naming the Python issue. `grep 279` across the query crate returned nothing, so the reason a reader would find for `min_by_key(transaction.date)` was a one-line note about chronology. It now explains the upstream bug, why our architecture is immune, and where the evidence lives.

It also records the one genuine semantic difference, separate from the bug: our `FIRST` means the chronologically earliest posting, beanquery's means the first row scanned. Reordering entries with **different** dates cannot change our answer but can change theirs. Same-date ties are **not** broken (`min_by_key` keeps the earliest-scanned), which is deterministic per input and matches Python; inventing a tie-break here would be a divergence with no upstream behavior to compare against.

## Gates

- verifier re-run end to end after the rewrite: 51 same-cause / 1 differ / 7 load-error, totalling 59
- `cargo test -p rustledger-query`: 631 passed, 0 failed
- `cargo +1.97.0 clippy -p rustledger-query --all-features --all-targets -D warnings`: clean
- `cargo fmt --check`: clean
- `compat-bql-test.py --self-test`: OK (stale/dangling pin detection still behaves)
- cross-check: every pin has a proof entry and every proof entry has a pin (0 unmatched either way)