### PR TITLE
feat(ffi): session.account-type, honoring the ledger's name_* renames

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1857,6 +1857,35 @@ impl SessionState {
             .map_err(|e| e.to_string())
     }
 
+    /// The account-type root for `account`, honoring this ledger's
+    /// `name_assets` … `name_expenses` renames (WIT 3.11.0, #1964).
+    ///
+    /// The free `util.get-account-type` classifies with hardcoded English
+    /// roots, so on a ledger that renames Expenses it answers "unknown" while
+    /// `report balsheet` — which classifies through
+    /// [`rustledger_core::AccountTypes`], the canonical CLAUDE.md names —
+    /// gets it right. Same ledger, different answers depending on the surface
+    /// asked. That utility cannot fix it: its interface holds no ledger. A
+    /// session does, so this one goes through the canonical.
+    ///
+    /// Returns the canonical lowercase kind — `assets`, `liabilities`,
+    /// `equity`, `income`, `expenses`, or `unknown` — exactly the vocabulary
+    /// `util.get-account-type` already returns, so a caller can swap one for
+    /// the other without re-reading the strings. `AccountTypes::root_name` is
+    /// the inverse when the ledger's own display name is wanted.
+    pub fn account_type(&self, account: &str) -> String {
+        let types = rustledger_core::AccountTypes {
+            assets: self.options.name_assets.clone(),
+            liabilities: self.options.name_liabilities.clone(),
+            equity: self.options.name_equity.clone(),
+            income: self.options.name_income.clone(),
+            expenses: self.options.name_expenses.clone(),
+        };
+        types
+            .kind(account)
+            .map_or_else(|| "unknown".to_string(), |k| k.as_str().to_string())
+    }
+
     /// Investment returns over the held ledger (WIT 3.9.0, #1847): the
     /// `rledger report returns` engine over the boundary, so a host charts
     /// returns without re-deriving the cash-flow extraction or the XIRR/TWR
@@ -3266,5 +3295,68 @@ option \"render_commas\" \"TRUE\"
             out.contains("1234567.89") && !out.contains("1,234,567.89"),
             "an undeclared ledger must not group; got:\n{out}",
         );
