### PR TITLE
fix(compat): fix the first-balance query instead of pinning its fallout

### DIFF
--- a/crates/rustledger-query/tests/first_balance_accumulates.rs
+++ b/crates/rustledger-query/tests/first_balance_accumulates.rs
@@ -1,0 +1,127 @@
+//! `FIRST(balance)` sees a fully-accumulated running balance.
+//!
+//! `balance` is a stateful column: evaluating it advances a running inventory.
+//! beanquery's `FIRST.update` evaluates its operand only on a group's first row,
+//! so postings after that row never reach the accumulator and later groups read
+//! a balance that skipped them — beanquery#279. Its answer changes depending on
+//! what else appears in the SELECT list, because adding `LAST(balance)` forces
+//! evaluation on every row.
+//!
+//! rledger pre-computes the balance per row, so `FIRST` and `LAST` always agree
+//! about what the running balance was, and the aggregate cannot be perturbed by
+//! its neighbors in the SELECT list.
+//!
+//! This is pinned here because the compatibility corpus can no longer catch it.
+//! `tests/compatibility/bql-queries.toml` selects `LAST(balance)` alongside
+//! `FIRST(balance)` precisely so beanquery evaluates correctly and the suites
+//! agree — which means the corpus no longer exercises the bare-`FIRST` shape at
+//! all. Without this test, a change to our accumulation would be invisible in
+//! both places.
+//!
+//! The fixture mirrors the worked example in that file: three postings in one
+//! month, four in the next, all +10 EUR, so the running balance is 10/20/30 then
+//! 40/50/60/70. `FIRST` per month is 10 and 40. beanquery answers 40 only when
+//! forced; unforced it says 20, which is March's first posting plus May's first
+//! posting — the four rows it never evaluated.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+/// Three postings on `march_day`, four on `may_day`, each +10.00 EUR.
+fn ledger() -> Vec<Directive> {
+    let mut dirs = vec![
+        Directive::Open(Open::new(date(2018, 1, 1), "Assets:Test")),
+        Directive::Open(Open::new(date(2018, 1, 1), "Equity:Opening-Balance")),
+    ];
+    for (month, day, count) in [(3u32, 17u32, 3), (5, 16, 4)] {
+        for _ in 0..count {
+            dirs.push(Directive::Transaction(
+                Transaction::new(date(2018, month, day), "Test")
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Test",
+                        Amount::new(dec!(10.00), "EUR"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Equity:Opening-Balance",
+                        Amount::new(dec!(-10.00), "EUR"),
+                    )),
+            ));
+        }
+    }
+    dirs
+}
+
+fn run(query_str: &str) -> Vec<Vec<Value>> {
+    let dirs = ledger();
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(&dirs);
+    executor.execute(&query).expect("query should execute").rows
+}
+
+/// The single EUR amount held in a row's inventory cell.
+fn eur(rows: &[Vec<Value>], row: usize, col: usize) -> rustledger_core::Decimal {
+    let inv = match &rows[row][col] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected an Inventory at row {row} col {col}, got {other:?}"),
+    };
+    let positions = inv.position_list();
+    assert_eq!(
+        positions.len(),
+        1,
+        "expected exactly one position, got {positions:?}"
+    );
+    assert_eq!(positions[0].units.currency.as_str(), "EUR");
+    positions[0].units.number
+}
+
+#[test]
+fn first_balance_reflects_every_prior_posting() {
+    let rows = run(
+        "SELECT year, month, FIRST(balance) WHERE account ~ '^Assets' \
+         ORDER BY year, month LIMIT 12",
+    );
+    assert_eq!(rows.len(), 2, "expected one row per month, got {rows:?}");
+    assert_eq!(
+        eur(&rows, 0, 2),
+        dec!(10.00),
+        "March's first posting is the first balance"
+    );
+    assert_eq!(
+        eur(&rows, 1, 2),
+        dec!(40.00),
+        "May's first balance must include all three March postings — 20.00 here \
+         would mean the accumulator skipped rows, which is beanquery#279"
+    );
+}
+
+/// The aggregate must not depend on what else is selected. This is the property
+/// beanquery lacks, and the reason its answer for May moves between 20 and 40.
+#[test]
+fn first_balance_is_unaffected_by_a_neighboring_aggregate() {
+    let bare = run(
+        "SELECT year, month, FIRST(balance) WHERE account ~ '^Assets' \
+         ORDER BY year, month LIMIT 12",
+    );
+    let forced = run(
+        "SELECT year, month, FIRST(balance), LAST(balance) WHERE account ~ '^Assets' \
+         ORDER BY year, month LIMIT 12",
+    );
+    assert_eq!(bare.len(), forced.len());
+    for row in 0..bare.len() {
+        assert_eq!(
+            eur(&bare, row, 2),
+            eur(&forced, row, 2),
+            "row {row}: FIRST(balance) changed when LAST(balance) was added to \
+             the SELECT list"
+        );
+    }
+    // And LAST is the end-of-month balance, confirming the accumulator ran to
+    // completion rather than stopping at each group's first row.
+    assert_eq!(eur(&forced, 0, 3), dec!(30.00));
+    assert_eq!(eur(&forced, 1, 3), dec!(70.00));
+}

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -93,94 +93,18 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
     ("testdata_source_generic_importer_test_invalid_journal.beancount", "*"),
     # DisplayContext common vs max precision (#724)
     ("testdata_source_ofx_test_fidelity_journal.beancount", "*"),
