### PR TITLE
feat(nix): export the VS Code extension as a flake package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,19 @@ jobs:
       # — named the way `mcp-server` above names the same arrangement. An
       # earlier revision ran `typecheck` as its own step for a clearer failure
       # label, which Copilot pointed out just runs `tsc` twice.
-      - name: Typecheck and build
+      # `npm run package` (= build + `vsce package`), NOT `npm run build`.
+      # vsce enforces things the bundler does not — notably that
+      # `@types/vscode` is <= `engines.vscode`. Dependabot bumped
+      # `@types/vscode` 1.91.0 -> 1.125.0 without touching `engines.vscode`,
+      # which vsce rejects, and nothing noticed: this job only ran the
+      # bundler, and `vsce` runs only in release-build.yml, on a tag. The
+      # release job has been broken on main since that bump; the first thing
+      # to actually run vsce was packaging the extension for the Nix flake
+      # (#1998). Packaging here means a tag is no longer the first time
+      # anyone finds out.
+      - name: Typecheck, build and package
         working-directory: packages/vscode
-        run: npm run build
+        run: npm run package
 
   mcp-server:
     name: MCP Server

--- a/crates/rustledger-lsp/README.md
+++ b/crates/rustledger-lsp/README.md
@@ -57,6 +57,36 @@ code --install-extension rustledger-vscode.vsix
 
 The extension provides syntax highlighting and automatically connects to `rledger-lsp` for completions, diagnostics, hover, and more. If `rledger-lsp` is not installed, it will prompt you to install it.
 
