### PR TITLE
fix(plugin): use an inverse rate when only the reverse pair is declared

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
@@ -143,7 +143,41 @@ fn build_price_map(
 }
 
 /// Get price for a currency pair on a specific date.
+/// The rate for `pair` as of `date`, falling back to the INVERSE of the
+/// declared pair.
+///
+/// A ledger declaring `price EUR 100 TUG` states the TUG/EUR rate just as
+/// surely as the other spelling would, and beancount treats it that way:
+/// `prices.build_price_map` inserts `(quote, base) = ONE / price` for every
+/// forward pair. rledger looked up one direction only, so on upstream's own
+/// `issue122` fixture — base EUR, with `USD 10 TUG` and `EUR 100 TUG` — it
+/// could not find TUG->EUR and silently emitted no `USD 0.10 EUR` at all
+/// (#1980). No error; just a price missing from the ledger every market
+/// valuation then reads.
+///
+/// The DECLARED direction is tried first, so a ledger stating both `A -> B`
+/// and `B -> A` keeps the rate it wrote rather than a reciprocal of the other.
 fn get_price(
+    price_map: &HashMap<(String, String), Vec<(String, Decimal)>>,
+    pair: &(String, String),
+    date: &str,
+) -> Option<Decimal> {
+    if let Some(rate) = lookup(price_map, pair, date) {
+        return Some(rate);
+    }
+    let inverse = (pair.1.clone(), pair.0.clone());
+    let rate = lookup(price_map, &inverse, date)?;
+    // Guard the reciprocal: a zero rate is a real thing in ledgers (a gifted
+    // option books at zero cost), and beancount filters those out of the
+    // inversion for the same reason rather than dividing by zero.
+    if rate.is_zero() {
+        return None;
+    }
+    Decimal::ONE.checked_div(rate)
+}
+
+/// Lookup with no inversion: the declared direction only.
+fn lookup(
     price_map: &HashMap<(String, String), Vec<(String, Decimal)>>,
     pair: &(String, String),
     date: &str,

--- a/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
@@ -167,12 +167,12 @@ fn get_price(
     }
     let inverse = (pair.1.clone(), pair.0.clone());
     let rate = lookup(price_map, &inverse, date)?;
-    // Guard the reciprocal: a zero rate is a real thing in ledgers (a gifted
-    // option books at zero cost), and beancount filters those out of the
-    // inversion for the same reason rather than dividing by zero.
-    if rate.is_zero() {
-        return None;
-    }
+    // `checked_div`, not `/`: a zero rate is a real thing in ledgers (a gifted
+    // option books at zero cost), and beancount filters those out of its own
+    // inversion rather than dividing by them. `checked_div` already returns
+    // `None` for a zero divisor, so an explicit `is_zero()` branch ahead of it
+    // would be dead — verified, and removed for that reason. Bare `/` would
+    // PANIC here, which is what the zero-rate test pins.
     Decimal::ONE.checked_div(rate)
 }
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -6170,6 +6170,108 @@ fn test_generate_base_ccy_prices_emits_derived_chain() {
     );
 }
 
