### PR TITLE
ci(mutation): diagnose and fix the parser shard deaths (memory, not disk or infra)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -238,6 +238,49 @@ jobs:
                   kill "$SAMPLER_PID" 2>/dev/null || true
                 fi' EXIT
 
+          # MEMORY CAP - why a mutation job needs one at all.
+          #
+          # Measured on run 30782530785 with the sampler above. Steady state
+          # was ~13.5 GB available; in a single 30-second window it fell to
+          # 179 MB with one `rustledger_parser` TEST BINARY at 12048 MB RSS
+          # and a second at 3049 MB, on a 16 GB runner. Disk was never a
+          # factor (86 GB free throughout). The runner agent was the thing
+          # that died, which is why the job reports SIGTERM and a "shutdown
+          # signal" rather than any error of ours.
+          #
+          # This is inherent to mutation testing, not one bad mutant: the tool
+          # deliberately compiles broken code, and some of it allocates without
+          # bound. `--timeout` only bounds WALL CLOCK, so a mutant that eats
+          # 12 GB in well under 300s is never caught by it - it takes the
+          # runner down first, losing the whole shard's results including the
+          # hundreds of mutants already tested.
+          #
+          # RLIMIT_AS is inherited by every descendant (cargo, rustc, the test
+          # binaries), so the runaway hits an allocation failure and dies as a
+          # FAILING TEST - which mutation testing scores as CAUGHT, the correct
+          # outcome - instead of killing the VM.
+          #
+          # WHY 6 GB AND NOT LESS. A cap set near legitimate usage would be
+          # WORSE than the crash it prevents: healthy mutants would die on
+          # allocation failure and score as CAUGHT, quietly INFLATING the
+          # mutation score while testing nothing. A crashed shard is at least
+          # loud. So the cap is set roughly 10x above measured honest peak
+          # (rustc topped out around 650 MB in the same samples) - high enough
+          # that only a genuine runaway can reach it, low enough that two
+          # concurrent slots stay inside the 16 GB runner.
+          #
+          # Verified locally: a full clean build plus the entire
+          # `rustledger-parser` suite passes under this exact limit, and a
+          # process asking for more gets MemoryError.
+          #
+          # This bounds ANY SINGLE process, which is the failure that was
+          # actually observed. It does not bound the sum, so N slots each
+          # legitimately near the cap could still exhaust the VM - not seen in
+          # practice (honest peak is ~0.65 GB), but it is why raising this
+          # number and raising `jobs_for()` have to be considered together.
+          ulimit -v 6291456
+          echo "RESOURCE ulimit_v_kb=$(ulimit -v)"
+
           echo "RESOURCE baseline follows (before any mutant runs)"
           df -h / "${TMPDIR:-/tmp}" | sed 's/^/RESOURCE df /'
           free -m | sed 's/^/RESOURCE free /'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -227,7 +227,16 @@ jobs:
           # leave a stray process for "Cleaning up orphan processes" to report.
           # `sleep` is a child of the subshell and outlives a bare kill of the
           # parent, so take both.
-          trap 'pkill -P "$SAMPLER_PID" 2>/dev/null || true; kill "$SAMPLER_PID" 2>/dev/null || true' EXIT
+          #
+          # The emptiness guard is about log hygiene, not safety: an unset
+          # SAMPLER_PID makes `pkill` print its usage block and `kill` print
+          # "not a pid or valid job spec" (verified - neither targets another
+          # process). Both would land in the log at exactly the moment this
+          # sampler exists to make readable, so keep them out of it.
+          trap 'if [ -n "${SAMPLER_PID:-}" ]; then
+                  pkill -P "$SAMPLER_PID" 2>/dev/null || true
+                  kill "$SAMPLER_PID" 2>/dev/null || true
+                fi' EXIT
 
           echo "RESOURCE baseline follows (before any mutant runs)"
           df -h / "${TMPDIR:-/tmp}" | sed 's/^/RESOURCE df /'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -153,6 +153,87 @@ jobs:
           echo "Timeout per mutant: ${TIMEOUT}s"
           echo ""
 
