### PR TITLE
fix(plugin): classify account roots by the ledger's configured names

### DIFF
--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -491,6 +491,7 @@ pub fn apply_plugins(
             options: PluginOptions {
                 operating_currencies: options.operating_currency.clone(),
                 title: options.title.clone(),
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -491,7 +491,17 @@ pub fn apply_plugins(
             options: PluginOptions {
                 operating_currencies: options.operating_currency.clone(),
                 title: options.title.clone(),
-                ..Default::default()
+                // The held options carry the ledger's root renames, so pass
+                // them: `..Default::default()` would hand plugins the English
+                // roots and reproduce on this surface exactly the silent
+                // misclassification this change fixes (#1964).
+                account_types: rustledger_plugin::PluginAccountTypes {
+                    assets: options.name_assets.clone(),
+                    liabilities: options.name_liabilities.clone(),
+                    equity: options.name_equity.clone(),
+                    income: options.name_income.clone(),
+                    expenses: options.name_expenses.clone(),
+                },
             },
             config: None,
         };
@@ -575,5 +585,65 @@ option \"operating_currency\" \"USD\"
             .filter(|d| matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t)))
             .count();
         assert_eq!(synth, 1, "expected exactly one synthesized Padding txn");
+    }
+}
+
+#[cfg(test)]
+mod plugin_options_tests {
+    use super::*;
+
+    /// `apply_plugins` must hand plugins the ledger's OWN root names.
+    ///
+    /// This surface built `PluginOptions` with `..Default::default()`, which
+    /// supplies the English roots — so a plugin classifying through
+    /// `account_types` still misclassified here after the native pipeline was
+    /// fixed. Caught in review of #1978: the bulk edit that silenced the new
+    /// field's compile errors treated this production site like a test one.
+    ///
+    /// Uses `check_drained`, which emits a balance assertion when a
+    /// BALANCE-SHEET account is closed. `apply_plugins` hardcodes
+    /// `config: None`, so a config-driven plugin like `split_expenses` is a
+    /// passthrough here and cannot discriminate — the first draft of this test
+    /// used it and passed with the bug reinstated.
+    #[test]
+    fn apply_plugins_passes_the_ledgers_account_roots() {
+        let options = crate::types::output::LedgerOptions {
+            name_assets: "Actifs".to_string(),
+            ..crate::types::output::LedgerOptions::default()
+        };
+
+        let source = "\
+2024-01-01 open Actifs:Bank
+2024-01-01 open Expenses:Food
+
+2024-02-01 * \"lunch\"
+  Expenses:Food   10.00 USD
+  Actifs:Bank    -10.00 USD
+
+2024-03-01 close Actifs:Bank
+";
+        let parsed = rustledger_parser::parse(source);
+        let directives: Vec<rustledger_core::Directive> =
+            parsed.directives.iter().map(|d| (**d).clone()).collect();
+        let n = directives.len();
+        let before = directives.len();
+        let mut errors = Vec::new();
+
+        let (out, _, _) = apply_plugins(
+            &["check_drained"],
+            directives,
+            vec![0; n],
+            vec!["<test>".to_string(); n],
+            &mut errors,
+            &options,
+        );
+
+        assert!(
+            out.len() > before,
+            "check_drained must add a balance assertion for the closed \
+             `Actifs:` account; unchanged output means the renamed root was \
+             not recognized as balance-sheet, so the ledger's names never \
+             reached the plugin",
+        );
     }
 }

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1019,6 +1019,15 @@ pub fn run_plugins(
     let plugin_options = PluginOptions {
         operating_currencies: file_options.operating_currency.clone(),
         title: file_options.title.clone(),
+        // Without these a plugin can only hardcode `Expenses:` etc., which
+        // silently matches nothing on a renamed ledger (#1964).
+        account_types: rustledger_plugin::PluginAccountTypes {
+            assets: file_options.name_assets.clone(),
+            liabilities: file_options.name_liabilities.clone(),
+            equity: file_options.name_equity.clone(),
+            income: file_options.name_income.clone(),
+            expenses: file_options.name_expenses.clone(),
+        },
     };
 
     // Dispatch each entry: resolve it to a concrete runtime, then run + apply

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -297,6 +297,76 @@ pub fn validate_op_coverage(n: usize, ops: &[PluginOp]) -> Result<(), String> {
     Ok(())
 }
 
+/// The ledger's account-type root names, as configured.
+///
+/// A plugin that wants to know whether an account is an expense must ask
+/// through these rather than testing `starts_with("Expenses:")`: a ledger
+/// with `option "name_expenses" "Depenses"` has no `Expenses:` accounts at
+/// all, so a hardcoded test matches nothing and the plugin silently emits
+/// nothing — no error, no output, a clean exit (#1964).
+///
+/// Mirrors `rustledger_core::AccountTypes`, which cannot be used directly:
+/// this crate is the plugin WIRE contract and deliberately does not depend
+/// on core.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginAccountTypes {
+    /// Configured root name for Assets.
+    pub assets: String,
+    /// Configured root name for Liabilities.
+    pub liabilities: String,
+    /// Configured root name for Equity.
+    pub equity: String,
+    /// Configured root name for Income.
+    pub income: String,
+    /// Configured root name for Expenses.
+    pub expenses: String,
+}
+
+impl Default for PluginAccountTypes {
+    /// Beancount's defaults — what a ledger that renames nothing has.
+    fn default() -> Self {
+        Self {
+            assets: "Assets".to_string(),
+            liabilities: "Liabilities".to_string(),
+            equity: "Equity".to_string(),
+            income: "Income".to_string(),
+            expenses: "Expenses".to_string(),
+        }
+    }
+}
+
+impl PluginAccountTypes {
+    /// Whether `account`'s root is the configured Expenses name.
+    #[must_use]
+    pub fn is_expense(&self, account: &str) -> bool {
+        self.has_root(account, &self.expenses)
+    }
+
+    /// Whether `account`'s root is the configured Income name.
+    #[must_use]
+    pub fn is_income(&self, account: &str) -> bool {
+        self.has_root(account, &self.income)
+    }
+
+    /// Whether `account` is a balance-sheet root — Assets, Liabilities or
+    /// Equity — under this ledger's configured names.
+    #[must_use]
+    pub fn is_balance_sheet(&self, account: &str) -> bool {
+        self.has_root(account, &self.assets)
+            || self.has_root(account, &self.liabilities)
+            || self.has_root(account, &self.equity)
+    }
+
+    /// Root match on a COMPONENT boundary, not a prefix.
+    ///
+    /// `starts_with(root)` alone would match `Expenses2:Food` and
+    /// `ExpensesOld` for a root of `Expenses`; the root is the first
+    /// colon-separated component, so compare that.
+    fn has_root(&self, account: &str, root: &str) -> bool {
+        account.split(':').next().is_some_and(|first| first == root)
+    }
+}
+
 /// Ledger options passed to plugins.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PluginOptions {
