### PR TITLE
feat(vscode): one language server per workspace folder

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rustledger-vscode",
   "displayName": "rustledger",
-  "description": "Beancount language support powered by rustledger — completions, diagnostics, formatting, and more",
+  "description": "Beancount language support powered by rustledger \u2014 completions, diagnostics, formatting, and more",
   "version": "0.1.0",
   "license": "GPL-3.0-only",
   "repository": {
@@ -76,7 +76,8 @@
         "rustledger.journalFile": {
           "type": "string",
           "default": "",
-          "description": "Path to the root journal file (e.g., main.beancount). If empty, the LSP discovers it automatically."
+          "description": "Path to the root journal file. Relative paths resolve against the workspace folder, so each folder in a multi-root workspace can point at its own ledger from its .vscode/settings.json. Leave empty to auto-discover.",
+          "scope": "resource"
         },
         "rustledger.checkForUpdates": {
           "type": "boolean",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import { createWriteStream } from "fs";
 import { get } from "https";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import * as vscode from "vscode";
 import {
   LanguageClient,
@@ -16,7 +16,14 @@ const GITHUB_API_URL =
   "https://api.github.com/repos/rustledger/rustledger/releases/latest";
 const VSIX_ASSET_NAME = "rustledger-vscode.vsix";
 
-let client: LanguageClient | undefined;
+// One client per ledger root, keyed by that root's URI string.
+//
+// Multi-root workspaces hold independent ledgers (#1974): two folders with
+// their own `main.beancount` share nothing, so they get a server each. That
+// also means the SERVER needs no change — `rledger-lsp` reads
+// `workspace_folders.first()` and holds one ledger, which is exactly right
+// once each process is given exactly one folder.
+const clients = new Map<string, LanguageClient>();
 // Created with `{ log: true }` below, so it's a LogOutputChannel — which is
 // also what vscode-languageclient v10's LanguageClientOptions.outputChannel
 // requires (v9 accepted a plain OutputChannel).
@@ -158,13 +165,40 @@ async function checkForUpdates(
   }
 }
 
-async function startClient(context: vscode.ExtensionContext): Promise<boolean> {
-  const config = vscode.workspace.getConfiguration("rustledger");
-  const command = config.get<string>("server.path", "rledger-lsp");
-  const extraArgs = config.get<string[]>("server.extraArgs", []);
-  const journalFile = config.get<string>("journalFile", "");
+// The ledger root a document belongs to.
+//
+// Its workspace folder when it has one. When it does not — a `.beancount`
+// file opened with no workspace, or from outside every folder — its own
+// directory stands in.
+//
+// A directory rather than one catch-all client with an unrestricted selector:
+// selectors have no "everything except" form, so a broad fallback would also
+// claim files already owned by a folder client and both servers would answer.
+// Rooting on the containing directory keeps every selector disjoint by
+// construction, and it preserves what single-file users have today.
+function rootFor(uri: vscode.Uri): {
+  root: vscode.Uri;
+  folder: vscode.WorkspaceFolder | undefined;
+} {
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  if (folder) {
+    return { root: folder.uri, folder };
+  }
+  return { root: vscode.Uri.file(dirname(uri.fsPath)), folder: undefined };
+}
 
-  if (!findBinary(command)) {
+// Whether the binary is present. Asked once per activation, not per client:
+// N missing-binary popups for N folders would be worse than one.
+let binaryChecked = false;
+let binaryPresent = false;
+
+async function ensureBinary(command: string): Promise<boolean> {
+  if (binaryChecked) {
+    return binaryPresent;
+  }
+  binaryChecked = true;
+  binaryPresent = findBinary(command);
+  if (!binaryPresent) {
     const install = "Install";
     const result = await vscode.window.showWarningMessage(
       `Could not find "${command}". Install rustledger to enable language features.`,
@@ -173,39 +207,140 @@ async function startClient(context: vscode.ExtensionContext): Promise<boolean> {
     if (result === install) {
       vscode.env.openExternal(vscode.Uri.parse(INSTALL_URL));
     }
-    return false;
+  }
+  return binaryPresent;
+}
+
+// Start a client for one ledger root, unless one is already running for it.
+async function startClientForRoot(
+  root: vscode.Uri,
+  folder: vscode.WorkspaceFolder | undefined,
+): Promise<void> {
+  const key = root.toString();
+  if (clients.has(key)) {
+    return;
   }
 
-  const serverOptions: ServerOptions = {
-    command,
-    args: extraArgs,
-  };
+  // Read config against the ROOT, which is what makes a folder-level
+  // `.vscode/settings.json` take effect. Without the resource argument this
+  // returns the window value and every folder gets the same journal.
+  const config = vscode.workspace.getConfiguration("rustledger", root);
+  const command = config.get<string>("server.path", "rledger-lsp");
+  const extraArgs = config.get<string[]>("server.extraArgs", []);
+  const journalFile = config.get<string>("journalFile", "");
+
+  if (!(await ensureBinary(command))) {
+    return;
+  }
+
+  const serverOptions: ServerOptions = { command, args: extraArgs };
 
   const initializationOptions: Record<string, string> = {};
   if (journalFile) {
+    // Left RELATIVE on purpose when the user wrote it that way. The server
+    // resolves a relative journal against its workspace root
+    // (`resolve_explicit_journal`), so the same `ledger/main.beancount` in two
+    // folders' settings resolves to two different files — which is the whole
+    // point of the request.
     initializationOptions.journalFile = journalFile;
   }
 
+  // Scope the selector to this root so exactly one client claims each file.
+  //
+  // Two spellings of the same pattern, because the two consumers take
+  // different types: `createFileSystemWatcher` wants VS Code's
+  // `RelativePattern` (whose `baseUri` is a `Uri`), while a
+  // `DocumentFilter.pattern` is the LSP protocol's, whose `baseUri` is a
+  // string. Passing the VS Code one to the selector does not type-check.
+  // RECURSIVE for a workspace folder, whose ledger legitimately spans
+  // subdirectories. NON-recursive for an ad-hoc directory root, and that
+  // difference is load-bearing rather than cosmetic.
+  //
+  // An ad-hoc root can CONTAIN workspace folders: open `/w/notes.beancount`
+  // while `/w/HK` and `/w/CA` are the folders, and a recursive `/w` selector
+  // also matches every file those two own — two clients claiming the same
+  // document, two sets of diagnostics. Verified by enumerating owners per
+  // file: recursive gives 2 owners for each folder file, non-recursive gives
+  // exactly 1 for every file.
+  //
+  // The cost is that a file outside every folder gets a client per DIRECTORY
+  // rather than per tree. Only reachable for files no workspace folder owns,
+  // and preferable to one document answered twice.
+  const glob = folder
+    ? "**/*.{beancount,bean}"
+    : "*.{beancount,bean}";
+  const watcherPattern = new vscode.RelativePattern(root, glob);
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "beancount" }],
+    documentSelector: [
+      {
+        scheme: "file",
+        language: "beancount",
+        pattern: { baseUri: root.toString(), pattern: glob },
+      },
+    ],
     synchronize: {
-      fileEvents:
-        vscode.workspace.createFileSystemWatcher("**/*.{beancount,bean}"),
+      fileEvents: vscode.workspace.createFileSystemWatcher(watcherPattern),
     },
     initializationOptions,
     outputChannel,
+    // Makes the client report THIS folder in `workspaceFolders`, so the
+    // server's `folders.first()` resolves the intended root rather than
+    // whichever folder happens to sort first in the window.
+    workspaceFolder: folder,
   };
 
-  client = new LanguageClient(
-    "rustledger",
+  // A distinct id per client: vscode-languageclient uses it for the output
+  // channel and for `client.stop()` bookkeeping, and reusing one id across
+  // clients makes the second silently shadow the first.
+  const client = new LanguageClient(
+    `rustledger:${key}`,
     "rustledger",
     serverOptions,
     clientOptions,
   );
+  clients.set(key, client);
 
   await client.start();
-  outputChannel?.appendLine(`Started rledger-lsp: ${command}`);
-  return true;
+  outputChannel?.appendLine(
+    `Started rledger-lsp for ${key}` +
+      (journalFile ? ` (journalFile: ${journalFile})` : " (auto-discovery)"),
+  );
+}
+
+// Start a client for a document's root if it does not have one yet.
+async function ensureClientForDocument(
+  document: vscode.TextDocument,
+): Promise<void> {
+  if (document.languageId !== "beancount" || document.uri.scheme !== "file") {
+    return;
+  }
+  const { root, folder } = rootFor(document.uri);
+  await startClientForRoot(root, folder);
+}
+
+async function stopClient(key: string): Promise<void> {
+  const client = clients.get(key);
+  if (!client) {
+    return;
+  }
+  clients.delete(key);
+  await client.stop();
+  outputChannel?.appendLine(`Stopped rledger-lsp for ${key}`);
+}
+
+async function stopAllClients(): Promise<void> {
+  await Promise.all([...clients.keys()].map(stopClient));
+}
+
+// Start clients for every beancount document already open.
+//
+// Activation happens on the first such document, but a window restored with
+// several open across several folders needs one client each — waiting for a
+// fresh `onDidOpenTextDocument` would leave all but one without features.
+async function startClientsForOpenDocuments(): Promise<void> {
+  await Promise.all(
+    vscode.workspace.textDocuments.map(ensureClientForDocument),
+  );
 }
 
 export async function activate(
@@ -222,11 +357,11 @@ export async function activate(
     "rustledger.restartServer",
     async () => {
       outputChannel?.appendLine("Restarting rledger-lsp...");
-      if (client) {
-        await client.stop();
-        client = undefined;
-      }
-      await startClient(context);
+      await stopAllClients();
+      // Re-ask for the binary: a restart is how a user retries after
+      // installing it, and a cached "missing" would make that do nothing.
+      binaryChecked = false;
+      await startClientsForOpenDocuments();
     },
   );
   context.subscriptions.push(restartCommand);
@@ -241,15 +376,49 @@ export async function activate(
   );
   context.subscriptions.push(updateCommand);
 
-  // Start the client
-  const started = await startClient(context);
-  if (started) {
-    context.subscriptions.push({
-      dispose: () => {
-        client?.stop();
-      },
-    });
-  }
+  // A document opened later may belong to a root with no client yet — a second
+  // folder's ledger, or a file outside the workspace entirely.
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(ensureClientForDocument),
+  );
+
+  // Folder added or removed. Removal must stop that folder's server; addition
+  // is handled when one of its documents opens.
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
+      await Promise.all(
+        event.removed.map((folder) => stopClient(folder.uri.toString())),
+      );
+      await startClientsForOpenDocuments();
+    }),
+  );
+
+  // Settings changed. `journalFile` reaches the server only through
+  // `initializationOptions`, which is sent once at startup, so the client for
+  // an affected root has to be restarted rather than notified.
+  //
+  // Before this, changing `journalFile` did nothing until the user found the
+  // restart command — true single-root as well, just less visible.
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      const affected = [...clients.keys()].filter((key) =>
+        event.affectsConfiguration("rustledger", vscode.Uri.parse(key)),
+      );
+      if (affected.length === 0) {
+        return;
+      }
+      outputChannel?.appendLine(
+        `Configuration changed; restarting ${affected.length} server(s)`,
+      );
+      await Promise.all(affected.map(stopClient));
+      binaryChecked = false;
+      await startClientsForOpenDocuments();
+    }),
+  );
+
+  context.subscriptions.push({ dispose: () => void stopAllClients() });
+
+  await startClientsForOpenDocuments();
 
   // Check for updates in background (don't await) if enabled
   const config = vscode.workspace.getConfiguration("rustledger");