-    # beancount/beanquery#279: FIRST aggregator short-circuits operand
-    # evaluation after the first row, leaving the stateful `balance`
-    # accumulator stale for subsequent groups. The exact same query
-    # against the exact same fixture gives different FIRST(balance)
-    # values depending on whether other aggregators (e.g. LAST) appear
-    # in the SELECT list — because LAST's presence forces the operand
-    # to be evaluated on every row. See tests/compatibility/exclusions.toml
-    # for the full root-cause writeup. rledger pre-computes ctx.balance
-    # per row so FIRST/LAST always agree; we don't want to mirror the
-    # upstream bug. Surgical pin (not "*") so any other genuine
-    # divergence on these fixtures stays surfaced.
-    ("cost_only.beancount", "first-balance-by-month"),
-    ("testdata_source_healthequity_test_invalid_journal.beancount", "first-balance-by-month"),
-    ("testdata_source_healthequity_test_matching_journal.beancount", "first-balance-by-month"),
-    ("testdata_source_ofx_test_fidelity_ira_journal.beancount", "first-balance-by-month"),
-    ("testdata_source_paypal_test_matching_journal.beancount", "first-balance-by-month"),
+    # beancount/beanquery#279 used to be pinned here, 56 fixtures of it. It is
+    # not masked any more because it is no longer a divergence: the corpus query
+    # now selects `LAST(balance)` alongside `FIRST(balance)`, which forces
+    # beanquery to evaluate the stateful `balance` accumulator on every row, and
+    # the two tools then agree exactly. See the rationale on
+    # `first-balance-by-month` in tests/compatibility/bql-queries.toml.
     #
