### PR TITLE
test: fix two vacuous tests found by sabotage (#1902 Phase 2)

### DIFF
--- a/crates/rustledger-loader/tests/fixtures/booking_none.beancount
+++ b/crates/rustledger-loader/tests/fixtures/booking_none.beancount
@@ -4,11 +4,21 @@ option "booking_method" "NONE"
 2020-01-01 open Assets:Stock
 2020-01-01 open Assets:Cash    USD
 
-2020-02-01 * "Buy"
-  Assets:Stock    10 CORP
-  Assets:Cash    -10 USD @ CORP
+; Two lots at DIFFERENT costs. The augmentations are what make the
+; reduction below ambiguous under STRICT — the previous fixture had no
+; cost specs at all, so there were no lots, and every booking method
+; produced the same (empty) result. That is what made this test unable
+; to tell NONE from STRICT.
+2020-02-01 * "Buy lot 1"
+  Assets:Stock    10 CORP {1 USD}
+  Assets:Cash    -10 USD
 
-; Sell without cost tracking - NONE doesn't track lots
-2020-03-01 * "Sell"
-  Assets:Stock    -5 CORP
-  Assets:Cash      10 USD @ CORP
+2020-03-01 * "Buy lot 2"
+  Assets:Stock    10 CORP {3 USD}
+  Assets:Cash    -30 USD
+
+; Ambiguous under STRICT: `{}` matches two lots at different costs.
+; NONE performs no lot matching, so it must accept this.
+2020-04-01 * "Sell"
+  Assets:Stock    -5 CORP {}
+  Assets:Cash      10 USD

--- a/crates/rustledger-lsp/src/handlers/declaration.rs
+++ b/crates/rustledger-lsp/src/handlers/declaration.rs
@@ -24,7 +24,7 @@ mod tests {
   Assets:Bank  -5.00 USD
   Expenses:Food
 "#;
-        let result = parse(source);
+        let parsed = parse(source);
         let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
 
         let params = GotoDefinitionParams {
@@ -39,11 +39,36 @@ mod tests {
         let result = handle_goto_declaration(
             &params,
             source,
-            &result,
+            &parsed,
             None,
             &uri,
             PositionEncoding::Utf16,
         );
-        assert!(result.is_some());
+
+        // The claim in this test's NAME is that declaration answers exactly as
+        // definition. `is_some()` alone never checked that: swap the re-export
+        // above for a separate implementation and, as long as it returned
+        // Some, this test would still pass while the two silently diverged.
+        //
+        // So compare them. Today they are the same symbol, which makes the
+        // equality trivially true — that is the point. It is a drift guard: it
+        // starts doing work the moment someone gives declaration its own body.
+        let definition = crate::handlers::definition::handle_goto_definition(
+            &params,
+            source,
+            &parsed,
+            None,
+            &uri,
+            PositionEncoding::Utf16,
+        );
+        assert!(
+            result.is_some(),
+            "the fixture must resolve to a location, or the equality below \
+             compares two Nones and proves nothing",
+        );
+        assert_eq!(
+            result, definition,
+            "goto-declaration must answer exactly as goto-definition",
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/import.rs
+++ b/crates/rustledger-lsp/src/handlers/import.rs
@@ -507,6 +507,34 @@ mod tests {
             .filter(|a| a.title.starts_with("Accept import:"))
             .collect();
         assert!(accept_actions.is_empty());
+
+        // Positive control, so the assertion above pins RANGE EXCLUSION rather
+        // than "import_code_actions never returns anything". Without it the
+        // test passes against a function that always returns an empty vec —
+        // `actions` really is empty here, so the filter above examines nothing.
+        let overlapping = Range {
+            start: Position {
+                line: 0,
+                character: 200,
+            },
+            end: Position {
+                line: 0,
+                character: 300,
+            },
+        };
+        let overlapping_actions =
+            import_code_actions(&directives, &source, overlapping, PositionEncoding::Utf16);
+        assert!(
+            overlapping_actions
+                .iter()
+                .any(|a| a.title.starts_with("Accept import:")),
+            "the same directive must yield an accept action when the range DOES \
+             overlap it, or the emptiness above proves nothing; got {:?}",
+            overlapping_actions
+                .iter()
+                .map(|a| &a.title)
+                .collect::<Vec<_>>(),
+        );
     }
 
     #[test]

--- a/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
+++ b/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
@@ -202,19 +202,46 @@ fn cost_data_msgpack_round_trip_preserves_all_variants() {
 
 #[test]
 fn accessors_exhaustively_cover_variants() {
-    // Regression guard: if a future variant is added without updating
-    // the accessors, this test stays green only by accident. The
-    // exhaustive match in the impl is what guarantees coverage; this
-    // test is a behavioral spot-check.
-    for cn in [
+    // The name promised exhaustiveness the test did not deliver: the sample
+    // list held PerUnit, Total and PerUnitFromTotal but NOT Compound, and the
+    // assertion was a blanket "at least one accessor returns Some".
+    //
+    // That blanket claim is FALSE for Compound, which is why it was quietly
+    // left out. Both accessors return None for it on purpose: the effective
+    // per-unit is (N*per_unit + total)/N and needs units, and the `total`
+    // field is only the lump component — exposing it as the total would
+    // recreate the #1700 misweighing in any consumer. So the test now pins
+    // the CONTRACT PER VARIANT instead, which states that decision rather
+    // than hiding it behind an omitted sample.
+    //
+    // The match is what keeps the name honest: adding a variant to
+    // `CostNumberData` makes this fail to COMPILE, forcing a decision about
+    // its accessors here.
+    let cases = [
         CostNumberData::PerUnit { value: "1".into() },
         CostNumberData::Total { value: "2".into() },
+        CostNumberData::Compound {
+            per_unit: "5".into(),
+            total: "10".into(),
+        },
         CostNumberData::PerUnitFromTotal {
             per_unit: "3".into(),
             total: "30".into(),
         },
-    ] {
-        // At least one accessor returns Some for every variant.
-        assert!(cn.per_unit().is_some() || cn.total().is_some());
+    ];
+
+    let mut seen = 0;
+    for cn in &cases {
+        let (want_per_unit, want_total): (Option<&str>, Option<&str>) = match cn {
+            CostNumberData::PerUnit { value } => (Some(value), None),
+            CostNumberData::Total { value } => (None, Some(value)),
+            // Deliberately neither — see above and #1700.
+            CostNumberData::Compound { .. } => (None, None),
+            CostNumberData::PerUnitFromTotal { per_unit, total } => (Some(per_unit), Some(total)),
+        };
+        seen += 1;
+        assert_eq!(cn.per_unit(), want_per_unit, "per_unit() for {cn:?}");
+        assert_eq!(cn.total(), want_total, "total() for {cn:?}");
     }
+    assert_eq!(seen, 4, "one case per CostNumberData variant");
 }

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -928,9 +928,25 @@ fn test_spanned_validation_valid_ledger_no_errors() {
     );
 }
 
+/// Out-of-order input is CANONICALISED before the ordering check, so
+/// `DateOutOfOrder` cannot be produced at all.
+///
+/// This replaces a test that claimed to pin location info on a `DateOutOfOrder`
+/// error. Every assertion in it sat inside `if let Some(error) = date_error`,
+/// and `date_error` was always `None` — the validator returned NO errors for
+/// its fixture — so the test asserted nothing whatsoever and would have passed
+/// against any implementation.
+///
+/// What it concealed is bigger than the test: `run_phase_internal` sorts by
+/// `booking_sort_key` — `(date, priority, has_cost_reduction)`, date first —
+/// before the `date < last` comparison, so that comparison can never be true
+/// and E10001 is unreachable. Confirmed by deleting the sort, at which point
+/// this fixture does produce `["E10001"]`. See #1970.
+///
+/// So this is a TRIPWIRE, not an endorsement. If someone moves the ordering
+/// check ahead of the sort, this fails and points them at the decision.
 #[test]
-fn test_spanned_validation_out_of_order_dates_have_location() {
-    // Test that date ordering warnings include location info
+fn out_of_order_input_is_canonicalised_before_the_ordering_check() {
     let directives = vec![
         spanned_directive(
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
@@ -938,37 +954,59 @@ fn test_spanned_validation_out_of_order_dates_have_location() {
             50,
             0,
         ),
-        // Later date first
+        // Later date first ...
         spanned_directive(
             Directive::Open(Open::new(date(2024, 1, 10), "Expenses:Food")),
             50,
             100,
             0,
         ),
-        // Earlier date second (out of order)
+        // ... earlier date second: out of order in the source.
         spanned_directive(
             Directive::Open(Open::new(date(2024, 1, 5), "Expenses:Transport")),
             100,
-            150, // span: bytes 100-150
-            6,   // file_id: 6
+            150,
+            6,
+        ),
+        // Deliberately unopened, so the run produces SOMETHING. Without this
+        // the fixture yields zero errors and "no DateOutOfOrder" would be
+        // indistinguishable from "the validator never ran" — which is exactly
+        // how the previous version of this test passed while asserting nothing.
+        spanned_directive(
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 20), "unopened")
+                    .with_synthesized_posting(Posting::new(
+                        "Expenses:Never",
+                        Amount::new(dec!(1), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Bank",
+                        Amount::new(dec!(-1), "USD"),
+                    )),
+            ),
+            150,
+            250,
+            0,
         ),
     ];
 
     let errors = validate_spanned_with_options(&directives, ValidationOptions::default());
 
-    let date_error = errors.iter().find(|e| e.code == ErrorCode::DateOutOfOrder);
+    // Non-vacuity first: the validator ran and had something to say.
+    assert!(
+        errors.iter().any(|e| e.code == ErrorCode::AccountNotOpen),
+        "fixture must produce E1001 or the absence below proves nothing; got {:?}",
+        errors.iter().map(|e| e.code.code()).collect::<Vec<_>>(),
+    );
 
-    // DateOutOfOrder is detected when directives are sorted - the error should have location
-    if let Some(error) = date_error {
-        assert!(
-            error.span.is_some(),
-            "DateOutOfOrder error should have span"
-        );
-        assert!(
-            error.file_id.is_some(),
-            "DateOutOfOrder error should have file_id"
-        );
-    }
+    assert!(
+        !errors.iter().any(|e| e.code == ErrorCode::DateOutOfOrder),
+        "E10001 became reachable — the ordering check now runs before the \
+         canonical sort. That is a behavior change, not a bug fix: decide \
+         whether the diagnostic should exist before making it live (#1970). \
+         Got {:?}",
+        errors.iter().map(|e| e.code.code()).collect::<Vec<_>>(),
+    );
 }
 
 // ============================================================================

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -946,7 +946,7 @@ fn test_spanned_validation_valid_ledger_no_errors() {
 /// So this is a TRIPWIRE, not an endorsement. If someone moves the ordering
 /// check ahead of the sort, this fails and points them at the decision.
 #[test]
-fn out_of_order_input_is_canonicalised_before_the_ordering_check() {
+fn test_out_of_order_input_is_canonicalised_before_the_ordering_check() {
     let directives = vec![
         spanned_directive(
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -1508,9 +1508,22 @@ t = "check"
     // Note: apply_env tests require setting environment variables which is unsafe.
     // These behaviors are tested via integration tests instead.
 
+    /// An empty environment leaves the config untouched — and a populated one
+    /// does not, which is what makes the first half mean something.
+    ///
+    /// The previous version built this config, called `apply_env()`, discarded
+    /// the result and asserted NOTHING. Its comment said "just verify the
+    /// method doesn't panic" while its name promised no changes, so it passed
+    /// against any implementation of `apply_env` — including one that wiped
+    /// every field.
+    ///
+    /// It also read the real environment, and hedged about it: "this test
+    /// assumes `RLEDGER_FILE` and `RLEDGER_FORMAT` are not set ... may fail". That
+    /// is the #1729 shape. `apply_env` already splits into an injectable
+    /// `apply_env_config(&EnvironmentConfig)`, so the test takes that and reads
+    /// no environment at all.
     #[test]
-    fn test_apply_env_no_changes() {
-        // When no env vars are set, apply_env should not change anything
+    fn an_empty_environment_leaves_the_config_untouched() {
         let config = Config {
             default: DefaultConfig {
                 file: Some("/config/file.beancount".to_string()),
@@ -1524,10 +1537,32 @@ t = "check"
             ..Default::default()
         };
 
-        // Note: This test assumes RLEDGER_FILE and RLEDGER_FORMAT are not set
-        // If they happen to be set in the test environment, this test may fail
-        // Just verify the method doesn't panic
-        let _ = config.apply_env();
+        let untouched = config
+            .clone()
+            .apply_env_config(&EnvironmentConfig::default());
+        assert_eq!(
+            untouched.default.file.as_deref(),
+            Some("/config/file.beancount"),
+            "an empty environment must not replace the configured file",
+        );
+        assert_eq!(untouched.output.format.as_deref(), Some("text"));
+        assert_eq!(untouched.output.color, Some(true));
+
+        // Non-vacuity. Without this the assertions above would be equally
+        // satisfied by an `apply_env_config` that ignored its argument
+        // entirely — "unchanged" and "never applies anything" would be
+        // indistinguishable.
+        let overridden = config.apply_env_config(&EnvironmentConfig {
+            file: Some("/env/file.beancount".to_string()),
+            no_color: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            overridden.default.file.as_deref(),
+            Some("/env/file.beancount"),
+            "a populated environment must override the configured file",
+        );
+        assert_eq!(overridden.output.color, Some(false), "NO_COLOR must win");
     }
 
     #[test]


### PR DESCRIPTION
#1902 Phase 2, the vacuous-test sweep. Two confirmed findings, one of which was
hiding unreachable production code.

## Method

Static detection cannot prove vacuity, so this was two stages: a detector
produced *candidates*, then a mechanical probe confirmed them. The probe inserts
`panic!("VACUITY_PROBE")` where the test claims to assert — **a test that still
passes never executed its own assertion.**

Scanned 4380 tests → 302 candidates across four shapes (`NO_ASSERT` 120,
`EMPTY_OK` 112, `GUARDED` 54, `OK_ONLY` 16). All 54 `GUARDED` were probed:
**1 vacuous, 52 real, 1 feature-gated.** Low precision by design — the detector
optimises for recall and the probe makes triage cheap.

## Finding 1: a test that asserted nothing, hiding dead code

`test_spanned_validation_out_of_order_dates_have_location` put every assertion
inside `if let Some(error) = date_error`, and that `Option` is *always* `None` —
the validator returns **zero** errors for its fixture. It would have passed
against any implementation.

What it concealed is bigger than the test. `run_phase_internal` sorts by
`booking_sort_key` — `(date, priority, has_cost_reduction)`, **date first** —
and only then checks `date < last`. After a date-major sort that is never true,
so **E10001 `DateOutOfOrder` is unreachable**. Proven by deleting the sort, at
which point the same fixture produces `["E10001"]`.

Filed as **#1970** — reviving or removing the diagnostic is a behavior decision,
since beancount does not warn on out-of-order dates either, and there is LSP
`code_lens` handling, a WASM conversion test and user-facing docs for something
nobody can trigger.

Replaced with a tripwire verified in **both** directions: remove the sort and it
fails (`E10001 became reachable`); suppress E1001 and its non-vacuity guard
fails (the fixture must produce *something*, or the absence of E10001 proves
nothing).

## Finding 2: a test that could not tell NONE from STRICT

`test_booking_method_none`'s fixture had **no cost specs at all** — bare
`10 CORP` postings. With no lots to book, every booking method produces the same
empty result, so the test could not detect the option being ignored.

Confirmed by making the loader ignore `booking_method` entirely:

| test | option ignored |
|---|---|
| `test_booking_method_average` | **fails** |
| `test_booking_method_hifo` | **fails** |
| `test_booking_method_lifo` | **fails** |
| `test_booking_method_none` | **passes** ← |

The siblings discriminate; only NONE did not. New fixture buys two lots at
different costs and reduces with `{}` — ambiguous under STRICT, accepted under
NONE. Verified both directions.

## What the sweep taught about the sweep

Four of my own verification tools were vacuous on first write, each caught only
by running the check that could report "dirty":

| tool | how it was vacuous |
|---|---|
| detector | missed a planted `OK_ONLY` case |
| GUARDED probe | emitted non-compiling code, so nothing was verified |
| verdict harness | read `0 passed; 401 filtered out` as success — declared all 14 `rustledger-query` candidates vacuous when all 14 are real |
| EMPTY_OK probe | gave verdicts for tests it never patched |

The `EMPTY_OK` probe also has a conceptual limit worth recording: forcing a
filter predicate true only distinguishes "found nothing" from "looked at
nothing" when the filtered collection is fixture-derived. For
`assert!(errors.is_empty())` the source is legitimately empty on success, so the
probe is uninformative there — which is why the booking-method family needed
hand-written sabotage instead. `NO_ASSERT` (120) and the rest of `EMPTY_OK`
remain untriaged.
