### PR TITLE
fix(ffi): metadata is part of a directive's identity

### DIFF
--- a/crates/rustledger-ffi-wasi/src/hash.rs
+++ b/crates/rustledger-ffi-wasi/src/hash.rs
@@ -200,7 +200,10 @@ fn incomplete_amount(hasher: &mut Sha256, amount: Option<&rustledger_core::Incom
 /// exhaustive match means adding a variant is a compile error here - which
 /// forces the identity question to be answered rather than silently defaulted.
 ///
-/// Posting `meta` and comments are deliberately NOT hashed; see #1968.
+/// Posting `meta` IS hashed and posting comments are not — the #1968 split.
+/// Metadata is structured user data with a write API premised on it being
+/// meaningful; comments are presentation, and do not reliably survive a
+/// parse/format round trip. See [`metadata`].
 fn posting_identity(hasher: &mut Sha256, p: &rustledger_core::directive::Posting) {
     use rustledger_core::CostNumber;
 

--- a/crates/rustledger-ffi-wasi/src/hash.rs
+++ b/crates/rustledger-ffi-wasi/src/hash.rs
@@ -85,6 +85,93 @@ fn decimal(hasher: &mut Sha256, d: rustledger_core::Decimal) {
     field(hasher, d.to_string().as_bytes());
 }
 
+/// Feed one metadata VALUE in, variant-tagged.
+///
+/// The tag is not decoration. `MetaValue`'s `Display` is lossy across variants -
+/// `Number(42)` and `Int(42)` both render `42`, and `Account("Assets:A")`
+/// renders the same as a `String` would if the quoting were dropped - so
+/// hashing the rendering would collide `key: 42` with `key: 42.0` where the
+/// parser went to deliberate trouble (#1766) to keep them distinct.
+///
+/// Written out variant by variant rather than through `Display` for the same
+/// reason `CostNumber` is below: an exhaustive match means adding a variant is
+/// a compile error here, which forces the identity question to be answered
+/// rather than silently defaulted. `MetaValue::Int` was appended once already.
+fn meta_value(hasher: &mut Sha256, v: &rustledger_core::MetaValue) {
+    use rustledger_core::MetaValue as V;
+
+    match v {
+        V::String(s) => {
+            hasher.update([1u8]);
+            field(hasher, s.as_bytes());
+        }
+        V::Account(a) => {
+            hasher.update([2u8]);
+            field(hasher, a.as_bytes());
+        }
+        V::Currency(c) => {
+            hasher.update([3u8]);
+            field(hasher, c.as_bytes());
+        }
+        V::Tag(t) => {
+            hasher.update([4u8]);
+            field(hasher, t.as_bytes());
+        }
+        V::Link(l) => {
+            hasher.update([5u8]);
+            field(hasher, l.as_bytes());
+        }
+        V::Date(d) => {
+            hasher.update([6u8]);
+            field(hasher, d.to_string().as_bytes());
+        }
+        V::Number(n) => {
+            hasher.update([7u8]);
+            decimal(hasher, *n);
+        }
+        V::Bool(b) => {
+            hasher.update([8u8]);
+            hasher.update([u8::from(*b)]);
+        }
+        V::Amount(a) => {
+            hasher.update([9u8]);
+            decimal(hasher, a.number);
+            field(hasher, a.currency.as_bytes());
+        }
+        V::None => hasher.update([10u8]),
+        V::Int(i) => {
+            hasher.update([11u8]);
+            field(hasher, i.to_string().as_bytes());
+        }
+    }
+}
+
+/// Feed a directive's or posting's user metadata in, key-sorted.
+///
+/// `Metadata` is an `FxHashMap`, so its iteration order is not stable across
+/// runs - hashing it as it iterates would make the digest nondeterministic,
+/// which is the one thing every consumer relies on. Sorting by key also makes
+/// this agree with `meta_entries_from_core` in the component's converter, which
+/// sorts for the same reason before filling the WIT `user` list. The two now
+/// order the same data the same way.
+///
+/// Metadata is IN the identity per #1968: it is structured user data with a
+/// whole write API (`insert_metadata`) premised on it being meaningful, so two
+/// postings differing only by a metadata key are not the same object.
+///
+/// Comments are OUT, per the same decision. They are presentation rather than
+/// data, they do not reliably survive a parse/format round trip, and including
+/// them would mean fixing a typo in a comment changes a directive's identity.
+fn metadata(hasher: &mut Sha256, m: &rustledger_core::Metadata) {
+    count(hasher, m.len());
+    let mut keys: Vec<&String> = m.keys().collect();
+    keys.sort_unstable();
+    for k in keys {
+        field(hasher, k.as_bytes());
+        meta_value(hasher, &m[k]);
+    }
+}
+
 /// Feed an optional amount in, presence-tagged, number then currency.
 fn incomplete_amount(hasher: &mut Sha256, amount: Option<&rustledger_core::IncompleteAmount>) {
     match amount {
@@ -167,6 +254,9 @@ fn posting_identity(hasher: &mut Sha256, p: &rustledger_core::directive::Posting
         }
         None => hasher.update([0u8]),
     }
+
+    metadata(hasher, &p.meta);
+    // `comments` / `trailing_comments` are deliberately NOT hashed - #1968.
 }
 
 /// Compute a SHA256 hash of a directive for unique identification.
@@ -193,6 +283,8 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             for posting in &t.postings {
                 posting_identity(&mut hasher, posting);
             }
+            metadata(&mut hasher, &t.meta);
+            // `trailing_comments` deliberately NOT hashed - #1968.
         }
         Directive::Open(o) => {
             field(&mut hasher, b"Open");
@@ -202,11 +294,17 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             for c in &o.currencies {
                 field(&mut hasher, c.as_bytes());
             }
+            // Never consulted before: two Opens differing only by booking
+            // method hashed identically, and the method decides how every
+            // reduction against the account is booked.
+            opt(&mut hasher, o.booking.as_deref().map(str::as_bytes));
+            metadata(&mut hasher, &o.meta);
         }
         Directive::Close(c) => {
             field(&mut hasher, b"Close");
             field(&mut hasher, c.date.to_string().as_bytes());
             field(&mut hasher, c.account.as_bytes());
+            metadata(&mut hasher, &c.meta);
         }
         Directive::Balance(b) => {
             field(&mut hasher, b"Balance");
@@ -214,17 +312,24 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             field(&mut hasher, b.account.as_bytes());
             field(&mut hasher, b.amount.number.to_string().as_bytes());
             field(&mut hasher, b.amount.currency.as_bytes());
+            // Never consulted before: `100 USD` and `100 USD ~ 0.05` are
+            // different assertions and hashed the same.
+            let tolerance = b.tolerance.map(|t| t.to_string());
+            opt(&mut hasher, tolerance.as_deref().map(str::as_bytes));
+            metadata(&mut hasher, &b.meta);
         }
         Directive::Pad(p) => {
             field(&mut hasher, b"Pad");
             field(&mut hasher, p.date.to_string().as_bytes());
             field(&mut hasher, p.account.as_bytes());
             field(&mut hasher, p.source_account.as_bytes());
+            metadata(&mut hasher, &p.meta);
         }
         Directive::Commodity(c) => {
             field(&mut hasher, b"Commodity");
             field(&mut hasher, c.date.to_string().as_bytes());
             field(&mut hasher, c.currency.as_bytes());
+            metadata(&mut hasher, &c.meta);
         }
         Directive::Price(p) => {
             field(&mut hasher, b"Price");
@@ -232,35 +337,57 @@ pub fn compute_directive_hash(directive: &Directive) -> String {
             field(&mut hasher, p.currency.as_bytes());
             field(&mut hasher, p.amount.number.to_string().as_bytes());
             field(&mut hasher, p.amount.currency.as_bytes());
+            metadata(&mut hasher, &p.meta);
         }
         Directive::Event(e) => {
             field(&mut hasher, b"Event");
             field(&mut hasher, e.date.to_string().as_bytes());
             field(&mut hasher, e.event_type.as_bytes());
             field(&mut hasher, e.value.as_bytes());
+            metadata(&mut hasher, &e.meta);
         }
         Directive::Note(n) => {
             field(&mut hasher, b"Note");
             field(&mut hasher, n.date.to_string().as_bytes());
             field(&mut hasher, n.account.as_bytes());
             field(&mut hasher, n.comment.as_bytes());
+            metadata(&mut hasher, &n.meta);
         }
         Directive::Document(d) => {
             field(&mut hasher, b"Document");
             field(&mut hasher, d.date.to_string().as_bytes());
             field(&mut hasher, d.account.as_bytes());
             field(&mut hasher, d.path.as_bytes());
+            // Never consulted before: a Document carries tags and links just
+            // as a Transaction does, and neither reached the digest.
+            count(&mut hasher, d.tags.len());
+            for tag in &d.tags {
+                field(&mut hasher, tag.as_bytes());
+            }
+            count(&mut hasher, d.links.len());
+            for link in &d.links {
+                field(&mut hasher, link.as_bytes());
+            }
+            metadata(&mut hasher, &d.meta);
         }
         Directive::Query(q) => {
             field(&mut hasher, b"Query");
             field(&mut hasher, q.date.to_string().as_bytes());
             field(&mut hasher, q.name.as_bytes());
             field(&mut hasher, q.query.as_bytes());
+            metadata(&mut hasher, &q.meta);
         }
         Directive::Custom(c) => {
             field(&mut hasher, b"Custom");
             field(&mut hasher, c.date.to_string().as_bytes());
             field(&mut hasher, c.custom_type.as_bytes());
+            // Never consulted before: the values ARE the directive. Every
+            // `custom "budget"` on a given date hashed identically.
+            count(&mut hasher, c.values.len());
+            for v in &c.values {
+                meta_value(&mut hasher, v);
+            }
+            metadata(&mut hasher, &c.meta);
         }
     }
 

--- a/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
+++ b/crates/rustledger-ffi-wasi/tests/hash_identity_properties.rs
@@ -380,3 +380,267 @@ fn cost_price_and_flag_are_part_of_posting_identity() {
         cases.len(),
     );
 }
