### PR TITLE
fix(ffi): length-prefix the directive-identity hash; it had real collisions

### DIFF
--- a/crates/rustledger-ffi-wasi/src/hash.rs
+++ b/crates/rustledger-ffi-wasi/src/hash.rs
@@ -6,6 +6,30 @@ use sha2::{Digest, Sha256};
 
 use rustledger_core::Directive;
 
+/// Feed one field into the hash, length-prefixed.
+///
+/// Without this the hash is ambiguous at every field boundary, because
+/// `Sha256::update` just concatenates. Real collisions this produced, all
+/// verified before the fix:
+///
+/// ```text
+///   payee "ab" + narration "c"   ==  payee "a"  + narration "bc"
+///   tags ["ab"]                  ==  tags ["a"] + links ["b"]
+///   no payee  + narration "ab"   ==  payee "a"  + narration "b"
+/// ```
+///
+/// The third is the worst: a transaction WITH a payee hashed identically to one
+/// WITHOUT. `compute_directive_hash` is the FFI identity contract - it is
+/// surfaced as `meta.hash` across the WIT boundary - so a collision means two
+/// distinct directives are the same object to rustfava and the desktop app.
+///
+/// Length-prefixing rather than a separator byte: fields are arbitrary UTF-8
+/// and any sentinel could legitimately occur inside one. A `u64` length cannot.
+fn field(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
 /// Compute a SHA256 hash of a directive for unique identification.
 pub fn compute_directive_hash(directive: &Directive) -> String {
     let mut hasher = Sha256::new();
@@ -13,97 +37,97 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
     // Hash the directive type and core content
     match directive {
         Directive::Transaction(t) => {
-            hasher.update(b"Transaction");
-            hasher.update(t.date.to_string().as_bytes());
-            hasher.update(t.flag.to_string().as_bytes());
+            field(&mut hasher, b"Transaction");
+            field(&mut hasher, t.date.to_string().as_bytes());
+            field(&mut hasher, t.flag.to_string().as_bytes());
             if let Some(ref payee) = t.payee {
-                hasher.update(payee.as_bytes());
+                field(&mut hasher, payee.as_bytes());
             }
-            hasher.update(t.narration.as_bytes());
+            field(&mut hasher, t.narration.as_bytes());
             for tag in &t.tags {
-                hasher.update(tag.as_bytes());
+                field(&mut hasher, tag.as_bytes());
             }
             for link in &t.links {
-                hasher.update(link.as_bytes());
+                field(&mut hasher, link.as_bytes());
             }
             for posting in &t.postings {
-                hasher.update(posting.account.as_bytes());
+                field(&mut hasher, posting.account.as_bytes());
                 if let Some(ref units) = posting.units {
                     if let Some(num) = units.number() {
-                        hasher.update(num.to_string().as_bytes());
+                        field(&mut hasher, num.to_string().as_bytes());
                     }
                     if let Some(cur) = units.currency() {
-                        hasher.update(cur.as_bytes());
+                        field(&mut hasher, cur.as_bytes());
                     }
                 }
             }
         }
         Directive::Open(o) => {
-            hasher.update(b"Open");
-            hasher.update(o.date.to_string().as_bytes());
-            hasher.update(o.account.as_bytes());
+            field(&mut hasher, b"Open");
+            field(&mut hasher, o.date.to_string().as_bytes());
+            field(&mut hasher, o.account.as_bytes());
             for c in &o.currencies {
-                hasher.update(c.as_bytes());
+                field(&mut hasher, c.as_bytes());
             }
         }
         Directive::Close(c) => {
-            hasher.update(b"Close");
-            hasher.update(c.date.to_string().as_bytes());
-            hasher.update(c.account.as_bytes());
+            field(&mut hasher, b"Close");
+            field(&mut hasher, c.date.to_string().as_bytes());
+            field(&mut hasher, c.account.as_bytes());
         }
         Directive::Balance(b) => {
-            hasher.update(b"Balance");
-            hasher.update(b.date.to_string().as_bytes());
-            hasher.update(b.account.as_bytes());
-            hasher.update(b.amount.number.to_string().as_bytes());
-            hasher.update(b.amount.currency.as_bytes());
+            field(&mut hasher, b"Balance");
+            field(&mut hasher, b.date.to_string().as_bytes());
+            field(&mut hasher, b.account.as_bytes());
+            field(&mut hasher, b.amount.number.to_string().as_bytes());
+            field(&mut hasher, b.amount.currency.as_bytes());
         }
         Directive::Pad(p) => {
-            hasher.update(b"Pad");
-            hasher.update(p.date.to_string().as_bytes());
-            hasher.update(p.account.as_bytes());
-            hasher.update(p.source_account.as_bytes());
+            field(&mut hasher, b"Pad");
+            field(&mut hasher, p.date.to_string().as_bytes());
+            field(&mut hasher, p.account.as_bytes());
+            field(&mut hasher, p.source_account.as_bytes());
         }
         Directive::Commodity(c) => {
-            hasher.update(b"Commodity");
-            hasher.update(c.date.to_string().as_bytes());
-            hasher.update(c.currency.as_bytes());
+            field(&mut hasher, b"Commodity");
+            field(&mut hasher, c.date.to_string().as_bytes());
+            field(&mut hasher, c.currency.as_bytes());
         }
         Directive::Price(p) => {
-            hasher.update(b"Price");
-            hasher.update(p.date.to_string().as_bytes());
-            hasher.update(p.currency.as_bytes());
-            hasher.update(p.amount.number.to_string().as_bytes());
-            hasher.update(p.amount.currency.as_bytes());
+            field(&mut hasher, b"Price");
+            field(&mut hasher, p.date.to_string().as_bytes());
+            field(&mut hasher, p.currency.as_bytes());
+            field(&mut hasher, p.amount.number.to_string().as_bytes());
+            field(&mut hasher, p.amount.currency.as_bytes());
         }
         Directive::Event(e) => {
-            hasher.update(b"Event");
-            hasher.update(e.date.to_string().as_bytes());
-            hasher.update(e.event_type.as_bytes());
-            hasher.update(e.value.as_bytes());
+            field(&mut hasher, b"Event");
+            field(&mut hasher, e.date.to_string().as_bytes());
+            field(&mut hasher, e.event_type.as_bytes());
+            field(&mut hasher, e.value.as_bytes());
         }
         Directive::Note(n) => {
-            hasher.update(b"Note");
-            hasher.update(n.date.to_string().as_bytes());
-            hasher.update(n.account.as_bytes());
-            hasher.update(n.comment.as_bytes());
+            field(&mut hasher, b"Note");
+            field(&mut hasher, n.date.to_string().as_bytes());
+            field(&mut hasher, n.account.as_bytes());
+            field(&mut hasher, n.comment.as_bytes());
         }
         Directive::Document(d) => {
-            hasher.update(b"Document");
-            hasher.update(d.date.to_string().as_bytes());
-            hasher.update(d.account.as_bytes());
-            hasher.update(d.path.as_bytes());
+            field(&mut hasher, b"Document");
+            field(&mut hasher, d.date.to_string().as_bytes());
+            field(&mut hasher, d.account.as_bytes());
+            field(&mut hasher, d.path.as_bytes());
         }
         Directive::Query(q) => {
-            hasher.update(b"Query");
-            hasher.update(q.date.to_string().as_bytes());
-            hasher.update(q.name.as_bytes());
-            hasher.update(q.query.as_bytes());
+            field(&mut hasher, b"Query");
+            field(&mut hasher, q.date.to_string().as_bytes());
+            field(&mut hasher, q.name.as_bytes());
+            field(&mut hasher, q.query.as_bytes());
         }
         Directive::Custom(c) => {
-            hasher.update(b"Custom");
-            hasher.update(c.date.to_string().as_bytes());
-            hasher.update(c.custom_type.as_bytes());
+            field(&mut hasher, b"Custom");
+            field(&mut hasher, c.date.to_string().as_bytes());
+            field(&mut hasher, c.custom_type.as_bytes());
         }
     }
 

--- a/crates/rustledger-ffi-wasi/src/hash.rs
+++ b/crates/rustledger-ffi-wasi/src/hash.rs
@@ -30,6 +30,56 @@ fn field(hasher: &mut Sha256, bytes: &[u8]) {
     hasher.update(bytes);
 }
 
+/// Feed a collection's LENGTH into the hash before its elements.
+///
+/// Length-prefixing each element is not enough on its own, which Copilot caught
+/// on review. A stream of length-prefixed fields decodes to a unique SEQUENCE
+/// of byte strings, but two different structures can produce the SAME sequence
+/// whenever a variable-length collection abuts anything else:
+///
+/// ```text
+///   tags ["a","b"], links []   ==  tags ["a"], links ["b"]
+/// ```
+///
+/// Both emit `["a", "b"]`. Counting the elements pins the partition, so a field
+/// can no longer migrate across a collection boundary undetected.
+///
+/// This is the same defect the length prefix fixed, one level up: the element
+/// boundaries were unambiguous, the COLLECTION boundaries were not.
+fn count(hasher: &mut Sha256, n: usize) {
+    hasher.update((n as u64).to_le_bytes());
+}
+
+/// Feed an OPTIONAL field into the hash, presence-tagged.
+///
+/// [`count`] does not subsume this. Within the postings list a posting emits
+/// its account and then zero, one, or two further fields depending on whether
+/// its units carry a number, a currency, both, or are absent - so even at a
+/// fixed posting COUNT the fields can be re-partitioned:
+///
+/// ```text
+///   [Assets:A  1 USD] [Assets:B]       ->  "Assets:A" "1" "USD" "Assets:B"
+///   [Assets:A  1    ] [USD  Assets:B]  ->  "Assets:A" "1" "USD" "Assets:B"
+/// ```
+///
+/// Same count, same fields, different transactions. That case is reachable only
+/// through the presence tag; the payee tag is the same mechanism applied
+/// uniformly, and is belt-and-braces rather than load-bearing (the fixed run of
+/// three collection counts after the narration already separates a present
+/// payee from an absent one).
+///
+/// The tag byte sits outside the field's own length prefix, so no field content
+/// can forge it.
+fn opt(hasher: &mut Sha256, bytes: Option<&[u8]>) {
+    match bytes {
+        Some(b) => {
+            hasher.update([1u8]);
+            field(hasher, b);
+        }
+        None => hasher.update([0u8]),
+    }
+}
+
 /// Compute a SHA256 hash of a directive for unique identification.
 pub fn compute_directive_hash(directive: &Directive) -> String {
     let mut hasher = Sha256::new();
@@ -40,25 +90,27 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             field(&mut hasher, b"Transaction");
             field(&mut hasher, t.date.to_string().as_bytes());
             field(&mut hasher, t.flag.to_string().as_bytes());
-            if let Some(ref payee) = t.payee {
-                field(&mut hasher, payee.as_bytes());
-            }
+            opt(&mut hasher, t.payee.as_deref().map(str::as_bytes));
             field(&mut hasher, t.narration.as_bytes());
+            count(&mut hasher, t.tags.len());
             for tag in &t.tags {
                 field(&mut hasher, tag.as_bytes());
             }
+            count(&mut hasher, t.links.len());
             for link in &t.links {
                 field(&mut hasher, link.as_bytes());
             }
+            count(&mut hasher, t.postings.len());
             for posting in &t.postings {
                 field(&mut hasher, posting.account.as_bytes());
-                if let Some(ref units) = posting.units {
-                    if let Some(num) = units.number() {
-                        field(&mut hasher, num.to_string().as_bytes());
+                match &posting.units {
+                    Some(units) => {
+                        hasher.update([1u8]);
+                        let number = units.number().map(|n| n.to_string());
+                        opt(&mut hasher, number.as_deref().map(str::as_bytes));
+                        opt(&mut hasher, units.currency().map(str::as_bytes));
                     }
-                    if let Some(cur) = units.currency() {
-                        field(&mut hasher, cur.as_bytes());
-                    }
+                    None => hasher.update([0u8]),
                 }
             }
         }
@@ -66,6 +118,7 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             field(&mut hasher, b"Open");
             field(&mut hasher, o.date.to_string().as_bytes());
             field(&mut hasher, o.account.as_bytes());
+            count(&mut hasher, o.currencies.len());
             for c in &o.currencies {
                 field(&mut hasher, c.as_bytes());
             }

--- a/crates/rustledger-ffi-wasi/src/hash.rs
+++ b/crates/rustledger-ffi-wasi/src/hash.rs
@@ -80,6 +80,95 @@ fn opt(hasher: &mut Sha256, bytes: Option<&[u8]>) {
     }
 }
 
+/// Feed a `Decimal` in, as its canonical rendering.
+fn decimal(hasher: &mut Sha256, d: rustledger_core::Decimal) {
+    field(hasher, d.to_string().as_bytes());
+}
+
+/// Feed an optional amount in, presence-tagged, number then currency.
+fn incomplete_amount(hasher: &mut Sha256, amount: Option<&rustledger_core::IncompleteAmount>) {
+    match amount {
+        Some(a) => {
+            hasher.update([1u8]);
+            let number = a.number().map(|n| n.to_string());
+            opt(hasher, number.as_deref().map(str::as_bytes));
+            opt(hasher, a.currency().map(str::as_bytes));
+        }
+        None => hasher.update([0u8]),
+    }
+}
+
+/// Feed a posting's whole identity in - not just its account and units.
+///
+/// `cost`, `price` and `flag` were absent from the digest entirely, which
+/// Copilot caught on review of #1961. That is a different defect from the
+/// boundary ambiguity above: not two fields blurring together, but fields
+/// never consulted at all. `2 HOOL {100.00 USD}` and `2 HOOL {200.00 USD}`
+/// hashed identically - two economically different transactions that rustfava
+/// and the desktop app could not tell apart.
+///
+/// The `CostNumber` match is written out variant by variant rather than
+/// through the `per_unit()`/`total()` accessors on purpose. Those two cannot
+/// distinguish `PerUnitFromTotal` from `Compound` (both set both), and an
+/// exhaustive match means adding a variant is a compile error here - which
+/// forces the identity question to be answered rather than silently defaulted.
+///
+/// Posting `meta` and comments are deliberately NOT hashed; see #1968.
+fn posting_identity(hasher: &mut Sha256, p: &rustledger_core::directive::Posting) {
+    use rustledger_core::CostNumber;
+
+    field(hasher, p.account.as_bytes());
+    incomplete_amount(hasher, p.units.as_ref());
+
+    let flag = p.flag.map(|c| c.to_string());
+    opt(hasher, flag.as_deref().map(str::as_bytes));
+
+    match &p.cost {
+        Some(c) => {
+            hasher.update([1u8]);
+            match &c.number {
+                None => hasher.update([0u8]),
+                Some(CostNumber::PerUnit { value }) => {
+                    hasher.update([1u8]);
+                    decimal(hasher, *value);
+                }
+                Some(CostNumber::Total { value }) => {
+                    hasher.update([2u8]);
+                    decimal(hasher, *value);
+                }
+                Some(CostNumber::PerUnitFromTotal(booked)) => {
+                    hasher.update([3u8]);
+                    decimal(hasher, booked.per_unit);
+                    decimal(hasher, booked.total);
+                }
+                Some(CostNumber::Compound { per_unit, total }) => {
+                    hasher.update([4u8]);
+                    decimal(hasher, *per_unit);
+                    decimal(hasher, *total);
+                }
+            }
+            opt(hasher, c.currency.as_deref().map(str::as_bytes));
+            let date = c.date.map(|d| d.to_string());
+            opt(hasher, date.as_deref().map(str::as_bytes));
+            opt(hasher, c.label.as_deref().map(str::as_bytes));
+            hasher.update([u8::from(c.merge)]);
+        }
+        None => hasher.update([0u8]),
+    }
+
+    match &p.price {
+        Some(price) => {
+            hasher.update([1u8]);
+            match price.kind {
+                rustledger_core::PriceKind::Unit => hasher.update([1u8]),
+                rustledger_core::PriceKind::Total => hasher.update([2u8]),
+            }
+            incomplete_amount(hasher, price.amount.as_ref());
+        }
+        None => hasher.update([0u8]),
+    }
+}
+
 /// Compute a SHA256 hash of a directive for unique identification.
 pub fn compute_directive_hash(directive: &Directive) -> String {
     let mut hasher = Sha256::new();
@@ -102,16 +191,7 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             }
             count(&mut hasher, t.postings.len());
             for posting in &t.postings {
-                field(&mut hasher, posting.account.as_bytes());
-                match &posting.units {
-                    Some(units) => {
-                        hasher.update([1u8]);
-                        let number = units.number().map(|n| n.to_string());
-                        opt(&mut hasher, number.as_deref().map(str::as_bytes));
-                        opt(&mut hasher, units.currency().map(str::as_bytes));
-                    }
-                    None => hasher.update([0u8]),
-                }
+                posting_identity(&mut hasher, posting);
             }
         }
         Directive::Open(o) => {

--- a/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
+++ b/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
@@ -280,3 +280,103 @@ fn units_presence_is_part_of_the_posting_boundary() {
         "units re-partitioned across a posting boundary must not collide",
     );
 }
+
+/// A posting's cost, price and flag are part of its identity.
+///
+/// They were not hashed at all — a different defect from the boundary
+/// ambiguity above: not two fields blurring together, but fields never
+/// consulted. Caught by Copilot on review, and all of these collided before
+/// the fix. The first is the one that matters: two purchases of the same stock
+/// at different prices were the same object to every consumer of `meta.hash`.
+#[test]
+fn cost_price_and_flag_are_part_of_posting_identity() {
+    use rustledger_core::{CostNumber, CostSpec, Decimal, IncompleteAmount, PriceKind};
+
+    fn cost(number: Option<CostNumber>) -> CostSpec {
+        CostSpec {
+            number,
+            currency: Some("USD".into()),
+            ..CostSpec::empty()
+        }
+    }
+    fn per_unit(v: i64) -> Option<CostNumber> {
+        Some(CostNumber::PerUnit {
+            value: Decimal::from(v),
+        })
+    }
+    let build = |mutate: &dyn Fn(&mut rustledger_core::directive::Posting)| {
+        let mut p = rustledger_core::directive::Posting::new(
+            "Assets:A",
+            rustledger_core::Amount::new(Decimal::ONE, "HOOL"),
+        );
+        mutate(&mut p);
+        let Directive::Transaction(mut t) = txn(None, "n", &[], &[]) else {
+            unreachable!()
+        };
+        t.postings = vec![rustledger_core::Spanned::new(
+            p,
+            rustledger_core::Span::new(0, 0),
+        )];
+        Directive::Transaction(t)
+    };
+
+    let plain = build(&|_| {});
+    let cost_100 = build(&|p| p.cost = Some(cost(per_unit(100))));
+    let cost_200 = build(&|p| p.cost = Some(cost(per_unit(200))));
+    let cost_total = build(&|p| {
+        p.cost = Some(cost(Some(CostNumber::Total {
+            value: Decimal::from(100),
+        })));
+    });
+    let cost_labelled = build(&|p| {
+        let mut c = cost(per_unit(100));
+        c.label = Some("lot-a".to_owned());
+        p.cost = Some(c);
+    });
+    let flagged = build(&|p| p.flag = Some('!'));
+    let priced = build(&|p| {
+        p.price = Some(rustledger_core::PriceAnnotation {
+            kind: PriceKind::Unit,
+            amount: Some(IncompleteAmount::complete(
+                Decimal::from(100),
+                "USD".to_owned(),
+            )),
+        });
+    });
+    let priced_total = build(&|p| {
+        p.price = Some(rustledger_core::PriceAnnotation {
+            kind: PriceKind::Total,
+            amount: Some(IncompleteAmount::complete(
+                Decimal::from(100),
+                "USD".to_owned(),
+            )),
+        });
+    });
+
+    let cases: [(&Directive, &Directive, &str); 7] = [
+        (&cost_100, &cost_200, "a different cost number"),
+        (&cost_100, &plain, "a cost vs no cost"),
+        (
+            &cost_100,
+            &cost_total,
+            "per-unit {100} vs total {{100}} — the accessors cannot tell these \
+             apart from the booked and compound shapes, which is why the match \
+             is written out",
+        ),
+        (&cost_100, &cost_labelled, "a lot label"),
+        (&flagged, &plain, "a posting flag"),
+        (&priced, &plain, "a price vs no price"),
+        (&priced, &priced_total, "@ vs @@ at the same amount"),
+    ];
+    let collisions: Vec<&str> = cases
+        .iter()
+        .filter(|(left, right, _)| hash(left) == hash(right))
+        .map(|(_, _, what)| *what)
+        .collect();
+    assert!(
+        collisions.is_empty(),
+        "{} of {} posting-identity cases collided: {collisions:#?}",
+        collisions.len(),
+        cases.len(),
+    );
+}

--- a/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
+++ b/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
@@ -128,3 +128,155 @@ fn directive_kind_is_part_of_the_identity() {
     });
     assert_ne!(hash(&open), hash(&close), "open and close must not collide");
 }
