### PR TITLE
test(compat): print the raw BQL match rate next to the effective one

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -811,6 +811,7 @@ jobs:
             check_exit_match_pct: ${{ steps.compat_test.outputs.check_match_pct }}
             full_match_pct: ${{ steps.compat_test.outputs.full_pct }}
             bql_match_pct: ${{ steps.bql_compat.outputs.bql_pct }}
+            bql_raw_match_pct: ${{ steps.bql_compat.outputs.bql_raw_pct }}
             regressions: ${{ steps.compat_test.outputs.regression_count }}
 
           check_compatibility:
@@ -835,6 +836,11 @@ jobs:
             queries_tested: ${{ steps.bql_compat.outputs.bql_total }}
             queries_matching: ${{ steps.bql_compat.outputs.bql_match }}
             match_pct: ${{ steps.bql_compat.outputs.bql_pct }}
+            # Raw = nothing masked. Reported next to match_pct so the size of
+            # KNOWN_*_DIVERGENCES is visible rather than inferable; the gap
+            # between the two moves whenever pins are added (#1902).
+            raw_match_pct: ${{ steps.bql_compat.outputs.bql_raw_pct }}
+            known_divergences: ${{ steps.bql_compat.outputs.bql_known_divergences }}
 
           regressions:
             count: ${{ steps.compat_test.outputs.regression_count }}
@@ -863,6 +869,7 @@ jobs:
           error_pct = int(os.environ.get('ERROR_PCT', 0))
           full_pct = int(os.environ.get('FULL_PCT', 0))
           bql_pct = int(os.environ.get('BQL_PCT', 0))
+          bql_raw_pct = int(os.environ.get('BQL_RAW_PCT', 0))
           regression_count = int(os.environ.get('REGRESSION_COUNT', 0))
 
           now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -1047,7 +1054,7 @@ jobs:
           print(f"Posting count match: {posting_pct}%")
           print(f"Error presence match: {error_pct}%")
           print(f"Full AST match: {full_pct}%")
-          print(f"BQL match: {bql_pct}%")
+          print(f"BQL match: {bql_pct}% (raw {bql_raw_pct}%, {bql_pct - bql_raw_pct} pts masked)")
           if regression_count > 0:
               print(f"⚠️ Regressions detected: {regression_count}")
           EOF
@@ -1058,6 +1065,7 @@ jobs:
           ERROR_PCT: ${{ steps.compat_test.outputs.error_pct }}
           FULL_PCT: ${{ steps.compat_test.outputs.full_pct }}
           BQL_PCT: ${{ steps.bql_compat.outputs.bql_pct }}
+          BQL_RAW_PCT: ${{ steps.bql_compat.outputs.bql_raw_pct }}
           REGRESSION_COUNT: ${{ steps.compat_test.outputs.regression_count }}
       - name: Update summary
         run: |
@@ -1070,6 +1078,8 @@ jobs:
           | **Check exit match** | **${{ steps.compat_test.outputs.check_match_pct }}%** |
           | **Full AST match** | **${{ steps.compat_test.outputs.full_pct }}%** |
           | **BQL match** | **${{ steps.bql_compat.outputs.bql_pct }}%** |
+          | BQL match (raw, nothing masked) | ${{ steps.bql_compat.outputs.bql_raw_pct }}% |
+          | BQL known divergences masked | ${{ steps.bql_compat.outputs.bql_known_divergences }} |
           | Regressions | ${{ steps.compat_test.outputs.regression_count }} |
           | JSON parse failures | ${{ steps.compat_test.outputs.json_parse_failures }} |
 

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -915,6 +915,15 @@ def main() -> int:
     real_mismatches = total - matching - known_div
     effective_match = matching + known_div
     pct = effective_match * 100 // total if total > 0 else 0