+
+/// Build a metadata map from key/value pairs.
+fn meta(pairs: &[(&str, rustledger_core::MetaValue)]) -> Metadata {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), v.clone()))
+        .collect()
+}
+
+fn txn_with_meta(m: Metadata) -> Directive {
+    let Directive::Transaction(mut t) = txn(None, "n", &[], &[]) else {
+        unreachable!()
+    };
+    t.meta = m;
+    Directive::Transaction(t)
+}
+
+/// User metadata is part of a directive's identity — the #1968 decision.
+///
+/// Two directives differing only by a metadata key were the same object to
+/// every consumer of `meta.hash`, including rustfava's `insert_metadata`, which
+/// resolves an entry BY hash and then writes to that entry's line without any
+/// second factor. The endpoint whose whole job is creating metadata-only
+/// differences was the one unguarded against them.
+#[test]
+fn metadata_is_part_of_the_identity() {
+    use rustledger_core::MetaValue as V;
+
+    let none = txn_with_meta(meta(&[]));
+    let a = txn_with_meta(meta(&[("k", V::String("a".into()))]));
+    let b = txn_with_meta(meta(&[("k", V::String("b".into()))]));
+    let other_key = txn_with_meta(meta(&[("j", V::String("a".into()))]));
+    let two = txn_with_meta(meta(&[
+        ("k", V::String("a".into())),
+        ("j", V::String("b".into())),
+    ]));
+
+    let cases: [(&Directive, &Directive, &str); 4] = [
+        (&none, &a, "metadata present vs absent"),
+        (&a, &b, "a different value under the same key"),
+        (&a, &other_key, "the same value under a different key"),
+        (&a, &two, "an additional key"),
+    ];
+    let collisions: Vec<&str> = cases
+        .iter()
+        .filter(|(left, right, _)| hash(left) == hash(right))
+        .map(|(_, _, what)| *what)
+        .collect();
+    assert!(
+        collisions.is_empty(),
+        "{} of {} metadata cases collided: {collisions:#?}",
+        collisions.len(),
+        cases.len(),
+    );
+}
+
+/// A metadata VALUE's type is part of its identity, not just its rendering.
+///
+/// `MetaValue`'s `Display` is lossy across variants: `Number(42)` and `Int(42)`
+/// both render `42`. The parser goes to deliberate trouble (#1766) to keep
+/// those distinct, so hashing the rendering would throw the distinction away
+/// again one layer down. Hence the variant tag.
+#[test]
+fn metadata_value_types_do_not_collide() {
+    use rustledger_core::MetaValue as V;
+
+    let int = txn_with_meta(meta(&[("k", V::Int(42))]));
+    let number = txn_with_meta(meta(&[("k", V::Number(42.into()))]));
+    let string = txn_with_meta(meta(&[("k", V::String("42".into()))]));
+    let null = txn_with_meta(meta(&[("k", V::None)]));
+    let bool_true = txn_with_meta(meta(&[("k", V::Bool(true))]));
+    let bool_false = txn_with_meta(meta(&[("k", V::Bool(false))]));
+
+    let cases: [(&Directive, &Directive, &str); 4] = [
+        (&int, &number, "Int(42) vs Number(42) — both render `42`"),
+        (&int, &string, "Int(42) vs String(\"42\")"),
+        (&null, &bool_false, "None vs Bool(false)"),
+        (&bool_true, &bool_false, "Bool(true) vs Bool(false)"),
+    ];
+    let collisions: Vec<&str> = cases
+        .iter()
+        .filter(|(left, right, _)| hash(left) == hash(right))
+        .map(|(_, _, what)| *what)
+        .collect();
+    assert!(
+        collisions.is_empty(),
+        "{} of {} meta-value cases collided: {collisions:#?}",
+        collisions.len(),
+        cases.len(),
+    );
+}
+
+/// The same metadata hashes the same however the map was built.
+///
+/// `Metadata` is an `FxHashMap`, so iteration order is an implementation
+/// detail. Hashing it as it iterates would make the digest depend on insertion
+/// history — nondeterminism in the one field every consumer treats as stable.
+/// Inserting the same pairs in the opposite order is the cheapest way to reach
+/// a differently-ordered map.
+#[test]
+fn metadata_hashing_does_not_depend_on_map_order() {
+    use rustledger_core::MetaValue as V;
+
+    let pairs = [
+        ("alpha", V::String("1".into())),
+        ("beta", V::Int(2)),
+        ("gamma", V::Bool(true)),
+        ("delta", V::None),
+    ];
+    let mut forward = Metadata::default();
+    for (k, v) in &pairs {
+        forward.insert((*k).to_owned(), v.clone());
+    }
+    let mut backward = Metadata::default();
+    for (k, v) in pairs.iter().rev() {
+        backward.insert((*k).to_owned(), v.clone());
+    }
+
+    // Self-check FIRST. This test only exercises the sort if the two maps
+    // actually iterate differently — and whether they do is a property of
+    // these particular keys and `FxHashMap`'s bucket layout, not something
+    // the test controls. If a hasher change or a different key set ever makes
+    // both iterate identically, the assertion below would pass with the sort
+    // deleted. Failing loudly here is the difference between a guard and a
+    // decoration.
+    let f: Vec<&String> = forward.keys().collect();
+    let b: Vec<&String> = backward.keys().collect();
+    assert_ne!(
+        f, b,
+        "these two maps iterate identically, so this test can no longer \
+         distinguish a sorted digest from an unsorted one — pick keys that \
+         do produce different orders"
+    );
+
+    assert_eq!(
+        hash(&txn_with_meta(forward)),
+        hash(&txn_with_meta(backward)),
+        "insertion order must not reach the digest"
+    );
+}
+
+/// Comments are deliberately NOT part of the identity — the other half of
+/// #1968.
+///
+/// This asserts a deliberate collision, which is the only way to pin a decision
+/// to EXCLUDE something: if a future change starts hashing comments, this test
+/// fails and the decision gets re-made on purpose rather than by accident.
+#[test]
+fn comments_are_deliberately_not_part_of_the_identity() {
+    let plain = txn(None, "n", &[], &[]);
+
+    let Directive::Transaction(mut t) = txn(None, "n", &[], &[]) else {
+        unreachable!()
+    };
+    t.trailing_comments = vec!["; a note to self".to_owned()];
+    let commented = Directive::Transaction(t);
+
+    assert_eq!(
+        hash(&plain),
+        hash(&commented),
+        "a comment must not change a directive's identity (#1968)"
+    );
+}
+
+/// Fields that reached NO digest at all, found by auditing every directive
+/// struct's fields against the arms of `compute_directive_hash`.
+///
+/// Same defect class as the `cost`/`price`/`flag` omission #1961 fixed — not
+/// two fields blurring together, but fields never consulted. These are not the
+/// #1968 judgment call; each is unambiguously identity-bearing:
+///
+/// - `Open::booking` decides how every reduction against the account is booked.
+/// - `Balance::tolerance` — `100 USD` and `100 USD ~ 0.05` are different
+///   assertions, and one can pass where the other fails.
+/// - `Document::tags`/`links` — a Document carries both, exactly as a
+///   Transaction does.
+/// - `Custom::values` — the values ARE the directive. Every `custom "budget"`
+///   on a given date hashed identically.
+#[test]
+fn every_directive_field_reaches_the_digest() {
+    use rustledger_core::MetaValue as V;
+    use rustledger_core::directive::{Balance, Custom, Document, Open};
+
+    let d = naive_date(2024, 1, 1).unwrap();
+    let amount = rustledger_core::Amount::new(rustledger_core::Decimal::ONE, "USD");
+
+    let mut open_fifo = Open::new(d, "Assets:A");
+    open_fifo.booking = Some("FIFO".to_owned());
+    let mut open_lifo = Open::new(d, "Assets:A");
+    open_lifo.booking = Some("LIFO".to_owned());
+    let open_none = Open::new(d, "Assets:A");
+
+    let bal_plain = Balance::new(d, "Assets:A", amount.clone());
+    let mut bal_tol = Balance::new(d, "Assets:A", amount.clone());
+    bal_tol.tolerance = Some("0.05".parse().unwrap());
+    let mut bal_tol2 = Balance::new(d, "Assets:A", amount);
+    bal_tol2.tolerance = Some("0.50".parse().unwrap());
+
+    let doc_plain = Document::new(d, "Assets:A", "/x.pdf");
+    let mut doc_tagged = Document::new(d, "Assets:A", "/x.pdf");
+    doc_tagged.tags = vec![Tag::new("t")];
+    let mut doc_linked = Document::new(d, "Assets:A", "/x.pdf");
+    doc_linked.links = vec![Link::new("t")];
+
+    let mut custom_a = Custom::new(d, "budget");
+    custom_a.values = vec![V::String("a".into())];
+    let mut custom_b = Custom::new(d, "budget");
+    custom_b.values = vec![V::String("b".into())];
+    let custom_empty = Custom::new(d, "budget");
+
+    let pairs: Vec<(Directive, Directive, &str)> = vec![
+        (
+            Directive::Open(open_fifo.clone()),
+            Directive::Open(open_lifo),
+            "Open: FIFO vs LIFO",
+        ),
+        (
+            Directive::Open(open_fifo),
+            Directive::Open(open_none),
+            "Open: a booking method vs none",
+        ),
+        (
+            Directive::Balance(bal_plain),
+            Directive::Balance(bal_tol.clone()),
+            "Balance: a tolerance vs none",
+        ),
+        (
+            Directive::Balance(bal_tol),
+            Directive::Balance(bal_tol2),
+            "Balance: a different tolerance",
+        ),
+        (
+            Directive::Document(doc_plain),
+            Directive::Document(doc_tagged.clone()),
+            "Document: a tag vs none",
+        ),
+        (
+            Directive::Document(doc_tagged),
+            Directive::Document(doc_linked),
+            "Document: the same name as a tag vs as a link",
+        ),
+        (
+            Directive::Custom(custom_a.clone()),
+            Directive::Custom(custom_b),
+            "Custom: a different value",
+        ),
+        (
+            Directive::Custom(custom_a),
+            Directive::Custom(custom_empty),
+            "Custom: a value vs none",
+        ),
+    ];
+    let collisions: Vec<&str> = pairs
+        .iter()
+        .filter(|(left, right, _)| hash(left) == hash(right))
+        .map(|(_, _, what)| *what)
+        .collect();
+    assert!(
+        collisions.is_empty(),
+        "{} of {} never-hashed-field cases collided: {collisions:#?}",
+        collisions.len(),
+        pairs.len(),
+    );
+}


