### PR TITLE
fix(query): route WEIGHT(position) to the canonical weight ladder

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -686,6 +686,19 @@ impl<'a> Executor<'a> {
             account_balances,
         })
     }
+    /// Is this call `WEIGHT(position)` over the posting COLUMN?
+    ///
+    /// Deliberately narrow. `WEIGHT(<anything else>)` — a literal, an
+    /// expression, `SUM(position)` — keeps going to the shared value registry,
+    /// so this reintroduces exactly one lazy-path arm rather than un-collapsing
+    /// the dual dispatch the registry exists to prevent.
+    fn is_position_column(func: &FunctionCall) -> bool {
+        matches!(
+            func.args.as_slice(),
+            [Expr::Column(c)] if c.eq_ignore_ascii_case("position")
+        )
+    }
+
     fn evaluate_function(
         &self,
         func: &FunctionCall,
@@ -701,6 +714,26 @@ impl<'a> Executor<'a> {
             // COALESCE short-circuits on its raw argument expressions and must
             // NOT pre-evaluate every argument, so it stays on the lazy path.
             "COALESCE" => self.eval_coalesce(func, ctx),
+            // `WEIGHT(position)` needs the POSTING, not the evaluated argument,
+            // for the same reason the META family does: the value registry has
+            // already lost what the answer depends on.
+            //
+            // The canonical weight ladder in `rustledger_booking::posting_weight`
+            // is cost, then PRICE, then units. A `Value::Position` carries units
+            // and cost and no price at all, so the eager path could implement
+            // only two of the three rungs and silently returned the units for a
+            // priced posting — `10 EUR @ 1.10 USD` gave `10 EUR` where the
+            // `weight` column gives `11.00 USD`. A different number in a
+            // different currency, so summing WEIGHT() over a ledger with priced
+            // postings produced a currency-mixed total (#1966).
+            //
+            // Routing to the same helper the `weight` COLUMN uses makes the two
+            // spellings one computation rather than two implementations that
+            // agree by inspection. It also closes the residual scale gap from
+            // #1963 — the column's exact `100.00` instead of a re-derived `100`.
+            "WEIGHT" if Self::is_position_column(func) => Ok(compute_posting_weight(
+                &ctx.transaction.postings[ctx.posting_index],
+            )),
             // Aggregates evaluate to Null per row; real aggregation happens in
             // the aggregation pass.
             "SUM" | "COUNT" | "MIN" | "MAX" | "FIRST" | "LAST" | "AVG" => Ok(Value::Null),
@@ -1582,11 +1615,17 @@ impl<'a> Executor<'a> {
                             // is the regression described above.
                             //
                             // It does NOT recover the original scale: this yields
-                            // `100` where the column yields `100.00`. Closing that
-                            // gap needs `Position` to retain the cost spec (or this
-                            // function to receive the `Posting`), which is a wider
-                            // change than the symptom warrants and is recorded on
-                            // the issue.
+                            // `100` where the column yields `100.00`. For
+                            // `WEIGHT(position)` that no longer matters — #1966
+                            // routes the position COLUMN to the canonical on the
+                            // lazy path, where the `Posting` is still in hand, so
+                            // it gets the column's exact `100.00`. This arm is
+                            // now reached only by arguments the canonical cannot
+                            // serve: an `Inventory` from `SUM(position)`, or a
+                            // `Position` built by an expression. Neither carries
+                            // a price, so the price rung of the weight ladder is
+                            // genuinely unavailable here and cost-or-units is the
+                            // best answer possible.
                             //
                             // `WEIGHT()` is a rustledger extension — beanquery has
                             // no `weight(position)` function — so there is no

--- a/crates/rustledger-query/tests/weight_function_matches_column.rs
+++ b/crates/rustledger-query/tests/weight_function_matches_column.rs
@@ -18,29 +18,57 @@
 
 use rustledger_query::{Executor, parse};
 
-/// `(weight column, WEIGHT(position))` per row, as rendered values.
-fn column_and_function(source: &str) -> Vec<(String, String)> {
+/// Render a result value the way a reader of the query sees it.
+///
+/// `Amount`'s `Display` is `{number} {currency}` straight off `Decimal`, so it
+/// PRESERVES scale — `100.00` stays `100.00`. That matters: this file exists to
+/// compare scale, and rendering through `DisplayContext` (as the CSV writer
+/// does) would round both sides to the same thing and make every assertion
+/// below vacuous.
+///
+/// Not `Debug`. The first version compared `format!("{:?}")` strings, which
+/// tied the test to `Value`/`Amount`'s debug formatting — a derive change would
+/// have moved it with no behavior changing, and the failure output was a wall
+/// of struct syntax.
+fn render(value: &rustledger_query::Value) -> String {
+    match value {
+        rustledger_query::Value::Amount(a) => a.to_string(),
+        rustledger_query::Value::Null => "NULL".to_owned(),
+        other => panic!("weight columns should only ever be Amount or NULL, got {other:?}"),
+    }
+}
+
+/// `(account, weight column, WEIGHT(position))` per row.
+fn rows_of(source: &str) -> Vec<(String, String, String)> {
     let parsed = rustledger_parser::parse(source);
     let directives: Vec<rustledger_core::Directive> =
         parsed.directives.iter().map(|d| (**d).clone()).collect();
     let mut executor = Executor::new(&directives);
     let table = executor
-        .execute(&parse("SELECT weight, WEIGHT(position)").expect("query parses"))
+        .execute(&parse("SELECT account, weight, WEIGHT(position)").expect("query parses"))
         .expect("query runs");
     table
         .rows
         .iter()
-        .map(|r| (format!("{:?}", r[0]), format!("{:?}", r[1])))
+        .map(|r| {
+            let account = match &r[0] {
+                rustledger_query::Value::String(s) => s.clone(),
+                other => panic!("account should be a string, got {other:?}"),
+            };
+            (account, render(&r[1]), render(&r[2]))
+        })
         .collect()
 }
 
 fn assert_agrees(source: &str, what: &str) {
-    let rows = column_and_function(source);
+    let rows = rows_of(source);
     assert!(!rows.is_empty(), "{what}: fixture produced no rows");
     let disagreements: Vec<String> = rows
         .iter()
-        .filter(|(column, function)| column != function)
-        .map(|(column, function)| format!("column={column} function={function}"))
+        .filter(|(_, column, function)| column != function)
+        .map(|(account, column, function)| {
+            format!("  {account}: column={column} function={function}")
+        })
         .collect();
     assert!(
         disagreements.is_empty(),
@@ -125,15 +153,17 @@ fn a_cost_outranks_a_price_as_the_column_does() {
                   \x20 Assets:Cash  -10.50 USD\n";
     assert_agrees(source, "cost outranks price");
 
-    let rows = column_and_function(source);
-    let broker = &rows[0].1;
-    assert!(
-        broker.contains("10.50"),
+    // Select the row by ACCOUNT, not by index. Row order is an engine
+    // implementation detail unless the query constrains it, so `rows[0]` would
+    // be asserting on whichever posting happened to come first.
+    let rows = rows_of(source);
+    let (_, _, broker) = rows
+        .iter()
+        .find(|(account, _, _)| account == "Assets:Broker")
+        .expect("the broker posting");
+    assert_eq!(
+        broker, "10.50 USD",
         "a posting with both a cost and a price must weigh by its COST \
-         (10.50 USD), not its price (12.00 USD); got {broker}",
-    );
-    assert!(
-        !broker.contains("12.00"),
-        "the price weight leaked through: {broker}",
+         (10.50 USD), not its price (12.00 USD)",
     );
 }

--- a/crates/rustledger-query/tests/weight_function_matches_column.rs
+++ b/crates/rustledger-query/tests/weight_function_matches_column.rs
@@ -1,0 +1,139 @@
+//! `WEIGHT(position)` and the `weight` column must be ONE computation (#1966).
+//!
+//! CLAUDE.md's canonical-function rule names this pair: a consumer surfacing a
+//! per-posting weight calls `rustledger_booking::posting_weight` rather than
+//! re-deriving it. The column always did. The function did not, because it was
+//! dispatched through the shared value registry, and by the time the registry
+//! sees a `Value::Position` the posting is gone — a `Position` carries units and
+//! cost and no PRICE.
+//!
+//! So the function implemented two rungs of a three-rung ladder (cost, price,
+//! units) and silently returned the units for the middle case. `10 EUR @ 1.10
+//! USD` gave `10 EUR` where the column gives `11.00 USD`: a different number in
+//! a different currency, which made any SUM over a priced ledger a
+//! currency-mixed total.
+//!
+//! These pin the two spellings together across every rung, so the function
+//! cannot drift from the canonical again.
+
+use rustledger_query::{Executor, parse};
+
+/// `(weight column, WEIGHT(position))` per row, as rendered values.
+fn column_and_function(source: &str) -> Vec<(String, String)> {
+    let parsed = rustledger_parser::parse(source);
+    let directives: Vec<rustledger_core::Directive> =
+        parsed.directives.iter().map(|d| (**d).clone()).collect();
+    let mut executor = Executor::new(&directives);
+    let table = executor
+        .execute(&parse("SELECT weight, WEIGHT(position)").expect("query parses"))
+        .expect("query runs");
+    table
+        .rows
+        .iter()
+        .map(|r| (format!("{:?}", r[0]), format!("{:?}", r[1])))
+        .collect()
+}
+
+fn assert_agrees(source: &str, what: &str) {
+    let rows = column_and_function(source);
+    assert!(!rows.is_empty(), "{what}: fixture produced no rows");
+    let disagreements: Vec<String> = rows
+        .iter()
+        .filter(|(column, function)| column != function)
+        .map(|(column, function)| format!("column={column} function={function}"))
+        .collect();
+    assert!(
+        disagreements.is_empty(),
+        "{what}: {} of {} rows disagree:\n{}",
+        disagreements.len(),
+        rows.len(),
+        disagreements.join("\n"),
+    );
+}
+
+/// The PRICE rung — the one that was missing entirely.
+///
+/// A posting with a price and no cost took the units fallthrough, so the
+/// function reported `10 EUR` against the column's `11.00 USD`.
+#[test]
+fn a_price_annotation_is_weighed_like_the_column() {
+    assert_agrees(
+        "2024-01-01 open Assets:Bank\n2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"per-unit price\"\n  Assets:Bank    10 EUR @ 1.10 USD\n\
+         \x20 Assets:Cash  -11.00 USD\n",
+        "@ per-unit price",
+    );
+}
+
+/// `@@` too, whose sign handling is its own trap (#1052).
+#[test]
+fn a_total_price_is_weighed_like_the_column() {
+    assert_agrees(
+        "2024-01-01 open Assets:Bank\n2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"total price\"\n  Assets:Bank   -10 EUR @@ 11.00 USD\n\
+         \x20 Assets:Cash   11.00 USD\n",
+        "@@ total price on a negative posting",
+    );
+}
+
+/// The COST rung, including the total-cost shape that #1963 was about.
+///
+/// This also pins the residual gap #1963 documented as unfixed: the function
+/// re-derived `100` where the column reports `100.00`. Routing to the canonical
+/// closes it, because there is no longer a re-derivation to lose scale in.
+#[test]
+fn a_cost_is_weighed_like_the_column() {
+    assert_agrees(
+        "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"per-unit cost\"\n  Assets:Broker  2 HOOL {5.25 USD}\n\
+         \x20 Assets:Cash  -10.50 USD\n",
+        "per-unit cost",
+    );
+    assert_agrees(
+        "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+         2024-02-01 * \"total cost\"\n  Assets:Broker  3 HOOL {{100.00 USD}}\n\
+         \x20 Assets:Cash  -100.00 USD\n",
+        "total cost — the #1963 scale case",
+    );
+}
+
+/// The UNITS rung, so the fix cannot have been "always take the price".
+#[test]
+fn a_plain_posting_is_weighed_like_the_column() {
+    assert_agrees(
+        "2024-01-01 open Assets:Bank\n2024-01-01 open Expenses:Food\n\
+         2024-02-01 * \"plain\"\n  Assets:Bank   -10.00 USD\n\
+         \x20 Expenses:Food  10.00 USD\n",
+        "no cost and no price",
+    );
+}
+
+/// Cost AND price on one posting: cost wins, per the ladder's order.
+///
+/// This one asserts the VALUE, not just agreement. Agreement alone cannot see
+/// the ladder order at all — both sides now route through the same canonical,
+/// so swapping cost and price inside `posting_weight` moves them together and
+/// every `assert_agrees` above stays green. Verified by doing exactly that.
+///
+/// `2 HOOL {5.25 USD} @ 6.00 USD` weighs by its COST: 10.50 USD, not the
+/// 12.00 USD the price would give.
+#[test]
+fn a_cost_outranks_a_price_as_the_column_does() {
+    let source = "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
+                  2024-02-01 * \"cost and price\"\n\
+                  \x20 Assets:Broker  2 HOOL {5.25 USD} @ 6.00 USD\n\
+                  \x20 Assets:Cash  -10.50 USD\n";
+    assert_agrees(source, "cost outranks price");
+
+    let rows = column_and_function(source);
+    let broker = &rows[0].1;
+    assert!(
+        broker.contains("10.50"),
+        "a posting with both a cost and a price must weigh by its COST \
+         (10.50 USD), not its price (12.00 USD); got {broker}",
+    );
+    assert!(
+        !broker.contains("12.00"),
+        "the price weight leaked through: {broker}",
+    );
+}

--- a/crates/rustledger-query/tests/weight_function_scale.rs
+++ b/crates/rustledger-query/tests/weight_function_scale.rs
@@ -97,14 +97,24 @@ fn an_ordinary_per_unit_cost_keeps_its_trailing_zeros() {
     );
 }
 
-/// The INVENTORY path must agree with the position path.
+/// The INVENTORY path must not invent precision the position path does not.
 ///
 /// `WEIGHT()` reaches the same `units x cost` arithmetic two ways, and the
-/// first fix for #1963 patched only the `Position` arm. The `Inventory` arm 30
-/// lines below kept the defect verbatim: `WEIGHT(position)` reported `100`
-/// while `WEIGHT(SUM(position))` still reported
-/// `100.00000000000000000000000000` for the same lot. Both now route through
-/// one helper, and this pins that they cannot drift apart again.
+/// first fix for #1963 patched only the `Position` arm. The `Inventory` arm
+/// kept the defect verbatim: `WEIGHT(position)` reported `100` while
+/// `WEIGHT(SUM(position))` still reported `100.00000000000000000000000000` for
+/// the same lot. Both re-derivations now route through one helper.
+///
+/// The two are no longer EQUAL, and that is the fix for #1966 rather than a
+/// regression: `WEIGHT(position)` is now dispatched to the canonical
+/// `posting_weight` on the lazy path, where the `Posting` still exists, so it
+/// returns the column's exact `100.00` (scale 2). The inventory path has no
+/// posting to route with — `SUM(position)` has already collapsed them — so it
+/// still re-derives and normalizes to `100` (scale 0).
+///
+/// The invariant that survives is the one that matters: the inventory path must
+/// not carry MORE scale than the position path. That still catches the original
+/// defect, which was scale 26 against scale 2.
 #[test]
 fn the_inventory_path_agrees_with_the_position_path() {
     let src = "2024-01-01 open Assets:Broker\n2024-01-01 open Assets:Cash\n\
@@ -123,16 +133,18 @@ fn the_inventory_path_agrees_with_the_position_path() {
 
     let pos_scale = number_of(&per_position[0].1).scale();
     let inv_scale = number_of(&aggregated[0].1).scale();
-    assert_eq!(
-        inv_scale, pos_scale,
+    assert!(
+        inv_scale <= pos_scale,
         "WEIGHT() over an inventory invented precision the position path does \
          not: inventory scale {inv_scale}, position scale {pos_scale} \
          (inventory={} position={})",
-        aggregated[0].1, per_position[0].1,
+        aggregated[0].1,
+        per_position[0].1,
     );
     assert_eq!(
         number_of(&aggregated[0].1),
         number_of(&per_position[0].1),
-        "the two WEIGHT() paths must agree numerically",
+        "the two WEIGHT() paths must agree numerically (Decimal equality \
+         is numeric, so 100 == 100.00 — only the scale differs)",
     );
 }


### PR DESCRIPTION
Closes #1966.

The canonical `rustledger_booking::posting_weight` is a three-rung ladder:
**cost**, then **price**, then **units**. `WEIGHT()` implemented two of them.

It was dispatched through the shared value registry, and by the time the
registry sees a `Value::Position` the posting is gone — a `Position` carries
units and cost and **no price at all**. So a priced posting fell straight
through to the units rung:

```
$ rledger query p.beancount "SELECT account, weight, WEIGHT(position)"
account      weight      WEIGHT
-----------  ----------  ----------
Assets:Bank  11.00 USD   10 EUR      <- 10 EUR @ 1.10 USD
```

A different number in a different currency. Any `SUM(WEIGHT(position))` over a
ledger with priced postings produced a silently currency-mixed total — worse
than #1963, which was the same value carrying invented scale.

## The fix

Dispatch `WEIGHT(position)` on the **lazy** path, where the `Posting` is still
in hand, straight to `compute_posting_weight` — the same helper the `weight`
COLUMN uses. The two spellings become one computation instead of two
implementations that agree by inspection.

This follows the precedent already in that match: the `META` family stays on
the lazy path because it reads the row context. Same reason here. The arm is
deliberately narrow — `WEIGHT` of anything but the bare `position` column still
goes to the shared registry, so this reintroduces exactly one lazy arm rather
than un-collapsing the dual dispatch.

**Side effect:** it also closes the residual scale gap #1963 recorded as
unfixed. With no re-derivation left there is nothing to lose scale in, so
`WEIGHT(position)` now returns the column's exact `100.00` rather than `100`.

## Tests

Five new cases pin every rung against the column — `@`, `@@`, per-unit cost,
total cost, plain units, and cost-outranking-price. **3 of 5 fail without the
fix.**

The cost-outranks-price case asserts the **value**, not agreement. Agreement
alone cannot see the ladder order: both sides route through the same canonical
now, so swapping cost and price inside `posting_weight` moves them together and
every agreement assertion stays green. Verified by doing exactly that, which is
how I found the first version of that test was vacuous.

## Two existing-test consequences, both correct

- The #1965 inventory-vs-position guard asserted **equality**. The position path
  is now *better* than the inventory path, not equal to it — `SUM(position)` has
  already collapsed the postings, so it has no posting to route with. Relaxed to
  `inv_scale <= pos_scale`, which still catches the original defect: verified it
  reports scale 26 against 2.
- The eager arm's comment described the scale gap as needing a wider change.
  Updated — that arm is now reached only by an `Inventory` or a constructed
  `Position`, neither of which carries a price, so cost-or-units genuinely is
  the best answer available there.

## Verification

`cargo test -p rustledger-query -p rustledger-booking` (23 suites), `-p
rustledger` (27 suites), the `dual_eval_parity` harness, `cargo +1.97.0 clippy
--workspace --all-targets`, and `cargo doc` all clean.
