### PR TITLE
refactor(core): one is_default_account_root, and a guard on the list it reads

### DIFF
--- a/crates/rustledger-completion/src/lib.rs
+++ b/crates/rustledger-completion/src/lib.rs
@@ -17,6 +17,18 @@
 //!    neutral [`CompletionCandidate`] lists for each context.
 
 /// Standard Beancount account types.
+///
+/// A DELIBERATE copy of `rustledger_core::ACCOUNT_TYPES`, which names this one
+/// in return. This crate has no dependencies at all — that is what lets both
+/// the LSP and the WASM editor take it — so it cannot read core's.
+///
+/// Kept honest by `account_types_match_core` in `rustledger-lsp`, which is a
+/// crate that can see both. Without that guard the copy is the #1964 shape:
+/// two lists that agree until one of them does not, with each side's tests
+/// passing throughout.
+///
+/// Only the DEFAULT roots. Classification of a real account belongs to
+/// `rustledger_core::AccountTypes`, which honors the `name_*` renames.
 pub const ACCOUNT_TYPES: &[&str] = &["Assets", "Liabilities", "Equity", "Income", "Expenses"];
 
 /// Standard Beancount directives.

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -335,6 +335,14 @@ pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income
 
 /// Whether a bare word is one of the DEFAULT account-type roots.
 ///
+/// Named for what it does, not for what it might be mistaken for. It was
+/// `is_account_type`, which promises CLASSIFICATION — and on a ledger with
+/// `option "name_expenses" "Depenses"` it answers `false` for `Depenses` and
+/// `true` for `Expenses`, both wrong as classification. It is inert today
+/// because a bare root is not a valid account name, so nothing downstream can
+/// act on it (#1964); the name was the part that could mislead the next
+/// caller, who might use it where it is not inert.
+///
 /// The single implementation of a question the editor surfaces both asked
 /// separately: `rustledger-lsp` matched against [`ACCOUNT_TYPES`] while
 /// `rustledger-wasm` inlined its own `matches!` over the same five strings.
@@ -356,7 +364,7 @@ pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income
 /// reference contains a `:` and should be classified with [`AccountTypes`],
 /// which honors the `name_*` renames.
 #[must_use]