-    # The 51 below hit the SAME upstream bug and were pinned later, once the
-    # corpus grew past the original five. Each was VERIFIED, not assumed:
-    # `scripts/verify-first-balance-divergence.py` checks that rledger's
-    # `FIRST(balance)` equals what beanquery itself produces when `balance` is
-    # forced to evaluate on every row (by adding `LAST(balance)` to the SELECT
-    # list). Where those agree, the only difference is the accumulation
-    # beanquery skipped, so the fixture is upstream's bug and not ours.
-    #
-    # Eight further fixtures mismatch on this query and are deliberately NOT
-    # pinned. Seven load third-party plugins (beancount_reds_plugins,
-    # beancount_lazy_plugins) that the verifier could not import; beancount
-    # reports that as a load error and then EXITS 0 with a partially-loaded
-    # ledger, so the comparison silently degrades to rledger-full against
-    # beancount-partial and proves nothing — including for three of them whose
-    # rows happened to match anyway. The eighth genuinely disagrees.
-    #
-    # All eight stay surfaced. Pinning on the strength of "same query name"
-    # would be exactly the too-broad mask this registry's surgical-pin rule
-    # exists to prevent, and would bury a real regression among known-bad
-    # pairs. Install those plugins and re-run the verifier to settle them.
-    ("bc_scripts_my_accounts.beancount", "first-balance-by-month"),
-    ("contrib_examples_budgets-example.beancount", "first-balance-by-month"),
-    ("contrib_examples_example.beancount", "first-balance-by-month"),
-    ("contrib_examples_huge-example.beancount", "first-balance-by-month"),
-    ("data_sample-west.beancount", "first-balance-by-month"),
-    ("data_sample.beancount", "first-balance-by-month"),
-    ("example_alipay_example-alipay-output.beancount", "first-balance-by-month"),
-    ("example_bocom_debit_example-bocom_debit-output.beancount", "first-balance-by-month"),
-    ("example_example.beancount", "first-balance-by-month"),
-    ("example_ledger.beancount", "first-balance-by-month"),
-    ("example_multiple-files-example_example.beancount", "first-balance-by-month"),
-    ("example_portfolio.beancount", "first-balance-by-month"),
-    ("example_wechat_example-wechat-output.beancount", "first-balance-by-month"),
-    ("examples_example.beancount", "first-balance-by-month"),
-    ("examples_ledger_ledger.beancount", "first-balance-by-month"),
-    ("examples_simple_basic.beancount", "first-balance-by-month"),
-    ("examples_simple_starter.beancount", "first-balance-by-month"),
-    ("examples_vesting_vesting.beancount", "first-balance-by-month"),
-    ("fava_investor_examples_example.beancount", "first-balance-by-month"),
-    ("fava_investor_examples_huge-example.beancount", "first-balance-by-month"),
-    ("fava_investor_modules_minimizegains_example.beancount", "first-balance-by-month"),
-    ("fava_investor_modules_tlh_example.beancount", "first-balance-by-month"),
-    ("frontend_tests_dashboards__testdata.beancount", "first-balance-by-month"),
-    ("nomina_examples_example.beancount", "first-balance-by-month"),
-    ("src_fava_portfolio_returns_test_ledger_example_stock.beancount", "first-balance-by-month"),
-    ("src_fava_portfolio_returns_test_ledger_linear_growth_stock.beancount", "first-balance-by-month"),
-    ("src_fava_portfolio_returns_test_ledger_savings_plan.beancount", "first-balance-by-month"),
-    ("testdata_source_venmo_test_invalid_references_journal.beancount", "first-balance-by-month"),
-    ("testdata_source_venmo_test_matching_journal.beancount", "first-balance-by-month"),
-    ("tests_amounts-decimal-comma.beancount", "first-balance-by-month"),
-    ("tests_amounts.beancount", "first-balance-by-month"),
-    ("tests_aux-date.beancount", "first-balance-by-month"),
-    ("tests_balance-assertion.beancount", "first-balance-by-month"),
-    ("tests_code.beancount", "first-balance-by-month"),
-    ("tests_comments.beancount", "first-balance-by-month"),
-    ("tests_commodities.beancount", "first-balance-by-month"),
-    ("tests_data_extension-report-example.beancount", "first-balance-by-month"),
-    ("tests_data_long-example.beancount", "first-balance-by-month"),
-    ("tests_data_query-example.beancount", "first-balance-by-month"),
-    ("tests_dates.beancount", "first-balance-by-month"),
-    ("tests_fixated.beancount", "first-balance-by-month"),
-    ("tests_hledger.beancount", "first-balance-by-month"),
-    ("tests_lots.beancount", "first-balance-by-month"),
-    ("tests_metadata.beancount", "first-balance-by-month"),
-    ("tests_narration.beancount", "first-balance-by-month"),
-    ("tests_payee.beancount", "first-balance-by-month"),
-    ("tests_prices.beancount", "first-balance-by-month"),
-    ("tests_samples_official.beancount", "first-balance-by-month"),
-    ("tests_tags.beancount", "first-balance-by-month"),
-    ("tests_test.beancount", "first-balance-by-month"),
-    ("tests_virtual-postings.beancount", "first-balance-by-month"),
+    # Pinning could never have finished the job. 499 of the 513 unpinned
+    # occurrences were `synthetic_*` fixtures, which the nightly generator
+    # recreates every run — a `(filename, query)` entry cannot mask a file that
+    # will not exist tomorrow, so the registry lost ground every night no matter
+    # how many entries were added.
 }
 
 

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -71,7 +71,33 @@ preserve_order = true
 
 [[query]]
 name = "first-balance-by-month"