### PR DESCRIPTION
Closes #1968 — with **option B**: metadata in, comments out.

## Why this way

`meta.hash` is not a label, it's a **write address**. rustfava resolves an entry
by it and then mutates that entry's line in the source file — `save_entry_slice`,
`delete_entry_slice`, `insert_metadata`.

Two of those carry a second factor (the sha256sum of the displayed source slice),
so a wrong resolution is caught. **`insert_metadata` carries nothing** — and it is
the endpoint whose entire job is *creating metadata-only differences*. The one
operation that could act on a metadata collision was the one operation unguarded
against it.

**Comments stay out.** They're presentation, they don't reliably survive a
parse/format round trip, and including them would mean fixing a typo in a comment
changes a directive's identity. `comments_are_deliberately_not_part_of_the_identity`
pins that, because a decision to *exclude* something is only recorded if a test
fails when someone quietly reverses it.

**This is closer to where fava started.** Before the rustledger hash was bolted on,
rustfava called `beancount.core.compare.hash_entry(entry)` — default
`exclude_meta=False`, i.e. metadata *including filename and lineno*. Beancount's
own docstring: *"when you're using the hashes to uniquely identify transactions,
you want to include the filenames and line numbers."*

## What this is not

**Uniqueness.** Two transactions identical in every hashed field still collide, and
duplicates like that are ordinary in real ledgers. Only hashing source position
would make it unique, and that costs stability under every edit above the entry.
The consumer-side half is rustfava#273, which stops `_get_entry` silently picking
the first match.