+
+/// A posting with an account, and optionally units.
+fn txn_with_postings(
+    narration: &str,
+    links: &[&str],
+    postings: &[(&str, Option<(&str, Option<&str>)>)],
+) -> Directive {
+    let postings: Vec<rustledger_core::Spanned<rustledger_core::directive::Posting>> = postings
+        .iter()
+        .map(|(account, units)| {
+            let mut p = rustledger_core::directive::Posting::new(
+                *account,
+                rustledger_core::Amount::new(rustledger_core::Decimal::ZERO, "USD"),
+            );
+            p.units = units.map(|(number, currency)| {
+                let n = number.parse().expect("a decimal");
+                match currency {
+                    Some(c) => rustledger_core::IncompleteAmount::complete(n, (*c).to_owned()),
+                    None => rustledger_core::IncompleteAmount::number_only(n),
+                }
+            });
+            rustledger_core::Spanned::new(p, rustledger_core::Span::new(0, 0))
+        })
+        .collect();
+    let Directive::Transaction(mut t) = txn(None, narration, &[], links) else {
+        unreachable!()
+    };
+    t.postings = postings;
+    Directive::Transaction(t)
+}
+
+/// A field must not be able to MIGRATE across a collection boundary.
+///
+/// Length-prefixing each field is not sufficient on its own, which Copilot
+/// caught on review. A stream of length-prefixed fields decodes to a unique
+/// SEQUENCE of byte strings, but two different structures can produce the same
+/// sequence whenever a variable-length collection abuts anything else — so
+/// `tags ["a","b"], links []` and `tags ["a"], links ["b"]` both emit
+/// `["a", "b"]` and collide.
+///
+/// This is the same defect class the length prefix fixed, one level up: the
+/// element boundaries were unambiguous but the COLLECTION boundaries were not.
+///
+/// All three collide against the previous commit. They are not equally
+/// load-bearing on one mechanism, which is why the failure lists every case
+/// rather than stopping at the first: the tag/link case is caught only by the
+/// collection counts, while the other two are caught independently by both the
+/// counts and the presence tags.
+#[test]
+fn fields_cannot_migrate_across_collection_boundaries() {
+    let cases: [(Directive, Directive, &str); 3] = [
+        (
+            txn(None, "n", &["a", "b"], &[]),
+            txn(None, "n", &["a"], &["b"]),
+            "tag/link boundary: a tag must not be able to become a link",
+        ),
+        (
+            txn(None, "a", &["b"], &[]),
+            txn(Some("a"), "b", &[], &[]),
+            "payee/narration/tag boundary: an absent payee must not let the \
+             narration and a tag shift up into its place",
+        ),
+        (
+            txn_with_postings("n", &["a", "b"], &[]),
+            txn_with_postings("n", &["a"], &[("b", None)]),
+            "link/posting boundary: a link must not be able to become a posting \
+             account",
+        ),
+    ];
+    // Collect rather than stop at the first: an assert_ne in a loop hides
+    // whether the remaining cases are load-bearing or riding on this one.
+    let collisions: Vec<&str> = cases
+        .iter()
+        .filter(|(left, right, _)| hash(left) == hash(right))
+        .map(|(_, _, what)| *what)
+        .collect();
+    assert!(
+        collisions.is_empty(),
+        "{} of {} boundary cases collided: {collisions:#?}",
+        collisions.len(),
+        cases.len(),
+    );
+}
+
+/// Units contribute a VARIABLE number of fields, so the posting boundary needs
+/// its own marker.
+///
+/// The collection counts alone do not cover this. Within the postings list a
+/// posting emits its account and then zero, one, or two more fields depending
+/// on whether its units carry a number, a currency, both, or are absent — so
+/// two postings can be re-partitioned into two different postings emitting the
+/// identical field sequence:
+///
+/// ```text
+///   [Assets:A  1 USD] [Assets:B]        -> "Assets:A" "1" "USD" "Assets:B"
+///   [Assets:A  1    ] [USD  Assets:B]   -> "Assets:A" "1" "USD" "Assets:B"
+/// ```
+///
+/// Same count, same fields, different transactions. The presence tag on units
+/// (and on the number and currency inside them) is what separates these; it is
+/// the one case the counts cannot reach.
+#[test]
+fn units_presence_is_part_of_the_posting_boundary() {
+    fn posting(
+        account: &str,
+        units: Option<rustledger_core::IncompleteAmount>,
+    ) -> rustledger_core::Spanned<rustledger_core::directive::Posting> {
+        let mut p = rustledger_core::directive::Posting::new(
+            account,
+            rustledger_core::Amount::new(rustledger_core::Decimal::ZERO, "USD"),
+        );
+        p.units = units;
+        rustledger_core::Spanned::new(p, rustledger_core::Span::new(0, 0))
+    }
+    fn with(
+        postings: Vec<rustledger_core::Spanned<rustledger_core::directive::Posting>>,
+    ) -> Directive {
+        let Directive::Transaction(mut t) = txn(None, "n", &[], &[]) else {
+            unreachable!()
+        };
+        t.postings = postings;
+        Directive::Transaction(t)
+    }
+    let one = rustledger_core::Decimal::ONE;
+    let left = with(vec![
+        posting(
+            "Assets:A",
+            Some(rustledger_core::IncompleteAmount::complete(
+                one,
+                "USD".to_owned(),
+            )),
+        ),
+        posting("Assets:B", None),
+    ]);
+    let right = with(vec![
+        posting(
+            "Assets:A",
+            Some(rustledger_core::IncompleteAmount::number_only(one)),
+        ),
+        posting(
+            "USD",
+            Some(rustledger_core::IncompleteAmount::currency_only(
+                "Assets:B".to_owned(),
+            )),
+        ),
+    ]);
+    assert_ne!(
+        hash(&left),
+        hash(&right),
+        "units re-partitioned across a posting boundary must not collide",
+    );
+}

