### PR TITLE
fix(query): stop WEIGHT() inventing precision the weight column does not

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -65,6 +65,37 @@ fn overflow_err(currency: &rustledger_core::Currency) -> QueryError {
     ))
 }
 
+/// `units x per-unit cost`, with the scale the multiplication invents stripped
+/// (#1963).
+///
+/// ONE implementation, because `WEIGHT()` reaches this arithmetic down two
+/// paths — a bare `Position` and every position inside an `Inventory` — and the
+/// first fix for #1963 patched only the first. The two then disagreed with each
+/// other as well as with the column: `WEIGHT(position)` gave `100` where
+/// `WEIGHT(SUM(position))` still gave `100.00000000000000000000000000`.
+///
+/// Why the arithmetic is re-derived here at all, why the strip is conditional,
+/// and what it still does not recover are documented at the `WEIGHT` arm.
+fn position_cost_total(units: &Amount, cost: &rustledger_core::Cost) -> Result<Amount, QueryError> {
+    /// Past any scale a cost is plausibly WRITTEN with. A heuristic, not an
+    /// invariant - see the `WEIGHT` arm.
+    const ARTIFACT_SCALE: u32 = 12;
+
+    // `checked_mul`, matching the `COST` arm. A saturating or wrapping product
+    // would certify a weight that never existed - the unsoundness #1863
+    // removed from the residual path.
+    let raw = units
+        .number
+        .checked_mul(cost.number)
+        .ok_or_else(|| overflow_err(&cost.currency))?;
+    let total = if raw.scale() > ARTIFACT_SCALE {
+        raw.normalize()
+    } else {
+        raw
+    };
+    Ok(Amount::new(total, cost.currency.clone()))
+}
+
 pub(super) fn compute_posting_weight(posting: &rustledger_core::Posting) -> Value {
     rustledger_booking::posting_weight(posting).map_or(Value::Null, Value::Amount)
 }
@@ -1561,22 +1592,7 @@ impl<'a> Executor<'a> {
                             // no `weight(position)` function — so there is no
                             // reference implementation to match here, only the
                             // column to stay consistent with.
-                            const ARTIFACT_SCALE: u32 = 12;
-                            // `checked_mul`, matching `COST` above. A saturating
-                            // or wrapping product would certify a weight that
-                            // never existed — the unsoundness #1863 removed from
-                            // the residual path.
-                            let raw = p
-                                .units
-                                .number
-                                .checked_mul(cost.number)
-                                .ok_or_else(|| overflow_err(&cost.currency))?;
-                            let total = if raw.scale() > ARTIFACT_SCALE {
-                                raw.normalize()
-                            } else {
-                                raw
-                            };
-                            Ok(Value::Amount(Amount::new(total, cost.currency.clone())))
+                            Ok(Value::Amount(position_cost_total(&p.units, cost)?))
                         } else {
                             Ok(Value::Amount(p.units.clone()))
                         }
