### PR TITLE
fix(booking): report a failed reduction instead of panicking in debug and lying in release

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -683,6 +683,49 @@ impl BookingEngine {
     /// what any one account can consume, which is the safe direction, and it
     /// avoids grouping postings by account and currency — an allocation, which
     /// is the thing being removed.
+    /// Whether `apply` must snapshot before mutating.
+    ///
+    /// Two reasons a posting can fail partway through, and both now abort the
+    /// transaction, so both need the earlier postings rolled back:
+    ///
+    /// * an `add` that overflows (#1863) — [`Self::overflow_is_possible`];
+    /// * a `reduce` with no matching lot, which since #1987 is an error rather
+    ///   than something to ignore.
+    ///
+    /// The reduction half is checked separately because `overflow_is_possible`
+    /// is about magnitudes and answers `true` for an unfilled posting only by
+    /// coincidence. Relying on that coincidence would leave a filled-but-
+    /// unbookable transaction (an ambiguous STRICT match with explicit
+    /// amounts) mutating half its accounts and then returning `Err`.
+    ///
+    /// Kept as two predicates rather than folded into one so the #1897
+    /// perf reasoning stays legible: snapshotting EVERY transaction cost 2.4x
+    /// heap churn and 6% CPU, which is why neither half is unconditional.
+    /// Reductions are a minority of transactions in a real ledger, so this
+    /// widens the gate without reopening that regression.
+    fn rollback_needed(&self, txn: &Transaction) -> bool {
+        self.overflow_is_possible(txn) || self.has_reduction(txn)
+    }
+
+    /// Whether any posting reduces an existing cost-bearing lot.
+    ///
+    /// Uses the canonical [`Inventory::is_booking_reduction`] rather than
+    /// re-deriving "is this a reduction" from the sign, which is the drift the
+    /// duplication review kept finding.
+    fn has_reduction(&self, txn: &Transaction) -> bool {
+        txn.postings.iter().any(|posting| {
+            let Some(units) = posting.amount() else {
+                // Unfilled: booking did not complete, so this transaction is
+                // exactly the unbookable kind that needs the rollback.
+                return true;
+            };
+            let method = self.method_for(&posting.account);
+            self.inventories
+                .get(&posting.account)
+                .is_some_and(|inv| inv.is_booking_reduction(units, posting.cost.as_ref(), method))
+        })
+    }
+
     fn overflow_is_possible(&self, txn: &Transaction) -> bool {
         let mut sum_abs = rustledger_core::Decimal::ZERO;
         for posting in &txn.postings {
@@ -718,24 +761,23 @@ impl BookingEngine {
     ///
     /// The transaction MUST already be booked — postings filled with complete
     /// units and resolved costs, as produced by [`Self::book_and_interpolate`]
-    /// or the free [`book`](crate::book) function. Applying an *unbooked*
-    /// transaction can silently over-sell an inventory: a reduction with no
-    /// matching lot yet is dropped (its `reduce` error is ignored, historical
-    /// release behavior). The loader pipeline guarantees this ordering; the
-    /// in-loop `debug_assert` below catches a violating caller in debug builds.
-    /// A caller that CANNOT guarantee booked input must not derive a figure from
-    /// this lot-matching realization — e.g. the returns engine values **net units
-    /// at market** (`rustledger-returns`), never `apply`, so a re-merged
-    /// booking-failed transaction cannot over-sell it.
+    /// or the free [`book`](crate::book) function. The loader pipeline
+    /// guarantees this ordering. A caller that CANNOT guarantee booked input
+    /// must not derive a figure from this lot-matching realization — e.g. the
+    /// returns engine values **net units at market** (`rustledger-returns`),
+    /// never `apply`, so a re-merged booking-failed transaction cannot
+    /// over-sell it.
+    ///
     /// # Errors
     ///
-    /// [`BookingError`] only for arithmetic overflow (#1863) — a property of
-    /// the ledger's numbers, not of the caller, so it is reported rather than
-    /// asserted. A failed *reduction* keeps the historical
-    /// debug-assert-then-ignore contract below: that means the caller applied
-    /// an unbooked transaction, which is a bug in the caller. Keeping it
-    /// non-fatal preserves every existing caller's release-build behavior;
-    /// only the overflow path is new.
+    /// [`BookingError`] for arithmetic overflow (#1863) or for a reduction
+    /// that finds no matching lot (#1987). Either way the transaction is rolled
+    /// back whole: no posting of a failing transaction stays applied.
+    ///
+    /// The reduction case used to be `debug_assert!`-then-ignore, which made
+    /// the two build profiles disagree about a user's ledger — debug panicked,
+    /// release silently over-stated the holding. Reporting it is what lets a
+    /// caller decide, which is the whole point of the precondition.
     pub fn apply(&mut self, txn: &Transaction) -> Result<(), BookingError> {
         // Snapshot every account this transaction touches, so an overflow
         // partway through cannot leave the earlier postings applied.
@@ -757,7 +799,7 @@ impl BookingEngine {
         // every transaction cost 2.4x heap churn and 6% CPU on the nightly
         // profile to guard a case needing values near 7.9e28 (#1897).
         let snapshot: Option<FxHashMap<rustledger_core::Account, Option<Inventory>>> =
-            if self.overflow_is_possible(txn) {
+            if self.rollback_needed(txn) {
                 let mut snap =
                     FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
                 for posting in &txn.postings {
@@ -784,42 +826,39 @@ impl BookingEngine {
             };
 
         for posting in &txn.postings {
-            let reduced = self.try_apply_posting(posting, txn.date);
-            if matches!(
-                reduced,
-                Err(BookingError::Inventory(
-                    rustledger_core::AccountedBookingError {
-                        error: rustledger_core::BookingError::Overflow(_),
-                        ..
-                    }
-                ))
-            ) {
-                // `snapshot` is `Some` whenever this arm is reachable: the
-                // guard only returns false when no add can overflow, and
-                // overflow is the sole error that reaches here. Restoring
-                // nothing would be silent corruption, so a violated guard must
-                // be loud rather than quiet.
+            // EVERY posting failure aborts the transaction and rolls back —
+            // overflow and failed reduction alike (#1987).
+            //
+            // A failed reduction used to be `debug_assert!` then ignored. That
+            // meant the two build profiles disagreed about what happens to a
+            // user's ledger: debug PANICKED (`report balances` exited 101 on an
+            // ambiguous STRICT match), while release dropped the reduction and
+            // carried on — reporting 20 AAPL for an account holding 15. A
+            // silently over-stated holding is the worse of the two, and it was
+            // the one real users got.
+            //
+            // The precondition is unchanged and still documented: `apply` wants
+            // booked input. What changed is that violating it is now reported
+            // instead of being asserted in one profile and ignored in the
+            // other. Callers already handle this — `book()` records the error
+            // and marks the transaction failed, the wasm entry point checks
+            // `is_ok()`, and the CLI refuses to derive a figure at all.
+            if let Err(e) = self.try_apply_posting(posting, txn.date) {
+                // `snapshot` is `Some` whenever this arm is reachable:
+                // `rollback_needed` covers both failure modes. Restoring
+                // nothing would be silent corruption — precisely the bug being
+                // fixed — so a violated guard must be loud rather than quiet.
                 assert!(
                     snapshot.is_some(),
-                    "overflow_is_possible() returned false but an overflow \
-                     occurred: the guard is unsound and the earlier postings \
-                     of this transaction cannot be rolled back"
+                    "rollback_needed() returned false but posting application \
+                     failed ({e}): the guard is unsound and the earlier \
+                     postings of this transaction cannot be rolled back"
                 );
                 if let Some(snapshot) = snapshot {
                     rollback(self, snapshot);
                 }
-                return reduced;
+                return Err(e);
             }
-            debug_assert!(
-                reduced.is_ok(),
-                "apply() reduction failed — the transaction must be booked \
-                 before apply() (postings filled, costs resolved); applying an \
-                 unbooked reduction silently over-sells inventory. A caller that \
-                 cannot guarantee booked input must not derive a figure from this \
-                 realization (e.g. returns values net units at market instead)."
-            );
-            // Release builds keep the historical ignore-and-continue behavior.
-            let _ = reduced;
         }
         Ok(())
     }

--- a/crates/rustledger-booking/tests/apply_precondition_test.rs
+++ b/crates/rustledger-booking/tests/apply_precondition_test.rs
@@ -43,12 +43,18 @@ const fn empty_spec() -> CostSpec {
 /// Seed two lots at different costs, applied normally.
 fn engine_with_two_lots() -> BookingEngine {
     let mut engine = BookingEngine::with_method(BookingMethod::Strict);
+    // The cash leg is derived from the lot rather than hard-coded: Copilot
+    // caught both buys paying -1500.00 while the second is 10 @ 200.00. `apply`
+    // does not check balance today, so nothing failed — which is exactly why an
+    // internally inconsistent fixture is worth fixing before it becomes load-
+    // bearing for a test that does.
     for (day, units, cost) in [(5u32, "10", "150.00"), (6, "10", "200.00")] {
         let mut buy = Posting::new("Assets:Broker", amount(units, "AAPL"));
         buy.cost = Some(spec(cost, "USD", day));
+        let paid = -(units.parse::<Decimal>().unwrap() * cost.parse::<Decimal>().unwrap());
         let txn = Transaction::new(date(day), "buy")
             .with_synthesized_posting(buy)
-            .with_synthesized_posting(Posting::new("Assets:Cash", amount("-1500.00", "USD")));
+            .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(paid, "USD")));
         engine.apply(&txn).expect("an augmentation applies");
     }
     engine

--- a/crates/rustledger-booking/tests/apply_precondition_test.rs
+++ b/crates/rustledger-booking/tests/apply_precondition_test.rs
@@ -1,0 +1,147 @@
+//! `apply` must report a failed reduction, not assert in one build profile and
+//! ignore it in the other (#1987).
+
+use rustledger_booking::BookingEngine;
+use rustledger_core::{Amount, BookingMethod, CostNumber, CostSpec, Decimal, Posting, Transaction};
+
+/// A resolved per-unit cost spec, as booking would leave it.
+fn spec(number: &str, cur: &str, day: u32) -> CostSpec {
+    CostSpec {
+        number: Some(CostNumber::PerUnit {
+            value: number.parse::<Decimal>().unwrap(),
+        }),
+        currency: Some(cur.into()),
+        date: Some(date(day)),
+        label: None,
+        merge: false,
+    }
+}
+
+fn date(d: u32) -> rustledger_core::NaiveDate {
+    rustledger_core::naive_date(2024, 1, d).unwrap()
+}
+
+fn amount(n: &str, cur: &str) -> Amount {
+    Amount::new(n.parse::<Decimal>().unwrap(), cur)
+}
+
+/// An EMPTY cost spec is what an unbooked reduction looks like.
+///
+/// `{}` is resolved by the booking phase; a transaction that reaches `apply`
+/// still carrying one is by definition unbooked. Under STRICT with two lots
+/// standing, it is ambiguous — the #1987 shape.
+const fn empty_spec() -> CostSpec {
+    CostSpec {
+        number: None,
+        currency: None,
+        date: None,
+        label: None,
+        merge: false,
+    }
+}
+
+/// Seed two lots at different costs, applied normally.
+fn engine_with_two_lots() -> BookingEngine {
+    let mut engine = BookingEngine::with_method(BookingMethod::Strict);
+    for (day, units, cost) in [(5u32, "10", "150.00"), (6, "10", "200.00")] {
+        let mut buy = Posting::new("Assets:Broker", amount(units, "AAPL"));
+        buy.cost = Some(spec(cost, "USD", day));
+        let txn = Transaction::new(date(day), "buy")
+            .with_synthesized_posting(buy)
+            .with_synthesized_posting(Posting::new("Assets:Cash", amount("-1500.00", "USD")));
+        engine.apply(&txn).expect("an augmentation applies");
+    }
+    engine
+}
+
+/// An ambiguous reduction is REPORTED, not asserted-then-ignored.
+///
+/// This used to be `debug_assert!` followed by `let _ = reduced`, so the two
+/// build profiles disagreed about a user's ledger: debug PANICKED, release
+/// dropped the reduction and over-stated the holding. This test runs in both
+/// and expects the same answer from each.
+#[test]
+fn an_ambiguous_reduction_is_reported() {
+    let mut engine = engine_with_two_lots();
+
+    let mut sell = Posting::new("Assets:Broker", amount("-5", "AAPL"));
+    sell.cost = Some(empty_spec());
+    let txn = Transaction::new(date(10), "sell 5")
+        .with_synthesized_posting(sell)
+        .with_synthesized_posting(Posting::new("Assets:Cash", amount("900.00", "USD")));
+
+    let err = engine
+        .apply(&txn)
+        .expect_err("an ambiguous reduction must be reported, not ignored");
+    assert!(
+        format!("{err}").contains("Ambiguous lot match"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Total USD units the cash account holds, via the public iterator.
+fn cash_units(engine: &BookingEngine) -> Decimal {
+    engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Cash")
+        .flat_map(|(_, inv)| inv.positions())
+        .filter(|p| p.units.currency.as_str() == "USD")
+        .map(|p| p.units.number)
+        .sum()
+}
+
+/// A failing transaction leaves NO posting applied.
+///
+/// The cash leg comes FIRST, so it is already applied when the reduction
+/// fails. Without the rollback the engine keeps half of a transaction it just
+/// rejected — the non-atomic-mutation shape from #1976, reachable here only
+/// because reduction failures became fatal.
+#[test]
+fn a_failing_transaction_is_rolled_back_whole() {
+    let mut engine = engine_with_two_lots();
+    let cash_before = cash_units(&engine);
+
+    let mut sell = Posting::new("Assets:Broker", amount("-5", "AAPL"));
+    sell.cost = Some(empty_spec());
+    let txn = Transaction::new(date(10), "sell 5")
+        .with_synthesized_posting(Posting::new("Assets:Cash", amount("900.00", "USD")))
+        .with_synthesized_posting(sell);
+
+    engine.apply(&txn).expect_err("must fail");
+
+    let cash_after = cash_units(&engine);
+    assert_eq!(
+        cash_before, cash_after,
+        "the cash leg of a rejected transaction stayed applied"
+    );
+}
+
+/// A well-formed reduction still applies, and still nets against its lot.
+///
+/// The other half: making failures fatal must not make successes fail.
+/// Without this, deleting the reduction path entirely would pass both tests
+/// above.
+#[test]
+fn a_matching_reduction_still_applies() {
+    let mut engine = engine_with_two_lots();
+
+    let mut sell = Posting::new("Assets:Broker", amount("-4", "AAPL"));
+    sell.cost = Some(spec("150.00", "USD", 5));
+    let txn = Transaction::new(date(10), "sell")
+        .with_synthesized_posting(sell)
+        .with_synthesized_posting(Posting::new("Assets:Cash", amount("600.00", "USD")));
+    engine
+        .apply(&txn)
+        .expect("an unambiguous reduction applies");
+
+    let inventories = engine.into_inventories();
+    let broker = inventories
+        .get(&rustledger_core::Account::from("Assets:Broker"))
+        .expect("broker holds something");
+    let total: Decimal = broker
+        .positions()
+        .filter(|p| p.units.currency.as_str() == "AAPL")
+        .map(|p| p.units.number)
+        .sum();
+    assert_eq!(total, "16".parse::<Decimal>().unwrap(), "20 bought, 4 sold");
+}

--- a/crates/rustledger/src/cmd/loadcache.rs
+++ b/crates/rustledger/src/cmd/loadcache.rs
@@ -171,3 +171,52 @@ pub fn bail_on_parse_errors(raw: &rustledger_loader::LoadResult, file: &Path) ->
     }
     Ok(())
 }
+
+/// Refuse to derive figures from a ledger whose transactions did not book.
+///
+/// The same principle as [`bail_on_parse_errors`], one phase later. A booking
+/// failure — an ambiguous STRICT lot match, a reduction with no matching lot —
+/// leaves that transaction in the directive stream in PRE-BOOKING shape:
+/// `run_booking` partitions failures out, and `finalize` re-merges them so the
+/// user still sees their own input. That re-merge is documented as being "for
+/// output", but nothing stopped the same directives flowing into computation.
+///
+/// The consequences were #1987, and they were worse than a wrong number:
+///
+/// * `report balances` realizes through `BookingEngine::apply`, whose
+///   precondition is booked input. In debug it PANICKED (exit 101); in release
+///   it dropped the reduction and reported 20 AAPL for an account holding 15.
+/// * `query BALANCES` re-aggregates by lot key and printed a dangling `-5
+///   AAPL` row, exiting 0.
+///
+/// So one surface crashed, the other answered wrongly, and neither said so in
+/// its exit code. `apply` now reports the failure rather than asserting in one
+/// build profile and ignoring it in the other; this stops the CLI reaching that
+/// point at all, and says what to do about it.
+///
+/// # Errors
+///
+/// When any directive failed to book.
+pub fn bail_on_booking_errors(ledger: &rustledger_loader::Ledger, file: &Path) -> Result<()> {
+    // Counting the BOOK-coded errors specifically. `ledger.errors` also carries
+    // validation diagnostics, which do NOT leave the stream unbooked and must
+    // not gate a report — `rledger check` is where those are read.
+    let failures: Vec<&str> = ledger
+        .errors
+        .iter()
+        .filter(|e| e.code == "BOOK")
+        .map(|e| e.message.as_str())
+        .collect();
+    if failures.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{}: {} transaction(s) could not be booked; refusing to derive figures \
+         from a ledger whose lots did not resolve — the affected accounts would \
+         be over-stated. Run `rledger check {}` to see them.\n  {}",
+        file.display(),
+        failures.len(),
+        file.display(),
+        failures.join("\n  "),
+    );
+}

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -173,14 +173,20 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;
 
+    // A booking failure leaves directives unbooked in this same stream; every
+    // figure below would be derived from them.
+    //
+    // OUTSIDE the `--no-errors` guard, which Copilot caught this sitting
+    // inside. `--no-errors` suppresses the printing of diagnostics; it is not
+    // permission to compute figures from a ledger that did not book. Nested,
+    // `rledger query --no-errors x.beancount BALANCES` returned the dangling
+    // `-5 AAPL` row and exited 0 — the exact bug this change exists to fix,
+    // reachable through a flag about verbosity.
+    crate::cmd::loadcache::bail_on_booking_errors(&ledger, file)?;
+
     // Report errors to stderr (matching bean-query behavior)
     // Continue with successfully parsed directives rather than bailing
     if !ledger.errors.is_empty() && !args.no_errors {
-        // A booking failure leaves directives unbooked in this same stream; every
-        // figure below would be derived from them. Checked before the diagnostics
-        // loop so the message the user acts on is the last thing printed.
-        crate::cmd::loadcache::bail_on_booking_errors(&ledger, file)?;
-
         for err in &ledger.errors {
             eprintln!("{}: {}", err.code, err.message);
         }

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -176,6 +176,11 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     // Report errors to stderr (matching bean-query behavior)
     // Continue with successfully parsed directives rather than bailing
     if !ledger.errors.is_empty() && !args.no_errors {
+        // A booking failure leaves directives unbooked in this same stream; every
+        // figure below would be derived from them. Checked before the diagnostics
+        // loop so the message the user acts on is the last thing printed.
+        crate::cmd::loadcache::bail_on_booking_errors(&ledger, file)?;
+
         for err in &ledger.errors {
             eprintln!("{}: {}", err.code, err.message);
         }

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -508,6 +508,11 @@ fn load(
     // ledger says. Left on `eprintln!`, they reached the terminal and nothing
     // else — a confident, complete-looking report over a file that did not
     // parse, which is the failure the sink was introduced to end.
+    // A booking failure leaves directives unbooked in this same stream; every
+    // figure below would be derived from them. Checked before the diagnostics
+    // loop so the message the user acts on is the last thing printed.
+    crate::cmd::loadcache::bail_on_booking_errors(&ledger, file)?;
+
     for err in &ledger.errors {
         warnings.emit(Diagnostic {
             code: Some(err.code.clone()),

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -384,6 +384,40 @@ fn strict_ambiguity_makes_both_surfaces_refuse() {
     }
 }
 
+/// `--no-errors` suppresses PRINTING, not the refusal.
+///
+/// Copilot's catch on the #1987 fix: the guard was nested inside the
+/// `!args.no_errors` block, so `rledger query --no-errors x BALANCES` walked
+/// straight past a booking failure and printed the dangling `-5 AAPL` row with
+/// exit 0 — the exact bug the fix exists to prevent, reachable through a flag
+/// about verbosity.
+///
+/// Note the argument ORDER. `rledger query FILE QUERY --no-errors` puts the
+/// flag after the positionals, where it is swallowed into the BQL text and
+/// never registers — which is how the first attempt to reproduce this
+/// "passed". The flag has to come before the positionals to mean anything.
+#[test]
+fn no_errors_does_not_permit_answering_from_an_unbooked_ledger() {
+    let bin = require_rledger!();
+    let f = write_fixture(&two_lot_fixture("STRICT"));
+    let path = f.path().to_str().unwrap();
+
+    let out = Command::new(&bin)
+        .args(["query", "--no-errors", path, "BALANCES"])
+        .output()
+        .expect("run query");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !out.status.success(),
+        "--no-errors must not license answering over an unbooked ledger: {stdout}"
+    );
+    assert!(
+        !stdout.contains("AAPL"),
+        "no holding may be reported from an unbooked ledger: {stdout}"
+    );
+}
+
 /// AVERAGE diverges today — #1985. Pinned, not skipped.
 ///
 /// A characterization test: it asserts the WRONG current behavior on purpose,

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -184,11 +184,31 @@ fn two_lot_fixture(method: &str) -> String {
   Assets:Cash  -2000.00 USD
 
 2024-06-10 * "sell 5"
-  Assets:Broker   -5 AAPL {{}} @ 180.00 USD
+{reduction}
   Assets:Cash    900.00 USD
   Income:PnL
-"#
+"#,
+        reduction = reduction_for(method),
     )
+}
+
+/// The reduction line, which cannot be the same for every method.
+///
+/// NONE turns cost tracking off, so an empty `{{}}` spec has nothing to
+/// resolve and interpolation fails with "2 unknowns" — the transaction never
+/// books at all. Before #1987 that did not show up here, because both surfaces
+/// then realized the UNBOOKED transaction and agreed: the guard was comparing
+/// two wrong answers and calling it parity. Making booking failures fatal is
+/// what exposed it.
+///
+/// NONE therefore reduces by price rather than by lot, which is the only shape
+/// that means anything when there are no lots.
+fn reduction_for(method: &str) -> &'static str {
+    if method == "NONE" {
+        "  Assets:Broker   -5 AAPL @ 180.00 USD"
+    } else {
+        "  Assets:Broker   -5 AAPL {} @ 180.00 USD"
+    }
 }
 
 /// Every `(units, cost)` pair a surface reports for AAPL, sorted.
@@ -297,21 +317,27 @@ fn every_agreeing_booking_method_realizes_identically() {
     );
 }
 
-/// STRICT ambiguity: both surfaces report it, and they diverge on what
-/// happens next — #1987.
+/// STRICT ambiguity: both surfaces must REFUSE, alike.
 ///
-/// This test used to assert only that both mentioned the message, which
-/// Copilot flagged as not matching its own stated intent ("must FAIL on both
-/// surfaces"). Checking the exit codes turned up a bug the message-only
-/// assertion was hiding: `report balances` PANICS (exit 101, an assertion in
-/// `apply()` about unbooked reductions), while `query BALANCES` exits 0 and
-/// prints a `-5 AAPL` row for an account holding 15 units.
+/// This test was a characterization test for #1987 and has been rewritten
+/// because the fix tripped it, which is exactly what it was for. What it used
+/// to pin:
 ///
-/// Pinned rather than skipped, for the same reason as AVERAGE below: a fix
-/// changes these exit codes and trips this test, forcing it to be rewritten as
-/// the agreement assertion it was always supposed to be.
+/// | surface | exit | behavior |
+/// |---|---|---|
+/// | `query BALANCES` | 0 | printed `-5 AAPL` for an account holding 15 |
+/// | `report balances` | 101 | **panicked** in `apply()` |
+///
+/// One crashed, the other answered wrongly, and neither said so in its exit
+/// code. Now both refuse with the same message and the same status: a
+/// transaction that did not book leaves the stream in pre-booking shape, and
+/// no figure derived from it can be trusted.
+///
+/// Asserting the STATUS and not only the message, which is the gap that hid
+/// the panic: the old version checked that both *printed* the ambiguity, and
+/// both did — one of them on its way to crashing.
 #[test]
-fn strict_ambiguity_is_reported_by_both_surfaces() {
+fn strict_ambiguity_makes_both_surfaces_refuse() {
     let bin = require_rledger!();
     let f = write_fixture(&two_lot_fixture("STRICT"));
     let path = f.path().to_str().unwrap();
@@ -333,33 +359,29 @@ fn strict_ambiguity_is_reported_by_both_surfaces() {
         )
     };
     let (q, r) = (combined(&query), combined(&report));
-    assert!(
-        q.contains("Ambiguous lot match"),
-        "BQL must report the ambiguity: {q}"
-    );
-    assert!(
-        r.contains("Ambiguous lot match"),
-        "report must report the ambiguity: {r}"
-    );
 
-    // The outcomes, which is where they part company (#1987).
     assert!(
-        query.status.success(),
-        "BQL exits 0 today despite the ambiguity — if this now fails, #1987 \
-         has been fixed on the query side; rewrite this test to assert both \
-         surfaces agree"
+        !query.status.success(),
+        "BQL must refuse to answer over an unbooked ledger: {q}"
     );
     assert!(
         !report.status.success(),
-        "report exits non-zero today (it panics in apply()) — if this now \
-         succeeds, #1987 has been fixed on the report side; rewrite this test \
-         to assert both surfaces agree"
+        "report must refuse to answer over an unbooked ledger: {r}"
     );
-    assert!(
-        r.contains("panicked"),
-        "the #1987 shape is a PANIC, not a clean error. If report now fails \
-         cleanly that is the fix landing — rewrite this test.\nreport: {r}"
-    );
+    for (surface, out) in [("query", &q), ("report", &r)] {
+        assert!(
+            out.contains("could not be booked"),
+            "{surface} must say WHY it refused: {out}"
+        );
+        assert!(
+            out.contains("Ambiguous lot match"),
+            "{surface} must name the underlying booking failure: {out}"
+        );
+        assert!(
+            !out.contains("panicked"),
+            "{surface} must fail cleanly, not panic (#1987): {out}"
+        );
+    }
 }
 
 /// AVERAGE diverges today — #1985. Pinned, not skipped.

--- a/crates/rustledger/tests/report_capgains_test.rs
+++ b/crates/rustledger/tests/report_capgains_test.rs
@@ -534,17 +534,44 @@ fn negative_long_term_days_is_rejected() {
     );
 }
 
+/// An ambiguous STRICT reduction makes the report REFUSE, not return empty.
+///
+/// This test previously asserted the opposite — that the report succeeded with
+/// a header-only CSV, on the reasoning that no disposal was fabricated. Not
+/// fabricating a row was right; exiting 0 was not. A header-only capital-gains
+/// CSV is indistinguishable from "you had no disposals this year", so the
+/// failure mode was a confident, complete-looking answer over a ledger that
+/// did not book — the exact hazard `bail_on_parse_errors` already exists to
+/// prevent one phase earlier.
+///
+/// Changed by #1987, where the same unbooked directives made `report balances`
+/// panic and `query BALANCES` print a negative holding. Booking failures are
+/// now refused across the board rather than each report improvising.
 #[test]
-fn ambiguous_strict_reduction_yields_no_rows() {
+fn ambiguous_strict_reduction_is_refused() {
     let bin = require_rledger!();
     let f = write_fixture(LEDGER_AMBIGUOUS);
     let path = f.path().to_str().unwrap();
-    // The report books with the ledger's STRICT method: the ambiguous bare-`{}`
-    // sale does not book, so no disposal is fabricated.
-    let out = run(&bin, &["report", path, "capgains", "--format", "csv"]);
-    assert_eq!(
-        out.lines().count(),
-        1,
-        "header only, no fabricated rows: {out}"
+
+    let out = Command::new(&bin)
+        .args(["report", path, "capgains", "--format", "csv"])
+        .output()
+        .expect("run");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "an unbooked ledger must not yield an exit-0 report: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        stderr.contains("could not be booked"),
+        "the refusal must say why: {stderr}"
+    );
+    // And still no fabricated disposal, which was the original point.
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("AAPL"),
+        "no disposal may be fabricated from an unbooked sale: {}",
+        String::from_utf8_lossy(&out.stdout)
     );
 }


### PR DESCRIPTION
Closes #1987.

## The bug was worse in release than the issue said

`apply()` ended its posting loop with `debug_assert!(reduced.is_ok())` followed by
`let _ = reduced`, commented *"release builds keep the historical
ignore-and-continue behavior"*. So the two build profiles disagreed about a
user's ledger:

| profile | on an ambiguous STRICT reduction |
|---|---|
| debug | `report balances` **panicked**, exit 101 |
| release | the reduction was **dropped** — 20 AAPL reported for an account holding 15 |

The release half is the worse one, and it's the one real users got. An
over-stated holding isn't a crash you can see; it's a number you act on. CI never
saw it because CI runs debug, where the same input panics instead.

Reduction failures are now **returned**. The precondition is unchanged and still
documented — `apply` wants booked input — but violating it is reported rather
than asserted in one profile and ignored in the other. Every existing caller
already handles the `Err`: `book()` records it and marks the transaction failed,
the wasm entry checks `is_ok()`.

## Atomicity

Returning mid-loop would leave earlier postings applied — exactly #1976's shape.
The snapshot gate widens from `overflow_is_possible` to `rollback_needed` =
overflow **or** the transaction contains a reduction.

Kept as two predicates so #1897's reasoning stays legible: snapshotting *every*
transaction cost 2.4× heap churn and 6% CPU, and reductions are a minority of
transactions, so this widens the gate without reopening that regression.
`has_reduction` calls the canonical `Inventory::is_booking_reduction` rather than
re-deriving "is this a reduction" from the sign.

Deliberately *not* relying on the coincidence that `overflow_is_possible` returns
true for an unfilled posting — a filled-but-unbookable transaction (ambiguous
STRICT with explicit amounts) would otherwise mutate half its accounts and then
return `Err`.

## The CLI half

The root cause is upstream of `apply`: `run_booking` partitions failures out, and
`finalize` re-merges them so the user still sees their own input — documented as
*"for output"*, with nothing stopping the same directives flowing into
computation. `account_balances` even documents the precondition the pipeline then
fails to establish.

`bail_on_booking_errors` now gates `query` and `report`, mirroring
`bail_on_parse_errors` one phase later. That also fixes the **query** half, which
never touched `apply`: BALANCES re-aggregates by lot key and printed a dangling
`-5 AAPL`, exiting 0.

```
before:  report → panic, exit 101      query → wrong row, exit 0
after:   both → "1 transaction(s) could not be booked; refusing to derive
                 figures … Run `rledger check x.beancount`", exit 1
```

`rledger check` still reports it, and a clean ledger is untouched (verified).

## Two tests changed because the behavior did

**`strict_ambiguity_is_reported_by_both_surfaces`** was the characterization test
added with the guard in #1986. It tripped — which is what it was for — and is now
the agreement assertion it was always meant to be.

**`ambiguous_strict_reduction_yields_no_rows`** asserted capgains *succeeded* with
a header-only CSV. Not fabricating a disposal was right; exiting 0 was not — a
header-only capital-gains CSV is indistinguishable from "you had no disposals this
year". It now asserts the refusal **and** that no row is fabricated.

## A third finding

The parity guard's NONE fixture was comparing two **wrong** answers. `-5 AAPL {}`
cannot book under NONE (cost tracking off → "2 unknowns"), so both surfaces were
realizing an unbooked transaction and agreeing. Making failures fatal is what
exposed it. NONE now reduces by price, the only shape that means anything without
lots.

## Verification

| sabotage | result |
|---|---|
| restore ignore-and-continue | 2 tests fail |
| return `Err` without rolling back | atomicity test fails |

The new tests pass identically under `--release`, which is the point — the old
`debug_assert` is exactly why debug and release disagreed.

`cargo test --workspace` — 134 suites, 0 failures. Clippy and fmt clean.