--- a/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
+++ b/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
@@ -35,7 +35,16 @@ fn hashing_is_deterministic() {
     for _ in 0..8 {
         assert_eq!(hash(&d), first, "the same directive must hash the same");
     }
+    // Length ALONE would also accept a 64-character non-hex encoding, which is
+    // the plausible way this changes: a switch to base64 or to an uppercase
+    // renderer would keep the count and break every consumer parsing the digest.
     assert_eq!(first.len(), 64, "a SHA256 hex digest is 64 characters");
+    assert!(
+        first
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+        "a SHA256 hex digest is lowercase hex; got {first}",
+    );
 }
 
 /// Moving a character across a field boundary must change the hash.

--- a/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
+++ b/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
@@ -1,0 +1,121 @@
+//! Properties of the FFI directive-identity hash (#1902 Phase 1).
+//!
+//! `compute_directive_hash` is surfaced as `meta.hash` across the WIT boundary,
+//! so rustfava and the desktop app treat it as a directive's identity. Two
+//! distinct directives sharing a hash means those consumers conflate them.
+//!
+//! This crate had the highest defect density on #1902's table (13.1 fixes/kloc)
+//! and fuzz as its only verification. The first property written found three
+//! real collisions.
+
+use rustledger_core::{Directive, Link, Metadata, Tag, naive_date};
+use rustledger_ffi_wasi::compute_directive_hash as hash;
+
+fn txn(payee: Option<&str>, narration: &str, tags: &[&str], links: &[&str]) -> Directive {
+    Directive::Transaction(rustledger_core::directive::Transaction {
+        date: naive_date(2024, 1, 1).unwrap(),
+        flag: '*',
+        payee: payee.map(std::convert::Into::into),
+        narration: narration.into(),
+        tags: tags.iter().copied().map(Tag::new).collect(),
+        links: links.iter().copied().map(Link::new).collect(),
+        meta: Metadata::default(),
+        postings: Vec::new(),
+        trailing_comments: Vec::new(),
+    })
+}
+
+/// The same directive hashes the same every time.
+///
+/// Cheap, and it is the assumption every other property here rests on.
+#[test]
+fn hashing_is_deterministic() {
+    let d = txn(Some("p"), "n", &["t"], &["l"]);
+    let first = hash(&d);
+    for _ in 0..8 {
+        assert_eq!(hash(&d), first, "the same directive must hash the same");
+    }
+    assert_eq!(first.len(), 64, "a SHA256 hex digest is 64 characters");
+}
+
+/// Moving a character across a field boundary must change the hash.
+///
+/// `Sha256::update` concatenates, so before #1902's Phase 1 work this function
+/// was ambiguous at every boundary and all three of these collided. The third
+/// is the one that mattered most: a transaction WITH a payee hashed identically
+/// to one WITHOUT.
+#[test]
+fn field_boundaries_are_unambiguous() {
+    let cases: [(Directive, Directive, &str); 3] = [
+        (
+            txn(Some("ab"), "c", &[], &[]),
+            txn(Some("a"), "bc", &[], &[]),
+            "payee/narration boundary",
+        ),
+        (
+            txn(None, "n", &["ab"], &[]),
+            txn(None, "n", &["a"], &["b"]),
+            "tag/link boundary",
+        ),
+        (
+            txn(None, "ab", &[], &[]),
+            txn(Some("a"), "b", &[], &[]),
+            "absent payee vs present payee",
+        ),
+    ];
+    for (a, b, what) in cases {
+        assert_ne!(
+            hash(&a),
+            hash(&b),
+            "{what}: distinct directives must not collide"
+        );
+    }
+}
+
+/// Every field the hash reads must be able to change the hash.
+///
+/// A field that is hashed but cannot move the digest would be dead weight; a
+/// field that is NOT hashed shows up here as a collision, which is the useful
+/// signal — it says the identity contract ignores something a consumer may
+/// consider identifying.
+#[test]
+fn each_hashed_field_affects_the_digest() {
+    let base = txn(Some("p"), "n", &["t"], &["l"]);
+    let variants: [(Directive, &str); 4] = [
+        (txn(Some("P"), "n", &["t"], &["l"]), "payee"),
+        (txn(Some("p"), "N", &["t"], &["l"]), "narration"),
+        (txn(Some("p"), "n", &["T"], &["l"]), "tag"),
+        (txn(Some("p"), "n", &["t"], &["L"]), "link"),
+    ];
+    for (v, field) in variants {
+        assert_ne!(
+            hash(&base),
+            hash(&v),
+            "changing the {field} must change the hash"
+        );
+    }
+}
+
+/// Directive KIND is part of the identity.
+///
+/// Two different directive types on the same date with the same account must
+/// not share a hash, or a close would be indistinguishable from an open in any
+/// consumer keyed on the digest.
+#[test]
+fn directive_kind_is_part_of_the_identity() {
+    let date = naive_date(2024, 1, 1).unwrap();
+    let acct = rustledger_core::Account::new("Assets:A");
+    let open = Directive::Open(rustledger_core::directive::Open {
+        date,
+        account: acct.clone(),
+        currencies: Vec::new(),
+        booking: None,
+        meta: Metadata::default(),
+    });
+    let close = Directive::Close(rustledger_core::directive::Close {
+        date,
+        account: acct,
+        meta: Metadata::default(),
+    });
+    assert_ne!(hash(&open), hash(&close), "open and close must not collide");
+}


