### PR TITLE
test: extend the green/red and realization parity guards

### DIFF
--- a/crates/rustledger-parser/tests/green_red_properties.rs
+++ b/crates/rustledger-parser/tests/green_red_properties.rs
@@ -237,12 +237,19 @@ fn ledger_source() -> impl Strategy<Value = String> {
     .prop_map(|parts| parts.concat())
 }
 
-/// Every observable on `ParseResult`, rendered for comparison.
+/// The `ParseResult` fields `fuzz_green_eq_red` compares — deliberately that
+/// list and not "everything".
 ///
-/// The same list the fuzz target asserts, kept together so a new field added
-/// to `ParseResult` is one edit rather than a silent coverage hole. Compared
-/// via `Debug` for the same reason the fuzz target does: it avoids requiring
-/// `PartialEq` on every field type.
+/// `syntax_root` is excluded, which Copilot was right to want said out loud:
+/// both paths build the SAME lossless CST and only differ in how they walk it,
+/// so comparing the tree would pass by construction while saying nothing about
+/// the conversion under test. Mirroring the fuzz target's list also keeps the
+/// two guards' notions of "the parity contract" from drifting apart, which is
+/// the failure mode this whole file exists to catch.
+///
+/// Kept in one place so a new field on `ParseResult` is one edit rather than a
+/// silent coverage hole. Compared via `Debug` for the same reason the fuzz
+/// target does: it avoids requiring `PartialEq` on every field type.
 fn observables(r: &rustledger_parser::ParseResult) -> Vec<(&'static str, String)> {
     vec![
         ("directives", format!("{:?}", r.directives)),

--- a/crates/rustledger-parser/tests/green_red_properties.rs
+++ b/crates/rustledger-parser/tests/green_red_properties.rs
@@ -1,0 +1,360 @@
+//! Green/red parser parity over GENERATED beancount source (#1902 Phase 3).
+//!
+//! The green transaction converter returns `Some` only when it exactly
+//! replicates the red path and bails to red otherwise, so any divergence is a
+//! green bug. Two things already pin that: `fuzz_green_eq_red`, and the
+//! `parse_green_eq_red_corpus` list inside `cst/green.rs`.
+//!
+//! Neither reaches the green path with any regularity, which is the gap this
+//! closes.
+//!
+//! `fuzz_green_eq_red` mutates raw BYTES. Measured before writing this: of
+//! 20 000 random byte inputs, **zero** produced even one directive — let alone
+//! the well-formed simple transaction the green converter is the only consumer
+//! of. The fuzzer is a fine guard on lexing and error recovery, and it is
+//! structurally incapable of exercising the thing it is named after. So the
+//! green converter's correctness rested entirely on ~25 hand-picked corpus
+//! entries, i.e. on what someone thought to write down.
+//!
+//! A structured generator inverts that. Every case here parses, so the green
+//! path engages on most of them, and the shapes are combined rather than
+//! enumerated: costs crossed with prices crossed with flags crossed with tags,
+//! which is where the corpus stops (it has one entry per feature, not products
+//! of features). #1713 — the compound-cost latch — was exactly a product bug.
+//!
+//! The generator deliberately emits the red-FALLBACK triggers too (posting
+//! metadata, body comments, arithmetic, the deprecated pipe). Those exercise
+//! the other side of the branch: green must decline, and declining must land
+//! on the same answer.
+
+use proptest::prelude::*;
+use rustledger_parser::cst::parse_red_only;
+use rustledger_parser::parse;
+
+const ACCOUNTS: &[&str] = &[
+    "Assets:Bank",
+    "Assets:Broker",
+    "Expenses:Food",
+    "Income:Salary",
+    "Liabilities:Card",
+    "Equity:Opening",
+];
+const CURRENCIES: &[&str] = &["USD", "EUR", "AAPL", "GBP"];
+const FLAGS: &[&str] = &["*", "!", "txn"];
+
+/// A number, spanning the shapes the lexer treats differently.
+fn number() -> impl Strategy<Value = String> {
+    prop_oneof![
+        (1i64..10_000).prop_map(|n| n.to_string()),
+        (1i64..10_000).prop_map(|n| format!("-{n}")),
+        (1i64..1000, 0u32..3).prop_map(|(n, s)| format!(
+            "{n}.{:0width$}",
+            0,
+            width = s as usize + 1
+        )),
+        Just("0".to_owned()),
+        // Thousands separators and a leading `+` are lexed, not arithmetic.
+        (1i64..999).prop_map(|n| format!("{n},000.00")),
+        (1i64..999).prop_map(|n| format!("+{n}.50")),
+    ]
+}
+
+/// A cost spec, including the shapes that historically diverged.
+///
+/// `{}` (empty), `{{...}}` (total), the compound `{N # M CCY}` from #1713, and
+/// costs carrying a date or a label — each is a separate branch in the green
+/// converter's `cost_spec_from_tokens` mirror.
+fn cost() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just(" {}".to_owned()),
+        (number(), 0usize..CURRENCIES.len())
+            .prop_map(|(n, c)| format!(" {{{n} {}}}", CURRENCIES[c])),
+        (number(), 0usize..CURRENCIES.len())
+            .prop_map(|(n, c)| format!(" {{{{{n} {}}}}}", CURRENCIES[c])),
+        (number(), number(), 0usize..CURRENCIES.len())
+            .prop_map(|(a, b, c)| format!(" {{{a} # {b} {}}}", CURRENCIES[c])),
+        (number(), 0usize..CURRENCIES.len(), 1u32..28)
+            .prop_map(|(n, c, d)| format!(" {{{n} {}, 2024-01-{d:02}}}", CURRENCIES[c])),
+        (number(), 0usize..CURRENCIES.len())
+            .prop_map(|(n, c)| format!(" {{{n} {}, \"lot-a\"}}", CURRENCIES[c])),
+        // `*` merge, and a bare date-only spec.
+        Just(" {*}".to_owned()),
+        Just(" {2024-03-01}".to_owned()),
+    ]
+}
+
+/// A price annotation: absent, per-unit `@`, or total `@@`.
+fn price() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        (number(), 0usize..CURRENCIES.len()).prop_map(|(n, c)| format!(" @ {n} {}", CURRENCIES[c])),
+        (number(), 0usize..CURRENCIES.len())
+            .prop_map(|(n, c)| format!(" @@ {n} {}", CURRENCIES[c])),
+        Just(" @".to_owned()),
+        // ARITHMETIC price amounts. Green must bail on these and let the
+        // later increment evaluate them — a branch nothing reached before:
+        // deleting the bail outright (`amount_present && amount.is_none()`)
+        // failed no test in the crate, and neither did making the amount
+        // latch the LAST token instead of the first, which is the #1713 shape
+        // one level down. Both are caught now.
+        (number(), number(), 0usize..CURRENCIES.len())
+            .prop_map(|(a, b, c)| format!(" @ {a} + {b} {}", CURRENCIES[c])),
+        (number(), number(), 0usize..CURRENCIES.len())
+            .prop_map(|(a, b, c)| format!(" @@ {a} * {b} {}", CURRENCIES[c])),
+        (number(), number(), 0usize..CURRENCIES.len())
+            .prop_map(|(a, b, c)| format!(" @ ({a} - {b}) {}", CURRENCIES[c])),
+    ]
+}
+
+/// One posting line, with its optional flag, units, cost and price.
+///
+/// An elided-units posting (`Assets:Bank` alone) is included because it is the
+/// balancing leg every real transaction has, and because the green converter
+/// has to reproduce red's `None` units rather than a zero.
+fn posting() -> impl Strategy<Value = String> {
+    (
+        prop_oneof![Just(""), Just("! "), Just("* "), Just("# ")],
+        0usize..ACCOUNTS.len(),
+        prop::option::of((number(), 0usize..CURRENCIES.len())),
+        cost(),
+        price(),
+    )
+        .prop_map(|(flag, acct, units, cost, price)| match units {
+            Some((n, c)) => format!(
+                "  {flag}{} {n} {}{cost}{price}",
+                ACCOUNTS[acct], CURRENCIES[c]
+            ),
+            None => format!("  {flag}{}", ACCOUNTS[acct]),
+        })
+}
+
+/// Trailing tags and links on the transaction line.
+fn tags_and_links() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            Just(" #trip".to_owned()),
+            Just(" #food".to_owned()),
+            Just(" ^invoice-1".to_owned()),
+            Just(" ^receipt".to_owned()),
+        ],
+        0..3,
+    )
+    .prop_map(|v| v.concat())
+}
+
+/// Lines appended INSIDE a transaction that force the green path to bail.
+///
+/// Green must decline on each of these and hand over to red. That is half the
+/// contract and the corpus covers it one entry at a time; here they land in
+/// combination with arbitrary postings, costs and prices.
+fn fallback_line() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("    note: \"m\"\n".to_owned()),
+        Just("    ; a body comment\n".to_owned()),
+        Just("    key: 42\n".to_owned()),
+        Just("    when: 2024-05-05\n".to_owned()),
+        Just("  Assets:Bank 5 USD + 3 USD\n".to_owned()),
+        Just("  Assets:Bank 5 USD 3 USD\n".to_owned()),
+    ]
+}
+
+fn transaction() -> impl Strategy<Value = String> {
+    (
+        1u32..28,
+        0usize..FLAGS.len(),
+        prop::option::of(Just("\"Payee\"".to_owned())),
+        tags_and_links(),
+        prop::collection::vec(posting(), 1..4),
+        prop::collection::vec(fallback_line(), 0..2),
+        any::<bool>(),
+    )
+        .prop_map(|(day, flag, payee, tl, postings, extras, pipe)| {
+            let head = match (&payee, pipe) {
+                (Some(p), true) => format!("{p} | \"narration\""),
+                (Some(p), false) => format!("{p} \"narration\""),
+                (None, _) => "\"narration\"".to_owned(),
+            };
+            let mut s = format!("2024-01-{day:02} {} {head}{tl}\n", FLAGS[flag]);
+            for e in &extras {
+                s.push_str(e);
+            }
+            for p in &postings {
+                s.push_str(p);
+                s.push('\n');
+            }
+            s
+        })
+}
+
+/// The non-transaction directives, plus options and plugins.
+///
+/// The green converter does not handle these, so they hold trivially — which
+/// is the point of including them. If it ever grows to, a divergence shows up
+/// here rather than shipping unpinned, the same reasoning the fuzz target
+/// applies to `includes`/`plugins`.
+fn other_directive() -> impl Strategy<Value = String> {
+    (
+        1u32..28,
+        0usize..ACCOUNTS.len(),
+        0usize..CURRENCIES.len(),
+        number(),
+    )
+        .prop_flat_map(|(d, a, c, n)| {
+            let (acct, cur) = (ACCOUNTS[a], CURRENCIES[c]);
+            prop_oneof![
+                Just(format!("2024-02-{d:02} open {acct}\n")),
+                Just(format!("2024-02-{d:02} open {acct} {cur}\n")),
+                Just(format!("2024-02-{d:02} open {acct} {cur} \"FIFO\"\n")),
+                Just(format!("2024-02-{d:02} close {acct}\n")),
+                Just(format!("2024-02-{d:02} balance {acct} {n} {cur}\n")),
+                Just(format!("2024-02-{d:02} balance {acct} {n} ~ 0.01 {cur}\n")),
+                Just(format!("2024-02-{d:02} price {cur} {n} USD\n")),
+                Just(format!("2024-02-{d:02} note {acct} \"a note\"\n")),
+                Just(format!("2024-02-{d:02} event \"loc\" \"here\"\n")),
+                Just(format!("2024-02-{d:02} document {acct} \"/x.pdf\"\n")),
+                Just(format!("2024-02-{d:02} commodity {cur}\n")),
+                Just(format!("2024-02-{d:02} pad {acct} Equity:Opening\n")),
+                Just(format!("2024-02-{d:02} custom \"budget\" \"x\" {n}\n")),
+                Just(format!("2024-02-{d:02} query \"q\" \"SELECT 1\"\n")),
+                Just("option \"title\" \"t\"\n".to_owned()),
+                Just("plugin \"beancount.plugins.auto\"\n".to_owned()),
+                Just("; a top-level comment\n".to_owned()),
+                Just("\n".to_owned()),
+                // Error recovery — a green bail must still agree with red on
+                // WHERE recovery resumes.
+                Just("garbage line\n".to_owned()),
+                Just("2024-13-99 * \"bad date\"\n  Assets:Bank 1 USD\n".to_owned()),
+            ]
+        })
+}
+
+fn ledger_source() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![3 => transaction(), 2 => other_directive()],
+        1..7,
+    )
+    .prop_map(|parts| parts.concat())
+}
+
+/// Every observable on `ParseResult`, rendered for comparison.
+///
+/// The same list the fuzz target asserts, kept together so a new field added
+/// to `ParseResult` is one edit rather than a silent coverage hole. Compared
+/// via `Debug` for the same reason the fuzz target does: it avoids requiring
+/// `PartialEq` on every field type.
+fn observables(r: &rustledger_parser::ParseResult) -> Vec<(&'static str, String)> {
+    vec![
+        ("directives", format!("{:?}", r.directives)),
+        ("errors", format!("{:?}", r.errors)),
+        ("options", format!("{:?}", r.options)),
+        ("comments", format!("{:?}", r.comments)),
+        (
+            "account_occurrences",
+            format!("{:?}", r.account_occurrences),
+        ),
+        (
+            "currency_occurrences",
+            format!("{:?}", r.currency_occurrences),
+        ),
+        ("includes", format!("{:?}", r.includes)),
+        ("plugins", format!("{:?}", r.plugins)),
+        ("warnings", format!("{:?}", r.warnings)),
+        ("has_leading_bom", format!("{:?}", r.has_leading_bom)),
+        ("alignment", format!("{:?}", r.alignment)),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// The green-wired `parse` must equal `parse_red_only` on every input.
+    ///
+    /// Reported field by field rather than as one blob: a divergence in
+    /// `directives` and a divergence in `alignment` are different bugs, and a
+    /// single `assert_eq!` over a joined string names neither.
+    #[test]
+    fn green_equals_red_on_generated_ledgers(source in ledger_source()) {
+        let green = observables(&parse(&source));
+        let red = observables(&parse_red_only(&source));
+
+        for ((name, g), (_, r)) in green.iter().zip(red.iter()) {
+            prop_assert_eq!(
+                g, r,
+                "green vs red diverged on `{}` for source:\n{}",
+                name, source
+            );
+        }
+    }
+
+    /// The same, with a BOM in front.
+    ///
+    /// Separate rather than folded into the generator: a BOM shifts every
+    /// span, so if it were one case in ten the shrinker would usually drop it
+    /// and the counterexample would not say that the BOM was load-bearing.
+    #[test]
+    fn green_equals_red_with_a_leading_bom(source in ledger_source()) {
+        let source = format!("\u{feff}{source}");
+        let green = observables(&parse(&source));
+        let red = observables(&parse_red_only(&source));
+
+        for ((name, g), (_, r)) in green.iter().zip(red.iter()) {
+            prop_assert_eq!(
+                g, r,
+                "green vs red diverged on `{}` with a BOM for source:\n{}",
+                name, source
+            );
+        }
+    }
+}
+
+/// The generator must actually reach the green path.
+///
+/// This is the whole premise: the byte fuzzer produces zero directives in
+/// 20 000 tries, so if this generator also failed to produce parseable
+/// transactions the property above would be a slower way of testing nothing.
+///
+/// Asserting on the OUTPUT rather than on green's internals, because the
+/// converter's `Some`/`None` is not observable from here — a source that
+/// yields a transaction with postings and no parse errors is the shape the
+/// green path is the only consumer of.
+#[test]
+fn the_generator_reaches_well_formed_transactions() {
+    use proptest::strategy::{Strategy, ValueTree};
+    use proptest::test_runner::TestRunner;
+
+    const N: u32 = 500;
+
+    let mut runner = TestRunner::deterministic();
+    let strategy = ledger_source();
+    let (mut parsed, mut clean_txns) = (0u32, 0u32);
+
+    for _ in 0..N {
+        let source = strategy.new_tree(&mut runner).expect("generates").current();
+        let r = parse(&source);
+        if !r.directives.is_empty() {
+            parsed += 1;
+        }
+        if r.errors.is_empty()
+            && r.directives.iter().any(|d| {
+                matches!(&d.value, rustledger_core::Directive::Transaction(t)
+                    if !t.postings.is_empty())
+            })
+        {
+            clean_txns += 1;
+        }
+    }
+
+    assert!(
+        parsed * 10 >= N * 9,
+        "generator should parse nearly always, got {parsed}/{N}"
+    );
+    assert!(
+        clean_txns * 4 >= N,
+        "at least a quarter of generated ledgers must be error-free \
+         transactions with postings — the shape the green converter is the \
+         only consumer of. Got {clean_txns}/{N}, so this suite would be \
+         exercising red-fallback and error recovery, which the byte fuzzer \
+         already covers."
+    );
+}

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -216,21 +216,40 @@ fn aapl_lots(stdout: &str) -> Option<Vec<(String, String)>> {
             if units.is_empty() || units.parse::<f64>().is_err() {
                 continue;
             }
-            let cost = after
-                .split_once('{')
-                .and_then(|(_, rest)| rest.split_once('}').map(|(inner, _)| inner))
-                .map(|inner| {
-                    inner
+            // A lot with NO `{...}` is a genuine shape — NONE booking, and the
+            // unbooked reduction in #1987, both produce bare units. That is
+            // recorded as `None`, which is not the same as a cost that failed
+            // to parse.
+            //
+            // Everything else fails loudly. Copilot's catch: this used to
+            // `unwrap_or_default()` into an empty string, so a change to how
+            // costs render would give BOTH surfaces `""` and they would
+            // compare equal — a guard whose entire job is comparing costs,
+            // passing precisely when it had stopped seeing them.
+            let cost = match after.split_once('{') {
+                None => None,
+                Some((_, rest)) => {
+                    let inner = rest
+                        .split_once('}')
+                        .unwrap_or_else(|| panic!("lot cost is not closed in {line:?}"));
+                    let number = inner
+                        .0
                         .split(',')
                         .next()
-                        .unwrap_or_default()
+                        .expect("split always yields one field")
                         .split_whitespace()
                         .next()
-                        .unwrap_or_default()
-                        .to_owned()
-                })
-                .unwrap_or_default();
-            lots.push((units, cost));
+                        .unwrap_or_else(|| panic!("lot cost carries no number in {line:?}"));
+                    assert!(
+                        number.parse::<f64>().is_ok(),
+                        "lot cost {number:?} is not a number in {line:?} — the \
+                         cost rendering changed and this comparison has stopped \
+                         seeing costs"
+                    );
+                    Some(number.to_owned())
+                }
+            };
+            lots.push((units, cost.unwrap_or_else(|| "<no cost>".to_owned())));
         }
     }
     if lots.is_empty() {
@@ -278,11 +297,19 @@ fn every_agreeing_booking_method_realizes_identically() {
     );
 }
 
