### PR TITLE
fix(parser): a metadata key needs at least two characters

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -397,7 +397,11 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     parse error (#1949). A file that previously loaded clean can now carry
 ///     errors, so a stale cache would serve the old clean parse on a build
 ///     that objects.
-const CACHE_VERSION: u32 = 21;
+/// v22: a metadata key now needs at least two characters, as in beancount
+///     (#1955). A file using `k: 42` previously loaded clean and now carries a
+///     parse error, so a stale cache would serve the old clean parse on a
+///     build that objects.
+const CACHE_VERSION: u32 = 22;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1113,7 +1117,7 @@ mod tests {
         // layout: the `CostNumber` discriminants and payload encodings the byte
         // arrays below pin are untouched, and those assertions prove it rather
         // than take this comment's word for it.
-        const FIXTURE_VERSION: u32 = 21;
+        const FIXTURE_VERSION: u32 = 22;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
@@ -1210,7 +1214,7 @@ mod tests {
         // still match — and the assertion, not this comment, is what proves it.
         // v20 (#1930) is an account-name lexer change; `MetaValue` is
         // untouched and the hash below must still match.
-        const FIXTURE_VERSION: u32 = 21;
+        const FIXTURE_VERSION: u32 = 22;
         const META_VALUE_LAYOUT_HASH: &str =
             "43e3c258fe376cede6a6c2c975100bcf67ddda0ab84b21566b123c01e0a54b25";
         assert_eq!(

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -5316,20 +5316,23 @@ mod tests {
     /// for metadata, so every latch guard could be flipped freely.
     #[test]
     fn metadata_latches_the_first_token_of_each_kind() {
+        // Two-character keys because beancount requires them, and so do we
+        // since #1955. These are fixture names only; the test is about
+        // first-of-kind LATCHING and nothing here depends on key length.
         let meta = meta_of(
-            "  s: \"one\" \"two\"\n  n: 1 2\n  c: USD EUR\n  d: 2024-06-01 2025-07-02\n  \
-             a: Assets:First Assets:Second\n  b: TRUE FALSE\n  t: #first #second\n",
+            "  ss: \"one\" \"two\"\n  nn: 1 2\n  cc: USD EUR\n  dd: 2024-06-01 2025-07-02\n  \
+             aa: Assets:First Assets:Second\n  bb: TRUE FALSE\n  tt: #first #second\n",
         );
         let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
 
-        assert_eq!(got("s"), MetaValue::String("one".into()));
-        assert_eq!(got("n"), MetaValue::Int(1));
-        assert_eq!(got("d"), MetaValue::Date(naive_date(2024, 6, 1).unwrap()));
-        assert_eq!(got("a"), MetaValue::Account(Account::new("Assets:First")));
-        assert_eq!(got("b"), MetaValue::Bool(true), "TRUE came first");
-        assert_eq!(got("t"), MetaValue::Tag(Tag::new("first")));
+        assert_eq!(got("ss"), MetaValue::String("one".into()));
+        assert_eq!(got("nn"), MetaValue::Int(1));
+        assert_eq!(got("dd"), MetaValue::Date(naive_date(2024, 6, 1).unwrap()));
+        assert_eq!(got("aa"), MetaValue::Account(Account::new("Assets:First")));
+        assert_eq!(got("bb"), MetaValue::Bool(true), "TRUE came first");
+        assert_eq!(got("tt"), MetaValue::Tag(Tag::new("first")));
         // `c` pairs a number-less currency run: the FIRST currency wins.
-        assert_eq!(got("c"), MetaValue::Currency(Currency::new("USD")));
+        assert_eq!(got("cc"), MetaValue::Currency(Currency::new("USD")));
     }
 
     /// The sign machine: a MINUS after the key negates the number.
@@ -5415,11 +5418,12 @@ mod tests {
     /// reversing it is what pins the guard on the other one.
     #[test]
     fn metadata_latches_bool_and_taglink_in_either_order() {
-        let meta = meta_of("  b: FALSE TRUE\n  tl: #tag ^link\n  lt: ^link #tag\n");
+        // Two-character keys, per #1955; `tl` / `lt` already were.
+        let meta = meta_of("  bb: FALSE TRUE\n  tl: #tag ^link\n  lt: ^link #tag\n");
         let got = |k: &str| meta.get(k).cloned().unwrap_or(MetaValue::None);
 
         assert_eq!(
-            got("b"),
+            got("bb"),
             MetaValue::Bool(false),
             "FALSE came first, so the later TRUE must not overwrite it"
         );

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -327,7 +327,17 @@ pub enum Token<'src> {
     /// Examples: filename:, lineno:, custom-key:, nameOnCard:
     /// The slice includes the trailing colon. Keys must start with a lowercase ASCII letter
     /// per the beancount v3 spec. Keys starting with uppercase are rejected.
-    #[regex(r"[a-z][a-zA-Z0-9_-]*:")]
+    ///
+    /// At least TWO characters before the colon (`+`, not `*`) — beancount's
+    /// key rule is a lowercase letter followed by one or more further
+    /// characters, so a bare `k:` does not lex as a key there at all and the
+    /// file fails to load. We accepted it (#1955).
+    ///
+    /// Only the LENGTH diverged. Every other part of this rule already matched:
+    /// `kk`, `k1`, `k-` and `k_` are accepted by both tools, and an uppercase
+    /// start like `A:` is rejected by both. So this is deliberately a minimal
+    /// `*` -> `+` rather than a rewrite of the character classes.
+    #[regex(r"[a-z][a-zA-Z0-9_-]+:")]
     MetaKey(&'src str),
 
     /// Indentation token (inserted by post-processing, not by Logos).

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -1285,3 +1285,32 @@ fn tags_and_links_are_rejected_only_where_beancount_rejects_them() {
         parsed.errors,
     );
 }
+
+/// #1955: a metadata key needs at least two characters, as in beancount.
+///
+/// The reject case is the fix; the accept cases are the point of the test.
+/// Only the LENGTH diverged — every other part of the key rule already matched
+/// beancount — so this pins the boundary rather than the one bug, and would
+/// catch a fix that over-tightened the character classes while it was at it.
+#[test]
+fn metadata_keys_need_at_least_two_characters() {
+    let parse =
+        |key: &str| rustledger_parser::parse(&format!("2018-01-01 open Assets:A\n  {key}: 42\n"));
+    assert!(
+        !parse("k").errors.is_empty(),
+        "a single-character key must be rejected (beancount: LexerError)",
+    );
+    for key in ["kk", "k1", "k-", "k_", "abc"] {
+        assert!(
+            parse(key).errors.is_empty(),
+            "{key}: must still be accepted (beancount accepts it), got {:?}",
+            parse(key).errors,
+        );
+    }
+    // Already agreed before this change, kept so a future edit to the rule
+    // cannot quietly relax it.
+    assert!(
+        !parse("A").errors.is_empty(),
+        "an uppercase start must stay rejected",
+    );
+}

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -1301,10 +1301,11 @@ fn metadata_keys_need_at_least_two_characters() {
         "a single-character key must be rejected (beancount: LexerError)",
     );
     for key in ["kk", "k1", "k-", "k_", "abc"] {
+        let parsed = parse(key);
         assert!(
-            parse(key).errors.is_empty(),
+            parsed.errors.is_empty(),
             "{key}: must still be accepted (beancount accepts it), got {:?}",
-            parse(key).errors,
+            parsed.errors,
         );
     }
     // Already agreed before this change, kept so a future edit to the rule

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -48,7 +48,10 @@ use crate::types::{Error, LedgerOptions};
 /// v7 (#1949): trailing tags/links on most directives are now parse
 /// errors, so a previously-clean file can carry errors. Same reasoning as the
 /// loader's v21; both caches move when a parser change alters output.
-pub const CACHE_VERSION: u32 = 7;
+/// v8 (#1955): metadata keys need two or more characters, so a
+/// previously-clean file can carry errors. Same reasoning as the loader's
+/// v22; both caches move when a parser change alters output.
+pub const CACHE_VERSION: u32 = 8;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";


### PR DESCRIPTION
`k: 42` loaded clean here and is a `LexerError` in beancount — its key rule is a lowercase letter followed by **one or more** further characters, so a bare `k:` never lexes as a key at all. Our regex used `*` where beancount uses `+`.

## Minimal on purpose

Only the **length** diverged. Everything else already matched, and the test pins the boundary rather than just the one bug:

| key | before | after | beancount |
|---|---|---|---|
| `k` | accept | **reject** | reject |
| `kk` | accept | accept | accept |
| `k1` | accept | accept | accept |
| `k-` | accept | accept | accept |
| `k_` | accept | accept | accept |
| `A` | reject | reject | reject |

So this is `*` → `+`, not a rewrite of the character classes. **The accept cases are the point of the test** — they would catch a fix that over-tightened the rule while it was in there.

## Two tests used one-character keys as fixture names

`metadata_latches_the_first_token_of_each_kind` and `metadata_latches_bool_and_taglink_in_either_order` wrote `s:`, `n:`, `b:` purely as short names while testing first-of-kind *latching*. Their intent is untouched; only their input became invalid. Keys lengthened, assertions unchanged.

Worth distinguishing from the cases earlier in this series where a test genuinely pinned wrong behavior (#1944's `42 - 1`, #1930's emoji rejection): these two were **not** asserting that a one-character key is valid — they just happened to use one.

## Corpus

**No file in the 800+ corpus uses a single-character metadata key** (verified by grep), and neither the parser nor CST baseline drifted. The change affects nothing real; it closes a portability trap where a ledger loads here and fails to parse in beancount.

## Verification

- new test verified to **fail** when the regex is reverted to `*`
- parser, loader, wasm, validate, query suites: 0 failures
- workspace clippy at 1.97.0 clean, `cargo fmt --check` clean
- caches: loader **21 → 22**, wasm **7 → 8** — a previously-clean file can now carry a parse error, so a stale cache would serve the old clean parse

Closes #1955.