### PR DESCRIPTION
#1902 Phase 1. `rustledger-ffi-wasi` is the most inverted cell on that issue's table — **13.1 fixes/kloc, the highest**, with fuzz as its only verification. The first property written for it found three collisions.

`compute_directive_hash` fed fields into SHA256 unseparated, and `Sha256::update` concatenates, so the digest was ambiguous at every field boundary:

```text
payee "ab" + narration "c"   ==  payee "a"  + narration "bc"
tags ["ab"]                  ==  tags ["a"] + links ["b"]
no payee  + narration "ab"   ==  payee "a"  + narration "b"
```

All three verified against the real function before the fix. **The third matters most: a transaction *with* a payee hashed identically to one *without*.**

## Why it matters

This isn't an internal convenience. The hash is surfaced as `meta.hash` across the WIT contract, so **rustfava and the desktop app use it as a directive's identity**. Two distinct directives sharing a digest are the same object to those consumers — conflated in a list, deduplicated wrongly, or one silently shadowing the other.

## The fix

Length-prefix every field. Not a separator byte: fields are arbitrary UTF-8 and any sentinel could legitimately occur inside one, where a `u64` length cannot.

Applied to **every arm**, not just `Transaction` — `Note` (account + comment), `Event` (type + value), `Query` (name + query), `Pad` (account + source) and `Document` (account + path) all had the same ambiguity.

