### PR TITLE
ci(mutation): cut the per-mutant timeout; re-sharding is the wrong lever

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,10 +39,12 @@ on:
       timeout:
         description: 'Timeout per mutant in seconds'
         required: false
-        # 300 -> 120. Measured on run 30785409699: all four parser shards test
-        # exactly 459 mutants, yet ran 36 / 53 / 63 / 93 minutes. Duration
-        # tracks TIMEOUTS, not mutant count — shard 3/4 spent 8 x 300s, about
-        # 40 of its 93 minutes, waiting on mutants that hang. See the
+        # 300 -> 120. Measured on run 30785409699: the four parser shards run
+        # DISJOINT slices of the mutant list (that is what `--shard k/n` does)
+        # and the slices are equal in SIZE — 459 mutants each — yet they took
+        # 36 / 53 / 63 / 93 minutes. Equal work by count, very unequal by
+        # clock. Duration tracks TIMEOUTS: shard 3/4 spent 8 x 300s, about 40
+        # of its 93 minutes, waiting on mutants that hang. See the
         # `shards_for` note below for why re-sharding is the wrong lever.
         #
         # 120s is still ~100x the measured baseline test (`Unmutated baseline
@@ -96,13 +98,14 @@ jobs:
           # Sharding splits the mutant list, so each job finishes well inside
           # the cap and a lost runner costs one shard instead of a crate.
           # NOT raised further on purpose. The obvious reading of a 93-minute
-          # shard is "split it more", and that is wrong here: every parser shard
-          # tests the SAME 459 mutants, so the spread is not workload
-          # imbalance. It is timeouts (0 / 1 / 7 / 8 across the four) plus how
-          # many mutants are unviable and therefore free (146 on the fastest,
-          # 34 on the slowest). More shards would divide the mutants but
+          # shard is "split it more", and that is wrong here. The shards already
+          # hold disjoint slices of EQUAL SIZE (459 mutants each), so the
+          # 36-to-93-minute spread is not workload imbalance to be divided
+          # away. It is timeouts (0 / 1 / 7 / 8 across the four) plus how many
+          # mutants are unviable and therefore free (146 on the fastest, 34 on
+          # the slowest). More shards would make each slice smaller but
           # multiply the fixed ~113s baseline build per runner, and the
-          # timeouts would simply redistribute.
+          # timeouts would simply redistribute across them.
           #
           # Headroom is also better than it looks: 93 minutes against a
           # 240-minute cap. Revisit if a shard passes ~180.

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,7 +39,22 @@ on:
       timeout:
         description: 'Timeout per mutant in seconds'
         required: false
-        default: '300'
+        # 300 -> 120. Measured on run 30785409699: all four parser shards test
+        # exactly 459 mutants, yet ran 36 / 53 / 63 / 93 minutes. Duration
+        # tracks TIMEOUTS, not mutant count — shard 3/4 spent 8 x 300s, about
+        # 40 of its 93 minutes, waiting on mutants that hang. See the
+        # `shards_for` note below for why re-sharding is the wrong lever.
+        #
+        # 120s is still ~100x the measured baseline test (`Unmutated baseline
+        # in 113s build + 1s test`), so a legitimate test has enormous room.
+        #
+        # And the failure direction is safe: the score is
+        # CAUGHT / (CAUGHT + MISSED + TIMEOUT), so a TIMEOUT sits in the
+        # denominator only. Cutting this too far makes the score DROP, which is
+        # loud — the opposite of the memory cap in #1928, where too tight would
+        # have silently inflated it. If the next run shows a score fall, this
+        # is the first thing to look at.
+        default: '120'
         type: string
 permissions:
   contents: read
@@ -80,6 +95,17 @@ jobs:
           #
           # Sharding splits the mutant list, so each job finishes well inside
           # the cap and a lost runner costs one shard instead of a crate.
+          # NOT raised further on purpose. The obvious reading of a 93-minute
+          # shard is "split it more", and that is wrong here: every parser shard
+          # tests the SAME 459 mutants, so the spread is not workload
+          # imbalance. It is timeouts (0 / 1 / 7 / 8 across the four) plus how
+          # many mutants are unviable and therefore free (146 on the fastest,
+          # 34 on the slowest). More shards would divide the mutants but
+          # multiply the fixed ~113s baseline build per runner, and the
+          # timeouts would simply redistribute.
+          #
+          # Headroom is also better than it looks: 93 minutes against a
+          # 240-minute cap. Revisit if a shard passes ~180.
           shards_for() {
             case "$1" in
               rustledger-core|rustledger-parser) echo 4 ;;


### PR DESCRIPTION
The parser shards run **36 / 53 / 63 / 93** minutes, and the obvious reading of that spread is "split the slow one further." Measuring it says otherwise.

From run 30785409699, every parser shard tests **exactly the same 459 mutants**:

| shard | timeouts | unviable | duration |
|---|---:|---:|---:|
| 0/4 | 0 | 146 | 36 min |
| 2/4 | 1 | 30 | 53 min |
| 1/4 | 7 | 75 | 63 min |
| 3/4 | **8** | 34 | **93 min** |

The spread isn't workload imbalance. It's **timeouts** — 8 × 300s is ~40 of shard 3/4's 93 minutes — plus how many mutants are unviable and therefore free.

More shards would divide the mutant list but multiply the fixed ~113s baseline build per runner, and the timeouts would simply redistribute. `shards_for` stays at 4, with the reasoning recorded in place so the next person doesn't re-derive it and reach the wrong answer.

Headroom is also better than I'd been assuming: **93 minutes against a 240-minute cap**, not the "2 hours of a 4-hour cap" I'd been repeating.

## Timeout 300 → 120

120s is still ~100× the measured baseline test (`Unmutated baseline in 113s build + 1s test`), so a legitimate test has enormous room.

**The failure direction is what makes this safe to change without a long validation loop.** The score is `CAUGHT / (CAUGHT + MISSED + TIMEOUT)`, so a TIMEOUT sits in the denominator only — cutting the timeout too far makes the score **drop**.

That's the opposite of the memory cap in #1928, where too tight would have silently *inflated* the score by turning healthy mutants into CAUGHT. Here the mistake is loud, and the per-shard summary already prints the timeout count, so the next run measures it.

Expected effect: ~24 minutes off shard 3/4. Being verified by a dispatched run rather than asserted.

Refs #1907.