### PR TITLE
ci(mutation): 120s was measurably too aggressive; 180s

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,7 +39,7 @@ on:
       timeout:
         description: 'Timeout per mutant in seconds'
         required: false
-        # 300 -> 120. Measured on run 30785409699: the four parser shards run
+        # 300 -> 180. Measured on run 30785409699: the four parser shards run
         # DISJOINT slices of the mutant list (that is what `--shard k/n` does)
         # and the slices are equal in SIZE — 459 mutants each — yet they took
         # 36 / 53 / 63 / 93 minutes. Equal work by count, very unequal by
@@ -47,8 +47,10 @@ on:
         # of its 93 minutes, waiting on mutants that hang. See the
         # `shards_for` note below for why re-sharding is the wrong lever.
         #
-        # 180s is ~150x the measured baseline test (`Unmutated baseline in
-        # 113s build + 1s test`), so a legitimate test has enormous room.
+        # 180s is 180x the measured baseline TEST — `Unmutated baseline in
+        # 113s build + 1s test`, and `--timeout` bounds the test phase, not
+        # the build (`--build-timeout` is separate) — so a legitimate test has
+        # enormous room.
         #
         # The failure direction is safe: the score is
         # CAUGHT / (CAUGHT + MISSED + TIMEOUT), so a TIMEOUT sits in the

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -47,16 +47,28 @@ on:
         # of its 93 minutes, waiting on mutants that hang. See the
         # `shards_for` note below for why re-sharding is the wrong lever.
         #
-        # 120s is still ~100x the measured baseline test (`Unmutated baseline
-        # in 113s build + 1s test`), so a legitimate test has enormous room.
+        # 180s is ~150x the measured baseline test (`Unmutated baseline in
+        # 113s build + 1s test`), so a legitimate test has enormous room.
         #
-        # And the failure direction is safe: the score is
+        # The failure direction is safe: the score is
         # CAUGHT / (CAUGHT + MISSED + TIMEOUT), so a TIMEOUT sits in the
         # denominator only. Cutting this too far makes the score DROP, which is
         # loud — the opposite of the memory cap in #1928, where too tight would
-        # have silently inflated it. If the next run shows a score fall, this
-        # is the first thing to look at.
-        default: '120'
+        # have silently inflated it.
+        #
+        # WHY 180 AND NOT 120. 120 was tried first (run 30876745352) and was
+        # measurably too aggressive. It took the worst shard 93 -> 78 minutes,
+        # but its timeouts went 8 -> 12: four mutants that previously COMPLETED
+        # and were scored now expire instead. A TIMEOUT is not a CAUGHT, so
+        # those four moved from the numerator to the denominator and the shard
+        # score fell 84.2% -> 83.1% without any test getting worse. That is a
+        # false signal, in the safe direction but still false.
+        #
+        # 180 sits above the four (they finish between 120s and 300s) while
+        # still cutting the eight genuine hangs from 300s. Re-measure if the
+        # timeout count moves off 8 again: it is the tell that this number is
+        # in the wrong place.
+        default: '180'
         type: string
 permissions:
   contents: read


### PR DESCRIPTION
Measured, not guessed. Run 30876745352 ran the parser shards at 120s:

| shard | duration | timeouts |
|---|---|---|
| 0/4 | 36 → 40 min | 0 → 0 |
| 1/4 | 63 → 53 min | 7 → 7 |
| 2/4 | 53 → 36 min | 1 → 1 |
| 3/4 | 93 → **78** min | 8 → **12** |

The saving was real but smaller than I predicted — **15 minutes** off the worst shard, not the ~24 I estimated. I'd assumed the same eight timeouts would each cost less; instead four more mutants crossed the line.

## Those four are the problem

They previously **completed and were scored**; at 120s they expire instead. A TIMEOUT is not a CAUGHT, so they moved from the numerator to the denominator and shard 3/4's score fell:

```
358/425 = 84.2%   →   358/431 = 83.1%
```

...without a single test getting worse. A false signal — in the safe direction, since it understates rather than flatters, but still false. A mutation score nobody trusts is one nobody reads.

## Why 180

It sits above those four (they finish between 120s and 300s) while still cutting the eight genuine hangs down from 300s. Both measurements are recorded at the constant so the next person doesn't repeat the 120 experiment.

**The tell to watch:** if the timeout count moves off 8, this number is in the wrong place.

## Caveat on the comparison

The crate grew 459 → 466 mutants per shard as this session's PRs merged, so some of the missed-count movement (1/4 went 40 → 57 missed) is new code rather than reclassification. **The timeout counts are the clean signal here; the missed counts are not.**

Being re-measured by a dispatched run rather than asserted.

Refs #1907.