### PR TITLE
refactor(core): thread render_commas through from_directives, not after it

### DIFF
--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -488,6 +488,7 @@ impl DisplayContext {
     pub fn from_directives<'a, I>(
         directives: I,
         fixed_precisions: impl IntoIterator<Item = (&'a str, u32)>,
+        render_commas: bool,
     ) -> Self
     where
         I: IntoIterator<Item = &'a Directive>,
@@ -584,6 +585,17 @@ impl DisplayContext {
         for (currency, precision) in fixed_precisions {
             ctx.set_fixed_precision(currency, precision);
         }
+
+        // Stage 2b: the ledger-wide grouping flag.
+        //
+        // A PARAMETER rather than a post-construction setter on purpose. Both
+        // production callers — the loader's `build_display_context` and the FFI
+        // component's `session.format` — used to call `set_render_commas`
+        // immediately after this, as two independent copies of the same
+        // six-line recipe with nothing asserting they agreed. Deleting the call
+        // from the FFI copy passed the entire workspace test suite. Threading it
+        // through the signature makes forgetting it a compile error instead.
+        ctx.set_render_commas(render_commas);
 
         // Stage 3: per-commodity `precision: N` metadata (see doc above).
         for directive in directives {
@@ -1813,7 +1825,7 @@ mod tests {
         ];
 
         // No overrides: pure inference.
-        let ctx = DisplayContext::from_directives(dirs.iter().take(4), std::iter::empty());
+        let ctx = DisplayContext::from_directives(dirs.iter().take(4), std::iter::empty(), false);
         assert_eq!(ctx.get_precision("USD"), Some(2), "mode of {{2,2,0}}dp");
         assert_eq!(ctx.get_precision("EUR"), Some(1));
         assert_eq!(
@@ -1829,7 +1841,7 @@ mod tests {
         );
 
         // Option override beats inference; commodity metadata beats both.
-        let ctx = DisplayContext::from_directives(dirs.iter(), [("EUR", 3), ("USD", 5)]);
+        let ctx = DisplayContext::from_directives(dirs.iter(), [("EUR", 3), ("USD", 5)], false);
         assert_eq!(
             ctx.get_precision("USD"),
             Some(4),
@@ -1871,7 +1883,7 @@ mod custom_directive_precision_tests {
     #[test]
     fn custom_amounts_do_not_inform_precision() {
         let directives = [custom_with_amount(1, Amount::new(dec!(0.5), "BTC"))];
-        let ctx = DisplayContext::from_directives(directives.iter(), std::iter::empty());
+        let ctx = DisplayContext::from_directives(directives.iter(), std::iter::empty(), false);
         assert_eq!(ctx.get_precision("BTC"), None);
         assert!(
             !ctx.currencies().any(|c| c == "BTC"),
@@ -1895,7 +1907,7 @@ mod custom_directive_precision_tests {
                 ),
             ),
         ];
-        let ctx = DisplayContext::from_directives(directives.iter(), std::iter::empty());
+        let ctx = DisplayContext::from_directives(directives.iter(), std::iter::empty(), false);
         assert_eq!(ctx.get_precision("USD"), Some(2));
     }
 

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -466,7 +466,7 @@ impl DisplayContext {
     /// calls it over the held entries (#1766) — so the sampling rules
     /// below stay in one place.
     ///
-    /// Three stages, in precedence order (later wins):
+    /// Four stages, in precedence order (later wins):
     /// 1. Scan every directive's amounts to infer per-currency dp
     ///    distributions (posting units, cost specs, price annotations,
     ///    balance amounts + tolerances, price directives).
@@ -479,12 +479,24 @@ impl DisplayContext {
     ///    surfaces them as `InvalidPrecisionMetadata` warnings (E5003) so
     ///    users see the problem without breaking loading.
     ///
+    /// 4. Apply `render_commas`, the ledger-wide grouping flag, plus the
+    ///    per-commodity `render_commas: TRUE|FALSE` declarations picked up in
+    ///    the same walk as stage 3. Grouping resolves by the same tiers as
+    ///    precision — see [`Self::render_commas_for`].
+    ///
     /// The iterator must be cheaply cloneable (e.g. a slice iter or a
     /// `map` over one) because the directives are walked twice (amount
     /// scan, then commodity metadata).
     ///
-    /// `render_commas` is NOT set here — it is presentation policy, not
-    /// precision inference; callers set it via [`Self::set_render_commas`].
+    /// `render_commas` is a PARAMETER rather than something callers apply
+    /// afterwards with [`Self::set_render_commas`]. It used to be the latter,
+    /// and both production callers carried their own copy of
+    /// `from_directives(..)` + `set_render_commas(..)`; deleting the second
+    /// line from the FFI copy passed the entire test suite. Requiring it here
+    /// makes that omission a compile error (#1902 Phase 2).
+    ///
+    /// [`Self::set_render_commas`] remains for contexts built some other way —
+    /// a derived or per-column context, which is not a ledger load.
     pub fn from_directives<'a, I>(
         directives: I,
         fixed_precisions: impl IntoIterator<Item = (&'a str, u32)>,

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1833,13 +1833,6 @@ impl SessionState {
     /// into scope; bare `rledger format <file>` has none and emits ungrouped
     /// text.
     pub fn format(&self) -> Result<String, String> {
-        let mut ctx = rustledger_core::DisplayContext::from_directives(
-            self.directives.iter(),
-            self.options
-                .display_precision
-                .iter()
-                .map(|(c, p)| (c.as_str(), *p)),
-        );
         // The session holds the ledger's options, so this path can honor
         // `render_commas` on disk — the boundary a machine consumer crosses is
         // the PARSER, and the grammar admits grouped numerals. (Contrast the
@@ -1848,7 +1841,14 @@ impl SessionState {
         // `false` because it is a per-file text transform with no options in
         // scope; giving it a context is a separate decision about whether
         // `format` becomes a ledger operation.
-        ctx.set_render_commas(self.options.render_commas);
+        let ctx = rustledger_core::DisplayContext::from_directives(
+            self.directives.iter(),
+            self.options
+                .display_precision
+                .iter()
+                .map(|(c, p)| (c.as_str(), *p)),
+            self.options.render_commas,
+        );
         let config = rustledger_core::format::FormatConfig {
             number_display: Some(ctx),
             ..Default::default()
@@ -3192,5 +3192,79 @@ option \"operating_currency\" \"USD\"
             .returns(&inv, &inc, "USD", "2020-12-31")
             .expect("net-units returns tolerate an un-booked from_entries over-sell");
         assert_eq!(r.current_value, "-600", "net −5 ACME × 120");
+    }
+}
+
+#[cfg(test)]
+mod format_policy_tests {
+    use super::SessionState;
+
+    /// Both grouping tiers, over the FFI `session.format` surface.
+    ///
+    /// This surface honors `render_commas` and per-commodity `render_commas:`
+    /// declarations — deliberately, per the doc on `SessionState::format`: the
+    /// session holds the ledger's options, and the boundary a machine consumer
+    /// crosses here is the PARSER, whose grammar admits grouped numerals.
+    ///
+    /// Nothing verified it. Deleting the flag from this path used to pass the
+    /// entire workspace suite, because the construction was a second private
+    /// copy of the loader's `build_display_context` and no test rendered
+    /// through it. `DisplayContext::from_directives` now takes the flag as a
+    /// parameter, so dropping it is a compile error rather than a silent
+    /// downgrade — and this pins the behavior itself.
+    const LEDGER: &str = "\
+option \"render_commas\" \"TRUE\"
+
+2024-01-01 commodity USD
+2024-01-01 commodity JPY
+  render_commas: FALSE
+
+2024-01-01 open Assets:Bank
+2024-01-01 open Assets:Yen
+2024-01-01 open Equity:Open
+
+2024-02-01 * \"big usd\"
+  Assets:Bank    1234567.89 USD
+  Equity:Open   -1234567.89 USD
+
+2024-02-02 * \"big jpy\"
+  Assets:Yen     9876543 JPY
+  Equity:Open   -9876543 JPY
+";
+
+    #[test]
+    fn format_honors_both_grouping_tiers() {
+        let out = SessionState::from_source(LEDGER)
+            .format()
+            .expect("format succeeds");
+
+        assert!(
+            out.contains("1,234,567.89"),
+            "the ledger-wide render_commas must group USD; got:\n{out}",
+        );
+        // The per-commodity opt-OUT is the half a global-only implementation
+        // passes anyway, so it is the one that matters here.
+        assert!(
+            out.contains("9876543 JPY"),
+            "JPY declares render_commas: FALSE and must stay ungrouped; got:\n{out}",
+        );
+        assert!(
+            !out.contains("9,876,543"),
+            "JPY was grouped despite its own declaration; got:\n{out}",
+        );
+    }
+
+    /// Without `render_commas`, nothing groups — so the assertions above pin
+    /// the OPTION rather than "this surface always groups".
+    #[test]
+    fn format_leaves_an_undeclared_ledger_ungrouped() {
+        let plain = LEDGER.replace("option \"render_commas\" \"TRUE\"\n", "");
+        let out = SessionState::from_source(&plain)
+            .format()
+            .expect("format succeeds");
+        assert!(
+            out.contains("1234567.89") && !out.contains("1,234,567.89"),
+            "an undeclared ledger must not group; got:\n{out}",
+        );
     }
 }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -728,15 +728,14 @@ impl Loader {
 /// overrides, then per-commodity `precision:` metadata. Only
 /// `render_commas` — presentation policy, not precision — is applied here.
 fn build_display_context(directives: &[Spanned<Directive>], options: &Options) -> DisplayContext {
-    let mut ctx = DisplayContext::from_directives(
+    DisplayContext::from_directives(
         directives.iter().map(|s| &s.value),
         options
             .display_precision
             .iter()
             .map(|(c, p)| (c.as_str(), *p)),
-    );
-    ctx.set_render_commas(options.render_commas);
-    ctx
+        options.render_commas,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#1902 Phase 2 — the policy-threading sweep. **No live divergence found; one
loaded gun defused.**

## What was checked

`DisplayContext` carries four presentation-policy fields (`render_commas`,
`group_overrides`, `fixed_precisions`, `precision`). Each was checked against
every rendering surface end-to-end, on **both tiers** — the ledger-wide option
and per-commodity `render_commas:` metadata — because the memory of #1892/#1896
is explicit that a one-tier test passes with the override wired to nothing:

| surface | USD (global on) | JPY (`render_commas: FALSE`) |
|---|---|---|
| `query` text | `1,234,567.890` ✓ | `9876543` ✓ |
| `query --format csv` | `1234567.890` ✓ (Machine suppresses) | `9876543` ✓ |
| `query --format json` | ungrouped ✓ | ungrouped ✓ |
| `query --format beancount` | `1,234,567.890` ✓ (LedgerText groups) | `9876543` ✓ |
| `report balances` | `1,234,567.890` ✓ | `9876543` ✓ |
| `format --ledger` | `1,234,567.89` ✓ | `9876543` ✓ |
| `format` (bare) | `1234567.89` ✓ (no options in scope) | `9876543` ✓ |

Every surface honors what it should.

## What it did find

The *mechanism* that produced #1892 and #1896 was still loaded. The ledger
context was built by a six-line recipe that existed **twice**:

```rust
let mut ctx = DisplayContext::from_directives(dirs, display_precision);
ctx.set_render_commas(options.render_commas);
```

— once in the loader's `build_display_context`, once inline in the FFI
component's `session.format`. Two independent copies with nothing asserting they
agree: the *state* equivalent of the canonical-function drift CLAUDE.md
describes. Both happened to be correct. Nothing kept them that way.

**Demonstrated, not asserted:** deleting the `set_render_commas` call from the
FFI copy passed the **entire workspace test suite**. That surface honors the
ledger's grouping deliberately — its doc explains why the *parser*, not the
file, is the machine boundary — and no test rendered through it.

## The fix

`from_directives` takes the flag as a parameter and applies it, so a caller
cannot construct a ledger context and forget the policy. The same sabotage is
now a **compile error**.

Adds the missing coverage in-process via `SessionState::from_source`, so it does
not need a built wasm. Verified three ways:

| sabotage | result |
|---|---|
| drop the argument | **compile error** |
| pass `false` | fails the global-tier assertion |
| ignore `group_overrides` | fails the per-commodity assertion |

## Deliberately not changed

- **`GroupingStyle::from_context`** borrows the whole context and delegates to
  `render_commas_for` — it cannot drop overrides by construction. The good
  pattern.
- **The query writer's per-column contexts** already adopt the policy whole via
  `adopt_grouping_from`, the canonical transfer added by #1896.
- **`format --ledger` honors grouping but not `display_precision`.** That is
  right: quantizing would rewrite the user's numbers, which is a data change
  rather than formatting.

## Verification

`cargo test --workspace` — **132 suites, 0 failures**. Clippy and doc clean.
End-to-end output across all seven surface/tier combinations above is
byte-identical before and after.