@@ -304,6 +374,15 @@ pub struct PluginOptions {
     pub operating_currencies: Vec<String>,
     /// Ledger title (from `option "title" "My Ledger"`).
     pub title: Option<String>,
+    /// Configured account-type root names (`option "name_expenses"` etc.).
+    ///
+    /// `#[serde(default)]` so this stays wire-compatible both ways: a plugin
+    /// built against the older shape ignores the new field, and a plugin
+    /// built against this one reading an older host's payload gets the
+    /// beancount defaults rather than empty strings — which would classify
+    /// nothing and reproduce the bug this exists to fix.
+    #[serde(default)]
+    pub account_types: PluginAccountTypes,
 }
 
 // ============================================================================
@@ -646,7 +725,7 @@ impl CostNumberData {
             Self::Total { value } | Self::PerUnitFromTotal { total: value, .. } => Some(value),
             // Compound's `total` field is only the lump component, not
             // the whole cost — exposing it here would recreate the #1700
-            // mis-weighing in any consumer that treats it as the total.
+            // misweighing in any consumer that treats it as the total.
             Self::PerUnit { .. } | Self::Compound { .. } => None,
         }
     }
@@ -1275,6 +1354,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: Some("Test Ledger".to_string()),
+                ..Default::default()
             },
             config: Some("threshold=100".to_string()),
         };
