### PR TITLE
fix(examples): repair the plugin examples and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,50 @@ jobs:
         working-directory: packages/vscode
         run: npm run build
 
+  example-plugins:
+    name: Example Plugins
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: 1.97.0 # pinned stable — bump deliberately, IN LOCKSTEP with rust-toolchain.toml (see #1745, #1750)
+      # `examples/*` each declare their own `[workspace]`, deliberately: they
+      # model what a third-party plugin crate looks like. That also means
+      # `cargo test --workspace` never builds them, so nothing in CI compiled
+      # them at all — and #1978 added a pub field to `PluginOptions` while
+      # every one of these examples constructed it with an exhaustive literal.
+      # All three broke, on main, silently. They are the copy-paste templates
+      # for writing a plugin, so a break here is a break in the documented
+      # onboarding path for the audience `rustledger-plugin-types` exists to
+      # serve ("use in your plugin crate").
+      #
+      # `cargo test`, NOT `cargo build`. Every one of those broken literals
+      # lived in a `#[cfg(test)]` module, so the plugins still built fine and a
+      # build-only gate would have stayed green through the exact regression
+      # this job exists to catch.
+      - name: Build and test each example plugin
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          found=0
+          for manifest in examples/*/Cargo.toml; do
+            dir=$(dirname "$manifest")
+            echo "::group::$dir"
+            cargo test --manifest-path "$manifest"
+            echo "::endgroup::"
+            found=$((found + 1))
+          done
+          # A loop over a glob that matches nothing exits 0 and reports
+          # success, which would silently restore the gap this job closes.
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no example plugins found under examples/ — the glob matched nothing"
+            exit 1
+          fi
+          echo "checked $found example plugin(s)"
+
   mcp-server:
     name: MCP Server
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,18 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      # The workflow-level `RUSTC_WRAPPER: sccache` only works in jobs that
+      # install sccache; this one does not, and cargo then dies with
+      # "could not execute process `sccache ... rustc -vV` (never executed)".
+      # Clearing it is what the SemVer job does for the same reason. These are
+      # five tiny crates — a shared compiler cache would buy less than the
+      # setup step costs.
+      #
+      # RUSTFLAGS is deliberately NOT cleared: the workflow's `-Dwarnings`
+      # should apply here. All five examples are warning-clean under it, and
+      # examples that accumulate warnings are examples nobody should copy.
+      RUSTC_WRAPPER: ''
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Rust build artifacts
 /target/
+# `examples/*` are standalone workspaces (they model third-party plugin
+# crates), so the root-anchored rule above does not cover their build dirs.
+examples/*/target/
 **/*.rs.bk
 
 # ts-rs intermediate per-type .d.ts output (ADR-0004 Phase 1, #1218).

--- a/examples/wasm-importer-csv-example/Cargo.lock
+++ b/examples/wasm-importer-csv-example/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.15.0"
+version = "0.21.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/examples/wasm-plugin-currency-check/src/lib.rs
+++ b/examples/wasm-plugin-currency-check/src/lib.rs
@@ -195,6 +195,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };

--- a/examples/wasm-plugin-duplicate-detect/src/lib.rs
+++ b/examples/wasm-plugin-duplicate-detect/src/lib.rs
@@ -218,6 +218,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -243,6 +244,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -265,6 +267,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("days=3".to_string()),
         };

--- a/examples/wasm-plugin-template/Cargo.lock
+++ b/examples/wasm-plugin-template/Cargo.lock
@@ -13,7 +13,7 @@ name = "example-plugin"
 version = "0.1.0"
 dependencies = [
  "rmp-serde",
- "serde",
+ "rustledger-plugin-types",
 ]
 
 [[package]]
@@ -59,6 +59,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rustledger-plugin-types"
+version = "0.21.0"
+dependencies = [
  "serde",
 ]
 

--- a/examples/wasm-plugin/src/lib.rs
+++ b/examples/wasm-plugin/src/lib.rs
@@ -241,6 +241,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: None,
         };
@@ -274,6 +275,7 @@ mod tests {
             options: PluginOptions {
                 operating_currencies: vec!["USD".to_string()],
                 title: None,
+                ..Default::default()
             },
             config: Some("threshold=1000".to_string()),
         };


### PR DESCRIPTION
Steps 1 and 2 of the plugin-types semver discussion. **This deliberately does not bump anything** — see the last section.

## Three of the five example plugins did not compile

#1978 added a pub field to `PluginOptions`, and every one of these examples constructed it with an exhaustive struct literal:

```rust
options: PluginOptions {
    operating_currencies: vec!["USD".to_string()],
    title: None,
},
```

That is exactly the break `cargo-semver-checks` reports as `constructible_struct_adds_field`. It is not hypothetical and it is not about some absent third party — **it had already landed here**, in the copy-paste templates for writing a plugin, for the precise audience `rustledger-plugin-types` advertises itself to ("WASM plugin interface types for rustledger — use in your plugin crate").

```
error[E0063]: missing field `account_types` in initializer of `PluginOptions`
   --> src/lib.rs:241:22
```

6 literals across `wasm-plugin`, `wasm-plugin-currency-check`, `wasm-plugin-duplicate-detect`.

They now end in `..Default::default()`, which is also the shape a plugin author should be copying: it survives the *next* field addition instead of breaking on it.

## Nothing caught it, and that is the more important half

`examples/*` each declare their own `[workspace]`. That is deliberate — they model what a third-party plugin crate looks like — but it also means `cargo test --workspace` never builds them, and **no CI job did either.** So the public plugin API broke its own examples on main, silently, and the only reason it surfaced is that the semver check complained about something else.

The new `Example Plugins` job closes that. Three design points, each load-bearing:

- **`cargo test`, not `cargo build`.** Every broken literal lived in a `#[cfg(test)]` module, so the plugins still *built* fine. A build-only gate would have stayed green straight through the regression it exists to catch.
- **A glob, not a hardcoded list.** I had been saying "the three examples" all along. The glob found **five** — `wasm-importer-csv-example` and `wasm-plugin-template` were not on my radar and are now covered. (Both compile; neither has tests.)
- **It fails when the glob matches nothing**, so the gap cannot silently reopen if the directory is ever restructured.

## Verification

Sabotage-checked in both directions:

| sabotage | result |
|---|---|
| drop `..Default::default()` back out of one example | job goes **RED** on that example |
| point the loop at an empty `examples/` | exits **1** with an error, instead of reporting success |

All five pass under the exact command the job runs (`cargo test --manifest-path`, from the repo root, which is not the same as `cd`-ing in — checked separately).

## Incidental

- The two **tracked** example lockfiles were rewritten by cargo on first build. `wasm-plugin-template` pinned `rustledger-plugin-types` **0.15.0**, which is its own evidence of how long nothing has compiled these. The three untracked lockfiles are left untracked — making them tracked is a separate decision.
- `examples/*/target/` is now ignored. The root rule is `/target/`, anchored to `/`, and these are separate workspaces; this PR makes them get built routinely.

## What this does not do

**It does not fix the `SemVer (plugin-types)` check.** That compares against the published 0.21.0 and is correctly reporting an unreleased breaking change in `PluginOptions`. It needs a version decision, which is independent of these examples being broken today — and which is now much better informed, because we know the break is real rather than theoretical.

If that bump happens, it is worth marking `PluginOptions` `#[non_exhaustive]` in the same change: on its own that is also breaking, so it costs nothing extra now and makes every future field addition non-breaking.

Refs #1978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
