### PR TITLE
docs: protect fuzz-corpus from branch cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,14 @@ resolve unless you've fetched it locally).
 | `spike/ffi-wit-component` | WIT / Component-Model FFI design spike for #1384. Reference if the `rustledger:ledger` component contract (the typed WIT API) changes. |
 | `spike/ledger-resource` | Stateful `resource session` "A+B boundary" redesign spike for #173. Reference for a future stateful embedding API. |
 | `benchmarks`, `compatibility`, `profiling` | CI-managed data branches (nightly benchmark / compatibility results; `profiling` holds the deterministic instruction-count + heap trend history written by `profile.yml`). Written by automation — never hand-delete. |
+| `fuzz-corpus` | CI-managed data branch holding the durable fuzz corpus (tens of thousands of inputs; the nightly commit message records the current count), written by the nightly `fuzz.yml` run and re-fetched by every later PR so each replays a corpus strictly stronger than the day before. Deleting it does not merely lose history: it silently resets every PR's fuzzing to cold, and nothing goes red to say so. Written by automation — never hand-delete. (Crash inputs are deliberately *not* kept here — they belong in-tree under `crates/<crate>/fuzz/regressions/<target>/`, committed alongside their fix, so losing this branch cannot resurrect a fixed bug.) |
 
 When pruning merged/closed PR branches, skip the rows above.
+
+None of these have an open PR, so any check of the form "no PR ⇒ stale" deletes
+all of them. `git branch --merged` is no help either: this repo squash-merges,
+so genuinely merged branches never appear in it. Classify by **PR state**
+(`gh pr list --head <branch> --state all`), then subtract this table.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
The "do NOT delete" table lists `benchmarks`, `compatibility` and `profiling` but omits `fuzz-corpus`, which is the same kind of branch: CI-managed, no open PR, written by automation. `fuzz.yml`'s own header already says the corpus is committed there "same convention as `benchmarks` and `profiling`" — the table just never caught up.

## Why this matters

That omission is a live hazard, not a tidiness issue. A cleanup pass classifies a branch as stale when it has no open PR — which `fuzz-corpus` never does — so **following this document as written deletes it.** I hit exactly that while pruning branches, and only stopped because the name looked like a data branch, not because anything here said so.

The cost is worse than losing history:

- Every PR re-fetches the corpus before fuzzing, so deleting the branch **silently resets every later run to cold**.
- Nothing goes red to report it. The workflow treats a missing branch as "starting cold" *deliberately*, so that a first run before the branch existed doesn't mark every PR red — which means the failure mode here is indistinguishable from normal operation.

The nightly commit currently records 71,189 inputs. I deliberately didn't put that number in the table, since a hardcoded count rots; the row points at the commit message instead.

Crash regressions are unaffected either way — they live in-tree under `crates/<crate>/fuzz/regressions/<target>/`, committed with their fix. Worth recording, so nobody reasons "the crashes are on that branch, so it's safe to lose." They are not on it.

## Also recorded

Two traps that make this table easy to defeat even when you've read it:

- **Every row lacks an open PR by nature**, so any "no PR ⇒ stale" heuristic sweeps up the whole table.
- **`git branch --merged` doesn't list genuinely merged branches**, because the repo squash-merges. It pushes a cleanup toward exactly the wrong answer: it hides the branches that *are* safe to delete while showing the ones that aren't.

The guidance is to classify by PR state (`gh pr list --head <branch> --state all`) and then subtract this table.

## Verification

Every factual claim in the new row was checked against the workflow rather than assumed:

| claim | source |
|---|---|
| written by the nightly run | `fuzz.yml` header + `fuzz: nightly corpus (…, 71189 inputs)` on the branch |
| re-fetched by every PR | `fuzz.yml:151` — `git fetch --depth=1 origin fuzz-corpus` |
| missing branch is silent, not red | `fuzz.yml:148-162` — the surrounding comment states this explicitly |
| crash inputs live in-tree | `fuzz.yml:168` — `REGRESSIONS="crates/<crate>/fuzz/regressions/<target>"` |

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