@@ -1643,5 +1723,73 @@ mod tests {
         let decoded: MetadataOutput = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(decoded.name, original.name);
         assert_eq!(decoded.description, original.description);
+    }
+}
+
+#[cfg(test)]
+mod account_root_tests {
+    use super::PluginAccountTypes;
+
+    /// Classification follows the CONFIGURED names, not the English ones.
+    ///
+    /// This is the whole point of #1964: a plugin testing
+    /// `starts_with("Expenses:")` on a ledger with
+    /// `option "name_expenses" "Depenses"` matches nothing, so it emits
+    /// nothing — no error, no warning, a clean exit that looks like success.
+    #[test]
+    fn a_renamed_root_classifies_by_the_configured_name() {
+        let types = PluginAccountTypes {
+            expenses: "Depenses".to_string(),
+            income: "Revenu".to_string(),
+            ..PluginAccountTypes::default()
+        };
+        assert!(types.is_expense("Depenses:Food"));
+        assert!(types.is_income("Revenu:Salaire"));
+
+        // And the English names are NOT roots on this ledger — pinning that
+        // the check reads the config rather than accepting both spellings.
+        assert!(!types.is_expense("Expenses:Food"));
+        assert!(!types.is_income("Income:Salary"));
+    }
+
+    /// An unrenamed ledger keeps working.
+    #[test]
+    fn the_defaults_are_beancounts() {
+        let types = PluginAccountTypes::default();
+        assert!(types.is_expense("Expenses:Food"));
+        assert!(types.is_income("Income:Salary"));
+        assert!(types.is_balance_sheet("Assets:Bank"));
+        assert!(types.is_balance_sheet("Liabilities:CC"));
+        assert!(types.is_balance_sheet("Equity:Opening"));
+        assert!(!types.is_balance_sheet("Expenses:Food"));
+    }
+
+    /// The root is a COMPONENT, not a prefix.
+    ///
+    /// A bare `starts_with("Expenses")` would claim `Expenses2:Food` and
+    /// `ExpensesOld`. A bare account with no colon is still its own root.
+    #[test]
+    fn the_root_matches_on_a_component_boundary() {
+        let types = PluginAccountTypes::default();
+        assert!(!types.is_expense("Expenses2:Food"));
+        assert!(!types.is_expense("ExpensesOld"));
+        assert!(
+            types.is_balance_sheet("Assets"),
+            "a bare root is its own root"
+        );
+    }
+
+    /// An older host's payload, with no `account_types`, must deserialize to
+    /// the beancount defaults rather than empty strings.
+    ///
+    /// Empty strings would match no account at all and reproduce exactly the
+    /// silent-no-op this change fixes — the failure would look identical.
+    #[test]
+    fn an_older_payload_defaults_rather_than_emptying() {
+        let opts: super::PluginOptions =
+            serde_json::from_str(r#"{"operating_currencies":["USD"],"title":null}"#)
+                .expect("an older payload still loads");
+        assert_eq!(opts.account_types.expenses, "Expenses");
+        assert!(opts.account_types.is_expense("Expenses:Food"));
     }
 }

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -70,6 +70,6 @@ pub use runtime::{
     validate_plugin_module,
 };
 pub use types::{
-    DirectiveWrapper, PluginError, PluginErrorSeverity, PluginInput, PluginOp, PluginOptions,
-    PluginOutput, validate_op_coverage,
+    DirectiveWrapper, PluginAccountTypes, PluginError, PluginErrorSeverity, PluginInput, PluginOp,
+    PluginOptions, PluginOutput, validate_op_coverage,
 };

--- a/crates/rustledger-plugin/src/native/plugins/auto_tag.rs
+++ b/crates/rustledger-plugin/src/native/plugins/auto_tag.rs
@@ -145,6 +145,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/box_accrual.rs
+++ b/crates/rustledger-plugin/src/native/plugins/box_accrual.rs
@@ -276,6 +276,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -346,6 +347,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
+++ b/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
@@ -627,6 +627,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some(
                 "{'Income.*:Capital-Gains:Long': [':Long', ':Long:Gains', ':Long:Losses']}"

--- a/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
@@ -285,6 +285,7 @@ mod check_average_cost_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -372,6 +373,7 @@ mod check_average_cost_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -495,6 +497,7 @@ mod check_average_cost_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -605,6 +608,7 @@ mod check_average_cost_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/check_drained.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_drained.rs
@@ -68,14 +68,12 @@ impl NativePlugin for CheckDrainedPlugin {
 
             if let DirectiveData::Close(data) = &wrapper.data {
                 // Only generate for balance sheet accounts (Assets,
-                // Liabilities, Equity). `account_type` classifies by the
-                // root component, so both `Assets:...` and a bare `Assets`
-                // land in the same arm (the old hand-written check needed
-                // six clauses for that).
-                let is_balance_sheet = matches!(
-                    rustledger_core::account_type(&data.account),
-                    "assets" | "liabilities" | "equity"
-                );
+                // Liabilities, Equity), under THIS ledger's configured root
+                // names — `account_type` hardcodes the English ones, so a
+                // renamed ledger classified every close as off-balance-sheet
+                // and silently skipped it (#1964). Root-component match, so
+                // both `Assets:...` and a bare `Assets` qualify.
+                let is_balance_sheet = input.options.account_types.is_balance_sheet(&data.account);
 
                 if !is_balance_sheet {
                     continue;
@@ -186,6 +184,7 @@ mod check_drained_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -246,6 +245,7 @@ mod check_drained_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -346,6 +346,7 @@ mod check_drained_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/commodity_attr.rs
+++ b/crates/rustledger-plugin/src/native/plugins/commodity_attr.rs
@@ -199,6 +199,7 @@ mod commodity_attr_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("{'name': null}".to_string()),
         };
@@ -230,6 +231,7 @@ mod commodity_attr_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("{'name': null}".to_string()),
         };
@@ -259,6 +261,7 @@ mod commodity_attr_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("{'sector': ['Tech', 'Finance']}".to_string()),
         };
@@ -290,6 +293,7 @@ mod commodity_attr_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("{'sector': ['Tech', 'Finance']}".to_string()),
         };

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -397,6 +397,7 @@ mod currency_accounts_tests {
         PluginOptions {
             operating_currencies: vec!["USD".to_string()],
             title: None,
+            ..Default::default()
         }
     }
 

--- a/crates/rustledger-plugin/src/native/plugins/effective_date.rs
+++ b/crates/rustledger-plugin/src/native/plugins/effective_date.rs
@@ -391,6 +391,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -423,6 +424,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -488,6 +490,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/forecast.rs
+++ b/crates/rustledger-plugin/src/native/plugins/forecast.rs
@@ -270,6 +270,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -303,6 +304,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -330,6 +332,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -356,6 +359,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -385,6 +389,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
@@ -240,6 +240,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("USD".to_string()),
         };
