### PR TITLE
fix(query): realize BALANCES through the booking engine, not a bare add

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -619,16 +619,6 @@ impl BookingEngine {
         })
     }
 
-    /// Apply ONE posting to the running inventories, returning an error if it
-    /// reduces a lot that is not held.
-    ///
-    /// The per-posting core of [`Self::apply`], which ignores a reduction failure
-    /// per its booked-input contract; the fallible signature keeps the over-sell
-    /// detectable by the `debug_assert` there.
-    ///
-    /// # Errors
-    /// Returns the reduce error when the posting reduces a lot that is not held
-    /// (an over-sell / unbooked-input contract violation).
     /// Apply ONE booked posting to the running inventories.
     ///
     /// The canonical "what does this posting do to an inventory" decision:
@@ -651,14 +641,6 @@ impl BookingEngine {
     ///
     /// Same as [`Self::apply`]: the posting must already be booked.
     pub fn apply_posting(
-        &mut self,
-        posting: &Posting,
-        date: rustledger_core::NaiveDate,
-    ) -> Result<(), BookingError> {
-        self.try_apply_posting(posting, date)
-    }
-
-    fn try_apply_posting(
         &mut self,
         posting: &Posting,
         date: rustledger_core::NaiveDate,
@@ -872,7 +854,7 @@ impl BookingEngine {
             // other. Callers already handle this — `book()` records the error
             // and marks the transaction failed, the wasm entry point checks
             // `is_ok()`, and the CLI refuses to derive a figure at all.
-            if let Err(e) = self.try_apply_posting(posting, txn.date) {
+            if let Err(e) = self.apply_posting(posting, txn.date) {
                 // `snapshot` is `Some` whenever this arm is reachable:
                 // `rollback_needed` covers both failure modes. Restoring
                 // nothing would be silent corruption — precisely the bug being

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -629,6 +629,35 @@ impl BookingEngine {
     /// # Errors
     /// Returns the reduce error when the posting reduces a lot that is not held
     /// (an over-sell / unbooked-input contract violation).
+    /// Apply ONE booked posting to the running inventories.
+    ///
+    /// The canonical "what does this posting do to an inventory" decision:
+    /// resolve the account's booking method, then REDUCE against a lot or ADD a
+    /// new one. Public because the query engine needs exactly this and was
+    /// re-deriving a broken half of it — `Inventory::add` unconditionally, with
+    /// no reduction branch at all (#1985). That looked right for FIFO/LIFO,
+    /// where booking has already resolved the reduction's cost so its lot key
+    /// matches an existing lot and `add` nets it by coincidence, and produced a
+    /// dangling negative position under AVERAGE, where the reduction is booked
+    /// at the merged average cost — a key belonging to no augmentation.
+    ///
+    /// # Errors
+    ///
+    /// [`BookingError`] when the reduction finds no matching lot, or an `add`
+    /// overflows. Unlike [`Self::apply`] this is a SINGLE posting, so there is
+    /// nothing to roll back — the caller owns transaction atomicity.
+    ///
+    /// # Precondition
+    ///
+    /// Same as [`Self::apply`]: the posting must already be booked.
+    pub fn apply_posting(
+        &mut self,
+        posting: &Posting,
+        date: rustledger_core::NaiveDate,
+    ) -> Result<(), BookingError> {
+        self.try_apply_posting(posting, date)
+    }
+
     fn try_apply_posting(
         &mut self,
         posting: &Posting,

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -506,6 +506,25 @@ impl Inventory {
     }
 
     /// AVERAGE booking: merge all lots of the currency.
+    ///
+    /// Stricter than Python: beancount does NOT implement this method.
+    /// `beancount.parser.booking_method.booking_method_AVERAGE` raises
+    /// `AmbiguousMatchError("AVERAGE method is not supported")`, with the real
+    /// implementation left commented out ("DISABLED - This is the code for
+    /// AVERAGE, which is currently disabled"). `Booking.AVERAGE` exists in the
+    /// enum and is accepted in an `open` directive, so a ledger declaring it
+    /// parses and then books nothing.
+    ///
+    /// Two consequences worth knowing before changing anything here:
+    ///
+    /// * The compat oracle cannot referee this. There is no reference answer
+    ///   to diff against, so correctness rests on the definition — the merged
+    ///   lot's cost is the cost-weighted average of the lots it replaces — and
+    ///   on the two rledger surfaces agreeing.
+    /// * That is exactly why #1985 survived: BQL netted by lot key and produced
+    ///   a dangling negative position where reports produced the merged lot,
+    ///   and no differential test could see it. The internal parity guard
+    ///   (`query_report_realization_parity_test`) is what caught it.
     pub(super) fn reduce_average(&mut self, units: &Amount) -> Result<BookingResult, BookingError> {
         let matching: Vec<&Position> = self
             .positions

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -528,8 +528,23 @@ impl<'a> Executor<'a> {
         // keeps (plus the pre-`open_on` carry-in below), independent of the WHERE
         // filter, so `account_balance` always reflects the account's true ledger
         // balance at the point of the posting.
-        let mut account_balances: FxHashMap<rustledger_core::Account, Inventory> =
-            FxHashMap::default();
+        // Realize through the BOOKING ENGINE, not a bare inventory map.
+        //
+        // This used to be `FxHashMap<Account, Inventory>` accumulated with
+        // `Inventory::add` — unconditionally, with no reduction branch at all.
+        // For FIFO/LIFO that looks right by coincidence: booking has already
+        // resolved a reduction's cost, so its lot key matches an existing lot
+        // and `add` nets it. Under AVERAGE it does not, because the reduction
+        // is booked at the MERGED average cost — a key belonging to no
+        // augmentation — so it survived as a dangling negative position and
+        // BALANCES reported `10 {200}  10 {150}  -5 {175}` for an account
+        // holding 15 (#1985).
+        //
+        // `apply_posting` is the same decision `report balances` realizes
+        // through, which is the point: two realizations of one ledger is the
+        // duplication registry's realization family, and this was the drift.
+        let mut engine = rustledger_booking::BookingEngine::new();
+        engine.register_account_methods(self.resolved_directives());
         // Single cumulative running balance across WHERE-filtered postings in
         // iteration order. This is the bean-query `balance` semantic: a snapshot
         // of "everything selected so far" rather than a per-account view.
@@ -563,13 +578,9 @@ impl<'a> Executor<'a> {
                         // didn't make it past the FROM filter.
                         if needs_account_balance {
                             for posting in &txn.postings {
-                                if let Some(pos) = resolve_position(posting, txn.date) {
-                                    let bal = account_balances
-                                        .entry(posting.account.clone())
-                                        .or_default();
-                                    bal.add(pos)
-                                        .map_err(|e| QueryError::Evaluation(e.to_string()))?;
-                                }
+                                engine
+                                    .apply_posting(posting, txn.date)
+                                    .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                         }
                         continue;
@@ -600,9 +611,9 @@ impl<'a> Executor<'a> {
                     // posting; `Inventory::add` allocates internally so the
                     // saving compounds across a long run).
                     let resolved = resolve_position(posting, txn.date);
-                    if needs_account_balance && let Some(pos) = resolved.clone() {
-                        let bal = account_balances.entry(posting.account.clone()).or_default();
-                        bal.add(pos)
+                    if needs_account_balance {
+                        engine
+                            .apply_posting(posting, txn.date)
                             .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                     }
 
@@ -650,7 +661,7 @@ impl<'a> Executor<'a> {
                             None
                         },
                         account_balance: if needs_account_balance {
-                            account_balances.get(&posting.account).cloned()
+                            engine.inventory(&posting.account).cloned()
                         } else {
                             None
                         },
@@ -683,7 +694,7 @@ impl<'a> Executor<'a> {
 
         Ok(PostingScan {
             postings,
-            account_balances,
+            account_balances: engine.into_inventories(),
         })
     }
     /// Is this call `WEIGHT(position)` over the posting COLUMN?

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -544,7 +544,6 @@ impl<'a> Executor<'a> {
         // through, which is the point: two realizations of one ledger is the
         // duplication registry's realization family, and this was the drift.
         let mut engine = rustledger_booking::BookingEngine::new();
-        engine.register_account_methods(self.resolved_directives());
         // Single cumulative running balance across WHERE-filtered postings in
         // iteration order. This is the bean-query `balance` semantic: a snapshot
         // of "everything selected so far" rather than a per-account view.
@@ -554,6 +553,11 @@ impl<'a> Executor<'a> {
         // Handle both spanned and unspanned directives
         let directive_iter: Vec<(usize, &Directive)> =
             self.resolved_directives().enumerate().collect();
+        // Register from the vec just built rather than walking the directive
+        // stream a second time — Copilot's catch. `register_account_methods`
+        // only reads `Open` directives, so the order is irrelevant and this is
+        // the same registration, one pass earlier.
+        engine.register_account_methods(directive_iter.iter().map(|(_, d)| *d));
 
         // Resolve a posting to a Position that preserves cost basis when present.
         // The single cost-resolve lives in `Position::from_posting`, shared with
@@ -610,7 +614,15 @@ impl<'a> Executor<'a> {
                     // account_balance (saves the `.clone()` + map probe per
                     // posting; `Inventory::add` allocates internally so the
                     // saving compounds across a long run).
-                    let resolved = resolve_position(posting, txn.date);
+                    // Only `needs_balance` reads this now. Before #1985 the
+                    // per-account accumulation used it too, so it was
+                    // unconditional; `apply_posting` resolves the position
+                    // itself, so computing it here for a query that reads
+                    // neither column was a `Position::from_posting` per
+                    // posting for nothing. Copilot's catch.
+                    let resolved = needs_balance
+                        .then(|| resolve_position(posting, txn.date))
+                        .flatten();
                     if needs_account_balance {
                         engine
                             .apply_posting(posting, txn.date)

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -1,16 +1,24 @@
 //! Drift guard: BQL `BALANCES` and `report balances` must agree on netted
 //! reductions.
 //!
-//! The two surfaces realize balances differently by construction: the query
-//! executor re-aggregates already-booked postings with naive `Inventory::add`
-//! (lot-key netting), while reports realize through the booking engine's
-//! lot-matching `apply`. They agree today ONLY because both consume
-//! post-booking directives — the loader's book phase has already matched
-//! every reduction against its lot, so naive re-aggregation lands on the
-//! same keys. That invariant holds by pipeline design, not by any type-level
-//! guarantee: feeding the executor unbooked directives (a new embedding
-//! path, a harness shortcut) would silently reactivate the #1726 class in
-//! BQL while reports stayed correct.
+//! The two surfaces now realize balances the SAME way — both through
+//! `BookingEngine`, which resolves the account's booking method and reduces
+//! against a lot or adds a new one.
+//!
+//! They did not always. Until #1985 the query executor re-aggregated
+//! already-booked postings with a naive `Inventory::add` — unconditionally,
+//! with no reduction branch at all — and this file used to explain that the
+//! two agreed "ONLY because both consume post-booking directives ... so naive
+//! re-aggregation lands on the same keys". That was true for FIFO/LIFO/HIFO
+//! and false for AVERAGE, where a reduction is booked at the merged average
+//! cost, a key belonging to no augmentation. It survived as a dangling
+//! negative position, and BQL reported a negative holding for an account that
+//! held 15 units.
+//!
+//! Recorded rather than deleted because the shape recurs: an invariant that
+//! holds "by pipeline design, not by any type-level guarantee" is one nobody
+//! is checking, and the exception had been shipping for as long as AVERAGE
+//! had. These tests are that check.
 //!
 //! These tests pin the agreement on the two reduction shapes that killed
 //! the reports in #1726: an explicit-cost reduction with a price
@@ -150,16 +158,11 @@ fn fifo_empty_spec_reduction_nets_identically() {
 //
 // The two fixtures above pin FIFO-via-empty-`{}` and an explicit-cost
 // reduction. That left five of seven booking methods unpinned, and the gap was
-// load-bearing: AVERAGE diverges today (#1985). The docstring at the top of
-// this file states the invariant that fails —
-//
-//   "they agree ... ONLY because both consume post-booking directives — the
-//    loader's book phase has already matched every reduction against its lot,
-//    so naive re-aggregation lands on the same keys"
-//
-// — and AVERAGE is the one method where a reduction is booked at a cost that
-// belongs to NO augmentation (the merged average), so it has no key to net
-// against and survives as a negative row.
+// load-bearing: extending the matrix is what found #1985 (AVERAGE realizing
+// differently on the two surfaces) and #1987 (STRICT ambiguity panicking one
+// surface while the other answered wrongly). Both are fixed; the matrix stays
+// so the next method added is pinned from the start rather than five releases
+// later.
 //
 // `broker_holding` above cannot express this: it asserts exactly ONE AAPL
 // line, which is right for a fully netted holding and wrong for every method
@@ -291,11 +294,14 @@ fn surfaces(method: &str) -> (Vec<(String, String)>, Vec<(String, String)>) {
     )
 }
 
-/// FIFO, LIFO, HIFO and NONE must realize identically on both surfaces.
+/// Every booking method must realize identically on both surfaces.
 ///
-/// Four methods, one test, because the failure mode is per-method and naming
-/// them all in one assertion means a regression in exactly one still reports
-/// which one.
+/// FIFO, LIFO, HIFO, NONE and — since #1985 — AVERAGE. One test rather than
+/// five, because the failure mode is per-method and collecting the
+/// disagreements means a regression in exactly one still names which one.
+///
+/// AVERAGE is asserted again on its own below, for the netted SHAPE that set
+/// comparison cannot express.
 #[test]
 fn every_agreeing_booking_method_realizes_identically() {
     let _ = require_rledger!();

--- a/crates/rustledger/tests/query_report_realization_parity_test.rs
+++ b/crates/rustledger/tests/query_report_realization_parity_test.rs
@@ -301,7 +301,7 @@ fn every_agreeing_booking_method_realizes_identically() {
     let _ = require_rledger!();
     let mut disagreed: Vec<String> = Vec::new();
 
-    for method in ["FIFO", "LIFO", "HIFO", "NONE"] {
+    for method in ["FIFO", "LIFO", "HIFO", "NONE", "AVERAGE"] {
         let (query, report) = surfaces(method);
         if query != report {
             disagreed.push(format!("{method}: query={query:?} report={report:?}"));
@@ -418,35 +418,65 @@ fn no_errors_does_not_permit_answering_from_an_unbooked_ledger() {
     );
 }
 
-/// AVERAGE diverges today — #1985. Pinned, not skipped.
+/// AVERAGE too — the divergence #1985 named, now fixed.
 ///
-/// A characterization test: it asserts the WRONG current behavior on purpose,
-/// so that whichever way #1985 is fixed, this fails and forces the guard above
-/// to be updated to include AVERAGE. Marking it `#[ignore]` instead would mean
-/// the fix lands with nothing noticing, which is how a known divergence
-/// quietly becomes a permanent one.
+/// This replaces `average_booking_diverges_today`, a characterization test
+/// that asserted the WRONG behavior on purpose so a fix would trip it. It did,
+/// which is what it was for. What it used to pin:
 ///
-/// The report is correct (one netted `15 AAPL {175.00}`); BQL re-aggregates by
-/// lot key and produces the two original lots plus a dangling `-5` at the
-/// merged average cost, which belongs to no augmentation.
+/// | surface | AAPL for an account holding 15 |
+/// |---|---|
+/// | `report balances` | `15 AAPL {175.00}` |
+/// | `query BALANCES` | `10 {200}` + `10 {150}` + **`-5 {175}`** |
+///
+/// The cause was two realizations of one ledger. BQL accumulated with
+/// `Inventory::add` unconditionally, with no reduction branch at all — right
+/// for FIFO/LIFO by coincidence, because booking has already resolved a
+/// reduction's cost so its lot key matches an existing lot and `add` nets it.
+/// Under AVERAGE the reduction is booked at the MERGED average cost, a key
+/// belonging to no augmentation, so it survived as a dangling negative.
+///
+/// BQL now realizes through `BookingEngine::apply_posting`, the same decision
+/// reports use, so this is one realization rather than two that agree by
+/// luck.
+///
+/// Kept SEPARATE from the loop above rather than folded into it, because the
+/// netting is what makes AVERAGE different: it is the only method whose
+/// holding collapses to a single lot, and asserting that shape is worth more
+/// than one more iteration of a set comparison.
+///
+/// DELIBERATE DEVIATION, and the reason this bug needed an internal guard.
+/// Python beancount does NOT implement AVERAGE: `booking_method_AVERAGE`
+/// raises `AmbiguousMatchError("AVERAGE method is not supported")` and the real
+/// implementation sits commented out ("DISABLED - This is the code for
+/// AVERAGE"). Run this fixture through beancount and it books no reduction at
+/// all, leaving 20 units.
+///
+/// So there is no oracle for this. The compat suite cannot referee it, and the
+/// value asserted here rests on the definition instead: 10 @ 150 plus 10 @ 200
+/// is 3500 over 20 units, so 175.00 per unit; selling 5 leaves 15 at 175.00.
+/// That is textbook average-cost, and it is what both surfaces now produce.
+///
+/// Worth stating because it is the general case, not a footnote: a divergence
+/// in a feature the reference implementation does not have is invisible to
+/// differential testing by construction. The parity guard between our OWN two
+/// surfaces is the only thing that could have found it.
 #[test]
-fn average_booking_diverges_today() {
+fn average_booking_nets_to_a_single_merged_lot() {
     let _ = require_rledger!();
     let (query, report) = surfaces("AVERAGE");
 
     assert_eq!(
         report,
         vec![("15".to_owned(), "175.00".to_owned())],
-        "report should net AVERAGE to a single merged lot"
+        "report must net AVERAGE to one merged lot"
     );
-    assert_ne!(
+    assert_eq!(
         query, report,
-        "AVERAGE now AGREES between query and report — #1985 is fixed. \
-         Delete this test and add \"AVERAGE\" to \
-         `every_agreeing_booking_method_realizes_identically`."
+        "BQL must realize AVERAGE the same way the report does (#1985)"
     );
     assert!(
-        query.iter().any(|(units, _)| units.starts_with('-')),
-        "the #1985 shape is a surviving NEGATIVE lot; got {query:?}"
+        !query.iter().any(|(units, _)| units.starts_with('-')),
+        "a negative holding is the #1985 shape and must not return: {query:?}"
     );
 }


### PR DESCRIPTION
Closes #1985.

## The bug

BQL accumulated per-account balances with `Inventory::add` — **unconditionally,
with no reduction branch at all**. Reports realize through `BookingEngine`, which
resolves the account's booking method and then *reduces against a lot* or *adds a
new one*.

The two agreed for FIFO/LIFO/HIFO **by coincidence**: booking has already
resolved a reduction's cost, so its lot key matches an existing lot and `add`
nets it. Under AVERAGE it doesn't — the reduction is booked at the *merged
average* cost, a key belonging to no augmentation — so it survived as a dangling
negative:

```
query BALANCES   10 AAPL {200.00}   10 AAPL {150.00}   -5 AAPL {175.00}
report balances  15 AAPL {175.00}
```

…for an account holding 15. `SELECT SUM(number)` agreed with the report all
along at 15, so the units were right and only the lot-keyed presentation was
wrong.

BQL now calls `BookingEngine::apply_posting`, newly public because the query
engine needed exactly this decision and was re-deriving a broken half of it. One
realization rather than two that agree by luck — the duplication registry's
realization family, and this was the drift.

## Why no differential test could have found this

**Python beancount does not implement AVERAGE.**
`beancount.parser.booking_method.booking_method_AVERAGE` raises
`AmbiguousMatchError("AVERAGE method is not supported")`, with the real
implementation left commented out (*"DISABLED - This is the code for AVERAGE,
which is currently disabled"*). Meanwhile `Booking.AVERAGE` stays in the enum and
is accepted in an `open` directive — so a ledger declaring it parses and then
books nothing. Run this PR's fixture through beancount and 20 units remain.

So the compat oracle **cannot referee this**. Correctness rests on the definition
— 10 @ 150 plus 10 @ 200 is 3500 over 20 units, so 175.00 per unit; less 5 leaves
15 at 175.00 — and on the two surfaces agreeing.

That's the general point rather than a footnote: **a divergence in a feature the
reference implementation lacks is invisible to differential testing by
construction.** The internal parity guard was the only thing that could have
caught it, which is a decent argument for #1902's whole approach. Documented at
`reduce_average`, where someone will next be tempted to "match beancount".

## Test churn

`average_booking_diverges_today` was the characterization test added with the
guard in #1986 — it asserted the wrong behavior on purpose so a fix would trip
it. It did. Replaced by `average_booking_nets_to_a_single_merged_lot`, and
AVERAGE joins the agreeing-methods loop.

## Verification

| sabotage | result |
|---|---|
| restore the unconditional `add` | 2 tests fail |
| build the engine without registering account methods (AVERAGE falls back to the default) | 2 tests fail |

`cargo test --workspace` — 134 suites, 0 failures. Clippy and fmt clean. The
beancount oracle reports 0 divergences on every axis, and its self-test passes.
