### PR TITLE
fix(compat): publish one population to the trend, not two

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -880,6 +880,7 @@ jobs:
           bql_pct = int(os.environ.get('BQL_PCT', 0))
           bql_raw_pct = int(os.environ.get('BQL_RAW_PCT', 0))
           regression_count = int(os.environ.get('REGRESSION_COUNT', 0))
+          bql_total = int(os.environ.get('BQL_TOTAL', 0))
 
           now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
           date_short = datetime.utcnow().strftime('%Y-%m-%d')
@@ -896,6 +897,10 @@ jobs:
               'error_pct': error_pct,
               'full_pct': full_pct,
               'bql_pct': bql_pct,
+              # The population this point was computed over. Without it a reader
+              # cannot tell real movement from a change in what was measured —
+              # which is how the denominator swing above went unnoticed for days.
+              'bql_runs': bql_total,
               'regression_count': regression_count,
           })
           history = history[-90:]  # Keep 90 days
@@ -1076,6 +1081,7 @@ jobs:
           BQL_PCT: ${{ steps.bql_compat.outputs.bql_pct }}
           BQL_RAW_PCT: ${{ steps.bql_compat.outputs.bql_raw_pct }}
           REGRESSION_COUNT: ${{ steps.compat_test.outputs.regression_count }}
+          BQL_TOTAL: ${{ steps.bql_compat.outputs.bql_total }}
       - name: Update summary
         run: |
           cat >> $GITHUB_STEP_SUMMARY << EOF
@@ -1232,8 +1238,25 @@ jobs:
                 body: body
               });
             }
+      # Only the SCHEDULED run publishes. It is the only one that sweeps the
+      # whole corpus — a push-to-main run queries `--max-files=150` of ~673,
+      # and publishing both put two incomparable populations into one series.
+      # The trend then tracked merge traffic rather than compatibility: two
+      # consecutive runs measured 11390 and 2499 file×query pairs, the smaller
+      # a strict subset of the larger, with ZERO cases changing answer — a pure
+      # denominator swing that read as a 1-2 point regression and recovery.
+      #
+      # It also truncated the baseline. `previous-bql-results.jsonl` is fetched
+      # from this branch, so every merge replaced a 673-file baseline with a
+      # 150-file one, leaving the other ~523 files nothing to regress against
+      # until the next nightly rebuilt it.
+      #
+      # Push runs still execute the full gate — they just no longer overwrite
+      # the record. That also stops a push advancing the baseline past an
+      # ungated regression (see the gate-ordering note below), and makes
+      # `history[-90:]` mean 90 days again instead of ~2 weeks of merges.
       - name: Commit results to compatibility branch
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -897,9 +897,12 @@ jobs:
               'error_pct': error_pct,
               'full_pct': full_pct,
               'bql_pct': bql_pct,
-              # The population this point was computed over. Without it a reader
-              # cannot tell real movement from a change in what was measured —
-              # which is how the denominator swing above went unnoticed for days.
+              # The population this point was computed over: file × query
+              # pairs executed, which is what the script calls a run (its
+              # `QueryRun`, its `Runs tested: N (file × query)` line). Without
+              # it a reader cannot tell real movement from a change in what was
+              # measured — which is how the denominator swing above went
+              # unnoticed for days.
               'bql_runs': bql_total,
               'regression_count': regression_count,
           })


### PR DESCRIPTION
`bql_pct` looked like it was flapping 93/94/95 between runs, sometimes within the hour with no merges in between. **It was not flaky.** Two runs an hour apart:

| run | file×query pairs | bql_pct |
|---|---|---|
| 2026-08-09T04:41 | **11390** | 94% |
| 2026-08-09T05:16 | **2499** | 95% |

The smaller set is a strict **subset** of the larger, and **zero cases changed answer**. The metric was moving because the denominator was.

## Cause

The workflow deliberately splits run modes, and that split is right — a full sweep costs ~11 minutes, which is free nightly and not free per PR:

```bash
if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
  MAX_FILES=100000   # ~673, the whole corpus
else
  MAX_FILES=150
fi
```

But the commit-to-branch step ran on `github.event_name != 'pull_request'`, so **every push to main also wrote its 150-file sample into the same history and badge**. The trend tracked merge traffic rather than compatibility, and the badge showed whichever mode ran last. The five PRs I merged today each appended a 150-file point between nightly full-corpus points.

## Why it matters beyond the chart

- **The baseline was being truncated.** `previous-bql-results.jsonl` is fetched from this branch, so every merge replaced a 673-file baseline with a 150-file one — leaving ~523 files with nothing to regress against until the next nightly rebuilt it.
- **It explains `regression_count: 0` on the 100 → 93 drop** (2026-07-31T02:47). Regressions are per-case, and the case *set* had changed.
- **`history[-90:]` is labelled "Keep 90 days"** but at merge cadence held about two weeks — the recorded span is 2026-07-27 → 2026-08-10.

## Fix

Only the scheduled full-corpus run publishes. Push runs still execute the entire gate — they just no longer overwrite the record. That also stops a push from advancing the baseline past an ungated regression, which is the exact failure the existing gate-ordering comment warns about.

Each point now also records `bql_runs`, the population it was computed over. The two runs above would read 11390 and 2499 rather than looking like a regression followed by a recovery.

## Verification

- `schedule` trigger confirmed present (`cron: 0 3 * * *`), so publishing continues daily rather than stopping — checked, because gating on an absent trigger would have silently frozen the badge forever.
- Both embedded Python heredocs still compile (I edited inside one).
- YAML parses.

**No compatibility behavior changes here.** Every check-side metric — `check_match`, `accounts`, `posting`, `error`, `full` — has been pinned at 100 across all 90 recorded runs, and the BQL cases themselves are untouched. This is a measurement fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