@@ -284,6 +285,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("USD".to_string()),
         };
@@ -310,6 +312,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("USD".to_string()),
         };
@@ -331,6 +334,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/no_unused.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_unused.rs
@@ -155,6 +155,7 @@ mod nounused_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -213,6 +214,7 @@ mod nounused_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -253,6 +255,7 @@ mod nounused_tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/rename_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/rename_accounts.rs
@@ -276,6 +276,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("{'Expenses:Taxes': 'Income:Taxes'}".to_string()),
         };
@@ -312,6 +313,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             // Rename all Food sub-accounts to Dining
             // In Rust regex, backreferences use $1 syntax
@@ -341,6 +343,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/rx_txn.rs
+++ b/crates/rustledger-plugin/src/native/plugins/rx_txn.rs
@@ -130,6 +130,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -162,6 +163,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -194,6 +196,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -220,6 +223,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
+++ b/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
@@ -60,9 +60,18 @@ impl NativePlugin for SellGainsPlugin {
                         let expected_gain = (sale_price - cost_per) * units_num.abs();
 
                         // Look for income/expense posting that should match
-                        let has_gain_posting = txn.postings.iter().any(|p| {
-                            p.account.starts_with("Income:") || p.account.starts_with("Expenses:")
-                        });
+                        // Classify through the ledger's CONFIGURED roots. The
+                        // hardcoded `starts_with("Income:")` matched nothing on
+                        // a ledger with `option "name_income" "Revenu"`, so
+                        // every sale looked like it had no gain posting and
+                        // this plugin warned on all of them — or, read the
+                        // other way, went silent exactly where it was needed
+                        // (#1964).
+                        let roots = &input.options.account_types;
+                        let has_gain_posting = txn
+                            .postings
+                            .iter()
+                            .any(|p| roots.is_income(&p.account) || roots.is_expense(&p.account));
 
                         if expected_gain != Decimal::ZERO && !has_gain_posting {
                             errors.push(PluginError::warning(format!(

--- a/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
+++ b/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
@@ -97,11 +97,15 @@ impl NativePlugin for SplitExpensesPlugin {
                 let mut new_postings = Vec::new();
 
                 for posting in &txn.postings {
-                    // Check if this is an expense account (root-component
-                    // classification via core; identical to the old
-                    // `starts_with("Expenses:")` for any parsable account,
-                    // which always has >= 2 components).
-                    let is_expense = rustledger_core::account_type(&posting.account) == "expenses";
+                    // Classify through the ledger's CONFIGURED roots.
+                    //
+                    // This line previously read `account_type(..) == "expenses"`
+                    // with a comment noting it was "identical to the old
+                    // `starts_with(\"Expenses:\")`" — which was the problem
+                    // rather than the fix. The raw string had been replaced by
+                    // a helper hardcoding the same string, so the drift
+                    // survived being centralized (#1964).
+                    let is_expense = input.options.account_types.is_expense(&posting.account);
 
                     // Check if account already contains a member name
                     let has_member = members.iter().any(|m| posting.account.contains(m.as_str()));
@@ -257,6 +261,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("Martin Caroline".to_string()),
         };
@@ -343,6 +348,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("Martin Caroline".to_string()),
         };
@@ -388,6 +394,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger-plugin/src/native/plugins/zerosum.rs
+++ b/crates/rustledger-plugin/src/native/plugins/zerosum.rs
@@ -512,6 +512,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some(config.to_string()),
         };
@@ -566,6 +567,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some(config.to_string()),
         };
@@ -636,6 +638,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some(config.to_string()),
         };

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -1200,6 +1200,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -1242,6 +1243,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
+                ..Default::default()
             },
             config: None,
         }