## Two details that aren't incidental

- **Keys are sorted.** `Metadata` is an `FxHashMap`; hashing it in iteration order
  would make the digest depend on insertion history — nondeterminism in the one
  field every consumer treats as stable. Sorting also matches
  `meta_entries_from_core` in the component converter, which sorts for the same
  reason.
- **Values are variant-tagged, not rendered.** `MetaValue`'s `Display` is lossy:
  `Number(42)` and `Int(42)` both print `42`. #1766 went to deliberate trouble to
  keep those distinct; hashing the rendering would throw it away one layer down.

## Separately — four fields reached no digest at all

Not the #1968 judgment call. Found by auditing every directive struct's fields
against the arms of `compute_directive_hash`; same class as the `cost`/`price`/
`flag` omission #1961 fixed.

| field | what collided |
|---|---|
| `Open::booking` | FIFO vs LIFO — and the method decides how every reduction against the account books |
| `Balance::tolerance` | `100 USD` and `100 USD ~ 0.05` are different assertions; one can pass where the other fails |
| `Document::tags` / `links` | a Document carries both exactly as a Transaction does |
| `Custom::values` | the values *are* the directive — every `custom "budget"` on a date hashed the same |

## Verification

Six sabotages, six failures, restored green: drop transaction metadata, flatten the
`MetaValue` variant tags, remove the key sort, un-hash `booking`, un-hash
`Custom::values`, and start hashing comments.

The map-order test **self-checks**: whether two maps iterate differently is a
property of the chosen keys and `FxHashMap`'s bucket layout, not something the test
controls — so it asserts the orders differ *before* asserting the hashes match.
Without that, a hasher change could leave it passing with the sort deleted.

`cargo test --workspace` — 132 suites, 0 failures. Clippy clean on 1.97.0.

## ⚠️ Ordering

No `CACHE_VERSION` bump (the digest is derived at convert time from cached
directives, which are unchanged) and no WIT bump (the type is untouched) — which is
exactly the thing worth flagging. **This is a breaking behavioral change to a wire
field that neither `cargo-semver-checks` nor the WIT gate can see.** rustfava's
snapshots are the only thing that catches it, which is #1967.
