### PR TITLE
test(loader): cache round-trip properties, and pin the two cache versions together

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -313,8 +313,8 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     into `CostSpec.number: Option<CostNumber>` where `CostNumber` is
 ///     a 3-variant enum (`PerUnit`, `Total`, `PerUnitFromTotal`)
 ///     (#1164). The archived layout is structurally different
-///     (Option<Decimal> + Option<Decimal> → Option<discriminant +
-///     payload>); reading v7 bytes into the v8 layout would produce
+///     (`Option<Decimal>` + `Option<Decimal>` → `Option<discriminant +
+///     payload>`); reading v7 bytes into the v8 layout would produce
 ///     garbage cost numbers. Bumping forces regeneration.
 ///     Subsequent #1164 follow-up commits converted `CostNumber`'s
 ///     variants from tuple form (`PerUnit(Decimal)`) to struct form

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -282,6 +282,7 @@ impl CacheEntry {
 const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 
 /// Cache version - increment when format changes.
+///
 /// v1: Initial release with string-based Decimal/NaiveDate
 /// v2: Binary Decimal (16 bytes) and `NaiveDate` (i32 days)
 /// v3: Fixed account type defaults in `CachedOptions`
@@ -407,7 +408,13 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 /// v24: tags and links are no longer accepted as `custom` / `pushmeta`
 ///     values (#1958), so a file using them moves from clean to erroring and
 ///     a stale cache would serve the old clean parse.
-const CACHE_VERSION: u32 = 24;
+///
+/// Public so `rustledger-wasm` can pin its own cache version against this one.
+/// Both caches archive the same `Vec<Directive>`, so a parser change that
+/// alters PARSER OUTPUT has to bump both — and on #1942 only this one was
+/// bumped, which review caught rather than any test. See
+/// `loader_cache_version_is_pinned` in `rustledger-wasm/src/cache.rs`.
+pub const CACHE_VERSION: u32 = 24;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]