@@ -259,6 +428,5 @@ export async function activate(
 }
 
 export async function deactivate(): Promise<void> {
-  await client?.stop();
-  client = undefined;
+  await stopAllClients();
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -187,18 +187,26 @@ function rootFor(uri: vscode.Uri): {
   return { root: vscode.Uri.file(dirname(uri.fsPath)), folder: undefined };
 }
 
-// Whether the binary is present. Asked once per activation, not per client:
-// N missing-binary popups for N folders would be worse than one.
-let binaryChecked = false;
-let binaryPresent = false;
+// Whether each configured binary is present, keyed BY COMMAND.
+//
+// Asked once per command rather than once per client, so N folders sharing a
+// server path produce one missing-binary popup instead of N. Keyed rather than
+// a single flag because `server.path` is readable per-resource: two folders can
+// name different binaries, and caching the first answer for the second would
+// report a missing binary as present, or warn about the wrong one.
+const binaryChecks = new Map<string, boolean>();
 
 async function ensureBinary(command: string): Promise<boolean> {
-  if (binaryChecked) {
-    return binaryPresent;
+  const cached = binaryChecks.get(command);
+  if (cached !== undefined) {
+    return cached;
   }
-  binaryChecked = true;
-  binaryPresent = findBinary(command);
-  if (!binaryPresent) {
+  // Recorded BEFORE awaiting the popup: `findBinary` is synchronous, so a
+  // concurrent caller that arrives while the dialog is open reads the cached
+  // answer and does not raise a second one.
+  const present = findBinary(command);
+  binaryChecks.set(command, present);
+  if (!present) {
     const install = "Install";
     const result = await vscode.window.showWarningMessage(
       `Could not find "${command}". Install rustledger to enable language features.`,
@@ -208,10 +216,14 @@ async function ensureBinary(command: string): Promise<boolean> {
       vscode.env.openExternal(vscode.Uri.parse(INSTALL_URL));
     }
   }
-  return binaryPresent;
+  return present;
 }
 
 // Start a client for one ledger root, unless one is already running for it.
+// Starts in flight, so a second caller for the same root joins the first
+// rather than racing it.
+const starting = new Map<string, Promise<void>>();
+
 async function startClientForRoot(
   root: vscode.Uri,
   folder: vscode.WorkspaceFolder | undefined,
@@ -220,7 +232,33 @@ async function startClientForRoot(
   if (clients.has(key)) {
     return;
   }
+  // The `clients` check alone is not enough, which Copilot caught: this
+  // function awaits before it records anything, so two documents from the SAME
+  // folder — exactly what `startClientsForOpenDocuments` produces via
+  // `Promise.all` — both passed the guard and started a server each.
+  // Reproduced at 2 servers for one folder.
+  //
+  // Reserving the in-flight promise closes it because the reservation happens
+  // in the same synchronous turn as the lookup: no other task can interleave
+  // between the `get` and the `set`.
+  const inFlight = starting.get(key);
+  if (inFlight) {
+    return inFlight;
+  }
+  const attempt = startClientForRootUncontended(root, folder, key);
+  starting.set(key, attempt);
+  try {
+    await attempt;
+  } finally {
+    starting.delete(key);
+  }
+}
 
+async function startClientForRootUncontended(
+  root: vscode.Uri,
+  folder: vscode.WorkspaceFolder | undefined,
+  key: string,
+): Promise<void> {
   // Read config against the ROOT, which is what makes a folder-level
   // `.vscode/settings.json` take effect. Without the resource argument this
   // returns the window value and every folder gets the same journal.
@@ -300,7 +338,19 @@ async function startClientForRoot(
   );
   clients.set(key, client);
 
-  await client.start();
+  try {
+    await client.start();
+  } catch (error) {
+    // Registered before starting so a concurrent caller sees it, which means a
+    // FAILED start would otherwise leave a dead client in the map — and
+    // `clients.has(key)` then makes every later attempt a no-op, disabling that
+    // folder until the window is reloaded. A spawn failure is usually
+    // transient (binary mid-upgrade, a bad `server.path` since corrected), so
+    // it must not be permanent.
+    clients.delete(key);
+    outputChannel?.appendLine(`Failed to start rledger-lsp for ${key}: ${error}`);
+    return;
+  }
   outputChannel?.appendLine(
     `Started rledger-lsp for ${key}` +
       (journalFile ? ` (journalFile: ${journalFile})` : " (auto-discovery)"),
@@ -319,6 +369,12 @@ async function ensureClientForDocument(
 }
 
 async function stopClient(key: string): Promise<void> {
+  // Wait for an in-flight start first. Removing a workspace folder while its
+  // server is still coming up would otherwise find nothing in `clients`,
+  // return, and let the start finish afterwards — leaving a server running for
+  // a folder that is gone.
+  await starting.get(key)?.catch(() => undefined);
+
   const client = clients.get(key);
   if (!client) {
     return;
@@ -358,9 +414,9 @@ export async function activate(
     async () => {
       outputChannel?.appendLine("Restarting rledger-lsp...");
       await stopAllClients();
-      // Re-ask for the binary: a restart is how a user retries after
-      // installing it, and a cached "missing" would make that do nothing.
-      binaryChecked = false;
+      // Re-ask for the binaries: a restart is how a user retries after
+      // installing one, and a cached "missing" would make that do nothing.
+      binaryChecks.clear();
       await startClientsForOpenDocuments();
     },
   );
@@ -411,7 +467,8 @@ export async function activate(
         `Configuration changed; restarting ${affected.length} server(s)`,
       );
       await Promise.all(affected.map(stopClient));
-      binaryChecked = false;
+      // `server.path` may be what changed.
+      binaryChecks.clear();
       await startClientsForOpenDocuments();
     }),
   );


### PR DESCRIPTION
Closes #1974.

## Two single-ledger assumptions, not one

The reporter found the first and suspected there was more:

| | |
|---|---|
| **extension** | a module-scoped `let client`, `journalFile` declared with no `scope` (VS Code defaults that to `window`), an unrestricted `documentSelector`, and `initializationOptions` sent once at startup |
| **server** | `folders.first()` in `get_workspace_root`, and a single `journal_file` with one loaded ledger in `MainLoopState` |

**The server needs no change.** Each process is now handed exactly one workspace
folder — precisely what it already assumed — so the assumption stops being a
limitation and becomes correct by construction. A multi-root-aware server would
have meant threading a ledger identity through `MainLoopState` to buy one process
instead of N, for folders that share nothing.

## What makes the reporter's proposal work

`journalFile` becomes `scope: "resource"`, and config is read against the **root**
rather than the window — that's what makes a folder-level `.vscode/settings.json`
take effect at all.

Relative paths already worked in our favor: the server resolves a relative journal
against its workspace root, so the identical `ledger/main.beancount` in two
folders' settings resolves to two different files. Their exact proposal, with no
Rust change.

## Files outside every folder

They get a client rooted at their own **directory**, not a catch-all. Document
selectors have no "everything except" form, so a broad fallback would also claim
files a folder client already owns and both servers would answer. It also
preserves what single-file users have today, which folder-scoped clients would
otherwise have taken away.

**That fallback had a bug I only found by enumerating owners per file.** An ad-hoc
root can *contain* workspace folders — open `/w/notes.beancount` while `/w/HK` and
`/w/CA` are the folders — and a recursive `/w` selector then matches everything
those two own:

| ad-hoc glob | result |
|---|---|
| `**/*` (recursive) | `/w/HK/ledger/main.beancount` → **2 owners** |
| `*` (non-recursive) | every file → exactly 1 owner |

So an ad-hoc root's glob is non-recursive while a workspace folder's stays
recursive. The cost is a client per directory for unowned files, which beats one
document answered twice.

## Fixes something already broken single-root

Changing `journalFile` did nothing until the user found the restart command,
because it reaches the server only through `initializationOptions`.
`onDidChangeConfiguration` now restarts the affected roots, and
`onDidChangeWorkspaceFolders` stops a removed folder's server.

`findBinary` is asked once per activation rather than per client — N
missing-binary popups for N folders would be worse than one — and reset on
restart, since restarting is how a user retries after installing it.

## Verification

- `tsc --noEmit` clean (it caught a real one: the protocol's `RelativePattern`
  takes `baseUri: string`, not VS Code's `Uri`, so the selector and the file
  watcher need different spellings of the same pattern);
- `npm run build` bundles;
- the routing decision checked against a stubbed workspace — two folders plus
  outside files → four clients, every file with exactly one owner.

## Known limitation

Nested workspace folders (adding both `/w` and `/w/HK`) would double-claim, since
the outer folder's recursive selector covers the inner. VS Code discourages
nesting and `getWorkspaceFolder` returns the innermost, so document routing is
right; only selector matching overlaps. Left alone rather than solved with
exclusion globs — worth revisiting if anyone actually nests.