## Four properties

| property | what it catches |
|---|---|
| deterministic, 64 hex chars | the assumption the others rest on |
| field boundaries unambiguous | the three collisions above |
| every hashed field can move the digest | a collision here says the identity contract **ignores** something a consumer may consider identifying |
| directive kind is part of identity | an `open` and a `close` on the same date/account cannot collide |

Verified the boundary property **fails** when the length prefix is removed:

```
assertion `left != right` failed: payee/narration boundary: distinct directives must not collide
```

## Wire impact, stated plainly

**Every hash value changes.** The WIT schema does not — `meta.hash` is still a `string` — so no contract version moves. A consumer that *persists* hashes across a rustledger upgrade would see them all differ; one that uses them within a session is unaffected. Worth knowing before the next release rather than after.

## Verification

- ffi-wasi, ffi-component, loader, wasm suites: 0 failures
- workspace clippy at 1.97.0 clean, `cargo fmt --check` clean

Refs #1902.

---

## BREAKING: every `meta.hash` value changes

Length-prefixing changes every digest this function produces. `meta.hash` is
the FFI identity contract, and **rustfava pins these values in committed
snapshots**, so landing this turns two of its tests red:

- `tests/test_internal_api.py::test_get_ledger_data`
- `tests/test_json_api.py::test_api[account_report_off_by_one_journal-…]`