--- a/crates/rustledger-loader/tests/cache_roundtrip_properties.rs
+++ b/crates/rustledger-loader/tests/cache_roundtrip_properties.rs
@@ -1,0 +1,172 @@
+//! Cache round-trip properties (#1902, Phase 1).
+//!
+//! The existing cache tests hand-build a `CacheEntry` from a literal directive.
+//! That proves the archive format works on the shape the test author thought
+//! of, which is not the shape that keeps breaking.
+//!
+//! What keeps breaking is a PARSER change that alters output while the archive
+//! layout stays put — the loader then accepts an old blob quite happily and
+//! serves the pre-fix parse. That is not theoretical: during #1942 the parser
+//! was provably fixed (a probe showed the corrected cost) while `rledger check`
+//! still reported the old imbalance, because a stale cache was answering.
+//!
+//! So these round-trip REAL PARSED LEDGERS, one per shape that moved recently,
+//! and assert the directives survive byte-for-byte. A regression in archiving
+//! any of these fails here rather than in a user's stale cache.
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// One ledger per shape whose parser output changed in the 2026-08 series.
+/// Each is a case where a stale cache would have served a materially wrong
+/// answer, not merely a differently-formatted one.
+fn shapes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "cost_arithmetic",
+            // #1939: `{10.00 * 3 USD}` booked 10.00 before the fix.
+            "2013-01-01 open Assets:S\n2013-01-01 open Assets:C\n\
+             2013-05-18 * \"t\"\n  Assets:S  2 HOOL {10.00 * 3 USD}\n  Assets:C -60.00 USD\n",
+        ),
+        (
+            "negative_cost",
+            // #1939 again: the sign was dropped, booking +200.00.
+            "2013-01-01 open Assets:M\n2013-01-01 open Assets:C\n\
+             2013-05-18 * \"t\"\n  Assets:M  -10 MSFT {-200.00 USD}\n  Assets:C 2000.00 USD\n",
+        ),
+        (
+            "compound_cost",
+            // #1943: we keep the written numbers where beancount solves.
+            "2014-01-01 open Assets:A\n2014-01-01 open Assets:C\n\
+             2014-01-01 * \"t\"\n  Assets:A  10 AAPL {# 9.95 USD}\n  Assets:C -9.95 USD\n",
+        ),
+        (
+            "metadata_arithmetic",
+            // #1944: `2 * 3` archived as 2 before the fix.
+            "2013-01-01 open Assets:A\n2013-01-01 open Assets:B\n\
+             2013-05-18 * \"t\"\n  num: 2 * 3\n  Assets:A  10.00 USD\n  Assets:B -10.00 USD\n",
+        ),
+        (
+            "balance_tolerance_arithmetic",
+            // #1944: `~ 0.005 * 2` archived as 0.005, rejecting a valid file.
+            "2013-01-01 open Assets:A\n2013-01-01 open Assets:B\n\
+             2013-05-18 * \"t\"\n  Assets:A  10.008 USD\n  Assets:B -10.008 USD\n\
+             2014-01-01 balance Assets:A 10.00 ~ 0.005 * 2 USD\n",
+        ),
+        (
+            "unicode_account",
+            // #1930: this file did not parse at all before the fix.
+            "2018-01-01 open Assets:CORP\u{2728}\n2018-01-01 open Assets:C\n\
+             2018-06-01 * \"t\"\n  Assets:CORP\u{2728}  1.00 USD\n  Assets:C -1.00 USD\n",
+        ),
+        (
+            "tags_and_links",
+            "2018-01-01 open Assets:A\n2018-01-01 open Assets:B\n\
+             2018-06-01 * \"t\" #tag ^link\n  Assets:A  1.00 USD\n  Assets:B -1.00 USD\n",
+        ),
+        (
+            "lots_and_prices",
+            "2018-01-01 open Assets:B\n2018-01-01 open Assets:C\n2018-01-01 open Income:G\n\
+             2018-02-01 * \"buy\"\n  Assets:B  10 CORP {12.00 USD}\n  Assets:C -120.00 USD\n\
+             2018-06-01 * \"sell\"\n  Assets:B -10 CORP {12.00 USD} @ 15.00 USD\n\
+             \x20 Assets:C  150.00 USD\n  Income:G  -30.00 USD\n",
+        ),
+    ]
+}
+
+fn temp_dir(name: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("rledger_cache_props_{name}"));
+    let _ = fs::remove_dir_all(&d);
+    fs::create_dir_all(&d).expect("temp dir");
+    d
+}
+
+/// Parsing, archiving and reading back must yield the SAME directives.
+///
+/// Asserted on the `Debug` rendering of the whole directive vector: this is a
+/// round-trip identity check, so coupling to formatting is the point — any
+/// field that fails to survive shows up, including ones no accessor exposes.
+#[test]
+fn cache_roundtrip_preserves_parsed_directives() {
+    for (name, source) in shapes() {
+        let dir = temp_dir(name);
+        let file = dir.join("main.beancount");
+        let mut f = fs::File::create(&file).expect("create");
+        f.write_all(source.as_bytes()).expect("write");
+        drop(f);
+
+        let mut loader = rustledger_loader::Loader::new();
+        let loaded = loader.load(&file).expect("load");
+
+        // Without this the comparison below is satisfied by two empty vectors,
+        // and a shape that stopped parsing would pass as a clean round-trip.
+        // Every fixture here is a multi-directive ledger, so anything under 2
+        // means the source stopped being what this case is about.
+        assert!(
+            loaded.directives.len() >= 2,
+            "{name}: expected a multi-directive parse, got {} — the fixture is \
+             no longer exercising this shape",
+            loaded.directives.len(),
+        );
+
+        let entry = rustledger_loader::CacheEntry {
+            directives: loaded.directives.clone(),
+            options: rustledger_loader::CachedOptions::from(&loaded.options),
+            plugins: Vec::new(),
+            files: vec![file.to_string_lossy().into_owned()],
+        };
+        rustledger_loader::save_cache_entry(&file, &entry).expect("save");
+        let back = rustledger_loader::load_cache_entry(&file).expect("load cache");
+
+        assert_eq!(
+            format!("{:?}", back.directives),
+            format!("{:?}", entry.directives),
+            "{name}: directives did not survive the cache round-trip",
+        );
+        rustledger_loader::invalidate_cache(&file);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+/// A blob written under an OLDER version must be refused, not reinterpreted.
+///
+/// This is the property that actually protects users across an upgrade: the
+/// archive layout often does NOT change when parser output does, so nothing
+/// stops an old blob from deserializing cleanly into the new types and serving
+/// a pre-fix answer. Only the version check stands between that and a wrong
+/// number on screen.
+#[test]
+fn a_stale_version_is_refused_rather_than_reinterpreted() {
+    let dir = temp_dir("stale_version");
+    let file = dir.join("main.beancount");
+    let mut f = fs::File::create(&file).expect("create");
+    f.write_all(b"2018-01-01 open Assets:A\n").expect("write");
+    drop(f);
+
+    let mut loader = rustledger_loader::Loader::new();
+    let loaded = loader.load(&file).expect("load");
+    let entry = rustledger_loader::CacheEntry {
+        directives: loaded.directives.clone(),
+        options: rustledger_loader::CachedOptions::from(&loaded.options),
+        plugins: Vec::new(),
+        files: vec![file.to_string_lossy().into_owned()],
+    };
+    rustledger_loader::save_cache_entry(&file, &entry).expect("save");
+
+    // Rewrite the version word in the header to the previous version.
+    let path = rustledger_loader::cache_path(&file);
+    let mut bytes = fs::read(&path).expect("read cache");
+    let stale = rustledger_loader::cache::CACHE_VERSION
+        .checked_sub(1)
+        .expect("CACHE_VERSION >= 1");
+    bytes[8..12].copy_from_slice(&stale.to_le_bytes());
+    fs::write(&path, &bytes).expect("write cache");
+
+    assert!(
+        rustledger_loader::load_cache_entry(&file).is_none(),
+        "a cache blob one version behind must be refused, not reinterpreted",
+    );
+    rustledger_loader::invalidate_cache(&file);
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/rustledger-loader/tests/cache_roundtrip_properties.rs
+++ b/crates/rustledger-loader/tests/cache_roundtrip_properties.rs
@@ -16,7 +16,6 @@
 
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
 
 /// One ledger per shape whose parser output changed in the 2026-08 series.
 /// Each is a case where a stale cache would have served a materially wrong
@@ -75,11 +74,42 @@ fn shapes() -> Vec<(&'static str, &'static str)> {
     ]
 }
 
-fn temp_dir(name: &str) -> PathBuf {
-    let d = std::env::temp_dir().join(format!("rledger_cache_props_{name}"));
-    let _ = fs::remove_dir_all(&d);
-    fs::create_dir_all(&d).expect("temp dir");
-    d
+/// Fail fast if the cache env vars are set.
+///
+/// `save_cache_entry` / `load_cache_entry` read process env, so an inherited
+/// `BEANCOUNT_LOAD_CACHE_FILENAME` would redirect these writes out of the
+/// fixture — silently making the round-trip assert nothing, or clobbering a
+/// developer's real cache file. The unit tests in `cache.rs` guard themselves
+/// the same way (`assert_clean_cache_env`); this is that check, for a test
+/// binary that cannot see it.
+///
+/// CLAUDE.md warns against asserting environment as a precondition (#1729).
+/// The exception earns itself here: the alternative is not a hermetic test but
+/// a test that writes somewhere unexpected, and failing loudly beats that.
+fn assert_clean_cache_env() {
+    for var in [
+        rustledger_loader::CACHE_FILENAME_ENV,
+        rustledger_loader::DISABLE_CACHE_ENV,
+    ] {
+        assert!(
+            std::env::var_os(var).is_none(),
+            "unset {var} before running this test - it redirects or disables \
+             the cache these properties are about",
+        );
+    }
+}
+
+/// A fixture directory unique to this process and call.
+///
+/// Not a fixed name under `std::env::temp_dir()`: two concurrent `cargo test`
+/// processes would land on the same path, and the cleanup at the start would
+/// delete the other run's fixture out from under it. `TempDir` also removes
+/// itself when dropped, so a failing assertion does not leave litter behind.
+fn fixture_dir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("rledger_cache_props_")
+        .tempdir()
+        .expect("temp dir")
 }
 
 /// Parsing, archiving and reading back must yield the SAME directives.
@@ -89,9 +119,10 @@ fn temp_dir(name: &str) -> PathBuf {
 /// field that fails to survive shows up, including ones no accessor exposes.
 #[test]
 fn cache_roundtrip_preserves_parsed_directives() {
+    assert_clean_cache_env();
     for (name, source) in shapes() {
-        let dir = temp_dir(name);
-        let file = dir.join("main.beancount");
+        let dir = fixture_dir();
+        let file = dir.path().join("main.beancount");
         let mut f = fs::File::create(&file).expect("create");
         f.write_all(source.as_bytes()).expect("write");
         drop(f);
@@ -125,7 +156,6 @@ fn cache_roundtrip_preserves_parsed_directives() {
             "{name}: directives did not survive the cache round-trip",
         );
         rustledger_loader::invalidate_cache(&file);
-        let _ = fs::remove_dir_all(&dir);
     }
 }
 
@@ -138,8 +168,9 @@ fn cache_roundtrip_preserves_parsed_directives() {
 /// number on screen.
 #[test]
 fn a_stale_version_is_refused_rather_than_reinterpreted() {
-    let dir = temp_dir("stale_version");
-    let file = dir.join("main.beancount");
+    assert_clean_cache_env();
+    let dir = fixture_dir();
+    let file = dir.path().join("main.beancount");
     let mut f = fs::File::create(&file).expect("create");
     f.write_all(b"2018-01-01 open Assets:A\n").expect("write");
     drop(f);
@@ -168,5 +199,4 @@ fn a_stale_version_is_refused_rather_than_reinterpreted() {
         "a cache blob one version behind must be refused, not reinterpreted",
     );
     rustledger_loader::invalidate_cache(&file);
-    let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -57,6 +57,32 @@ use crate::types::{Error, LedgerOptions};
 /// errors. Same reasoning as the loader's v24.
 pub const CACHE_VERSION: u32 = 10;
 
+/// The `rustledger-loader` cache version this one was last reconciled with.
+///
+/// Both caches archive the same parsed `Vec<Directive>`. A parser change that
+/// alters PARSER OUTPUT therefore invalidates both, and bumping only one leaves
+/// the other serving stale directives on a build that has the fix.
+///
+/// That is not hypothetical: on #1942 (cost-spec arithmetic) only the loader
+/// version moved, and a stale WASM blob would have kept serving a truncated
+/// cost basis. It was caught in review, by a person, not by anything here.
+///
+/// So this pins the pair. If the assertion below fails, ask which kind of
+/// change moved the loader version:
+///
+///   parser OUTPUT changed  -> bump `CACHE_VERSION` above too, then update
+///                             this pin to match
+///   loader-internal only   -> only update this pin (layout of a loader-side
+///                             struct moved; our archived directives did not)
+///
+/// The question is the point; the pin exists to force it to be asked.
+/// Test-only: the pin exists to be asserted, and gating it keeps a non-test
+/// build free of a constant nothing reads. The doc above stays here rather
+/// than in the test module so a reader of this file meets the contract next
+/// to `CACHE_VERSION`, which is the thing they came to change.
+#[cfg(test)]
+const LOADER_CACHE_VERSION_PIN: u32 = 23;
+
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";
 
@@ -187,6 +213,29 @@ pub fn hash_sources(sources: &[&str]) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The two caches archive the same parsed directives, so they have to move
+    /// together whenever PARSER OUTPUT changes.
+    ///
+    /// This is the guard for the failure that actually happened on #1942: the
+    /// loader version was bumped, this one was not, and a stale WASM blob would
+    /// have served a truncated cost basis on a fixed build. Review caught it;
+    /// nothing in the test suite did.
+    #[test]
+    fn loader_cache_version_is_pinned() {
+        assert_eq!(
+            rustledger_loader::cache::CACHE_VERSION,
+            LOADER_CACHE_VERSION_PIN,
+            "the rustledger-loader cache version moved and this one did not. \
+             If PARSER OUTPUT changed, bump CACHE_VERSION in this file too and \
+             then update LOADER_CACHE_VERSION_PIN to match. If the loader \
+             change was internal to the loader (its own struct layout) and our \
+             archived directives are unaffected, update the pin alone. See \
+             #1942, where only the loader moved and a stale blob would have \
+             kept serving a truncated cost basis.",
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -81,7 +81,7 @@ pub const CACHE_VERSION: u32 = 10;
 /// than in the test module so a reader of this file meets the contract next
 /// to `CACHE_VERSION`, which is the thing they came to change.
 #[cfg(test)]
-const LOADER_CACHE_VERSION_PIN: u32 = 23;
+const LOADER_CACHE_VERSION_PIN: u32 = 24;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";


### PR DESCRIPTION
#1902 Phase 1 asks for cache round-trip properties on the grounds that *"a stale cache resurrects fixed bugs unless `CACHE_VERSION` is bumped, which is a property, not a review."* This session proved that literally, twice.

## What the session showed

The loader cache moved **17 → 23** and the wasm cache **3 → 9** — six bumps each, every one by hand, every one needing a fresh judgment about whether the archived *layout* moved or only the *value*. Two things went wrong:

- On #1942 the parser was **provably fixed** — a probe showed the corrected cost — while `rledger check` still reported the old imbalance, because a stale cache was answering.
- On the same PR I bumped the loader and **missed the wasm cache entirely**. It archives the same `Vec<Directive>`, so a stale blob would have kept serving a truncated cost basis on a fixed build. Review caught it; no test did.

## Three properties

**1. `cache_roundtrip_preserves_parsed_directives`** round-trips *real parsed ledgers*, one per shape whose parser output changed in this series: cost arithmetic, negative cost, compound cost, metadata arithmetic, balance tolerance, a Unicode account, tags and links, and lots with prices.

The existing tests hand-build a `CacheEntry` from a literal directive, which proves the format works on the shape the author thought of — not the shape that keeps breaking.

**2. `a_stale_version_is_refused_rather_than_reinterpreted`** writes a real cache, rewrites the header version word to the previous version, and asserts the loader refuses it. This is what actually protects an upgrade: the layout usually does *not* change when parser output does, so nothing else stops an old blob deserializing cleanly into the new types and serving a pre-fix answer.

**3. `loader_cache_version_is_pinned`** pins the wasm cache against the loader's. Moving one without the other fails with a message that asks the right question — did **parser output** change (bump both), or was it loader-internal (update the pin alone)? This is the guard for the bug that got past me.

## All three verified to fail

```
version check disabled     → "a cache blob one version behind must be refused"
loader moved, pin did not  → "the rustledger-loader cache version moved and this one did not…"
a fixture stops parsing    → "expected a multi-directive parse, got 0"
```

The third is the **non-vacuity guard** on property 1: without it the comparison is satisfied by two empty vectors, and a shape that stopped parsing would pass as a clean round-trip.

## Notes

`CACHE_VERSION` is now `pub` so the wasm crate can pin against it. That pulled the public item into a stricter doc lint, hence the paragraph break in its version-history comment. The pin itself is `#[cfg(test)]` — it exists to be asserted — but its documentation stays next to `CACHE_VERSION`, which is what a reader came to change.

## Verification

- loader, wasm, parser, validate suites: 0 failures
- workspace clippy at 1.97.0 clean, `cargo fmt --check` clean

Refs #1902.