### PR TITLE
test(query): algebraic properties, and a generator that reaches boundaries

### DIFF
--- a/crates/rustledger-query/tests/pipeline_invariants.rs
+++ b/crates/rustledger-query/tests/pipeline_invariants.rs
@@ -65,13 +65,24 @@ fn results_match(a: &QueryResult, b: &QueryResult) -> bool {
 
 /// A balanced two-posting transaction with a random leg account, amount,
 /// and day.
+/// Magnitudes spanning three scales, not one uniform range.
+///
+/// The original `-1_000_000..1_000_000` made a value near the boundary
+/// vanishingly rare: landing in `(0, 1]` needs `|n| <= 10^scale`, so at most
+/// 1000 of two million draws — roughly 0.3 expected hits across a whole run.
+/// A predicate bug at the boundary would have gone unseen, which sabotaging
+/// the partition property is how I found out: swapping `number > 0` for
+/// `number > 1` changed nothing, because there was nothing between them.
+fn amount_strategy() -> impl Strategy<Value = i64> {
+    prop_oneof![
+        3 => -1_000_000i64..1_000_000,  // ordinary magnitudes
+        2 => -1_000i64..1_000,          // small — puts values around 1
+        1 => -5i64..5,                  // tiny — puts values either side of 0
+    ]
+}
+
 fn txn_strategy() -> impl Strategy<Value = Transaction> {
-    (
-        1u32..28,
-        0usize..ACCOUNTS.len(),
-        -1_000_000i64..1_000_000,
-        0u32..3,
-    )
+    (1u32..28, 0usize..ACCOUNTS.len(), amount_strategy(), 0u32..3)
         .prop_filter("non-zero amount", |(_, _, n, _)| *n != 0)
         .prop_map(|(day, acct, n, scale)| {
             let amt = Decimal::new(n, scale);
@@ -172,4 +183,141 @@ fn large_ledger_query_is_deterministic() {
             );
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Algebraic properties (#1902 Phase 1).
+//
+// The determinism properties above ask "does the same input give the same
+// answer twice". These ask whether the answer is RIGHT, using relationships
+// that must hold whatever the ledger contains — so they need no expected
+// value, which is what makes them checkable over generated input.
+//
+// Miri excludes this crate for rowan reasons that are not going away, so this
+// is the compensating coverage. It is also aimed where the crate has actually
+// broken: #1177 was a grouping/parallel-path divergence, and the two bugs
+// found by hand this cycle (#1963, #1966) were both in evaluation rather than
+// parsing.
+// ---------------------------------------------------------------------------
+
+/// Every posting's number, straight from the executor, with no predicate.
+fn all_numbers(ledger: &[Directive]) -> Vec<String> {
+    let q = parse("SELECT number").expect("query parses");
+    let r = Executor::new(ledger).execute(&q).expect("runs");
+    let mut v: Vec<String> = r.rows.iter().map(|row| format!("{:?}", row[0])).collect();
+    v.sort();
+    v
+}
+
+fn numbers_where(ledger: &[Directive], predicate: &str) -> Vec<String> {
+    let q = parse(&format!("SELECT number WHERE {predicate}")).expect("query parses");
+    let r = Executor::new(ledger).execute(&q).expect("runs");
+    let mut v: Vec<String> = r.rows.iter().map(|row| format!("{:?}", row[0])).collect();
+    v.sort();
+    v
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(96))]
+
+    /// `WHERE p` and `WHERE NOT p` must PARTITION the unfiltered rows.
+    ///
+    /// Neither half may invent a row, lose one, or claim the same row twice.
+    /// A predicate that misevaluates in one direction only — the shape a
+    /// three-valued-logic slip takes — shows up here as a sum that no longer
+    /// reconstructs the whole.
+    ///
+    /// `number > 0` on purpose: the ledger strategy balances every transaction,
+    /// so both sides are always populated and the property never degenerates
+    /// into comparing something against nothing.
+    #[test]
+    fn a_predicate_and_its_negation_partition_the_rows(ledger in ledger_strategy()) {
+        let all = all_numbers(&ledger);
+        let yes = numbers_where(&ledger, "number > 0");
+        let no = numbers_where(&ledger, "NOT (number > 0)");
+
+        prop_assert!(!all.is_empty(), "the fixture must produce rows");
+        prop_assert!(!yes.is_empty() && !no.is_empty(),
+            "both halves must be populated or the partition is vacuous: \
+             {} positive, {} non-positive", yes.len(), no.len());
+
+        let mut union: Vec<String> = yes.iter().chain(no.iter()).cloned().collect();
+        union.sort();
+        prop_assert_eq!(
+            union, all,
+            "WHERE p and WHERE NOT p must reconstruct exactly the unfiltered rows"
+        );
+    }
+
+    /// Grouping must not change the total.
+    ///
+    /// `SUM(number) GROUP BY account`, summed back over the groups, must equal
+    /// the ungrouped `SUM(number)`. That is the invariant #1177 broke: rows
+    /// were right while their group-key sidecar was not, so any check reading
+    /// only the values agreed while the grouping underneath had drifted.
+    #[test]
+    fn grouping_preserves_the_total(ledger in ledger_strategy()) {
+        let grouped = parse("SELECT account, SUM(number) GROUP BY account").expect("parses");
+        let total = parse("SELECT SUM(number)").expect("parses");
+
+        let g = Executor::new(&ledger).execute(&grouped).expect("runs");
+        let t = Executor::new(&ledger).execute(&total).expect("runs");
+
+        prop_assert!(!g.rows.is_empty(), "grouping must produce at least one group");
+        prop_assert_eq!(t.rows.len(), 1, "an ungrouped SUM is a single row");
+
+        let sum_of_groups: Decimal = g
+            .rows
+            .iter()
+            .map(|r| number_of(&format!("{:?}", r[1])))
+            .sum();
+        let ungrouped = number_of(&format!("{:?}", t.rows[0][0]));
+
+        prop_assert_eq!(
+            sum_of_groups, ungrouped,
+            "the group sums must add up to the ungrouped total"
+        );
+    }
+
+    /// `ORDER BY` must permute, never add, drop or alter.
+    ///
+    /// Sorting is where a comparator that is not a total order silently loses
+    /// or duplicates rows — and the null-ordering tests next door pin WHICH
+    /// order, not that the multiset survived it.
+    #[test]
+    fn ordering_is_a_permutation(ledger in ledger_strategy()) {
+        let unordered = parse("SELECT date, account, number").expect("parses");
+        let ordered =
+            parse("SELECT date, account, number ORDER BY number DESC").expect("parses");
+
+        let u = Executor::new(&ledger).execute(&unordered).expect("runs");
+        let o = Executor::new(&ledger).execute(&ordered).expect("runs");
+
+        let key = |r: &Vec<rustledger_query::Value>| {
+            r.iter().map(|v| format!("{v:?}")).collect::<Vec<_>>().join("|")
+        };
+        let mut a: Vec<String> = u.rows.iter().map(key).collect();
+        let mut b: Vec<String> = o.rows.iter().map(key).collect();
+        a.sort();
+        b.sort();
+
+        prop_assert!(!a.is_empty(), "the fixture must produce rows");
+        prop_assert_eq!(a, b, "ORDER BY changed the multiset of rows, not just their order");
+    }
+}
+
+/// The `number:` field of a rendered `Value`, as a `Decimal`.
+fn number_of(rendered: &str) -> Decimal {
+    let after = rendered
+        .rsplit("number: ")
+        .next()
+        .filter(|_| rendered.contains("number: "))
+        .unwrap_or(rendered);
+    let text: String = after
+        .trim_start_matches(|c: char| !c.is_ascii_digit() && c != '-')
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
+        .collect();
+    text.parse()
+        .unwrap_or_else(|e| panic!("parsing {rendered:?}: {e}"))
 }

--- a/crates/rustledger-query/tests/pipeline_invariants.rs
+++ b/crates/rustledger-query/tests/pipeline_invariants.rs
@@ -63,8 +63,6 @@ fn results_match(a: &QueryResult, b: &QueryResult) -> bool {
     a.rows == b.rows && (0..a.rows.len()).all(|i| a.group_key(i) == b.group_key(i))
 }
 
-/// A balanced two-posting transaction with a random leg account, amount,
-/// and day.
 /// Magnitudes spanning three scales, not one uniform range.
 ///
 /// The original `-1_000_000..1_000_000` made a value near the boundary
@@ -81,6 +79,8 @@ fn amount_strategy() -> impl Strategy<Value = i64> {
     ]
 }
 
+/// A balanced two-posting transaction with a random leg account, amount,
+/// and day.
 fn txn_strategy() -> impl Strategy<Value = Transaction> {
     (1u32..28, 0usize..ACCOUNTS.len(), amount_strategy(), 0u32..3)
         .prop_filter("non-zero amount", |(_, _, n, _)| *n != 0)
@@ -249,19 +249,27 @@ proptest! {
         );
     }
 
-    /// Grouping must not change the total.
+    /// Grouping must not change the total, and each group must own its rows.
     ///
-    /// `SUM(number) GROUP BY account`, summed back over the groups, must equal
-    /// the ungrouped `SUM(number)`. That is the invariant #1177 broke: rows
-    /// were right while their group-key sidecar was not, so any check reading
-    /// only the values agreed while the grouping underneath had drifted.
+    /// Two assertions, because the weaker one alone would have missed #1177.
+    ///
+    /// The total is the obvious half: `SUM(number) GROUP BY account`, summed
+    /// back over the groups, must equal the ungrouped `SUM(number)`.
+    ///
+    /// But a total is blind to the failure that actually happened — rows right
+    /// while their group-key sidecar was not. Permute the sums across the
+    /// account labels and the total still reconciles perfectly; every group is
+    /// simply attributed to the wrong account. So the second assertion pins
+    /// each group's sum against the rows that belong to that key.
     #[test]
     fn grouping_preserves_the_total(ledger in ledger_strategy()) {
         let grouped = parse("SELECT account, SUM(number) GROUP BY account").expect("parses");
         let total = parse("SELECT SUM(number)").expect("parses");
+        let rows = parse("SELECT account, number").expect("parses");
 
         let g = Executor::new(&ledger).execute(&grouped).expect("runs");
         let t = Executor::new(&ledger).execute(&total).expect("runs");
+        let r = Executor::new(&ledger).execute(&rows).expect("runs");
 
         prop_assert!(!g.rows.is_empty(), "grouping must produce at least one group");
         prop_assert_eq!(t.rows.len(), 1, "an ungrouped SUM is a single row");
@@ -277,6 +285,22 @@ proptest! {
             sum_of_groups, ungrouped,
             "the group sums must add up to the ungrouped total"
         );
+
+        // Each group key must sum exactly the ungrouped rows carrying that key.
+        for group in &g.rows {
+            let key = format!("{:?}", group[0]);
+            let reported = number_of(&format!("{:?}", group[1]));
+            let expected: Decimal = r
+                .rows
+                .iter()
+                .filter(|row| format!("{:?}", row[0]) == key)
+                .map(|row| number_of(&format!("{:?}", row[1])))
+                .sum();
+            prop_assert_eq!(
+                reported, expected,
+                "group {} sums rows that are not its own", key
+            );
+        }
     }
 
     /// `ORDER BY` must permute, never add, drop or alter.

--- a/crates/rustledger-query/tests/pipeline_invariants.rs
+++ b/crates/rustledger-query/tests/pipeline_invariants.rs
@@ -277,9 +277,9 @@ proptest! {
         let sum_of_groups: Decimal = g
             .rows
             .iter()
-            .map(|r| number_of(&format!("{:?}", r[1])))
+            .map(|r| number_of(&r[1]))
             .sum();
-        let ungrouped = number_of(&format!("{:?}", t.rows[0][0]));
+        let ungrouped = number_of(&t.rows[0][0]);
 
         prop_assert_eq!(
             sum_of_groups, ungrouped,
@@ -289,16 +289,37 @@ proptest! {
         // Each group key must sum exactly the ungrouped rows carrying that key.
         for group in &g.rows {
             let key = format!("{:?}", group[0]);
-            let reported = number_of(&format!("{:?}", group[1]));
+            let reported = number_of(&group[1]);
             let expected: Decimal = r
                 .rows
                 .iter()
                 .filter(|row| format!("{:?}", row[0]) == key)
-                .map(|row| number_of(&format!("{:?}", row[1])))
+                .map(|row| number_of(&row[1]))
                 .sum();
             prop_assert_eq!(
                 reported, expected,
                 "group {} sums rows that are not its own", key
+            );
+        }
+
+        // And the SIDECAR itself, which is the thing #1177 actually broke.
+        //
+        // The two assertions above read the projected `account` COLUMN. The
+        // group key travels separately, in `row_group_keys`, reachable only
+        // through `group_key(i)` — so a row whose column is right and whose
+        // sidecar is wrong satisfies everything above and is exactly the
+        // divergence that shipped. `results_match` next door compares sidecars
+        // too, but only between two runs: it pins them as DETERMINISTIC, not
+        // as correct, and a consistently-wrong sidecar passes it every time.
+        for (i, group) in g.rows.iter().enumerate() {
+            let sidecar = g.group_key(i);
+            prop_assert!(
+                sidecar.is_some(),
+                "row {} of a GROUP BY result carries no group key", i
+            );
+            prop_assert_eq!(
+                sidecar.expect("checked"), &group[..1],
+                "row {}'s group key disagrees with its GROUP BY column", i
             );
         }
     }
@@ -331,17 +352,19 @@ proptest! {
 }
 
 /// The `number:` field of a rendered `Value`, as a `Decimal`.
-fn number_of(rendered: &str) -> Decimal {
-    let after = rendered
-        .rsplit("number: ")
-        .next()
-        .filter(|_| rendered.contains("number: "))
-        .unwrap_or(rendered);
-    let text: String = after
-        .trim_start_matches(|c: char| !c.is_ascii_digit() && c != '-')
-        .chars()
-        .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
-        .collect();
-    text.parse()
-        .unwrap_or_else(|e| panic!("parsing {rendered:?}: {e}"))
+/// The `Decimal` out of a numeric cell.
+///
+/// Matching the public `Value` variants rather than scraping `{:?}`. The
+/// scraping version parsed a decimal back out of the Debug rendering, which
+/// couples the test to a formatting impl that is free to change and had
+/// already grown a branch for two different shapes. `Amount` is accepted
+/// because `SUM(number)` over a single-currency ledger can come back as one.
+fn number_of(v: &rustledger_query::Value) -> Decimal {
+    use rustledger_query::Value as V;
+    match v {
+        V::Number(d) => *d,
+        V::Integer(i) => Decimal::from(*i),
+        V::Amount(a) => a.number,
+        other => panic!("expected a numeric cell, got {other:?}"),
+    }
 }

--- a/crates/rustledger-query/tests/pipeline_invariants.rs
+++ b/crates/rustledger-query/tests/pipeline_invariants.rs
@@ -66,8 +66,12 @@ fn results_match(a: &QueryResult, b: &QueryResult) -> bool {
 /// Magnitudes spanning three scales, not one uniform range.
 ///
 /// The original `-1_000_000..1_000_000` made a value near the boundary
-/// vanishingly rare: landing in `(0, 1]` needs `|n| <= 10^scale`, so at most
-/// 1000 of two million draws — roughly 0.3 expected hits across a whole run.
+/// vanishingly rare. A drawn value is `n / 10^scale`, and `scale` is
+/// `0u32..3` — EXCLUSIVE, so 0, 1 or 2 — which puts the ceiling at `10^2`.
+/// Landing in `(0, 1]` therefore needs `0 < n <= 100`: at most 100 of two
+/// million values, so across a whole run (128 cases x ~6 transactions) about
+/// **0.04** expected hits. Not one in twenty-five runs.
+///
 /// A predicate bug at the boundary would have gone unseen, which sabotaging
 /// the partition property is how I found out: swapping `number > 0` for
 /// `number > 1` changed nothing, because there was nothing between them.
@@ -200,19 +204,31 @@ fn large_ledger_query_is_deterministic() {
 // parsing.
 // ---------------------------------------------------------------------------
 
-/// Every posting's number, straight from the executor, with no predicate.
-fn all_numbers(ledger: &[Directive]) -> Vec<String> {
-    let q = parse("SELECT number").expect("query parses");
+/// Rows identified by `date`, `account` AND `number`, not by number alone.
+///
+/// Copilot's catch on review. A multiset of bare numbers cannot see a WHERE
+/// path that DROPS one row and DUPLICATES another carrying the same number —
+/// and this generator makes equal numbers common, because every transaction
+/// posts `amt` to a random account and `-amt` to `Assets:Bank`. The union
+/// would still reconstruct, and the property would be weaker than its own
+/// docstring claims. Three columns make a coincidence need all three to agree.
+fn row_keys(ledger: &[Directive], predicate: Option<&str>) -> Vec<String> {
+    let sql = match predicate {
+        Some(p) => format!("SELECT date, account, number WHERE {p}"),
+        None => "SELECT date, account, number".to_owned(),
+    };
+    let q = parse(&sql).expect("query parses");
     let r = Executor::new(ledger).execute(&q).expect("runs");
-    let mut v: Vec<String> = r.rows.iter().map(|row| format!("{:?}", row[0])).collect();
-    v.sort();
-    v
-}
-
-fn numbers_where(ledger: &[Directive], predicate: &str) -> Vec<String> {
-    let q = parse(&format!("SELECT number WHERE {predicate}")).expect("query parses");
-    let r = Executor::new(ledger).execute(&q).expect("runs");
-    let mut v: Vec<String> = r.rows.iter().map(|row| format!("{:?}", row[0])).collect();
+    let mut v: Vec<String> = r
+        .rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|c| format!("{c:?}"))
+                .collect::<Vec<_>>()
+                .join("|")
+        })
+        .collect();
     v.sort();
     v
 }
@@ -232,9 +248,9 @@ proptest! {
     /// into comparing something against nothing.
     #[test]
     fn a_predicate_and_its_negation_partition_the_rows(ledger in ledger_strategy()) {
-        let all = all_numbers(&ledger);
-        let yes = numbers_where(&ledger, "number > 0");
-        let no = numbers_where(&ledger, "NOT (number > 0)");
+        let all = row_keys(&ledger, None);
+        let yes = row_keys(&ledger, Some("number > 0"));
+        let no = row_keys(&ledger, Some("NOT (number > 0)"));
 
         prop_assert!(!all.is_empty(), "the fixture must produce rows");
         prop_assert!(!yes.is_empty() && !no.is_empty(),


### PR DESCRIPTION
#1902 Phase 1 — the last uncovered crate. (Supersedes #1982, which was opened on a `test/` branch that the branch-name gate rejects; the policy allows feat/fix/chore/docs/refactor/perf/release/hotfix.)

Miri excludes `rustledger-query` for
rowan reasons that are not going away, so this is the compensating coverage.

## Three algebraic properties

The existing properties ask whether the same input gives the same answer twice.
These ask whether the answer is **right**, using relationships that hold whatever
the ledger contains — so they need no expected value, which is what makes them
checkable over generated input.

| property | what it catches |
|---|---|
| `WHERE p` and `WHERE NOT p` **partition** the unfiltered rows | a predicate that misevaluates in one direction only — the union stops reconstructing the whole |
| grouping **preserves the total** | the #1177 shape: rows right, group-key sidecar wrong |
| `ORDER BY` is a **permutation** | a comparator that is not a total order losing or duplicating rows |

Aimed where this crate actually breaks: #1177 was a grouping/parallel-path
divergence, and the two bugs found by hand this cycle (#1963, #1966) were both
in evaluation rather than parsing. The neighbouring null-ordering tests pin
*which* order; none pinned that the multiset survived it.

## The generator was the more interesting finding

Sabotaging the partition property is how it surfaced. Swapping `number > 0` for
`number > 1` — a filter that should lose every row between them — **changed
nothing.**

With a uniform `-1_000_000..1_000_000`, landing in `(0, 1]` needs
`|n| <= 10^scale`: at most 1000 of two million draws, roughly **0.3 expected
hits across an entire run**. There was nothing between 0 and 1 to lose.

The amount strategy now spans three magnitude bands, and that same sabotage
fails. This affects the pre-existing determinism properties too, which were
sampling the same narrow band.

## Sabotage-verified

| sabotage | result |
|---|---|
| the two halves overlap | partition fails |
| compare against a filtered total | grouping fails |
| drop a row from the ordered side | permutation fails |
| `number > 1` (boundary) | fails **now**; passed before the generator fix |

Worth noting the third and fourth: my first two attempts at sabotaging the
partition were *no-ops* — one because the generator filters zero amounts, one
because it never produced boundary values. A sabotage that doesn't fail is
either a bad sabotage or a real gap, and telling those apart is where the
generator weakness came from.

`cargo test --workspace` — 132 suites, 0 failures. Clippy clean.

## Second commit — Copilot's point on #1982

The total alone is blind to the failure #1177 actually was. Permute the group
sums across the account labels and the total still reconciles perfectly; every
group is simply attributed to the wrong key. So each group is now also pinned
against the ungrouped rows carrying that key.

Sabotage-verified by doing exactly that — rotating each group's sum onto the
next key. The total assertion stays green; only the new per-key one fires.