@@ -1313,6 +1315,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -1352,6 +1355,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -1387,6 +1391,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
+                ..Default::default()
             },
             config: None,
         }

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -46,6 +46,7 @@ fn make_input(directives: Vec<DirectiveWrapper>) -> PluginInput {
         options: PluginOptions {
             operating_currencies: vec!["USD".to_string()],
             title: None,
+            ..Default::default()
         },
         config: None,
     }
@@ -3690,6 +3691,7 @@ fn test_check_closing_units_none_uses_operating_currency_eur() {
         options: PluginOptions {
             operating_currencies: vec!["EUR".to_string()],
             title: None,
+            ..Default::default()
         },
         config: None,
     };
@@ -3747,6 +3749,7 @@ fn test_check_closing_units_none_falls_back_to_usd_when_no_operating_ccy() {
         options: PluginOptions {
             operating_currencies: vec![],
             title: None,
+            ..Default::default()
         },
         config: None,
     };
@@ -4307,6 +4310,7 @@ fn make_input_with_config(directives: Vec<DirectiveWrapper>, config: &str) -> Pl
         options: PluginOptions {
             operating_currencies: vec!["USD".to_string()],
             title: None,
+            ..Default::default()
         },
         config: Some(config.to_string()),
     }
@@ -8614,5 +8618,58 @@ fn test_capital_gains_gain_loss_zero_renames_to_losses() {
     assert_eq!(
         renamed_units.number, "0",
         "zero amount preserved through the rename"
+    );
+}
+
+/// `split_expenses` must split on a RENAMED expense root (#1964).
+///
+/// It previously classified with `account_type(..) == "expenses"`, which
+/// hardcodes the English roots — so on `option "name_expenses" "Depenses"`
+/// nothing was an expense, nothing split, and the plugin exited cleanly having
+/// done nothing. There was no error to notice.
+///
+/// The neighboring test above is the same scenario on an UNRENAMED ledger, so
+/// the pair separates "splitting works" from "splitting works on this ledger".
+#[test]
+fn test_split_expenses_splits_a_renamed_expense_root() {
+    let plugin = SplitExpensesPlugin;
+    let mut input = make_input_with_config(
+        vec![
+            make_open("2024-01-01", "Depenses:Food"),
+            make_open("2024-01-01", "Assets:Cash"),
+            make_transaction(
+                "2024-01-15",
+                "Lunch",
+                vec![
+                    ("Depenses:Food", "100", "USD"),
+                    ("Assets:Cash", "-100", "USD"),
+                ],
+            ),
+        ],
+        "Alice Bob",
+    );
+    input.options.account_types = PluginAccountTypes {
+        expenses: "Depenses".to_string(),
+        ..PluginAccountTypes::default()
+    };
+
+    let output = process_and_materialize(&plugin, input);
+    assert!(output.errors.is_empty(), "{:?}", output.errors);
+
+    let expense_postings = output
+        .directives
+        .iter()
+        .filter_map(|d| match &d.data {
+            DirectiveData::Transaction(t) => Some(t),
+            _ => None,
+        })
+        .flat_map(|t| t.postings.iter())
+        .filter(|p| p.account.starts_with("Depenses:"))
+        .count();
+
+    assert_eq!(
+        expense_postings, 2,
+        "one sub-posting per member; 1 means the renamed root was not \
+         recognized and nothing split",
     );
 }