Attribution is isolated — #1960 and #1962 carry no hash change and fail only
the 2 pre-existing rustfava tests; this PR fails those plus the two above, and
the assertion diff is literally the `hash` values moving.

Landing knowingly with **#1967** tracking the snapshot regeneration. The
collisions being fixed here are worse than a red downstream check: a
transaction *with* a payee hashing identically to one *without* means two
distinct directives are the same object to every consumer of `meta.hash`.

If you are bisecting rustfava snapshot churn to this commit — this is why.


---

## Review found the prefix was only half of it

Copilot caught that length-prefixing individual fields does not disambiguate
*collection* boundaries, and it was right. Three further structures collided
against the first commit:

```text
  tags ["a","b"], links []             ==  tags ["a"], links ["b"]
  no payee, narration "a", tags ["b"]  ==  payee "a", narration "b", no tags
  links ["a","b"], no postings         ==  links ["a"], posting on "b"
```

Same defect one level up: length prefixes make the stream decode to a unique
*sequence* of byte strings, but two structures can produce the same sequence
wherever a variable-length collection abuts anything else.

Every collection length is now hashed before its elements. Counting alone is
still not sufficient — a posting emits a variable number of fields itself, so
even at a fixed posting count:

```text
  [Assets:A  1 USD] [Assets:B]       ->  "Assets:A" "1" "USD" "Assets:B"
  [Assets:A  1    ] [USD  Assets:B]  ->  "Assets:A" "1" "USD" "Assets:B"
```