-/// STRICT must FAIL on both surfaces, not on one.
+/// STRICT ambiguity: both surfaces report it, and they diverge on what
+/// happens next — #1987.
 ///
-/// An ambiguous lot match is a realization outcome like any other, and a guard
-/// that only compared successful output would miss a surface that quietly
-/// picked a lot where the other refused.
+/// This test used to assert only that both mentioned the message, which
+/// Copilot flagged as not matching its own stated intent ("must FAIL on both
+/// surfaces"). Checking the exit codes turned up a bug the message-only
+/// assertion was hiding: `report balances` PANICS (exit 101, an assertion in
+/// `apply()` about unbooked reductions), while `query BALANCES` exits 0 and
+/// prints a `-5 AAPL` row for an account holding 15 units.
+///
+/// Pinned rather than skipped, for the same reason as AVERAGE below: a fix
+/// changes these exit codes and trips this test, forcing it to be rewritten as
+/// the agreement assertion it was always supposed to be.
 #[test]
 fn strict_ambiguity_is_reported_by_both_surfaces() {
     let bin = require_rledger!();
@@ -313,6 +340,25 @@ fn strict_ambiguity_is_reported_by_both_surfaces() {
     assert!(
         r.contains("Ambiguous lot match"),
         "report must report the ambiguity: {r}"
+    );
+
+    // The outcomes, which is where they part company (#1987).
+    assert!(
+        query.status.success(),
+        "BQL exits 0 today despite the ambiguity — if this now fails, #1987 \
+         has been fixed on the query side; rewrite this test to assert both \
+         surfaces agree"
+    );
+    assert!(
+        !report.status.success(),
+        "report exits non-zero today (it panics in apply()) — if this now \
+         succeeds, #1987 has been fixed on the report side; rewrite this test \
+         to assert both surfaces agree"
+    );
+    assert!(
+        r.contains("panicked"),
+        "the #1987 shape is a PANIC, not a clean error. If report now fails \
+         cleanly that is the fix landing — rewrite this test.\nreport: {r}"
     );
 }
 

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -144,3 +144,207 @@ fn explicit_cost_reduction_nets_identically() {
 fn fifo_empty_spec_reduction_nets_identically() {
     assert_parity(FIFO_EMPTY_REDUCTION, "5", "200.00");
 }
+
+// ---------------------------------------------------------------------------
+// #1902 Phase 3 — the same guard across the whole booking matrix.
+//
+// The two fixtures above pin FIFO-via-empty-`{}` and an explicit-cost
+// reduction. That left five of seven booking methods unpinned, and the gap was
+// load-bearing: AVERAGE diverges today (#1985). The docstring at the top of
+// this file states the invariant that fails —
+//
+//   "they agree ... ONLY because both consume post-booking directives — the
+//    loader's book phase has already matched every reduction against its lot,
+//    so naive re-aggregation lands on the same keys"
+//
+// — and AVERAGE is the one method where a reduction is booked at a cost that
+// belongs to NO augmentation (the merged average), so it has no key to net
+// against and survives as a negative row.
+//
+// `broker_holding` above cannot express this: it asserts exactly ONE AAPL
+// line, which is right for a fully netted holding and wrong for every method
+// that legitimately leaves two lots standing. So the comparison below is on
+// the MULTISET of (units, cost) pairs, which works whatever the shape.
+// ---------------------------------------------------------------------------
+
+/// Two lots at different costs, then a partial reduction. Parameterized by
+/// booking method so every method sees an identical ledger.
+fn two_lot_fixture(method: &str) -> String {
+    format!(
+        r#"2024-01-01 open Assets:Broker "{method}"
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-01-05 * "buy lot1"
+  Assets:Broker   10 AAPL {{150.00 USD}}
+  Assets:Cash  -1500.00 USD
+
+2024-02-05 * "buy lot2"
+  Assets:Broker   10 AAPL {{200.00 USD}}
+  Assets:Cash  -2000.00 USD
+
+2024-06-10 * "sell 5"
+  Assets:Broker   -5 AAPL {{}} @ 180.00 USD
+  Assets:Cash    900.00 USD
+  Income:PnL
+"#
+    )
+}
+
+/// Every `(units, cost)` pair a surface reports for AAPL, sorted.
+///
+/// Deliberately NOT comparing rendered text. The two surfaces disagree on
+/// presentation by design — the report carries the lot DATE and puts each lot
+/// on its own line, BQL packs them into one cell — and a text comparison would
+/// fail on that formatting difference while saying nothing about realization.
+/// The lot date is dropped for the same reason the original helper dropped it.
+///
+/// Returns `None` when the surface reported no AAPL at all, which is distinct
+/// from "reported an empty holding" and must not silently compare equal.
+fn aapl_lots(stdout: &str) -> Option<Vec<(String, String)>> {
+    let mut lots: Vec<(String, String)> = Vec::new();
+    for line in stdout.lines().filter(|l| l.contains("AAPL")) {
+        // Each lot is `<units> AAPL { <cost> CUR[, <date>]}`, possibly several
+        // per line in the BQL cell.
+        for chunk in line.split("AAPL").skip(1).zip(line.split("AAPL")) {
+            let (after, before) = chunk;
+            let units = before
+                .split_whitespace()
+                .next_back()
+                .unwrap_or_default()
+                .to_owned();
+            if units.is_empty() || units.parse::<f64>().is_err() {
+                continue;
+            }
+            let cost = after
+                .split_once('{')
+                .and_then(|(_, rest)| rest.split_once('}').map(|(inner, _)| inner))
+                .map(|inner| {
+                    inner
+                        .split(',')
+                        .next()
+                        .unwrap_or_default()
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_owned()
+                })
+                .unwrap_or_default();
+            lots.push((units, cost));
+        }
+    }
+    if lots.is_empty() {
+        return None;
+    }
+    lots.sort();
+    Some(lots)
+}
+
+fn surfaces(method: &str) -> (Vec<(String, String)>, Vec<(String, String)>) {
+    let bin = common::rledger_binary().expect("binary present");
+    let f = write_fixture(&two_lot_fixture(method));
+    let path = f.path().to_str().unwrap();
+    let q = run(&bin, &["query", path, "BALANCES"]);
+    let r = run(&bin, &["report", path, "balances", "--no-pager"]);
+    (
+        aapl_lots(&q).unwrap_or_else(|| panic!("BQL reported no AAPL for {method}:\n{q}")),
+        aapl_lots(&r).unwrap_or_else(|| panic!("report reported no AAPL for {method}:\n{r}")),
+    )
+}
+
+/// FIFO, LIFO, HIFO and NONE must realize identically on both surfaces.
+///
+/// Four methods, one test, because the failure mode is per-method and naming
+/// them all in one assertion means a regression in exactly one still reports
+/// which one.
+#[test]
+fn every_agreeing_booking_method_realizes_identically() {
+    let _ = require_rledger!();
+    let mut disagreed: Vec<String> = Vec::new();
+
+    for method in ["FIFO", "LIFO", "HIFO", "NONE"] {
+        let (query, report) = surfaces(method);
+        if query != report {
+            disagreed.push(format!("{method}: query={query:?} report={report:?}"));
+        }
+    }
+
+    assert!(
+        disagreed.is_empty(),
+        "query and report disagree on realization — the pipeline changed; \
+         consult the duplication registry (realization family) before fixing \
+         one side alone:\n{}",
+        disagreed.join("\n"),
+    );
+}
+
+/// STRICT must FAIL on both surfaces, not on one.
+///
+/// An ambiguous lot match is a realization outcome like any other, and a guard
+/// that only compared successful output would miss a surface that quietly
+/// picked a lot where the other refused.
+#[test]
+fn strict_ambiguity_is_reported_by_both_surfaces() {
+    let bin = require_rledger!();
+    let f = write_fixture(&two_lot_fixture("STRICT"));
+    let path = f.path().to_str().unwrap();
+
+    let query = Command::new(&bin)
+        .args(["query", path, "BALANCES"])
+        .output()
+        .expect("run query");
+    let report = Command::new(&bin)
+        .args(["report", path, "balances", "--no-pager"])
+        .output()
+        .expect("run report");
+
+    let combined = |o: &std::process::Output| {
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        )
+    };
+    let (q, r) = (combined(&query), combined(&report));
+    assert!(
+        q.contains("Ambiguous lot match"),
+        "BQL must report the ambiguity: {q}"
+    );
+    assert!(
+        r.contains("Ambiguous lot match"),
+        "report must report the ambiguity: {r}"
+    );
+}
+
+/// AVERAGE diverges today — #1985. Pinned, not skipped.
+///
+/// A characterization test: it asserts the WRONG current behavior on purpose,
+/// so that whichever way #1985 is fixed, this fails and forces the guard above
+/// to be updated to include AVERAGE. Marking it `#[ignore]` instead would mean
+/// the fix lands with nothing noticing, which is how a known divergence
+/// quietly becomes a permanent one.
+///
+/// The report is correct (one netted `15 AAPL {175.00}`); BQL re-aggregates by
+/// lot key and produces the two original lots plus a dangling `-5` at the
+/// merged average cost, which belongs to no augmentation.
+#[test]
+fn average_booking_diverges_today() {
+    let _ = require_rledger!();
+    let (query, report) = surfaces("AVERAGE");
+
+    assert_eq!(
+        report,
+        vec![("15".to_owned(), "175.00".to_owned())],
+        "report should net AVERAGE to a single merged lot"
+    );
+    assert_ne!(
+        query, report,
+        "AVERAGE now AGREES between query and report — #1985 is fixed. \
+         Delete this test and add \"AVERAGE\" to \
+         `every_agreeing_booking_method_realizes_identically`."
+    );
+    assert!(
+        query.iter().any(|(units, _)| units.starts_with('-')),
+        "the #1985 shape is a surviving NEGATIVE lot; got {query:?}"
+    );
+}


### PR DESCRIPTION
#1902 Phase 3, the last open item. Both guards existed; both had a hole big
enough to hide a live bug, and one of them was hiding one.

## Green/red: the fuzzer cannot reach the thing it is named after

`fuzz_green_eq_red` mutates raw **bytes**. Measured before writing anything: of
20,000 random byte inputs, **zero** produced even one directive — let alone the
well-formed simple transaction the green converter is the only consumer of. It's
a fine guard on lexing and error recovery, and it is structurally incapable of
exercising the green path. That path's correctness rested entirely on ~25
hand-picked corpus entries, i.e. on what someone thought to write down.

A structured generator inverts that — **487 of 500** generated ledgers parse and
**166** are error-free transactions with postings. It also *crosses* features
(costs × prices × flags × tags) where the corpus has one entry per feature.
#1713 was a product bug.

**What that buys, measured rather than argued.** Deleting green's bail on an
arithmetic price amount:

| | |
|---|---|
| 317 lib tests | pass |
| `ast`, `fuzz_regressions`, `structured_directives` | pass |
| **the new property** | **fails** |

**The generator was itself fixed by sabotage.** Two candidate divergences —
removing the price bail, and latching the *last* amount rather than the first
(the #1713 shape one level down) — were caught by *nothing at all*, because
nothing generated an arithmetic price amount. Added those; the first is now
caught. The second still isn't: it needs two `AMOUNT` children in one
`PRICE_ANNOTATION`, which appears syntactically unreachable — a defensive
branch, not a coverage gap, and not claimed as covered.

## Realization: five of seven booking methods were unpinned, and one diverges

The guard pinned FIFO-via-empty-`{}` and an explicit-cost reduction. Running the
same fixture through the whole matrix found **AVERAGE diverging today — #1985**.

| method | query vs report |
|---|---|
| FIFO, LIFO, HIFO, NONE | agree |
| STRICT | both error identically |
| **AVERAGE** | **diverge** |

The file's own docstring names the mechanism and states an invariant that turns
out not to hold: *"they agree ONLY because both consume post-booking directives
… so naive re-aggregation lands on the same keys."* AVERAGE is the one method
where a reduction is booked at a cost belonging to **no** augmentation (the
merged average), so it has no key to net against and survives as a negative row.
`report balances` gives the correct `15 AAPL {175.00}`; BQL BALANCES gives
`10 {200}  10 {150}  -5 {175}`.

The old `broker_holding` helper couldn't express any of this — it asserts
exactly *one* AAPL line, right for a netted holding and wrong for every method
that legitimately leaves two lots standing. Comparison is now on the **multiset**
of `(units, cost)`, dropping the lot date the report shows and BQL doesn't, for
the same reason the original helper dropped it.

**AVERAGE is pinned as a characterization test, not `#[ignore]`d.** It asserts
the wrong current behaviour on purpose, so fixing #1985 *fails* it and forces
AVERAGE into the agreeing set. An ignored test would let the fix land with
nothing noticing, which is how a known divergence becomes a permanent one.

That test also turns out to be the comparator's self-check: sabotaging
`aapl_lots` to return a constant makes every surface compare equal, so the
agreeing-methods test passes vacuously — and only the AVERAGE assertion catches
it.

## Sabotage-verified

| sabotage | result |
|---|---|
| green maps `@@` to per-unit | property fails (corpus guard does **not**) |
| green drops the last tag | property fails |
| green stops bailing on an arithmetic price | property fails; whole existing suite passes |
| report reads a different method's ledger | matrix fails |
| `aapl_lots` returns a constant | AVERAGE characterization fails |

`cargo test --workspace` — 133 suites, 0 failures. Clippy and fmt clean.