+    }
+}
+
+#[cfg(test)]
+mod account_type_tests {
+    use super::SessionState;
+
+    /// A renamed root classifies through the ledger's own names (#1964).
+    ///
+    /// `util.get-account-type` hardcodes the English roots, so it answers
+    /// `unknown` for `Depenses:Food` while `report balsheet` — going through
+    /// `AccountTypes`, the canonical — classifies it as Expenses. Two answers
+    /// for one ledger depending on which surface is asked. This pins that the
+    /// session agrees with the reports.
+    const RENAMED: &str = "\
+option \"name_expenses\" \"Depenses\"
+
+2024-01-01 open Assets:Bank
+2024-01-01 open Depenses:Food
+
+2024-02-01 * \"lunch\"
+  Depenses:Food   10.00 USD
+  Assets:Bank    -10.00 USD
+";
+
+    #[test]
+    fn account_type_honors_a_renamed_root() {
+        let session = SessionState::from_source(RENAMED);
+        assert_eq!(
+            session.account_type("Depenses:Food"),
+            "expenses",
+            "the configured root must classify as Expenses",
+        );
+
+        // Non-vacuity, and the actual bug: the ledger-free utility cannot see
+        // the rename, so it disagrees. If this ever starts returning
+        // "Expenses" the utility gained ledger awareness and the two surfaces
+        // no longer need separating.
+        assert_eq!(
+            super::get_account_type("Depenses:Food"),
+            "unknown",
+            "util.get-account-type is ledger-free and cannot see the rename",
+        );
+    }
+
+    #[test]
+    fn account_type_still_answers_for_default_roots() {
+        let session = SessionState::from_source(RENAMED);
+        assert_eq!(session.account_type("Assets:Bank"), "assets");
+        // `Expenses:` is NOT a root on this ledger — it was renamed away, so
+        // the canonical rejects it. Pins that the method reads the config
+        // rather than accepting both spellings.
+        assert_eq!(
+            session.account_type("Expenses:Food"),
+            "unknown",
+            "the English root is not configured on this ledger",
+        );
+    }
+
+    #[test]
+    fn account_type_rejects_an_unknown_root() {
+        let session = SessionState::from_source(RENAMED);
+        assert_eq!(session.account_type("Nonsense:Thing"), "unknown");
     }
 }

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -45,7 +45,11 @@ use exports::rustledger::ledger::ledger::{
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. 3.10 adds
+/// The Component-Model api-version this build implements. 3.11 adds
+/// `session.account-type` (the account-type root honoring THIS ledger's
+/// `name_*` renames — the free `util.get-account-type` hardcodes the
+/// English roots and so disagrees with every report surface on a renamed
+/// ledger, #1964); 3.10 adds
 /// `session.budget` (budgeted vs actual over the held ledger — the
 /// `rledger report budget` engine, so a host can render a Fava-style
 /// budget view without re-deriving the accrual); 3.9 adds
@@ -63,7 +67,7 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 /// encrypted (`.gpg`/`.asc`) ledgers can be decrypted by the host (#1667);
 /// 3.1 added the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
 /// `expand-pads` parameter on `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.10";
+const API_VERSION: &str = "3.11";
 
 struct Component;
 
@@ -138,6 +142,10 @@ impl GuestSession for LedgerSession {
 
     fn info(&self) -> LoadResult {
         self.state.info()
+    }
+
+    fn account_type(&self, account: String) -> String {
+        self.state.account_type(&account)
     }
 
     fn query(&self, query: String) -> QueryResult {

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.10.0;
+package rustledger:ledger@3.11.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -580,6 +580,18 @@ interface ledger {
     /// Everything the host needs at load time: entries, errors, options,
     /// plugins, and the resolved include graph.
     info: func() -> load-result;
+    /// The account-type root for `account`, honoring THIS ledger's
+    /// `name_assets` … `name_expenses` renames.
+    ///
+    /// `util.get-account-type` hardcodes the English roots, so it disagrees
+    /// with every other surface on a renamed ledger — `report balsheet` and
+    /// friends classify through the configured names while the FFI answered
+    /// "unknown" (#1964). A session holds the options, so this can agree.
+    ///
+    /// Returns the same vocabulary `util.get-account-type` does — `assets`,
+    /// `liabilities`, `equity`, `income`, `expenses`, or `unknown` — so the
+    /// two are drop-in interchangeable.
+    account-type: func(account: string) -> string;
     /// Run a BQL query against the held ledger.
     query: func(query: string) -> query-result;
     /// Keep only directives within `[begin, end)`.
@@ -724,7 +736,13 @@ interface util {
   types: func() -> types-info;
   /// Whether the file at `path` is an encrypted (GPG) ledger.
   is-encrypted: func(path: string) -> bool;
-  /// The account-type root (Assets/Liabilities/…) for an account name.
+  /// The account-type root (Assets/Liabilities/…) for an account name,
+  /// against the DEFAULT root names only.
+  ///
+  /// This interface is ledger-free by design, so it cannot see a ledger's
+  /// `name_assets` … `name_expenses` renames: on a ledger that renames
+  /// Expenses to Depenses this answers "unknown" for `Depenses:Food`. When
+  /// you hold a session, prefer [`session.account-type`], which honors them.
   get-account-type: func(account: string) -> string;
 }
 


### PR DESCRIPTION
Item 1 of #1964. **WIT 3.10.0 → 3.11.0, additive.**

## The divergence

CLAUDE.md names `AccountTypes` as the canonical for *"config-aware account
classification — never match root prefixes by string."* The report surfaces use
it. The FFI did not: `util.get-account-type` hardcodes the English roots, so on

```beancount
option "name_expenses" "Depenses"
```

`report balsheet` classifies `Depenses:Food` as expenses while the FFI answers
`unknown`. **One ledger, two answers, depending on which surface you ask.**

## Why this turned out to be additive

I originally filed this as needing a WIT contract change and parked it as a
decision for later. Re-checking against main, that was wrong and made it look
more blocked than it was:

- `get-account-type` sits in the **stateless `util` interface by design** —
  alongside `types()` and `is-encrypted(path)`. Making *it* ledger-aware is not
  the fix.
- The **`session` resource already carries `ledger-options`**, which already
  exposes `name-assets` … `name-expenses`.

So this adds `session.account-type` and breaks nothing. `util.get-account-type`
is unchanged; only its doc is narrowed to say it answers for the **default**
roots and to point at the session method.

## Vocabulary

Returns exactly what `util.get-account-type` returns — `assets`,
`liabilities`, `equity`, `income`, `expenses`, `unknown` — so the two are
drop-in interchangeable.

My first draft returned capitalized English kinds, which read better in
isolation and would have been wrong: the existing surface is lowercase, and
consistency with it matters more than my preference. Caught by the test failing
with `left: "expenses", right: "Expenses"`.

## Tests

Three, all in-process via `SessionState::from_source` (no built wasm needed).

The renamed-root test also asserts `util.get-account-type` **still** answers
`unknown` for the same account. That is deliberate: it is the non-vacuity half,
and it records the divergence itself rather than only the fix — if it ever
starts returning `expenses`, the utility gained ledger awareness and these two
surfaces no longer need separating.

Sabotage-verified: routing the session method through the hardcoded classifier
fails 2 of 3.

## Verification

`cargo test --workspace` — 132 suites, 0 failures. Clippy and doc clean.
`scripts/check-wit-version-bump.sh` passes locally:

```
WIT interface changed and version bumped
(package rustledger:ledger@3.10.0 -> package rustledger:ledger@3.11.0). OK.
```

`scripts/regen-bindings.sh` produces no diff — those bindings derive from the
WASM crate's types, not the session resource.

## Still open on #1964

- **The plugin case**, which is the sharpest: `sell_gains`' raw
  `starts_with("Income:")` silently no-ops on a renamed ledger — no error, just
  missing directives. Gated on plugins getting a view of the options.
- **LSP/WASM `is_account_type`**, which is a *lexical* guess about a bare word
  with no ledger necessarily loaded. It wants an options-when-available
  fallback, not a straight swap onto `AccountTypes`.
