### PR TITLE
fix(plugin): update a tracked plugin and its mtime atomically

### DIFF
--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -634,12 +634,25 @@ impl WatchingPluginManager {
     }
 
     /// Force reload all plugins.
+    ///
+    /// Every fallible step for a plugin runs BEFORE either of its fields is
+    /// written, so the pair is updated atomically. The previous order assigned
+    /// `tracked.plugin` and only then called `metadata.modified()?`, which on
+    /// failure left the NEW plugin recorded against the OLD timestamp — an
+    /// inconsistent pair, and the only state `reload_if_changed` consults to
+    /// decide whether a reload is due. That sibling already gets this right;
+    /// this matches it (#1902 Phase 2).
+    ///
+    /// Atomicity is per PLUGIN, not across the loop: a failure on the third
+    /// plugin leaves the first two reloaded and returns `Err`. That is
+    /// deliberate — each is a valid instance either way, so the result is
+    /// incomplete rather than corrupt, and the error tells the caller.
     pub fn reload_all(&mut self) -> Result<()> {
         for tracked in &mut self.plugins {
             let new_plugin = Plugin::load(&tracked.path, &self.config)?;
-            let metadata = std::fs::metadata(&tracked.path)?;
+            let modified = std::fs::metadata(&tracked.path)?.modified()?;
             tracked.plugin = new_plugin;
-            tracked.modified = metadata.modified()?;
+            tracked.modified = modified;
         }
         Ok(())
     }

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -639,8 +639,8 @@ impl WatchingPluginManager {
     /// written, so the pair is updated atomically. The previous order assigned
     /// `tracked.plugin` and only then called `metadata.modified()?`, which on
     /// failure left the NEW plugin recorded against the OLD timestamp — an
-    /// inconsistent pair, and the only state `reload_if_changed` consults to
-    /// decide whether a reload is due. That sibling already gets this right;
+    /// inconsistent pair, and the only state `check_and_reload` consults to
+    /// decide whether a reload is due. `check_and_reload` already gets this right;
     /// this matches it (#1902 Phase 2).
     ///
     /// Atomicity is per PLUGIN, not across the loop: a failure on the third


### PR DESCRIPTION
#1902 Phase 2 — the non-atomic multi-step mutation sweep. **One small real
defect; everything else was already atomic**, which is most of what this reports.

## Method

The shape, from `BookingEngine::apply` (#1863/#1897), which gets it right:

```
snapshot the state a failure would strand
for each step: mutate; on failure roll back and return Err
```

The defect is the same loop *without* the snapshot — a mid-loop `?` leaves
everything before it applied, while the caller sees `Err` and reasonably assumes
nothing happened.

Detector: `&mut` + returns `Result` + mutates + can exit early *after* the first
mutation + no snapshot/staging vocabulary. Self-checked against a planted
non-atomic function, a snapshot-guarded one, a validate-first one, and an
infallible one.

**Recall correction worth flagging:** the first version matched only `self.X`
mutations and found 5 candidates. That pattern is blind to mutation through
`&mut` *parameters* — which is exactly how this codebase accumulates
(`directives: &mut Vec<_>`, `errors: &mut Vec<_>`). Fixing it took the candidate
set from 5 to **28**. A sweep reporting "no defect" from the narrow pattern
would have been worthless.

## The defect

`WatchingPluginManager::reload_all`:

```rust
let new_plugin = Plugin::load(&tracked.path, &self.config)?;
let metadata = std::fs::metadata(&tracked.path)?;
tracked.plugin = new_plugin;                 // mutate
tracked.modified = metadata.modified()?;     // ...then a fallible call
```

A failure on the last line leaves the **new plugin recorded against the old
timestamp** — an inconsistent pair, and `tracked.modified` is the only state
`reload_if_changed` consults to decide whether a reload is due.

Its sibling `reload_if_changed` already resolves the timestamp *before* touching
either field. This matches it.

Atomicity is per **plugin**, not across the loop, and the doc now says so: a
failure on the third leaves the first two reloaded and returns `Err`. Each is a
valid instance either way, so the result is incomplete rather than corrupt.

**Honest limit:** this is structural, not behavioral. `metadata.modified()`
fails only where the platform has no mtime, which I cannot reproduce in a test.
The guarantee is that no fallible call sits between the paired writes — checkable
by reading, and matching the sibling's shape.

## Everything else was already atomic

Four different mechanisms, all correct:

| site | mechanism |
|---|---|
| `BookingEngine::apply` | snapshot + rollback, skipped only when overflow is *provably* impossible |
| `apply_plugin_ops` | stages into a fresh `Vec`, swaps at the end |
| `execute_insert` | validates everything, then commits with no fallible step in the loop |
| `load_recursive` | include-stack push/pop balanced; the only `Err` returns *before* the push |
| `dispatch_sync` | the mutation and the error are in mutually exclusive match arms |
| `report_*` / `run_with_writer` | streaming output — a partial write cannot be rolled back, and callers do not expect it to be |

## Verification

`cargo test --workspace` — 132 suites, 0 failures. Clippy and doc clean.