+/// Only the INVERSE pair is declared — upstream's `issue122` fixture.
+///
+/// ```beancount
+/// plugin "tariochbctools.plugins.generate_base_ccy_prices" "EUR"
+/// 2020-01-01 price USD  10 TUG
+/// 2020-01-01 price EUR 100 TUG
+/// ```
+///
+/// To express `USD 10 TUG` in EUR the plugin needs TUG→EUR, and the ledger
+/// declares only EUR→TUG. beancount finds it because `build_price_map`
+/// inserts `(quote, base) = ONE / price` for every forward pair; rledger
+/// looked up one direction and silently emitted nothing (#1980) — no error,
+/// just a price missing from what every market valuation then reads.
+///
+/// Upstream's expected output is `price USD 0.10 EUR`, and the arithmetic is
+/// beancount's: invert (1/100 = 0.01), then multiply (10 * 0.01).
+#[test]
+fn test_generate_base_ccy_prices_uses_an_inverse_rate() {
+    let plugin = GenerateBaseCcyPricesPlugin;
+    let input = make_input_with_config(
+        vec![
+            make_price("2020-01-01", "USD", "10", "TUG"),
+            make_price("2020-01-01", "EUR", "100", "TUG"),
+        ],
+        "EUR",
+    );
+    let output = process_and_materialize(&plugin, input);
+    assert!(output.errors.is_empty(), "{:?}", output.errors);
+
+    let prices: Vec<_> = output
+        .directives
+        .iter()
+        .filter(|d| d.directive_type == "price")
+        .collect();
+    assert_eq!(
+        prices.len(),
+        3,
+        "two inputs plus the derived USD->EUR; 2 means the inverse rate was \
+         not found and the entry was silently skipped",
+    );
+
+    let derived = prices
+        .iter()
+        .find_map(|d| match &d.data {
+            DirectiveData::Price(p) if p.currency == "USD" && p.amount.currency == "EUR" => Some(p),
+            _ => None,
+        })
+        .expect("derived USD->EUR price must be emitted");
+    // Upstream renders `0.10`; this plugin's `format_decimal` trims trailing
+    // zeros, so the string is `0.1`. Assert the VALUE, which is what the
+    // fixture is about — and what the compat oracle compares, since
+    // `_num_agrees` quantizes before comparing. Pinning the string here would
+    // be pinning a formatting choice that has nothing to do with #1980.
+    assert_eq!(
+        derived
+            .amount
+            .number
+            .parse::<rust_decimal::Decimal>()
+            .unwrap(),
+        "0.10".parse::<rust_decimal::Decimal>().unwrap(),
+        "10 TUG * (1/100 EUR/TUG) = 0.10 EUR, matching upstream's fixture; \
+         got {}",
+        derived.amount.number,
+    );
+}
+
+/// A DECLARED direction must win over the inverse of the other.
+///
+/// With both `A -> B` and `B -> A` on the books, the rate the ledger wrote is
+/// the rate to use; falling through to a reciprocal would silently prefer
+/// derived data over stated data. Rates chosen so the two disagree — a
+/// reciprocal of 0.5 is 2, not 3 — otherwise the test cannot tell them apart.
+#[test]
+fn test_generate_base_ccy_prices_prefers_a_declared_rate_over_an_inverse() {
+    let plugin = GenerateBaseCcyPricesPlugin;
+    let input = make_input_with_config(
+        vec![
+            make_price("2020-01-01", "TUG", "3", "EUR"),
+            make_price("2020-01-01", "EUR", "0.5", "TUG"),
+            make_price("2020-01-01", "USD", "10", "TUG"),
+        ],
+        "EUR",
+    );
+    let output = process_and_materialize(&plugin, input);
+    assert!(output.errors.is_empty(), "{:?}", output.errors);
+
+    let derived = output
+        .directives
+        .iter()
+        .filter(|d| d.directive_type == "price")
+        .find_map(|d| match &d.data {
+            DirectiveData::Price(p) if p.currency == "USD" && p.amount.currency == "EUR" => Some(p),
+            _ => None,
+        })
+        .expect("derived USD->EUR price must be emitted");
+    assert_eq!(
+        derived.amount.number, "30",
+        "10 TUG * 3 EUR/TUG (DECLARED) = 30; the inverse of EUR 0.5 TUG would \
+         give 20 and would mean derived data beat stated data",
+    );
+}
+
 /// Target price already exists (ETH→USD already given) → plugin
 /// must NOT emit a duplicate. Pins the `already_existing_price`
 /// short-circuit.

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -6236,6 +6236,48 @@ fn test_generate_base_ccy_prices_uses_an_inverse_rate() {
     );
 }
 