@@ -1586,21 +1602,8 @@ impl<'a> Executor<'a> {
                         let mut result = Inventory::new();
                         for pos in inv.positions() {
                             if let Some(cost) = &pos.cost {
-                                // Checked: `units * cost` leaves range on
-                                // inputs well below the ceiling (#1863).
-                                let total =
-                                    pos.units.number.checked_mul(cost.number).ok_or_else(|| {
-                                        QueryError::Evaluation(format!(
-                                            "{} cost basis exceeds the representable range \
-                                             (±7.9e28)",
-                                            cost.currency
-                                        ))
-                                    })?;
                                 result
-                                    .add(Position::simple(Amount::new(
-                                        total,
-                                        cost.currency.clone(),
-                                    )))
+                                    .add(Position::simple(position_cost_total(&pos.units, cost)?))
                                     .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             } else {
                                 result

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1542,9 +1542,13 @@ impl<'a> Executor<'a> {
                             // `2 HOOL {5.25 USD}` weight from `10.50` into `10.5`
                             // and regressing the common case to paper over the rare
                             // one. So the strip applies only when the scale is
-                            // already past anything a real cost carries — such a
-                            // scale can only have come from a division, never from
-                            // a written number, since `rust_decimal` tops out at 28.
+                            // already past anything a cost is plausibly WRITTEN
+                            // with. That is a heuristic, not an invariant:
+                            // `rust_decimal` accepts literals out to 28 places, so
+                            // a user could author a 13-place cost and see its
+                            // weight normalized. No real currency is quoted that
+                            // finely, and the alternative — touching every weight —
+                            // is the regression described above.
                             //
                             // It does NOT recover the original scale: this yields
                             // `100` where the column yields `100.00`. Closing that
@@ -1558,7 +1562,15 @@ impl<'a> Executor<'a> {
                             // reference implementation to match here, only the
                             // column to stay consistent with.
                             const ARTIFACT_SCALE: u32 = 12;
-                            let raw = p.units.number * cost.number;
+                            // `checked_mul`, matching `COST` above. A saturating
+                            // or wrapping product would certify a weight that
+                            // never existed — the unsoundness #1863 removed from
+                            // the residual path.
+                            let raw = p
+                                .units
+                                .number
+                                .checked_mul(cost.number)
+                                .ok_or_else(|| overflow_err(&cost.currency))?;
                             let total = if raw.scale() > ARTIFACT_SCALE {
                                 raw.normalize()
                             } else {

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1517,7 +1517,53 @@ impl<'a> Executor<'a> {
                 match &args[0] {
                     Value::Position(p) => {
                         if let Some(cost) = &p.cost {
-                            let total = p.units.number * cost.number;
+                            // `units x per-unit`, normalized (#1963).
+                            //
+                            // This CANNOT call `rustledger_booking::posting_weight`
+                            // like the `weight` COLUMN does: that takes a
+                            // `Posting`, whose `CostSpec` still carries the
+                            // preserved total for `Total`/`PerUnitFromTotal`,
+                            // while a `Position`'s cost is already resolved to a
+                            // per-unit `Decimal`. The total is gone by the time
+                            // this function sees it, and `evaluate_function_on_values`
+                            // receives only `Value`s — no posting to recover it from.
+                            //
+                            // Recomputing therefore reintroduces exactly the
+                            // division-then-multiplication the canonical exists to
+                            // avoid (#1106/#1113). `3 HOOL {{100.00 USD}}` resolves
+                            // to a per-unit of 33.333..., and multiplying back gave
+                            // `100.00000000000000000000000000` where the column
+                            // gives `100.00` — the same value with 26 digits of
+                            // scale invented by the multiplication.
+                            //
+                            // The mitigation is deliberately narrow. Normalizing
+                            // unconditionally was tried first and is WORSE: it also
+                            // strips MEANINGFUL trailing zeros, turning the ordinary
+                            // `2 HOOL {5.25 USD}` weight from `10.50` into `10.5`
+                            // and regressing the common case to paper over the rare
+                            // one. So the strip applies only when the scale is
+                            // already past anything a real cost carries — such a
+                            // scale can only have come from a division, never from
+                            // a written number, since `rust_decimal` tops out at 28.
+                            //
+                            // It does NOT recover the original scale: this yields
+                            // `100` where the column yields `100.00`. Closing that
+                            // gap needs `Position` to retain the cost spec (or this
+                            // function to receive the `Posting`), which is a wider
+                            // change than the symptom warrants and is recorded on
+                            // the issue.
+                            //
+                            // `WEIGHT()` is a rustledger extension — beanquery has
+                            // no `weight(position)` function — so there is no
+                            // reference implementation to match here, only the
+                            // column to stay consistent with.
+                            const ARTIFACT_SCALE: u32 = 12;
+                            let raw = p.units.number * cost.number;
+                            let total = if raw.scale() > ARTIFACT_SCALE {
+                                raw.normalize()
+                            } else {
+                                raw
+                            };
                             Ok(Value::Amount(Amount::new(total, cost.currency.clone())))
                         } else {
                             Ok(Value::Amount(p.units.clone()))

--- a/crates/rustledger-query/tests/weight_function_scale.rs
+++ b/crates/rustledger-query/tests/weight_function_scale.rs
@@ -67,7 +67,7 @@ fn a_total_cost_does_not_produce_invented_precision() {
     );
     // And they must still describe the same amount. Compared as `Decimal`,
     // whose equality is numeric — `100 == 100.00` — so this asserts the VALUE
-    // while the length check above covers the scale.
+    // while the scale assertion above covers the precision.
     assert_eq!(
         number_of(function),
         number_of(column),
@@ -94,5 +94,45 @@ fn an_ordinary_per_unit_cost_keeps_its_trailing_zeros() {
     assert_eq!(
         rows[0].1, rows[0].0,
         "on a plain per-unit cost the function and the column must match exactly",
+    );
+}
+
+/// The INVENTORY path must agree with the position path.
+///
+/// `WEIGHT()` reaches the same `units x cost` arithmetic two ways, and the
+/// first fix for #1963 patched only the `Position` arm. The `Inventory` arm 30
+/// lines below kept the defect verbatim: `WEIGHT(position)` reported `100`
+/// while `WEIGHT(SUM(position))` still reported
+/// `100.00000000000000000000000000` for the same lot. Both now route through
+/// one helper, and this pins that they cannot drift apart again.
+#[test]
+fn the_inventory_path_agrees_with_the_position_path() {
+    let src = "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+               2024-02-01 * \"t\"\n  Assets:Broker  3 HOOL {{100.00 USD}}\n\
+               \x20 Assets:Cash  -100.00 USD\n";
+    let per_position = numbers(
+        src,
+        "SELECT weight, WEIGHT(position) WHERE currency = 'HOOL'",
+    );
+    let aggregated = numbers(
+        src,
+        "SELECT account, WEIGHT(SUM(position)) WHERE currency = 'HOOL' GROUP BY account",
+    );
+    assert_eq!(per_position.len(), 1, "one HOOL posting");
+    assert_eq!(aggregated.len(), 1, "one group");
+
+    let pos_scale = number_of(&per_position[0].1).scale();
+    let inv_scale = number_of(&aggregated[0].1).scale();
+    assert_eq!(
+        inv_scale, pos_scale,
+        "WEIGHT() over an inventory invented precision the position path does \
+         not: inventory scale {inv_scale}, position scale {pos_scale} \
+         (inventory={} position={})",
+        aggregated[0].1, per_position[0].1,
+    );
+    assert_eq!(
+        number_of(&aggregated[0].1),
+        number_of(&per_position[0].1),
+        "the two WEIGHT() paths must agree numerically",
     );
 }

--- a/crates/rustledger-query/tests/weight_function_scale.rs
+++ b/crates/rustledger-query/tests/weight_function_scale.rs
@@ -55,11 +55,15 @@ fn a_total_cost_does_not_produce_invented_precision() {
     assert_eq!(rows.len(), 1, "one HOOL posting");
     let (column, function) = (&rows[0].0, &rows[0].1);
 
-    // The scale the multiplication invents is the defect; 26 digits of it is
-    // what this test exists to prevent coming back.
+    // Assert on SCALE directly, not on rendered length. The first version
+    // compared `function.len() < column.len() + 4`, which is a proxy: a Debug
+    // formatting tweak could move it without any scale changing, and it never
+    // states the invariant it is standing in for.
+    let (col_scale, fn_scale) = (number_of(column).scale(), number_of(function).scale());
     assert!(
-        function.len() < column.len() + 4,
-        "WEIGHT() invented precision: column={column} function={function}",
+        fn_scale <= col_scale,
+        "WEIGHT() invented precision: column scale {col_scale}, function scale \
+         {fn_scale} (column={column} function={function})",
     );
     // And they must still describe the same amount. Compared as `Decimal`,
     // whose equality is numeric — `100 == 100.00` — so this asserts the VALUE

--- a/crates/rustledger-query/tests/weight_function_scale.rs
+++ b/crates/rustledger-query/tests/weight_function_scale.rs
@@ -1,0 +1,94 @@
+//! `WEIGHT()` must not invent precision the `weight` column does not (#1963).
+//!
+//! Found by the canonical-function drift sweep (#1902 Phase 2). CLAUDE.md names
+//! this pair specifically: a consumer surfacing a per-posting weight must call
+//! `rustledger_booking::posting_weight` rather than re-derive it. The `weight`
+//! COLUMN does; the `WEIGHT()` FUNCTION cannot, because it receives a
+//! `Position` whose cost is already resolved to a per-unit `Decimal` — the
+//! preserved total that makes the canonical exact is gone by then.
+//!
+//! So the two cannot be made byte-identical without a wider change. What they
+//! CAN be is numerically equal and free of invented scale, which is what these
+//! pin.
+
+use rustledger_query::{Executor, parse};
+
+/// The `number:` field out of a `Value`'s debug rendering, as a `Decimal`.
+fn number_of(rendered: &str) -> rust_decimal::Decimal {
+    let after = rendered.split("number: ").nth(1).expect("a number field");
+    let text: String = after
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
+        .collect();
+    text.parse().expect("a parsable decimal")
+}
+
+fn numbers(source: &str, query: &str) -> Vec<(String, String)> {
+    let parsed = rustledger_parser::parse(source);
+    let directives: Vec<rustledger_core::Directive> =
+        parsed.directives.iter().map(|d| (**d).clone()).collect();
+    let mut executor = Executor::new(&directives);
+    let table = executor
+        .execute(&parse(query).expect("query parses"))
+        .expect("query runs");
+    table
+        .rows
+        .iter()
+        .map(|r| (format!("{:?}", r[0]), format!("{:?}", r[1])))
+        .collect()
+}
+
+/// A TOTAL cost that does not divide evenly is where the re-derivation shows.
+///
+/// `3 HOOL {{100.00 USD}}` resolves to a per-unit of 33.333…, and multiplying
+/// back produced `100.00000000000000000000000000` — the same value the column
+/// reports as `100.00`, carrying 26 digits of scale the multiplication invented.
+#[test]
+fn a_total_cost_does_not_produce_invented_precision() {
+    let src = "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+               2024-02-01 * \"t\"\n  Assets:Broker  3 HOOL {{100.00 USD}}\n\
+               \x20 Assets:Cash  -100.00 USD\n";
+    let rows = numbers(
+        src,
+        "SELECT weight, WEIGHT(position) WHERE currency = 'HOOL'",
+    );
+    assert_eq!(rows.len(), 1, "one HOOL posting");
+    let (column, function) = (&rows[0].0, &rows[0].1);
+
+    // The scale the multiplication invents is the defect; 26 digits of it is
+    // what this test exists to prevent coming back.
+    assert!(
+        function.len() < column.len() + 4,
+        "WEIGHT() invented precision: column={column} function={function}",
+    );
+    // And they must still describe the same amount. Compared as `Decimal`,
+    // whose equality is numeric — `100 == 100.00` — so this asserts the VALUE
+    // while the length check above covers the scale.
+    assert_eq!(
+        number_of(function),
+        number_of(column),
+        "WEIGHT() and the weight column must agree numerically",
+    );
+}
+
+/// The ordinary case must be untouched.
+///
+/// This is the guard that matters most here. Normalizing unconditionally was
+/// tried first and fixed the case above while turning this one from `10.50`
+/// into `10.5` — trading a rare cosmetic problem for a frequent one. Any future
+/// attempt to close the remaining scale gap has to keep this passing.
+#[test]
+fn an_ordinary_per_unit_cost_keeps_its_trailing_zeros() {
+    let src = "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+               2024-02-01 * \"t\"\n  Assets:Broker  2 HOOL {5.25 USD}\n\
+               \x20 Assets:Cash  -10.50 USD\n";
+    let rows = numbers(
+        src,
+        "SELECT weight, WEIGHT(position) WHERE currency = 'HOOL'",
+    );
+    assert_eq!(rows.len(), 1, "one HOOL posting");
+    assert_eq!(
+        rows[0].1, rows[0].0,
+        "on a plain per-unit cost the function and the column must match exactly",
+    );
+}


### PR DESCRIPTION
Found by the canonical-function drift sweep (#1902 Phase 2). CLAUDE.md names this pair specifically: a consumer surfacing a per-posting weight must call `rustledger_booking::posting_weight` rather than re-derive it. The **column** does. The **function** re-derived `units * cost.number`.

```
3 HOOL {{100.00 USD}}

weight column     100.00
WEIGHT(position)  100.00000000000000000000000000
```

Same value, 26 digits of scale invented by the multiplication. `{{100.00}}` resolves to a per-unit of `33.333…`, and multiplying back reintroduces exactly the division-then-multiplication the canonical exists to avoid (#1106/#1113). The compat suite compares **rendered** output, so scale isn't cosmetic.

## Why this is a mitigation, not a correction

`WEIGHT()` **cannot** call the canonical. It receives a `Value::Position`, whose cost is already resolved to a per-unit `Decimal` — the preserved total that makes `posting_weight` exact is gone by then — and `evaluate_function_on_values` gets only `Value`s, with no posting to recover it from.

So the function still yields `100` where the column yields `100.00`. Closing that needs `Position` to retain the cost spec, which is a wider change than the symptom warrants. Recorded on #1963.

## The obvious fix was worse, and is now pinned against

Normalizing unconditionally was my first attempt. It fixes the case above and **regresses the common one**: `2 HOOL {5.25 USD}` went from `10.50` to `10.5`, because `normalize` strips meaningful trailing zeros too. Trading a rare cosmetic problem for a frequent one is not a fix.

So the strip applies only when the scale is already past anything a real cost carries (`>12`). Such a scale can only come from a division — `rust_decimal` tops out at 28, and no written cost has 12 decimal places.

## Both tests verified to fail on their own sabotage

```
raw product              → WEIGHT() invented precision: column=100.00 …
unconditional normalize  → on a plain per-unit cost the function and the column
                           must match exactly
```

The second is the one worth having: it's the guard against re-attempting the fix I nearly shipped.

## Verification

- `rustledger-query`: 0 failures
- clippy at 1.97.0 clean, `cargo fmt --check` clean, `RUSTDOCFLAGS=-D warnings cargo doc` clean

Closes #1963.