+          # WHY THIS SAMPLER EXISTS
+          #
+          # `rustledger-parser` shards keep dying with exit 143 (SIGTERM) plus
+          # "The runner has received a shutdown signal", 25-47 minutes into a
+          # 240-minute budget. That is the runner VM going away underneath us,
+          # not our own timeout and not a cargo-mutants failure.
+          #
+          # Two rounds of fixes were aimed at guesses. `--jobs 4 -> 2` (run
+          # 30765289550) and the convert.rs unbounded-loop fix (#1926) each
+          # recovered some shards and left others dying, which is what you get
+          # from treating a symptom you cannot see. NOTHING in the job records
+          # disk or memory, so the logs cannot distinguish the candidates:
+          #
+          #   disk        cargo-mutants keeps one full build tree PER --jobs
+          #               slot, and the runner documents only ~14 GB free.
+          #               Measured locally at 1.7 GB for two slots, so this is
+          #               the WEAKEST of the three - but "weakest" was measured
+          #               on a short run, and it costs nothing to sample.
+          #   memory      several concurrent rustc/test processes. The parser
+          #               suite is the heavy one (proptest, fuzz-corpus replay,
+          #               insta), which fits the fact that only this package
+          #               dies. Leading candidate.
+          #   infra       GitHub reclaiming the VM, nothing to do with us.
+          #
+          # The sampler writes to STDOUT on purpose. When the VM is reclaimed
+          # the post-job steps are skipped and the artifact upload never runs
+          # (that is why every previous failure uploaded nothing), but the log
+          # stream is preserved right up to the kill. Stdout is the only
+          # channel that survives the failure being diagnosed.
+          #
+          # Read it with: grep '^RESOURCE' in the failed job's log. The last
+          # line before the kill is the verdict. If free disk or free memory
+          # is collapsing, it is ours to fix; if both look healthy, it is
+          # infrastructure and the fix is retry/self-hosted, not more tuning.
+          # cargo-mutants scratch lives at $TMPDIR/cargo-mutants-<dir>-*.tmp,
+          # one per --jobs slot, and is removed on exit. Verified against
+          # cargo-mutants 27.1.0.
+          #
+          # EVERY sample below is failure-proofed with `|| true`, and the
+          # subshell turns `set -e` OFF. That is not defensive padding, it is
+          # the bug this sampler was born with: the step runs under bash
+          # `-eo pipefail`, the scratch glob matches nothing until cargo-mutants
+          # has started, so `du` exits 1, so the assignment exits 1, so `set -e`
+          # killed the sampler on its FIRST iteration. It produced no output at
+          # all, which is the one failure mode an instrument must not have -
+          # a silent no-op looks exactly like "nothing to report". Caught by
+          # running the block standalone before pushing it.
+          (
+            set +e
+            while true; do
+              root_avail=$(df -m --output=avail / 2>/dev/null | tail -1 | tr -d ' ' || true)
+              tmp_avail=$(df -m --output=avail "${TMPDIR:-/tmp}" 2>/dev/null | tail -1 | tr -d ' ' || true)
+              mem_avail=$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || true)
+              swap_free=$(awk '/SwapFree/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || true)
+              scratch=$({ du -sm "${TMPDIR:-/tmp}"/cargo-mutants-*.tmp 2>/dev/null || true; } \
+                | awk '{s+=$1} END {print s+0}' || true)
+              # Name the heaviest processes, not just the shortfall. "memory
+              # ran out" does not tell you what to change; "two rustc at 3 GB
+              # each" says lower --jobs, and "one test binary at 9 GB" says
+              # fix the test.
+              top=$({ ps -eo rss=,comm= --sort=-rss 2>/dev/null || true; } | head -3 \
+                | awk '{printf "%s:%dMB ", $2, $1/1024}' || true)
+              echo "RESOURCE t=$(date -u +%H:%M:%S) root_avail_mb=${root_avail:--1}" \
+                   "tmp_avail_mb=${tmp_avail:--1} mem_avail_mb=${mem_avail:--1}" \
+                   "swap_free_mb=${swap_free:--1} mutants_scratch_mb=${scratch:--1}" \
+                   "top_rss=[${top}]"
+              sleep 30
+            done
+          ) &
+          SAMPLER_PID=$!
+          # Stop sampling however this step ends, so a passing run does not
+          # leave a stray process for "Cleaning up orphan processes" to report.
+          # `sleep` is a child of the subshell and outlives a bare kill of the
+          # parent, so take both.
+          trap 'pkill -P "$SAMPLER_PID" 2>/dev/null || true; kill "$SAMPLER_PID" 2>/dev/null || true' EXIT
+
+          echo "RESOURCE baseline follows (before any mutant runs)"
+          df -h / "${TMPDIR:-/tmp}" | sed 's/^/RESOURCE df /'
+          free -m | sed 's/^/RESOURCE free /'
+          nproc | sed 's/^/RESOURCE nproc /'
+
           # `--shard k/n` splits the generated mutant list; every shard still
           # builds the crate once, so this trades a little repeated build time
           # for jobs that actually finish.