+    # The RAW rate: what matched with nothing masked. `pct` is the number that
+    # gets quoted (release notes, badge, the job summary), and quoting it alone
+    # invites exactly the doubt #1902 raised - is the headline real, or is it
+    # the registry doing the work? Printing both makes the masking's size
+    # visible instead of inferable, and it moves: #1927 pinned 51 more pairs
+    # (all proven upstream bugs), which widened the gap between these two by
+    # about 2 points in a single PR. A reader who sees only the effective
+    # figure cannot tell that happened.
+    raw_pct = matching * 100 // total if total > 0 else 0
 
     # Per-query empty-result rate. A query that returns 0 rows on >50%
     # of files isn't actually being tested by the corpus and should
@@ -944,10 +953,14 @@ def main() -> int:
     )
     print(f"Runs tested:         {total}  (file × query)")
     print(f"Runs matching:       {matching}")
+    print(f"Raw match:           {matching}/{total} ({raw_pct}%)  [nothing masked]")
     print(f"Known Python diffs:  {known_py}")
     print(f"Known Rust diffs:    {known_rs}")
     print(f"Real mismatches:     {real_mismatches}")
-    print(f"Effective match:     {effective_match}/{total} ({pct}%)")
+    print(
+        f"Effective match:     {effective_match}/{total} ({pct}%)"
+        f"  [+{known_div} masked, {pct - raw_pct} pts over raw]"
+    )
 
     # Empty-result warnings — corpus signal, not a test failure
     print()
@@ -1028,6 +1041,7 @@ def main() -> int:
                 f.write(f"bql_known_python={known_py}\n")
                 f.write(f"bql_known_rust={known_rs}\n")
                 f.write(f"bql_pct={pct}\n")
+                f.write(f"bql_raw_pct={raw_pct}\n")
                 f.write(f"bql_weak_queries={len(weak)}\n")
 
     # Stale-mask gate. A KNOWN_*_DIVERGENCE entry whose pair now MATCHES


### PR DESCRIPTION
The compat run reports **"BQL match: 93%"**. That is the *effective* rate, after `KNOWN_PYTHON_DIVERGENCES` and `KNOWN_RUST_DIVERGENCES` absorb pairs where the upstream tool is the one that's wrong. The raw count was printed, but only the effective figure carried a percentage — and the percentage is what gets quoted: release notes, the badge, the job summary.

That's precisely the doubt #1902 raised about this metric: *is the headline real, or is the registry doing the work?* A reader couldn't answer without opening the script.

**The gap also moves, and just moved a lot.** #1927 pinned 51 more pairs — every one a proven beanquery#279 case — taking masked pairs from 108 to ~159 and widening the raw-vs-effective difference by roughly 2 points in a single PR. Nothing in the output would have shown that happening.

## What changes

```
Raw match:           2282/2550 (89%)  [nothing masked]
Effective match:     2441/2550 (95%)  [+159 masked, 6 pts over raw]
```

Same treatment everywhere the number is actually read:

- `GITHUB_OUTPUT` gains `bql_raw_pct` alongside `bql_pct`
- the **step-summary table** gains `BQL match (raw, nothing masked)` and `BQL known divergences masked` rows under the existing `BQL match` — this is the table people quote
- `compat-results.yaml` gains `raw_match_pct` and `known_divergences`
- the console recap prints `93% (raw 89%, 4 pts masked)`

## Scope

Reporting only. **No pin is added or removed**, the stale-mask gate is untouched, and `bql_pct` keeps its meaning so the history series and badge stay comparable across runs.

## Verified by running the harness, not by reading the diff

```
Runs tested:         68
Raw match:           0/68 (0%)  [nothing masked]
Known Python diffs:  4
Effective match:     4/68 (5%)  [+4 masked, 5 pts over raw]
```

Run against a file set chosen *because* it carries known-divergence pins, so the masked-vs-raw split is genuinely exercised rather than both reading zero. `bql_raw_pct=0` and `bql_pct=5` were written to `GITHUB_OUTPUT` in that same run.

- `compat-bql-test.py --self-test`: OK (stale/dangling detection unaffected)
- `compat.yml` parses

Refs #1902.