-query = "SELECT year, month, FIRST(balance) WHERE account ~ '^Assets' ORDER BY year, month LIMIT 12"
+# `LAST(balance)` is not idle curiosity — it is load-bearing, and removing it
+# reintroduces ~570 mismatches.
+#
+# `balance` mutates a shared accumulator when it is evaluated, and beanquery's
+# `FIRST.update` evaluates its operand only on a group's FIRST row. So with
+# `FIRST(balance)` alone, postings after each group's first row never reach the
+# accumulator and beanquery reports the balance of a ledger that skipped them.
+# Worked example (`tests_code.beancount`, 3 Assets postings in March and 4 in
+# May, all +10.00 EUR, so the true running balance is 10/20/30 then 40/50/60/70):
+#
+#     bare FIRST(balance)   ->  2018-03  10.00 EUR   2018-05  20.00 EUR
+#     with LAST(balance)    ->  2018-03  10.00 EUR   2018-05  40.00 EUR
+#
+# 20.00 is March's first posting plus May's first posting — the four rows
+# beanquery never evaluated. rledger returns 40.00 either way, which is correct.
+# Selecting LAST too forces evaluation on every row and the two tools then agree
+# exactly, so this is upstream beanquery#279 rather than anything on our side.
+#
+# The fix is in the query rather than the mask registry because the divergence is
+# overwhelmingly hit by the nightly `synthetic_*` fixtures, which are regenerated
+# every run — a `(filename, query)` pin cannot cover a file that will not exist
+# tomorrow, and 499 of 513 unpinned occurrences were synthetic.
+#
+# rledger's bare-`FIRST(balance)` behavior is pinned independently by
+# `crates/rustledger-query/tests/first_balance_accumulates.rs`, so widening the
+# SELECT here does not stop us noticing if OUR semantics change.
+query = "SELECT year, month, FIRST(balance), LAST(balance) WHERE account ~ '^Assets' ORDER BY year, month LIMIT 12"
 preserve_order = true
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
`first-balance-by-month` was **572 of the 1307** full-corpus BQL mismatches. It is fixed here rather than masked.

## Why the registry could never have caught up

56 fixtures were pinned. The corpus produces ten times that — and **499 of the 513 unpinned occurrences are `synthetic_*` fixtures**, which the nightly generator recreates every run. A `(filename, query)` pin cannot mask a file that will not exist tomorrow, so the list lost ground every night no matter how many entries were added.

## The divergence is beanquery#279, and it is fixable in the query

`balance` mutates a shared accumulator when evaluated, and beanquery's `FIRST.update` evaluates its operand only on a group's **first** row — so later postings never reach the accumulator. Selecting `LAST(balance)` as well forces evaluation on every row, and the two tools then agree exactly.

Worked example, `tests_code.beancount` — 3 `Assets` postings in March and 4 in May, all `+10.00 EUR`, so the true running balance is 10/20/30 then 40/50/60/70:

```
bare FIRST(balance)   ->  2018-03  10.00 EUR    2018-05  20.00 EUR
with LAST(balance)    ->  2018-03  10.00 EUR    2018-05  40.00 EUR
```

`20.00` is March's first posting plus May's first posting — the four rows beanquery never evaluated. rledger answers `40.00` either way.

## Measured, not asserted

Real harness, over the 70 previously-mismatching corpus fixtures present locally (70 × 17 = **1190 runs**), same files both ways:

| | old query | new query |
|---|---|---|
| **raw match** | 949 (79%) | **1010 (84%)** |
| effective match | 1044 (87%) | 1048 (88%) |
| masked as known | 95 | **38** |
| `first-balance` mismatches | 70 | **9** |

The gain lands in the **raw** number — the one that cannot be gamed — while the masked count *falls by 57*. That is the difference between fixing a divergence and hiding it. The nine that remain stay surfaced; spot-checking them shows trailing-zero rendering and one brace-spacing difference, which are separate issues.

Note this sample is deliberately adversarial: every one of those 70 files previously failed this query. The full-corpus effect is larger, and it covers the ~499 synthetic fixtures that no pin could ever reach.

## Removing the pins is required, not tidying

The stale-mask gate fails a run when a pinned pair starts matching. Leaving the 56 entries in place would have turned the suite red — the mechanism enforces its own cleanup.

## What this gives up, and how it is covered

Widening the SELECT means the corpus no longer exercises **bare** `FIRST(balance)` — which is precisely where beanquery is wrong and we are right. `crates/rustledger-query/tests/first_balance_accumulates.rs` pins that independently: the same 10/40 arithmetic, plus an assertion that `FIRST(balance)` does **not** change when `LAST(balance)` joins the SELECT list, which is the property beanquery lacks. Sabotage-checked — flipping the expected 40.00 to 20.00 fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