+/// A ZERO reverse rate yields no derived price, and does not panic.
+///
+/// Zero prices are legitimate — a gifted option books at zero cost — so the
+/// inverse fallback meets them, and `1/0` has no answer. Review asked for
+/// coverage of the zero branch; the branch turned out to be redundant, because
+/// `Decimal::checked_div` already returns `None` for a zero divisor, so an
+/// explicit `is_zero()` test ahead of it could never change the outcome. It was
+/// removed rather than tested.
+///
+/// This pins the BEHAVIOR instead, which is not redundant: switching to bare
+/// `Decimal::ONE / rate` would panic on this input rather than skip the entry.
+#[test]
+fn test_generate_base_ccy_prices_skips_a_zero_inverse_rate() {
+    let plugin = GenerateBaseCcyPricesPlugin;
+    let input = make_input_with_config(
+        vec![
+            make_price("2020-01-01", "USD", "10", "TUG"),
+            make_price("2020-01-01", "EUR", "0", "TUG"),
+        ],
+        "EUR",
+    );
+    let output = process_and_materialize(&plugin, input);
+    assert!(output.errors.is_empty(), "{:?}", output.errors);
+
+    let prices: Vec<_> = output
+        .directives
+        .iter()
+        .filter(|d| d.directive_type == "price")
+        .collect();
+    assert_eq!(
+        prices.len(),
+        2,
+        "a zero reverse rate has no reciprocal, so no USD->EUR price can be \
+         derived; the two inputs must pass through unchanged",
+    );
+    assert!(
+        !prices.iter().any(|d| matches!(&d.data,
+            DirectiveData::Price(p) if p.currency == "USD" && p.amount.currency == "EUR")),
+        "no derived USD->EUR price may be emitted from a zero rate",
+    );
+}
+
 /// A DECLARED direction must win over the inverse of the other.
 ///
 /// With both `A -> B` and `B -> A` on the books, the rate the ledger wrote is


### PR DESCRIPTION
Closes #1980 — found by the price axis added in #1979, on its first full-corpus
run.

## The bug

Upstream's own `issue122` fixture:

```beancount
plugin "…generate_base_ccy_prices" "EUR"
2020-01-01 price USD  10 TUG
2020-01-01 price EUR 100 TUG
```

should generate `price USD 0.10 EUR`. **rledger emitted nothing.**

To express USD in EUR the plugin needs TUG→EUR, and the ledger declares only
EUR→TUG. `tariochbctools` finds it because it builds its map with beancount's
`prices.build_price_map`, which inserts `(quote, base) = ONE / price` for every
forward pair. rledger's plugin-local map stored one direction, so the lookup
missed and the entry was skipped — no error, just a price absent from what
`VALUE()`, `report holdings` / `networth` and the returns engine all read.

## The fix

`get_price` falls back to the inverse of the declared pair.

**Declared beats derived.** The declared direction is tried first, so a ledger
stating both `A→B` and `B→A` keeps the rate it wrote rather than a reciprocal of
the other. Tested with rates chosen so the two *disagree* — a reciprocal of 0.5
is 2, not 3 — since equal rates cannot tell the branches apart.

**Zero rates return `None` rather than dividing.** Zero prices are real (a gifted
option books at zero cost), and beancount filters them out of its own inversion
for the same reason.

## Verification

End to end on the fixture: rledger now emits all three prices.

```
2020-01-01 EUR 100 TUG
2020-01-01 USD 10 TUG
2020-01-01 USD 0.1 EUR     <-- was missing
```

The value is `0.1` where upstream renders `0.10` — this plugin's
`format_decimal` trims trailing zeros. The test asserts the **value**, which is
what the fixture is about and what the compat oracle compares (`_num_agrees`
quantizes before comparing). Pinning the string would pin a formatting choice
unrelated to this bug.

Sabotage-verified both ways:

| sabotage | result |
|---|---|
| remove the inverse fallback | `issue122` test fails |
| prefer the inverse over the declared rate | precedence test fails |

`cargo test --workspace` — 132 suites, 0 failures. Clippy clean.

## Why this one is satisfying

The inverse-synthesis in `build_price_map` is exactly the property I had to
design *around* in #1979 — comparing price directives rather than maps, because
maps would have been all false divergence. The same asymmetry I worked around in
the oracle turned out to be what the plugin was missing.