--- a/crates/rustledger-plugin/tests/plugin_determinism.rs
+++ b/crates/rustledger-plugin/tests/plugin_determinism.rs
@@ -121,6 +121,7 @@ fn make_input(directives: &[Directive]) -> PluginInput {
         options: PluginOptions {
             operating_currencies: vec!["USD".to_string()],
             title: None,
+            ..Default::default()
         },
         config: None,
     }

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -35,6 +35,7 @@ fn make_input(directives: Vec<DirectiveWrapper>) -> PluginInput {
         options: PluginOptions {
             operating_currencies: vec!["USD".to_string()],
             title: None,
+            ..Default::default()
         },
         config: None,
     }

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -644,6 +644,7 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
             options: PluginOptions {
                 operating_currencies: ledger.options.operating_currency.clone(),
                 title: ledger.options.title.clone(),
+                ..Default::default()
             },
             config: None,
         };

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -644,7 +644,16 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
             options: PluginOptions {
                 operating_currencies: ledger.options.operating_currency.clone(),
                 title: ledger.options.title.clone(),
-                ..Default::default()
+                // Same as the loader pipeline: CLI-specified WASM plugins must
+                // see the ledger's own root names, or they misclassify on a
+                // renamed ledger just as the native ones did (#1964).
+                account_types: rustledger_plugin::PluginAccountTypes {
+                    assets: ledger.options.name_assets.clone(),
+                    liabilities: ledger.options.name_liabilities.clone(),
+                    equity: ledger.options.name_equity.clone(),
+                    income: ledger.options.name_income.clone(),
+                    expenses: ledger.options.name_expenses.clone(),
+                },
             },
             config: None,
         };