### PR DESCRIPTION
`rustledger-parser` shards kept dying with **exit 143 (SIGTERM)** and "The runner has received a shutdown signal", 25 to 47 minutes into a 240-minute budget. Two earlier fixes (`--jobs 4→2`, and the `convert.rs` loop fix in #1926) were aimed at guesses and each left shards dying, because **nothing in the job recorded disk or memory**.

This PR adds the measurement, then fixes what the measurement found.

## What the telemetry showed

Run 30782530785, shard 3/4, the last sample **14 seconds before the kill**:

```
t=04:10:50  mem_avail_mb=13428  root_avail_mb=86485  top_rss=[rustc:648MB rustc:507MB ...]
t=04:11:40  mem_avail_mb=179    root_avail_mb=86477  top_rss=[rustledger_pars:12048MB
                                                              rustledger_pars:3049MB ...]
```

A `rustledger-parser` **test binary reached 12 GB RSS**, with a second at 3 GB, on a 16 GB runner. Available memory fell from 13.4 GB to 179 MB inside one 30-second window and the runner agent died.

- **Disk was never involved** — 86 GB free throughout, scratch steady at 1.8 GB. It was a live hypothesis; it's now dead.
- **Infrastructure was never involved** — the VM died because we exhausted it.

## Why a cap, rather than hunting the mutant

This is inherent to mutation testing, not one bad mutant: the tool deliberately compiles broken code and some of it allocates without bound. `--timeout` bounds only **wall clock**, so a mutant that eats 12 GB well inside 300s is never caught by it — it takes the runner down first, and the shard loses every result it had already produced. #1926 fixed one such mutant by hand; there will always be another.

`RLIMIT_AS` is inherited by every descendant (cargo, rustc, test binaries), so a runaway now hits an allocation failure and dies as a **failing test — which mutation testing scores as CAUGHT**, the correct outcome — instead of killing the VM.

## Why 6 GB and not less

A cap near legitimate usage would be **worse than the crash it prevents**: healthy mutants would die on allocation failure and score as CAUGHT, quietly *inflating* the mutation score while testing nothing. A crashed shard is at least loud.

6 GB is ~10x the measured honest peak (rustc topped out around 650 MB in the same samples). It bounds any *single* process, which is the failure actually observed; it does not bound the sum, so raising it and raising `jobs_for()` have to be considered together.

## The sampler shipped broken and the self-test caught it

Run standalone it emitted **no periodic lines at all**. The step runs under `bash -eo pipefail`; the scratch glob matches nothing until cargo-mutants starts, so `du` exits 1 → the assignment exits 1 → `set -e` killed the sampler on iteration 1. It would have produced an empty log, indistinguishable from "nothing to report" — the one failure mode an instrument must not have. Fixed with `set +e` plus `|| true` on every sample.

## Verification

| claim | how |
|---|---|
| sampler reports at all | run standalone under `bash -eo pipefail`, no scratch dirs (the exact CI condition) |
| sampler can report non-zero | planted 300 MB blob → `mutants_scratch_mb=301`, `root_avail_mb` drops 300 |
| sampler survived a real run | 68 `RESOURCE` lines captured from the shard that died |
| cap does not create false CAUGHTs | full clean build + entire `rustledger-parser` suite passes under the exact limit |
| cap actually bites | a process asking beyond it gets `MemoryError` |
| ordering | cap applied after sampler start (sampler unaffected), before `cargo mutants` (all mutant work covered) |

## Honest residuals

- I could not pin the individual runaway mutant. The two candidates that were in flight by list order both run clean locally (601 MB peak, caught in 0.05s), and my reconstruction of cargo-mutants' in-flight set from the log was not reliable enough to trust. The fix does not depend on knowing which one it is.
- Shard 3/4 had completed only ~36 of its 459 mutants in ~28 minutes. Even without the crash it would not have finished inside the cap, so shard counts likely need revisiting once runs stop dying. Not addressed here.

Refs #1907.