### PR TITLE
refactor(validate): remove E10001 DateOutOfOrder, which could never fire

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -270,8 +270,8 @@ const BALANCE_ERROR_CODES: &[&str] = &[
 ///   `⚠ Balance: X USD (see diagnostic)` — "see diagnostic" is a true
 ///   link by construction.
 /// - `Some(diags)` with some OTHER non-HINT diagnostic at `line`
-///   (e.g., `E1001` AccountNotOpen ERROR, `FutureDate` WARNING,
-///   `DateOutOfOrder` INFORMATION) but NO `BALANCE_ERROR_CODES`:
+///   (e.g., `E1001` AccountNotOpen ERROR, `FutureDate` WARNING) but
+///   NO `BALANCE_ERROR_CODES`:
 ///   the validator has something to say about this directive but
 ///   it isn't a balance-arithmetic failure. Render neutrally; don't
 ///   misattribute it as a balance failure AND don't claim ✓ on a
@@ -316,7 +316,7 @@ fn has_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
 /// (ERROR, WARNING, or INFORMATION severity) anchored at `line.start`?
 ///
 /// Severity matters: a balance directive can carry a WARNING-severity
-/// diagnostic (`FutureDate` E10002, `DateOutOfOrder` E10001, etc.) that
+/// diagnostic (`FutureDate` E10002, etc.) that
 /// gets the balance directive's span patched onto it via
 /// `validate/lib.rs:548-562`. If we filtered on ERROR only, the lens
 /// would render `✓ Balance: X USD` for a directive the validator is
@@ -789,7 +789,7 @@ mod tests {
     }
 
     /// WARNING-severity diagnostics that anchor on the balance line —
-    /// `FutureDate`, `DateOutOfOrder`, `AccountCloseNotEmpty` —
+    /// `FutureDate`, `AccountCloseNotEmpty` —
     /// disqualify ✓. Without this, the lens claims the assertion holds
     /// while the validator is actively flagging the directive's date or
     /// account state, which is the same false-confidence pattern #1264
@@ -830,9 +830,14 @@ mod tests {
     }
 
     /// INFORMATION-severity diagnostics at the balance line also
-    /// disqualify ✓ — same rationale as WARNING, applied to
-    /// `DateOutOfOrder` and similar advisory-level findings the
-    /// validator anchors via the span-patch path.
+    /// disqualify ✓ — same rationale as WARNING, applied to advisory-level
+    /// findings the validator anchors via the span-patch path.
+    ///
+    /// No `ErrorCode` maps to INFORMATION today — E10001 was the only one and
+    /// it was removed as unreachable (#1970) — so the code below is a
+    /// synthetic diagnostic. The severity branch is still live: this handler
+    /// classifies by LSP severity, not by code, so anything that arrives at
+    /// INFORMATION must behave this way.
     #[test]
     fn balance_lens_neutral_on_information_severity_at_line() {
         let source = r#"2024-01-31 balance Assets:Bank 100 USD
@@ -841,7 +846,7 @@ mod tests {
         let params = code_lens_params();
 
         let diags = vec![diagnostic_with_code_severity_at_line(
-            "E10001",
+            "E-SYNTHETIC-INFO",
             DiagnosticSeverity::INFORMATION,
             0,
         )];

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -86,8 +86,6 @@ pub enum ErrorCode {
     DocumentNotFound,
 
     // === Date Errors (E10xxx) ===
-    /// E10001: Date out of order (info only).
-    DateOutOfOrder,
     /// E10002: Entry dated in the future (warning).
     FutureDate,
 }
@@ -145,7 +143,6 @@ impl ErrorCode {
         Self::InvalidOptionValue,
         Self::DuplicateOption,
         Self::DocumentNotFound,
-        Self::DateOutOfOrder,
         Self::FutureDate,
     ];
 
@@ -192,7 +189,6 @@ impl ErrorCode {
             // Document errors
             Self::DocumentNotFound => "E8001",
             // Date errors
-            Self::DateOutOfOrder => "E10001",
             Self::FutureDate => "E10002",
         }
     }
@@ -205,16 +201,9 @@ impl ErrorCode {
             Self::FutureDate
                 | Self::SinglePosting
                 | Self::AccountCloseNotEmpty
-                | Self::DateOutOfOrder
                 | Self::InvalidPrecisionMetadata
                 | Self::MalformedBudget
         )
-    }
-
-    /// Check if this is just informational.
-    #[must_use]
-    pub const fn is_info(&self) -> bool {
-        matches!(self, Self::DateOutOfOrder)
     }
 
     /// Whether this diagnostic is advisory-only and must NOT be surfaced by
@@ -268,7 +257,6 @@ impl ErrorCode {
             Self::InvalidOptionValue => "Invalid option value",
             Self::DuplicateOption => "Non-repeatable option given more than once",
             Self::DocumentNotFound => "Document file not found",
-            Self::DateOutOfOrder => "Directive date out of order",
             Self::FutureDate => "Directive dated in the future",
         }
     }
