### PR TITLE
fix(plugin): follow symlinked subtrees during document discovery

### DIFF
--- a/crates/rustledger-loader/tests/document_discovery_symlinks.rs
+++ b/crates/rustledger-loader/tests/document_discovery_symlinks.rs
@@ -1,0 +1,218 @@
+//! Document discovery follows symlinked subtrees, as beancount does.
+//!
+//! Regression tests for #1997. Discovery used `symlink_metadata` and skipped
+//! every symlink outright, so a linked subtree was never visited — not walked
+//! and filtered, but never reached. An entire document tree could be absent
+//! with no error, no warning, and nothing to distinguish it from an empty
+//! folder.
+//!
+//! Beancount follows them: `beancount/ops/documents.py` walks with
+//! `account.walk(directory)`, and that function's signature is
+//! `walk(root_directory, followlinks: bool = True)`.
+//!
+//! The issue was reported for Windows directory junctions, and the mechanism
+//! there is a real asymmetry — Rust's `FileType::is_symlink` is true for
+//! name-surrogate reparse points while Python's `os.path.islink` is false for
+//! them, so a junction is where the two disagree even under `followlinks=False`.
+//! But `followlinks` defaults to `True`, so the divergence is not
+//! Windows-specific: it covers ordinary POSIX symlinks, which is what these
+//! tests use. Measured against beancount on Linux before the fix — beancount
+//! found 2 documents in `symlinked_subtree_is_discovered`'s shape, rledger
+//! found 1.
+//!
+//! Unix-gated because creating a symlink on Windows needs elevation or
+//! Developer Mode. The Windows manifestation is a junction, which needs
+//! neither, but is not creatable from `std`.
+#![cfg(unix)]
+
+use rustledger_loader::{LoadOptions, load};
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+/// Build a ledger dir with `option "documents" "docs"` and the given open
+/// accounts, returning the tempdir.
+fn fixture(opens: &[&str]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+    let mut open_lines = String::new();
+    for account in opens {
+        open_lines.push_str("2020-01-01 open ");
+        open_lines.push_str(account);
+        open_lines.push('\n');
+    }
+    std::fs::write(
+        dir.path().join("ledger.bean"),
+        format!("option \"documents\" \"docs\"\n\n{open_lines}"),
+    )
+    .unwrap();
+    dir
+}
+
+fn touch(path: &Path) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, "dummy").unwrap();
+}
+
+/// Discovered documents, as `(account, filename)`, sorted.
+fn discovered(dir: &tempfile::TempDir) -> Vec<(String, String)> {
+    let ledger =
+        load(&dir.path().join("ledger.bean"), &LoadOptions::default()).expect("ledger loads");
+    let mut found: Vec<(String, String)> = ledger
+        .directives
+        .iter()
+        .filter_map(|d| match &d.value {
+            rustledger_core::Directive::Document(doc) => {
+                Some((doc.account.as_ref().to_string(), doc.path.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+fn warnings(dir: &tempfile::TempDir) -> Vec<String> {
+    let ledger =
+        load(&dir.path().join("ledger.bean"), &LoadOptions::default()).expect("ledger loads");
+    ledger.errors.iter().map(|e| e.message.clone()).collect()
+}
+
+/// The #1997 bug: a subtree reached through a symlink must be walked.
+#[test]
+fn symlinked_subtree_is_discovered() {
+    let dir = fixture(&["Expenses:Direct", "Expenses:Bar"]);
+    touch(
+        &dir.path()
+            .join("docs/Expenses/Direct/2026-07-07 control.pdf"),
+    );
+
+    // The linked-to tree lives outside `docs/`, which is the real shape: a
+    // document library that cannot share a root with the ledger.
+    touch(&dir.path().join("library/2026-07-07 behind.pdf"));
+    symlink(
+        dir.path().join("library"),
+        dir.path().join("docs/Expenses/Bar"),
+    )
+    .unwrap();
+
+    let found = discovered(&dir);
+    assert_eq!(
+        found.len(),
+        2,
+        "the linked subtree must be walked, not skipped: {found:?}"
+    );
+    assert!(
+        found.iter().any(|(account, _)| account == "Expenses:Bar"),
+        "expected a document under Expenses:Bar: {found:?}"
+    );
+}
+
+/// A skipped subtree used to be indistinguishable from an empty one. An
+/// unopened account under the link proves the walk actually entered it.
+#[test]
+fn a_walked_subtree_reports_its_unopened_accounts() {
+    let dir = fixture(&["Expenses:Direct"]);
+    touch(
+        &dir.path()
+            .join("docs/Expenses/Direct/2026-07-07 control.pdf"),
+    );
+    touch(&dir.path().join("library/2026-07-07 other.pdf"));
+    // `Expenses:Nope` is deliberately not opened.
+    symlink(
+        dir.path().join("library"),
+        dir.path().join("docs/Expenses/Nope"),
+    )
+    .unwrap();
+
+    assert!(
+        warnings(&dir)
+            .iter()
+            .any(|w| w.contains("Expenses:Nope") && w.contains("unknown account")),
+        "walking the link should surface its unopened account, got: {:?}",
+        warnings(&dir)
+    );
+}
+
+/// Two accounts may link to the same physical folder, and beancount emits one
+/// document per account. This is why the cycle guard tracks the ancestor chain
+/// rather than a global visited-set: a set also terminates, but would walk
+/// whichever link came first and silently drop the other.
+#[test]
+fn two_links_to_the_same_target_are_both_discovered() {
+    let dir = fixture(&["Expenses:Alpha", "Expenses:Beta"]);
+    std::fs::create_dir_all(dir.path().join("docs/Expenses")).unwrap();
+    touch(&dir.path().join("shared/2026-07-07 shared.pdf"));
+    symlink(
+        dir.path().join("shared"),
+        dir.path().join("docs/Expenses/Alpha"),
+    )
+    .unwrap();
+    symlink(
+        dir.path().join("shared"),
+        dir.path().join("docs/Expenses/Beta"),
+    )
+    .unwrap();
+
+    let accounts: Vec<String> = discovered(&dir).into_iter().map(|(a, _)| a).collect();
+    assert_eq!(
+        accounts,
+        vec!["Expenses:Alpha".to_string(), "Expenses:Beta".to_string()],
+        "the same folder reached by two links belongs to both accounts"
+    );
+}
+
+/// A cycle must terminate and say so. Beancount's `os.walk(followlinks=True)`
+/// has no cycle guard and hangs on this shape (verified: it did not finish in
+/// 45s), so this is deliberately stricter than the behavior it matches.
+#[test]
+fn symlink_cycle_terminates_and_warns() {
+    let dir = fixture(&["Expenses:Deep"]);
+    touch(&dir.path().join("docs/Expenses/Deep/2026-07-07 real.pdf"));
+    // Points back at the documents root, and at its own parent.
+    symlink(
+        dir.path().join("docs"),
+        dir.path().join("docs/Expenses/Loop"),
+    )
+    .unwrap();
+    symlink(
+        dir.path().join("docs/Expenses"),
+        dir.path().join("docs/Expenses/Self"),
+    )
+    .unwrap();
+
+    // Reaching this line at all is most of the assertion: before the guard,
+    // this recurses until the depth cap and does 32 redundant walks; without
+    // any guard it does not return.
+    let found = discovered(&dir);
+    assert_eq!(
+        found.len(),
+        1,
+        "the real document, discovered exactly once: {found:?}"
+    );
+
+    let warns = warnings(&dir);
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("links back into a directory")),
+        "a skipped cycle must not be silent, got: {warns:?}"
+    );
+}
+
+/// A dangling link is skipped, not an error: a walk that cannot enter it does
+/// the same thing.
+#[test]
+fn dangling_symlink_is_skipped() {
+    let dir = fixture(&["Expenses:Direct"]);
+    touch(
+        &dir.path()
+            .join("docs/Expenses/Direct/2026-07-07 control.pdf"),
+    );
+    symlink(
+        dir.path().join("nowhere"),
+        dir.path().join("docs/Expenses/Broken"),
+    )
+    .unwrap();
+
+    assert_eq!(discovered(&dir).len(), 1);
+}

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -170,6 +170,12 @@ impl NativePlugin for DocumentDiscoveryPlugin {
                 continue;
             }
 
+            // Seed the ancestor chain with this root so a link pointing at
+            // the root itself is caught. Fresh per root: a cycle is a property
+            // of one walk, not of the whole scan.
+            let mut ancestors =
+                vec![std::fs::canonicalize(dir_path).unwrap_or_else(|_| dir_path.to_path_buf())];
+
             if let Err(e) = scan_documents(
                 dir_path,
                 dir,
@@ -178,6 +184,7 @@ impl NativePlugin for DocumentDiscoveryPlugin {
                 &mut new_directives,
                 &mut unknown,
                 &mut errors,
+                &mut ancestors,
                 0, // Initial depth
             ) {
                 errors.push(PluginError::error(format!(
@@ -262,10 +269,38 @@ fn unknown_account_warning(
 
 /// Recursively scan a directory for document files.
 ///
+/// Symlinked subdirectories ARE followed, because beancount follows them:
+/// `beancount/ops/documents.py` walks with `account.walk(directory)`, whose
+/// `followlinks` parameter defaults to `True`. Skipping them made an entire
+/// document tree silently invisible — no error, no warning, indistinguishable
+/// from an empty folder (#1997). A documents tree assembled from links is the
+/// normal shape whenever the ledger repo and the document library cannot share
+/// a root, e.g. invoices in a synced folder linked into the `documents` tree.
+///
+/// This is not Windows-specific. It was reported for Windows directory
+/// junctions, because Rust's `FileType::is_symlink` is true for name-surrogate
+/// reparse points while Python's `os.path.islink` is false for them — so a
+/// junction was the case where the two implementations visibly disagreed even
+/// under `followlinks=False`. But `followlinks` is `True`, so the divergence
+/// covers ordinary POSIX symlinks too, and it reproduces on Linux.
+///
 /// # Security
-/// - Uses `symlink_metadata` to detect and skip symlinks, preventing infinite loops
+/// - Breaks symlink cycles by tracking the canonicalized *ancestor chain* of
+///   the current walk. Following links without a guard would hang;
+///   beancount's `os.walk(followlinks=True)` has none, so this is deliberately
+///   stricter than the thing it matches.
+///
+///   Deliberately an ancestor chain and NOT a global visited-set. A visited-set
+///   also terminates, but it silently drops legitimate re-reachability: two
+///   account directories may link to the same physical folder, and beancount
+///   walks both, emitting one document per account. A global set would walk
+///   whichever came first and drop the other — trading this bug for a new
+///   divergence. A directory is only a cycle when it is its own ancestor.
 /// - Enforces maximum recursion depth to prevent denial-of-service from deeply nested directories
-#[allow(clippy::only_used_in_recursion)]
+// One argument more than the lint allows. The alternative is a context struct
+// that exists only to satisfy the count; `load_recursive` in the loader
+// carries the same allow for the same reason.
+#[allow(clippy::too_many_arguments)]
 fn scan_documents(
     path: &std::path::Path,
     base_dir: &str,
@@ -274,6 +309,7 @@ fn scan_documents(
     directives: &mut Vec<DirectiveWrapper>,
     unknown: &mut std::collections::BTreeMap<String, Vec<String>>,
     errors: &mut Vec<PluginError>,
+    ancestors: &mut Vec<std::path::PathBuf>,
     depth: usize,
 ) -> std::io::Result<()> {
     use std::fs;
@@ -291,20 +327,33 @@ fn scan_documents(
         let entry = entry?;
         let entry_path = entry.path();
 
-        // Use symlink_metadata to check file type WITHOUT following symlinks.
-        // This prevents infinite recursion from symlink cycles.
-        let metadata = match fs::symlink_metadata(&entry_path) {
+        // `metadata`, not `symlink_metadata`: this FOLLOWS the link, so a
+        // linked subtree is classified by what it points at rather than being
+        // seen as an opaque "symlink" and dropped. A broken link fails to stat
+        // and is skipped here, which is also what a walk that cannot enter it
+        // would do.
+        let metadata = match fs::metadata(&entry_path) {
             Ok(m) => m,
-            Err(_) => continue, // Skip entries we can't stat
+            Err(_) => continue, // Skip entries we can't stat (incl. dangling links)
         };
 
-        // Skip symlinks entirely to prevent security issues
-        if metadata.file_type().is_symlink() {
-            continue;
-        }
-
         if metadata.is_dir() {
-            scan_documents(
+            // Cycle guard: canonicalize so a link collapses to its target,
+            // then refuse to descend into a directory that is already on the
+            // path we took to get here. `a/b -> a` is caught; `x -> t` and
+            // `y -> t` are both still walked.
+            let key = fs::canonicalize(&entry_path).unwrap_or_else(|_| entry_path.clone());
+            if ancestors.contains(&key) {
+                errors.push(PluginError::warning(format!(
+                    "Skipped {} while scanning documents: it links back into a \
+                     directory already being scanned ({})",
+                    entry_path.display(),
+                    key.display()
+                )));
+                continue;
+            }
+            ancestors.push(key);
+            let result = scan_documents(
                 &entry_path,
                 base_dir,
                 existing,
@@ -312,8 +361,11 @@ fn scan_documents(
                 directives,
                 unknown,
                 errors,
+                ancestors,
                 depth + 1,
-            )?;
+            );
+            ancestors.pop();
+            result?;
         } else if metadata.is_file() {
             // Try to parse filename as YYYY-MM-DD.description.ext
             if let Some(file_name) = entry_path.file_name().and_then(|n| n.to_str())


### PR DESCRIPTION
Closes #1997.

## The bug

Discovery used `symlink_metadata` and skipped every symlink outright, so a linked subtree was never visited — not walked and then filtered, but never reached. An entire document tree could be absent with **no error, no warning, and nothing to distinguish it from an empty folder.**

## Beancount does follow them

The issue asked me to sanity-check its claim about beancount rather than act on it, so I read the installed source. `beancount/ops/documents.py:129` walks with `account.walk(directory)`, and that function is:

```python
def walk(root_directory: str, followlinks: bool = True) -> ...
```

`followlinks` defaults to **`True`**.

**This is not Windows-specific.** The report was about directory junctions, and that mechanism is real — Rust's `FileType::is_symlink` is true for name-surrogate reparse points while Python's `os.path.islink` is false for them, so a junction is where the two implementations disagree *even under* `followlinks=False`. But since `followlinks` is `True`, the divergence covers ordinary POSIX symlinks too. Measured on Linux, both engines, same tree:

| | before | after |
|---|---|---|
| beancount | 2 documents | 2 documents |
| rledger | **1 document** | 2 documents |

The issue's own tell also now works: an unopened account under the link produces the usual `document(s) reference unknown account` warning, which is how you distinguish "walked and filtered" from "never visited."

## The cycle guard, and a bug I introduced writing it

Following links needs loop protection. I wrote it as a global visited-set first, and it was wrong:

> two account directories may link to the same physical folder, and beancount walks both, emitting one document per account

A visited-set terminates, but walks whichever link comes first and **silently drops the other** — trading this bug for a new divergence. I caught it by testing that shape against beancount (2 documents) versus my build (1).

So the guard tracks the canonicalized **ancestor chain**: a directory is a cycle only when it is its own ancestor. `a/b -> a` is caught; `x -> t` and `y -> t` are both walked. There's a regression test for exactly this, and it's the *only* test that fails if the visited-set is reinstated.

A detected cycle now **warns** instead of vanishing, which was the issue's main complaint about the old behavior:

```
warning[PLUGIN]: Skipped …/docs/Expenses/Loop while scanning documents:
  it links back into a directory already being scanned (…/docs)
```

Beancount has no cycle guard at all and hangs on that shape — verified, it did not finish in 45s — so this is deliberately stricter than the behavior it matches, and the code says so.

## Tests

Five regression tests, unix-gated (creating a symlink on Windows needs elevation; the Windows manifestation is a junction, which doesn't, but `std` can't create one).

Sabotage-checked, both directions:

| sabotage | result |
|---|---|
| restore skip-all-symlinks | **4 of 5 fail** — the #1997 bug is caught |
| global visited-set instead of ancestor chain | **exactly 1 fails** — `two_links_to_the_same_target_are_both_discovered` |

`cargo test --workspace` green (137 suites); `cargo +1.97.0 clippy --workspace --all-targets` clean.

## Unrelated, noticed while verifying

`RUSTDOCFLAGS="-D warnings" cargo doc -p rustledger-plugin` fails on **main** with a broken intra-doc link at `crates/rustledger-plugin/src/dispatch.rs:112` (`crate::python::is_python_plugin_file_ref` — no `python` module). Pre-existing and untouched by this PR, but CI's Documentation check is evidently not catching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