-pub fn is_account_type(word: &str) -> bool {
+pub fn is_default_account_root(word: &str) -> bool {
     ACCOUNT_TYPES.contains(&word)
 }
 

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -333,6 +333,33 @@ pub fn is_subaccount_or_equal(child: &str, parent: &str) -> bool {
 /// classify accounts in a config-aware context.
 pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
 
+/// Whether a bare word is one of the DEFAULT account-type roots.
+///
+/// The single implementation of a question the editor surfaces both asked
+/// separately: `rustledger-lsp` matched against [`ACCOUNT_TYPES`] while
+/// `rustledger-wasm` inlined its own `matches!` over the same five strings.
+/// They agreed only because the two lists happened to hold the same words, and
+/// each carried its own copy of the same five-case test — so a drift would have
+/// left both suites passing while the two surfaces disagreed. That is the
+/// re-derivation shape the duplication review (#1731–#1743) traced every found
+/// bug to, and #1964 is the same shape one layer up.
+///
+/// # Not config-aware, deliberately
+///
+/// This answers for the default English roots only. It exists for the editor's
+/// lexical question — "does this bare word look like an account root, so should
+/// I offer hover/definition affordances?" — asked about a word that is often
+/// typed into a buffer with no ledger loaded at all.
+///
+/// It is NOT the classifier for an account you hold. A bare root is not even a
+/// valid account name (`open Assets` is a parse error), so every real account
+/// reference contains a `:` and should be classified with [`AccountTypes`],
+/// which honors the `name_*` renames.
+#[must_use]
+pub fn is_account_type(word: &str) -> bool {
+    ACCOUNT_TYPES.contains(&word)
+}
+
 /// The five beancount account-type kinds, independent of their configured
 /// root names.
 ///

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -83,7 +83,7 @@ pub use format::{
 };
 pub use identifiers::{
     ACCOUNT_TYPES, Account, AccountTypeKind, AccountTypes, Currency, Link, Tag, account_type,
-    is_account_type, is_subaccount_or_equal,
+    is_default_account_root, is_subaccount_or_equal,
 };
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -83,7 +83,7 @@ pub use format::{
 };
 pub use identifiers::{
     ACCOUNT_TYPES, Account, AccountTypeKind, AccountTypes, Currency, Link, Tag, account_type,
-    is_subaccount_or_equal,
+    is_account_type, is_subaccount_or_equal,
 };
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};

--- a/crates/rustledger-lsp/src/handlers/definition.rs
+++ b/crates/rustledger-lsp/src/handlers/definition.rs
@@ -10,9 +10,7 @@ use rustledger_parser::ParseResult;
 
 use crate::ledger_state::LedgerState;
 
-use super::utils::{
-    LineIndex, PositionEncoding, get_word_at_source_position, is_account_type, is_currency_like,
-};
+use super::utils::{LineIndex, PositionEncoding, get_word_at_source_position, is_currency_like};
 
 /// Handle a go-to-definition request.
 pub fn handle_goto_definition(
@@ -36,7 +34,7 @@ pub fn handle_goto_definition(
     // after a one-shot O(n) build.
     let line_index = LineIndex::new(source, encoding);
 
-    let is_account = word.contains(':') || is_account_type(&word);
+    let is_account = word.contains(':') || rustledger_core::is_default_account_root(&word);
 
     // Check if it's an account name (current file first).
     if is_account

--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -13,7 +13,7 @@ use crate::ledger_state::LedgerState;
 
 use super::utils::{
     PositionEncoding, commodity_declaration_spans, count_noun, get_word_at_source_position,
-    is_account_type, is_currency_like_simple,
+    is_currency_like_simple,
 };
 
 /// Handle a hover request.
@@ -36,7 +36,7 @@ pub fn handle_hover(
     let ledger_directives = ledger_state.and_then(LedgerState::directives);
 
     // Check if it's an account name
-    if (word.contains(':') || is_account_type(&word))
+    if (word.contains(':') || rustledger_core::is_default_account_root(&word))
         && let Some(info) = get_account_info(&word, parse_result, ledger_directives)
     {
         return Some(Hover {

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -473,12 +473,6 @@ pub fn is_account_like(s: &str) -> bool {
             .any(|t| s.starts_with(t))
 }
 
-/// Check if a string is a standard root account type.
-#[must_use]
-pub fn is_account_type(s: &str) -> bool {
-    rustledger_core::is_account_type(s)
-}
-
 /// Check if a string looks like a currency (simple format check).
 ///
 /// Currencies are typically 2-5 uppercase letters/digits (e.g., USD, EUR, BTC).
@@ -904,15 +898,6 @@ mod tests {
         assert!(!is_account_like("Random:Thing"));
     }
 
-    #[test]
-    fn test_is_account_type() {
-        assert!(is_account_type("Assets"));
-        assert!(is_account_type("Liabilities"));
-        assert!(is_account_type("Income"));
-        assert!(!is_account_type("Bank"));
-        assert!(!is_account_type("assets"));
-    }
-
     /// The two account-root lists must not drift apart.
     ///
     /// `rustledger-completion` keeps its own copy because it has no
@@ -939,19 +924,19 @@ mod tests {
     /// And the predicate must answer for exactly that list.
     ///
     /// Guards the direction the equality above cannot: a future
-    /// `is_account_type` that hardcoded its own words would still pass a test
+    /// `is_default_account_root` that hardcoded its own words would still pass a test
     /// comparing two constants. This asks the function about every root, and
     /// about a word that is not one.
     #[test]
-    fn is_account_type_answers_for_every_root() {
+    fn is_default_account_root_answers_for_every_root() {
         for root in rustledger_core::ACCOUNT_TYPES {
             assert!(
-                is_account_type(root),
-                "{root} is an account root but is_account_type says otherwise"
+                rustledger_core::is_default_account_root(root),
+                "{root} is an account root but is_default_account_root says otherwise"
             );
         }
         assert!(
-            !is_account_type("Depenses"),
+            !rustledger_core::is_default_account_root("Depenses"),
             "a renamed root is not a default"
         );
     }

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -476,7 +476,7 @@ pub fn is_account_like(s: &str) -> bool {
 /// Check if a string is a standard root account type.
 #[must_use]
 pub fn is_account_type(s: &str) -> bool {
-    rustledger_core::ACCOUNT_TYPES.contains(&s)
+    rustledger_core::is_account_type(s)
 }
 
 /// Check if a string looks like a currency (simple format check).
@@ -911,6 +911,49 @@ mod tests {
         assert!(is_account_type("Income"));
         assert!(!is_account_type("Bank"));
         assert!(!is_account_type("assets"));
+    }
+
+    /// The two account-root lists must not drift apart.
+    ///
+    /// `rustledger-completion` keeps its own copy because it has no
+    /// dependencies at all — that is what lets both the LSP and the WASM editor
+    /// take it. A deliberate copy is only allowed here if something asserts the
+    /// agreement (CLAUDE.md's canonical-function rule), and nothing did: each
+    /// crate tested its own list against its own expectations, so a change to
+    /// one would have left both suites green while the two surfaces disagreed
+    /// about what an account root is.
+    ///
+    /// This lives in the LSP because it is a crate that can see BOTH, which
+    /// neither of the two owners can.
+    #[test]
+    fn account_types_match_core() {
+        assert_eq!(
+            rustledger_completion::ACCOUNT_TYPES,
+            rustledger_core::ACCOUNT_TYPES,
+            "rustledger-completion's ACCOUNT_TYPES has drifted from \
+             rustledger-core's; they are a deliberate copy of one another and \
+             every editor surface assumes they agree"
+        );
+    }
+
+    /// And the predicate must answer for exactly that list.
+    ///
+    /// Guards the direction the equality above cannot: a future
+    /// `is_account_type` that hardcoded its own words would still pass a test
+    /// comparing two constants. This asks the function about every root, and
+    /// about a word that is not one.
+    #[test]
+    fn is_account_type_answers_for_every_root() {
+        for root in rustledger_core::ACCOUNT_TYPES {
+            assert!(
+                is_account_type(root),
+                "{root} is an account root but is_account_type says otherwise"
+            );
+        }
+        assert!(
+            !is_account_type("Depenses"),
+            "a renamed root is not a default"
+        );
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/editor/definitions.rs
+++ b/crates/rustledger-wasm/src/editor/definitions.rs
@@ -5,7 +5,7 @@ use rustledger_parser::ParseResult;
 
 use crate::types::EditorLocation;
 
-use super::helpers::{get_word_at_position, is_account_type, is_currency_like};
+use super::helpers::{get_word_at_position, is_currency_like};
 use super::line_index::{EditorCache, LineIndex};
 
 /// Get the definition location for the symbol at the given position (using cached data).
@@ -19,7 +19,7 @@ pub fn get_definition_cached(
     let word = get_word_at_position(source, line, character)?;
 
     // Check if it's an account name
-    if (word.contains(':') || is_account_type(&word))
+    if (word.contains(':') || rustledger_core::is_default_account_root(&word))
         && let Some(location) =
             find_account_definition_cached(&word, parse_result, &cache.line_index)
     {

--- a/crates/rustledger-wasm/src/editor/helpers.rs
+++ b/crates/rustledger-wasm/src/editor/helpers.rs
@@ -48,11 +48,6 @@ pub fn is_word_char(c: char) -> bool {
     c.is_alphanumeric() || c == ':' || c == '_' || c == '-'
 }
 
-/// Check if a string looks like an account type.
-pub fn is_account_type(s: &str) -> bool {
-    rustledger_core::is_account_type(s)
-}
-
 /// Check if a string looks like a currency (all uppercase, 2-5 chars).
 pub fn is_currency_like(s: &str) -> bool {
     s.len() >= 2
@@ -236,17 +231,6 @@ mod tests {
         assert!(!is_currency_like("U")); // Too short
         assert!(!is_currency_like("VERYLONGCURRENCY")); // Too long
         assert!(!is_currency_like("usd")); // Lowercase
-    }
-
-    #[test]
-    fn test_is_account_type() {
-        assert!(is_account_type("Assets"));
-        assert!(is_account_type("Liabilities"));
-        assert!(is_account_type("Equity"));
-        assert!(is_account_type("Income"));
-        assert!(is_account_type("Expenses"));
-        assert!(!is_account_type("Other"));
-        assert!(!is_account_type("assets")); // Case-sensitive
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/editor/helpers.rs
+++ b/crates/rustledger-wasm/src/editor/helpers.rs
@@ -50,10 +50,7 @@ pub fn is_word_char(c: char) -> bool {
 
 /// Check if a string looks like an account type.
 pub fn is_account_type(s: &str) -> bool {
-    matches!(
-        s,
-        "Assets" | "Liabilities" | "Equity" | "Income" | "Expenses"
-    )
+    rustledger_core::is_account_type(s)
 }
 
 /// Check if a string looks like a currency (all uppercase, 2-5 chars).

--- a/crates/rustledger-wasm/src/editor/hover.rs
+++ b/crates/rustledger-wasm/src/editor/hover.rs
@@ -6,8 +6,7 @@ use rustledger_parser::ParseResult;
 use crate::types::EditorHoverInfo;
 
 use super::helpers::{
-    count_account_usages, count_currency_usages, get_word_at_position, is_account_type,
-    is_currency_like,
+    count_account_usages, count_currency_usages, get_word_at_position, is_currency_like,
 };
 use super::line_index::EditorCache;
 
@@ -33,7 +32,7 @@ pub fn get_hover_info(
     let word = get_word_at_position(source, line, character)?;
 
     // Check if it's an account name
-    if (word.contains(':') || is_account_type(&word))
+    if (word.contains(':') || rustledger_core::is_default_account_root(&word))
         && let Some(info) = get_account_hover_info(&word, parse_result)
     {
         return Some(EditorHoverInfo {

--- a/crates/rustledger-wasm/src/editor/references.rs
+++ b/crates/rustledger-wasm/src/editor/references.rs
@@ -7,7 +7,7 @@ use crate::types::{EditorRange, EditorReference, EditorReferencesResult, Referen
 
 use super::helpers::{
     find_nth_word_in_line, find_quoted_string_in_line, find_word_in_line, get_line,
-    get_word_at_position, is_account_type, is_currency_like,
+    get_word_at_position, is_currency_like,
 };
 use super::line_index::{EditorCache, LineIndex};
 
@@ -22,7 +22,7 @@ pub fn get_references_cached(
     let word = get_word_at_position(source, line, character)?;
 
     // Check if it's an account name
-    if word.contains(':') || is_account_type(&word) {
+    if word.contains(':') || rustledger_core::is_default_account_root(&word) {
         return Some(find_account_references(
             &word,
             source,


### PR DESCRIPTION
Follow-up from reviewing #1964. That issue is about classifiers that hardcode
account roots — and the predicate asking that very question was itself
duplicated, in the two crates that must agree about it:

```rust
// crates/rustledger-wasm/src/editor/helpers.rs
matches!(s, "Assets" | "Liabilities" | "Equity" | "Income" | "Expenses")

// crates/rustledger-lsp/src/handlers/utils.rs
rustledger_core::ACCOUNT_TYPES.contains(&s)
```

They agreed only because those five words happened to appear in both, and **each
crate carried its own five-case unit test** — so a change to either would have
left both suites green while the two editor surfaces disagreed about what an
account root is.

Now one function in `rustledger-core`, next to the list it reads. Both editor
crates already depend on core, so this needed no new dependency edge.

## The list that stays duplicated, and why that is now safe

`rustledger-completion` keeps its own copy: the crate has **zero dependencies**,
which is precisely what lets both the LSP and the WASM editor take it. Core's
constant already documented that copy; completion's now names core's back — the
half of CLAUDE.md's "document the divergence at BOTH sites" that was missing.

What was *also* missing is the part that makes a deliberate copy safe: a copy is
only allowed if something asserts the agreement, and nothing did.
`account_types_match_core` now does, from `rustledger-lsp` — a crate that can see
both, which neither owner can.

A second test asks the **predicate** about every root rather than comparing two
constants, because the equality alone can't see a future `is_account_type` that
hardcodes its own words again.

## Deliberately not config-aware

This answers the editor's *lexical* question — "does this bare word look like an
account root, so should I offer hover/definition affordances?" — often asked with
no ledger loaded at all.

It is **not** the classifier for an account you hold. A bare root isn't even a
valid account name (`open Assets` is a parse error, P0012), so every real account
reference contains a `:` and belongs to `AccountTypes`, which honors the `name_*`
renames. That's said in the doc, because the distinction is what #1964 is about
and it's what made item 3 of that issue look bigger than it is.

## Verification

| sabotage | result |
|---|---|
| add a sixth root to completion's list only | `account_types_match_core` fails |
| reimplement the predicate with its own hardcoded words | `is_account_type_answers_for_every_root` fails |

`cargo test --workspace` — 134 suites, 0 failures. Clippy and fmt clean.

Behaviour is unchanged: both lists hold the same five words today, so this is a
structural fix, not a functional one.