which needs a presence tag on the optionals. Verified by removing the tag while
keeping every count: that case, and only that case, fails.

The three mechanisms are not uniformly load-bearing, so the boundary test
collects every colliding case rather than stopping at the first. The payee tag
is belt-and-braces and is documented as such rather than pinned by a test it
cannot fail.


## And a third defect: fields that were never hashed

Copilot then caught that the posting hash fed in only `account` and `units` —
`cost`, `price` and `flag` were absent entirely. Not two fields blurring
together, but fields never consulted. Seven cases collided:

```text
  a different cost number         2 HOOL {100 USD} == 2 HOOL {200 USD}
  a cost vs no cost
  per-unit {100} vs total {{100}}
  a lot label
  a posting flag
  a price vs no price
  @ vs @@ at the same amount
```

The first is the one that matters: two purchases of the same stock at different
prices were the same object to every consumer of `meta.hash`.

The `CostNumber` match is written out variant by variant rather than using the
`per_unit()`/`total()` accessors, which cannot separate `PerUnitFromTotal` from
`Compound` (both set both). Exhaustiveness also makes adding a variant a
compile error here.

**Deliberately out of scope:** posting and transaction `meta` and comments.
That is a contract question, not a bug — including them means adding a comment
changes a directive's identity. Filed as **#1968**.