### PR DESCRIPTION
Item 2 of #1964 — the sharpest of the three, because it **fails silently**.

## The bug

Three plugins classified accounts against the English roots:

| plugin | how |
|---|---|
| `sell_gains` | `starts_with("Income:")` / `starts_with("Expenses:")` |
| `check_drained` | `account_type(..)` matched against `"assets"｜"liabilities"｜"equity"` |
| `split_expenses` | `account_type(..) == "expenses"` |

On a ledger with `option "name_expenses" "Depenses"`, **none of those match
anything**. The plugins emit nothing, report nothing, and exit cleanly. There is
no error to notice — the ledger just quietly loses whatever the plugin was for.

`split_expenses` is the pointed case. It had already been moved *off* a raw
`starts_with("Expenses:")` onto `account_type`, with a comment stating the new
call was *"identical to the old `starts_with(\"Expenses:\")`"*. That was the
problem rather than the fix: the raw string was replaced by a helper hardcoding
the same string, so centralizing it changed nothing.

## I had this filed as blocked, and it wasn't

I wrote that this needed "a view of options that plugins may not currently get."
Wrong in the same way my note on item 1 was: **`PluginInput` already carries
`PluginOptions`** — it just didn't carry the root names. Second time this issue's
scope notes were more pessimistic than the code.

## The change

`PluginAccountTypes` joins the plugin wire contract, populated by the loader from
the file's `name_*` options, with `is_expense` / `is_income` /
`is_balance_sheet`. Root matching is on a **component boundary**, so a root of
`Expenses` does not claim `Expenses2:Food` or `ExpensesOld`.

`#[serde(default)]` both directions, and the `Default` is beancount's English
roots — **not** empty strings. Empty would match no account at all and reproduce
exactly the silent no-op being fixed, which is why there's a test for an older
payload deserializing to the defaults rather than to nothing.

## ⚠️ SemVer

Adding a field to `PluginOptions` breaks struct-literal construction for external
plugin crates, and the advisory `SemVer (plugin-types)` job will flag it.

**I did not bump the crate.** All 17 workspace crates are pinned at `0.21.0`
together, so that's a release-sequencing decision rather than mine to make in a
bug fix. In-workspace callers now use `..Default::default()`, which is also what
makes them forward-compatible with the next field added.

Worth noting the gate is advisory *by design* — its own comment says it exists to
surface exactly this for a human call.

## Tests

Four wire-level tests plus one end-to-end through `split_expenses` on a renamed
ledger. The end-to-end one sits next to the existing unrenamed-ledger test, so
the pair separates "splitting works" from "splitting works *on this ledger*".

Sabotage-verified both ways:

| sabotage | result |
|---|---|
| `split_expenses` back to the hardcoded classifier | renamed-root test fails |
| default the roots to empty strings | 3 of 4 wire tests fail |

## Verification

`cargo test --workspace` — 132 suites, 0 failures. Clippy and doc clean.

## Remaining on #1964

Only the LSP/WASM `is_account_type`, which is a *lexical* guess about a bare word
with no ledger necessarily loaded — it wants an options-when-available fallback
rather than a straight swap onto `AccountTypes`.