@@ -444,12 +432,6 @@ impl ErrorCode {
                  containing the directive (matching `include`).\n\nFix: correct the \
                  path, or remove the directive."
             }
-            Self::DateOutOfOrder => {
-                "A directive's date is earlier than the preceding directive's date \
-                 in the same file (informational only — directives are sorted before \
-                 processing, so this never changes results).\n\nFix: reorder the \
-                 file chronologically if you care about source order."
-            }
             Self::MalformedBudget => {
                 "A `custom \"budget\"` directive that is recognizably a budget \
                  carries content rledger cannot use (warning).\n\nBudgets follow \
@@ -474,9 +456,10 @@ impl ErrorCode {
     /// Get the severity level.
     #[must_use]
     pub const fn severity(&self) -> Severity {
-        if self.is_info() {
-            Severity::Info
-        } else if self.is_warning() {
+        // No code maps to `Severity::Info`. E10001 was the only one, and it was
+        // unreachable — see #1970. The level is kept on `Severity` because it
+        // is public and consumers match it exhaustively.
+        if self.is_warning() {
             Severity::Warning
         } else {
             Severity::Error
@@ -516,6 +499,10 @@ pub enum Severity {
     /// Suspicious but valid.
     Warning,
     /// Informational only.
+    ///
+    /// No [`ErrorCode`] currently maps here. E10001 did, and it could never be
+    /// emitted (#1970); the level is retained because `Severity` is public and
+    /// the LSP maps it to `DiagnosticSeverity::INFORMATION`.
     Info,
 }
 
@@ -625,8 +612,8 @@ mod tests {
         // spec. (The spec may also carry codes emitted by other crates — e.g.
         // loader include errors E9001/E9002 — so this is a subset check, not
         // strict equality.) Codes are backtick-wrapped in the spec (`**Code:**
-        // `E1001``), so the backtick delimiters keep `E1001` from matching
-        // inside `E10001`.
+        // `E1001``), so the backtick delimiters keep a shorter code from
+        // matching inside a longer one.
         // The spec lives at the workspace root (`spec/core/validation.md`),
         // OUTSIDE this crate, so it is not packaged to crates.io. Read it at
         // runtime relative to `CARGO_MANIFEST_DIR` and skip when it is absent —

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -333,7 +333,6 @@ pub struct LedgerState {
     pending_pads: FxHashMap<rustledger_core::Account, Vec<PendingPad>>,
     /// Validation options.
     options: ValidationOptions,
-    /// Track previous directive date for out-of-order detection.
     /// `(account, close_date)` pairs whose late-phase Close check has
     /// already fired. Guards against duplicate same-day Close
     /// directives running the non-empty-balance check twice (the early

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -38,7 +38,6 @@
 //! | E7002 | Invalid option value |
 //! | E7003 | Duplicate option |
 //! | E8001 | Document file not found |
-//! | E10001 | Date out of order (info) |
 //! | E10002 | Entry dated in the future (warning) |
 
 #![forbid(unsafe_code)]
@@ -335,7 +334,6 @@ pub struct LedgerState {
     /// Validation options.
     options: ValidationOptions,
     /// Track previous directive date for out-of-order detection.
-    last_date: Option<NaiveDate>,
     /// `(account, close_date)` pairs whose late-phase Close check has
     /// already fired. Guards against duplicate same-day Close
     /// directives running the non-empty-balance check twice (the early
@@ -553,9 +551,9 @@ fn sum_account_subtree(
 /// account/commodity/pad bookkeeping accumulated by `Early` is visible
 /// to `Late`'s balance/inventory checks.
 ///
-/// Date-ordering and future-date checks run only in `Early` (date is
-/// independent of booking), so callers running both phases don't get
-/// duplicate `DateOutOfOrder` / `FutureDate` warnings.
+/// The future-date check runs only in `Early` (date is independent of
+/// booking), so callers running both phases don't get duplicate
+/// `FutureDate` warnings.
 fn validate_phase_inner<D: ValidatableDirective>(
     directives: &[D],
     state: &mut LedgerState,
@@ -569,13 +567,6 @@ fn validate_phase_inner<D: ValidatableDirective>(
     } else {
         FxHashMap::default()
     };
-
-    // Reset `last_date` at the start of each phase so the date-ordering
-    // check (which runs in Early) doesn't get confused by a previous
-    // Late pass having advanced past every directive.
-    if phase == Phase::Early {
-        state.last_date = None;
-    }
 
     let mut errors = Vec::new();
 
@@ -607,34 +598,26 @@ fn validate_phase_inner<D: ValidatableDirective>(
 
         // Snapshot before ANY errors are pushed for this directive so the
         // downstream patching loop can enrich every error tied to this
-        // directive — including the ordering / future-date checks below,
+        // directive — including the future-date check below,
         // not just the ones produced by the per-kind validators
         // (issue #896). No cost for the unspanned path; the skip-then-
         // patch loop is bypassed when `span_info()` returns `None`.
         let error_count_before = errors.len();
 
-        // Date-ordering and future-date checks only run in Early. Date
-        // is independent of booking, and we don't want duplicate errors
-        // when both phases iterate.
-        if phase == Phase::Early {
-            if let Some(last) = state.last_date
-                && date < last
-            {
-                errors.push(ValidationError::new(
-                    ErrorCode::DateOutOfOrder,
-                    format!("Directive date {date} is before previous directive {last}"),
-                    date,
-                ));
-            }
-            state.last_date = Some(date);
-
-            if state.options.warn_future_dates && date > today {
-                errors.push(ValidationError::new(
-                    ErrorCode::FutureDate,
-                    format!("Entry dated in the future: {date}"),
-                    date,
-                ));
-            }
+        // The future-date check only runs in Early. Date is independent
+        // of booking, and we don't want duplicate errors when both phases
+        // iterate.
+        //
+        // There was a date-ORDERING check here too, emitting E10001. It
+        // could never fire: this loop walks `keyed`, sorted by
+        // `booking_sort_key` (date first) immediately above, so `date <
+        // last` was unreachable. Removed with the code (#1970).
+        if phase == Phase::Early && state.options.warn_future_dates && date > today {
+            errors.push(ValidationError::new(
+                ErrorCode::FutureDate,
+                format!("Entry dated in the future: {date}"),
+                date,
+            ));
         }
 
         match (phase, directive) {
@@ -2577,7 +2560,6 @@ mod tests {
         );
 
         // Info
-        assert_eq!(ErrorCode::DateOutOfOrder.severity(), Severity::Info);
     }
 
     #[test]

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -916,96 +916,16 @@ fn test_spanned_validation_valid_ledger_no_errors() {
 
     let errors = validate_spanned_with_options(&directives, ValidationOptions::default());
 
-    // Filter out any info-level "date out of order" messages
+    // FutureDate is advisory and unrelated to what this test pins. E10001
+    // used to be filtered here too; it no longer exists (#1970).
     let critical_errors: Vec<_> = errors
         .iter()
-        .filter(|e| !matches!(e.code, ErrorCode::DateOutOfOrder | ErrorCode::FutureDate))
+        .filter(|e| !matches!(e.code, ErrorCode::FutureDate))
         .collect();
 
     assert!(
         critical_errors.is_empty(),
         "expected no validation errors, got {critical_errors:?}"
-    );
-}
-
-/// Out-of-order input is CANONICALISED before the ordering check, so
-/// `DateOutOfOrder` cannot be produced at all.
-///
-/// This replaces a test that claimed to pin location info on a `DateOutOfOrder`
-/// error. Every assertion in it sat inside `if let Some(error) = date_error`,
-/// and `date_error` was always `None` — the validator returned NO errors for
-/// its fixture — so the test asserted nothing whatsoever and would have passed
-/// against any implementation.
-///
-/// What it concealed is bigger than the test: `run_phase_internal` sorts by
-/// `booking_sort_key` — `(date, priority, has_cost_reduction)`, date first —
-/// before the `date < last` comparison, so that comparison can never be true
-/// and E10001 is unreachable. Confirmed by deleting the sort, at which point
-/// this fixture does produce `["E10001"]`. See #1970.
-///
-/// So this is a TRIPWIRE, not an endorsement. If someone moves the ordering
-/// check ahead of the sort, this fails and points them at the decision.
-#[test]
-fn test_out_of_order_input_is_canonicalised_before_the_ordering_check() {
-    let directives = vec![
-        spanned_directive(
-            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
-            0,
-            50,
-            0,
-        ),
-        // Later date first ...
-        spanned_directive(
-            Directive::Open(Open::new(date(2024, 1, 10), "Expenses:Food")),
-            50,
-            100,
-            0,
-        ),
-        // ... earlier date second: out of order in the source.
-        spanned_directive(
-            Directive::Open(Open::new(date(2024, 1, 5), "Expenses:Transport")),
-            100,
-            150,
-            6,
-        ),
-        // Deliberately unopened, so the run produces SOMETHING. Without this
-        // the fixture yields zero errors and "no DateOutOfOrder" would be
-        // indistinguishable from "the validator never ran" — which is exactly
-        // how the previous version of this test passed while asserting nothing.
-        spanned_directive(
-            Directive::Transaction(
-                Transaction::new(date(2024, 1, 20), "unopened")
-                    .with_synthesized_posting(Posting::new(
-                        "Expenses:Never",
-                        Amount::new(dec!(1), "USD"),
-                    ))
-                    .with_synthesized_posting(Posting::new(
-                        "Assets:Bank",
-                        Amount::new(dec!(-1), "USD"),
-                    )),
-            ),
-            150,
-            250,
-            0,
-        ),
-    ];
-
-    let errors = validate_spanned_with_options(&directives, ValidationOptions::default());
-
-    // Non-vacuity first: the validator ran and had something to say.
-    assert!(
-        errors.iter().any(|e| e.code == ErrorCode::AccountNotOpen),
-        "fixture must produce E1001 or the absence below proves nothing; got {:?}",
-        errors.iter().map(|e| e.code.code()).collect::<Vec<_>>(),
-    );
-
-    assert!(
-        !errors.iter().any(|e| e.code == ErrorCode::DateOutOfOrder),
-        "E10001 became reachable — the ordering check now runs before the \
-         canonical sort. That is a behavior change, not a bug fix: decide \
-         whether the diagnostic should exist before making it live (#1970). \
-         Got {:?}",
-        errors.iter().map(|e| e.code.code()).collect::<Vec<_>>(),
     );
 }
 

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -355,8 +355,8 @@ mod warning_severity_tests {
         let lookup = LineLookup::new("x");
         let date = rustledger_core::naive_date(2020, 1, 1).unwrap();
         let mk = |code| ValidationError::new(code, "m", date);
-        // DateOutOfOrder is a warning code; AccountNotOpen (E1001) is an error.
-        let warn = validation_error_to_wasm(&mk(ErrorCode::DateOutOfOrder), &lookup, None, Some(1));
+        // FutureDate is a warning code; AccountNotOpen (E1001) is an error.
+        let warn = validation_error_to_wasm(&mk(ErrorCode::FutureDate), &lookup, None, Some(1));
         assert_eq!(warn.severity, Severity::Warning);
         let err = validation_error_to_wasm(&mk(ErrorCode::AccountNotOpen), &lookup, None, Some(1));
         assert_eq!(err.severity, Severity::Error);

--- a/docs/development/lsp-support.md
+++ b/docs/development/lsp-support.md
@@ -32,7 +32,7 @@ diagnostic vector for the file — and renders one of:
   - Validation was skipped this turn (file > 500 KB or buffer has
     parse errors elsewhere — see `validation_would_run`).
   - A non-balance non-HINT diagnostic (e.g., `E1001 AccountNotOpen`
-    ERROR, `FutureDate` WARNING, `DateOutOfOrder` INFORMATION) anchors
+    ERROR, `FutureDate` WARNING) anchors
     on the balance directive's line — the diagnostic explains a
     different problem; claiming `⚠ Balance` would misattribute the
     failure and claiming `✓` would dismiss a real concern.

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -308,12 +308,6 @@ Only directives rledger is confident are budgets get reported. Ownership is one 
 
 ## Date Warnings (E10xxx)
 
-### E10001: Date Out of Order (Info)
-
-**Cause**: Entries are not in chronological order.
-
-**Note**: This is informational only and does not prevent validation.
-
 ### E10002: Entry Dated in Future (Warning)
 
 **Cause**: Entry has a date in the future.

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -433,16 +433,6 @@ A trailing quoted NOTE is not an error — Fava reads only the first three value
 
 ## Date Errors
 
-### DATE_OUT_OF_ORDER
-
-**Code:** `E10001`
-
-**Condition:** Directive date is before previous directive (informational only).
-
-**Message:** `Directive date {date} is before previous directive {prev_date}`
-
-**Severity:** Info (directives are auto-sorted)
-
 ### DATE_IN_FUTURE
 
 **Code:** `E10002`


### PR DESCRIPTION
Closes #1970.

`run_phase_internal` sorts every directive by `booking_sort_key` — a tuple led
by the date — and *then* walked that sorted sequence checking `date < last`.
After a date-major sort the comparison is never true, so **E10001 could never be
emitted.** Proven before removing it: delete the sort and the same fixture
produces `["E10001"]`; restore it and the code list is `[]`.

## Why remove rather than revive

Python beancount does not warn on out-of-order dates either — it sorts too. So
making the check live would mean adding a diagnostic beancount lacks and
carrying it as a deliberate divergence under the CLAUDE.md checklist, and it
would fire on plenty of legitimate ledgers. Nothing depends on the code, because
it has never once been emitted in production.

## Removed

- the emitter, and `LedgerState::last_date` which existed only to feed it (plus
  its per-phase reset)
- `ErrorCode::DateOutOfOrder` and its `code` / title / explanation / `ALL` arms
- **`ErrorCode::is_info`** — it was `matches!(self, Self::DateOutOfOrder)` and
  would otherwise be permanently `false`. That is precisely the
  dead-but-live-looking shape this issue was about, so leaving it would have
  reproduced the bug one level up.
- the defensive `filter(|e| !matches!(e.code, DateOutOfOrder | FutureDate))` in
  a validate integration test — it was guarding against an error that cannot
  occur
- the tripwire test added in #1971 that pinned the unreachability; with the code
  gone there is nothing to pin
- doc references in LSP `code_lens`, `docs/development/lsp-support.md`,
  `docs/reference/errors.md`, `spec/core/validation.md`

## Deliberately kept

**`Severity::Info`.** It is public, the LSP maps it to
`DiagnosticSeverity::INFORMATION`, and consumers match it exhaustively — so
removing the variant breaks them for no benefit. Its doc now records that no
`ErrorCode` maps there today.

The `code_lens` INFORMATION test keeps its severity branch too. That handler
classifies by **LSP severity, not by error code**, so the branch stays live for
anything arriving at INFORMATION; only its synthetic diagnostic stopped
borrowing a code that no longer exists.

## ⚠️ Breaking

Removing a public enum variant is a breaking change to `rustledger-validate`'s
API surface. Also removed from the public impl: `ErrorCode::is_info`.

## Verification

`cargo test --workspace` — **132 suites, 0 failures**. `cargo +1.97.0 clippy
--workspace --all-targets` and `cargo doc --workspace` clean. Clippy caught the
now-collapsible `if phase == Phase::Early` left behind by the removal; collapsed.