+#### Nix / home-manager
+
+The extension is a flake output, so it can be pinned with the same input as
+everything else (issue #1998):
+
+```nix
+{
+  inputs.rustledger.url = "github:rustledger/rustledger";
+
+  # ...
+  programs.vscode.profiles.default.extensions = [
+    rustledger.packages.${pkgs.system}.vscode-extension
+  ];
+
+  # The extension looks for `rledger-lsp` on PATH. This flake's `rustledger`
+  # package ships it alongside `rledger`, so installing it here gives an
+  # extension and a server that are guaranteed to be the same version.
+  home.packages = [ rustledger.packages.${pkgs.system}.default ];
+}
+```
+
+If you would rather not put the server on PATH, set `rustledger.server.path`
+to an absolute path instead.
+
+The extension's built-in update check is **disabled by default in the Nix
+build**. Elsewhere it offers to download a newer `.vsix` from GitHub and
+install it, which would place a second copy outside Nix and quietly detach the
+extension from your configuration. Re-enable `rustledger.checkForUpdates` if
+you want that behavior anyway.
+
 ### Neovim (nvim-lspconfig)
 
 ```lua

--- a/crates/rustledger-lsp/README.md
+++ b/crates/rustledger-lsp/README.md
@@ -62,11 +62,29 @@ The extension provides syntax highlighting and automatically connects to `rledge
 The extension is a flake output, so it can be pinned with the same input as
 everything else (issue #1998):
 
+In your flake, add the input and hand it to home-manager:
+
 ```nix
+# flake.nix
 {
   inputs.rustledger.url = "github:rustledger/rustledger";
 
-  # ...
+  outputs = { nixpkgs, home-manager, rustledger, ... }: {
+    homeConfigurations."you" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      extraSpecialArgs = { inherit rustledger; };
+      modules = [ ./home.nix ];
+    };
+  };
+}
+```
+
+Then, in the home-manager module:
+
+```nix
+# home.nix
+{ pkgs, rustledger, ... }:
+{
   programs.vscode.profiles.default.extensions = [
     rustledger.packages.${pkgs.system}.vscode-extension
   ];

--- a/flake.nix
+++ b/flake.nix
@@ -204,7 +204,9 @@
             meta = {
               description = "rustledger VS Code extension (LSP client for beancount files)";
               homepage = "https://github.com/rustledger/rustledger";
-              license = lib.licenses.mit;
+              # GPL-3.0-only, matching packages/vscode/package.json, its
+              # LICENSE file, and the workspace. Not MIT.
+              license = lib.licenses.gpl3Only;
               platforms = lib.platforms.all;
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,81 @@
             ];
           };
 
+          # ---- VS Code extension (issue #1998) ------------------------
+          # The extension version IS the release tag, and the release tag is the
+          # workspace version, so read it from Cargo.toml rather than writing a
+          # literal here. `packages/vscode/package.json` carries a `0.1.0`
+          # placeholder that CI overwrites from the tag at release time
+          # (`npm pkg set version`), so it is not a usable source — and a second
+          # literal in this file would just be one more thing to drift.
+          vscodeVersion =
+            (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+          vscodeVsix = pkgs.buildNpmPackage {
+            pname = "rustledger-vscode-vsix";
+            version = vscodeVersion;
+            src = ./packages/vscode;
+            npmDepsHash = "sha256-+uUy4mzGgOyEv3e5O9oSkVZ/qZB1P6qaT+v4iBqfGuk=";
+
+            # esbuild's npm postinstall downloads a prebuilt binary for the host
+            # platform, and the build sandbox has no network. Skip install scripts
+            # and point esbuild at the nixpkgs build instead.
+            npmFlags = [ "--ignore-scripts" ];
+            ESBUILD_BINARY_PATH = "${pkgs.esbuild}/bin/esbuild";
+
+            nativeBuildInputs = [ pkgs.jq ];
+
+            # `package` is `build` (typecheck + esbuild) plus `vsce package`.
+            npmBuildScript = "package";
+
+            # Both edits run AFTER `npm ci`, not in postPatch: `npm ci` refuses to
+            # run when package.json and package-lock.json disagree, and the lock
+            # records the root package's own version.
+            preBuild = ''
+              npm pkg set version="${vscodeVersion}"
+
+              # Default the self-updater OFF for this channel. It does not update
+              # the LSP binary — it fetches the .vsix from the GitHub release and
+              # calls `workbench.extensions.installExtension`, which would install
+              # a SECOND copy outside Nix and silently un-manage a declarative
+              # install. That is precisely the outcome someone installing this
+              # from a flake is trying to avoid. The setting can still be turned
+              # back on by anyone who wants it.
+              jq '.contributes.configuration.properties["rustledger.checkForUpdates"].default = false' \
+                package.json > package.json.new
+              mv package.json.new package.json
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              install -Dm644 rustledger-vscode.vsix "$out/rustledger-vscode.vsix"
+              runHook postInstall
+            '';
+          };
+
+          # `rustledger.server.path` is deliberately NOT patched to a store path.
+          # The extension defaults it to `rledger-lsp` on PATH, and this flake's own
+          # `rustledger` package already ships that binary next to `rledger`
+          # (`rustledger-lsp` is in `default-members`), so installing both from this
+          # flake gives a version-matched pair for free. Hardcoding it would couple
+          # this derivation to the Rust build — every `.rs` change would rebuild the
+          # extension — and put a /nix/store path in the settings UI as the default.
+          vscodeExtension = pkgs.vscode-utils.buildVscodeExtension {
+            pname = "rustledger-vscode";
+            version = vscodeVersion;
+            src = "${vscodeVsix}/rustledger-vscode.vsix";
+            vscodeExtPublisher = "rustledger";
+            vscodeExtName = "rustledger-vscode";
+            vscodeExtUniqueId = "rustledger.rustledger-vscode";
+
+            meta = {
+              description = "rustledger VS Code extension (LSP client for beancount files)";
+              homepage = "https://github.com/rustledger/rustledger";
+              license = lib.licenses.mit;
+              platforms = lib.platforms.all;
+            };
+          };
+
           # Build dependencies only (for caching)
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
@@ -284,6 +359,10 @@
           packages = {
             default = rustledger;
             rustledger = rustledger;
+            
+            # VS Code extension, installable via home-manager's
+            # `programs.vscode.extensions` or `vscode-with-extensions` (#1998).
+            vscode-extension = vscodeExtension;
 
             # Documentation
             doc = craneLib.cargoDoc (

--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "@types/vscode": "1.125.0",
+        "@types/vscode": "1.91.0",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1",
         "typescript": "^7.0.2"
@@ -1009,9 +1009,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+      "integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,8 @@
 {
   "name": "rustledger-vscode",
+  "publisher": "rustledger",
   "displayName": "rustledger",
-  "description": "Beancount language support powered by rustledger \u2014 completions, diagnostics, formatting, and more",
+  "description": "Beancount language support powered by rustledger — completions, diagnostics, formatting, and more",
   "version": "0.1.0",
   "license": "GPL-3.0-only",
   "repository": {
@@ -98,7 +99,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "@types/vscode": "1.125.0",
+    "@types/vscode": "1.91.0",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
Closes #1998.

Adds `packages.vscode-extension`, so the extension pins with the same flake input as everything else instead of hand-maintaining a `fetchurl` hash per release:

```nix
programs.vscode.profiles.default.extensions = [
  rustledger.packages.${pkgs.system}.vscode-extension
];
```

Built with `buildNpmPackage`, wrapped by `vscode-utils.buildVscodeExtension`, so the output is an **installable extension derivation** under `share/vscode/extensions/rustledger.rustledger-vscode` — not a bare `.vsix`, which home-manager cannot consume.

Verified from the built store path:

```
$out/share/vscode/extensions/rustledger.rustledger-vscode/
  name      : rustledger-vscode
  publisher : rustledger
  version   : 0.21.0          <- from Cargo.toml, not the 0.1.0 placeholder
  checkForUpdates default : false
  server.path default     : rledger-lsp
  out/extension.js (450 KB)
```

## Decisions worth reviewing

- **Version from `Cargo.toml`'s workspace version**, not a literal here. `package.json` carries a `0.1.0` placeholder that CI overwrites from the tag, so it isn't a usable source, and a literal in `flake.nix` would be one more thing to drift.
- **`publisher` was missing from `package.json` entirely** — the extension had no unique id at all. Added there rather than invented in the derivation, since CI wants it too.
- **esbuild's postinstall downloads a prebuilt binary** and the sandbox has no network → `--ignore-scripts` + `ESBUILD_BINARY_PATH`.
- **The self-updater is defaulted off in this build.** It does not update the LSP binary — it fetches the `.vsix` from the GitHub release and calls `workbench.extensions.installExtension`, installing a second copy outside Nix and quietly detaching the extension from the user's config. With the `0.1.0` placeholder it would also have fired on *every activation forever*, since `0.1.0` is below every release. Users can turn it back on.
- **`rustledger.server.path` deliberately left alone.** The extension already defaults it to `rledger-lsp` on PATH, and this flake's `rustledger` package ships that binary next to `rledger` — verified, `bin/` contains both — so installing both from the flake gives a version-matched pair for free. Hardcoding a store path would couple this derivation to the Rust build (every `.rs` change rebuilds the extension) and put `/nix/store/…` in the settings UI as the visible default.

## Two things this surfaced

**The release pipeline's `build-vscode` job is broken on main**, and has been since `@types/vscode` was bumped:

| | `engines.vscode` | `@types/vscode` |
|---|---|---|
| v0.21.0 (last shipped vsix) | `^1.91.0` | `1.91.0` ✓ |
| main before this PR | `^1.91.0` | `1.125.0` ✗ |

`vsce` refuses to package when `@types/vscode` exceeds `engines.vscode`. Fixed by pinning `@types/vscode` back to match, which is the right direction — the types describe the API surface the declared engine permits, and `tsc --noEmit` still passes, so nothing was using newer APIs. Bumping `engines.vscode` instead would have silently dropped support for every VS Code between 1.91 and 1.125.

**Nothing ran `vsce` before a tag.** The PR job ran `npm run build` (typecheck + bundler); `vsce` ran only in `release-build.yml`, on a tag. The first thing to actually exercise it was packaging for this flake. That job now runs `npm run package`, so a tag is no longer the first time anyone finds out. Same shape as the examples gap in #2003: the check that would catch it wasn't running until it was too late.

## Not done

Publishing to Open VSX is worth considering separately. About 150 of `extension.ts`'s 489 lines are a hand-rolled self-updater that exists *because* the extension isn't on a marketplace — and that machinery is exactly what has to be defused here. On Open VSX it could be deleted outright, VSCodium users could install it at all, and this workaround would not have been needed in the first place. That's a distribution decision, not a blocker for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
