### PR TITLE
fix(compat): stop a merge cancelling the nightly compatibility sweep

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -28,9 +28,24 @@ on:
         required: false
         default: ''
         type: string
-# Prevent concurrent runs from racing on the compatibility branch
+# Prevent concurrent runs from racing on the compatibility branch.
+#
+# Keyed on the EVENT, not a shared 'nightly' literal. `pull_request.number` is
+# empty for both `push` and `schedule`, so both used to resolve to
+# `compatibility-nightly` and, with cancel-in-progress, any merge to main killed
+# an in-flight nightly. The full sweep takes ~11 minutes and merges are frequent,
+# so that happened often — and it stopped being harmless once the scheduled run
+# became the only one that publishes (see "Commit results to compatibility
+# branch"). A cancelled nightly is now a missing data point rather than one
+# replaced by a push run's narrower sample: the 2026-08-10T04:38 nightly was
+# cancelled by a 04:47 merge and the trend simply did not advance that day.
+#
+# Push runs no longer write to the branch at all, so the writer-vs-writer race
+# this guard exists for is only schedule-vs-schedule, which distinct groups still
+# cover. Pushes keep cancelling each other, which is the resource behavior they
+# already had.
 concurrency:
-  group: compatibility-${{ github.event.pull_request.number || 'nightly' }}
+  group: compatibility-${{ github.event.pull_request.number || github.event_name }}
   cancel-in-progress: true
 permissions:
   contents: write


### PR DESCRIPTION
Follow-up to #2005, fixing a hole that PR opened.

## The bug

```yaml
group: compatibility-${{ github.event.pull_request.number || 'nightly' }}
cancel-in-progress: true
```

`pull_request.number` is empty for **both** `push` and `schedule`, so both resolved to `compatibility-nightly`. With `cancel-in-progress`, any merge to main cancelled an in-flight nightly. The full sweep takes ~11 minutes and merges are frequent.

That used to be survivable — the push run would publish in the cancelled nightly's place. **#2005 removed that fallback** by making the scheduled run the only publisher (correctly: a push run measures 150 files against the nightly's ~673, and the two are not comparable). So a cancelled nightly is now a *missing* data point rather than a substituted one.

## It has already happened — #2005 did it to itself

```
scheduled run           started 04:38:23   cancelled 04:47:30
push run (#2005 merge)  started 04:47:12
```

Eighteen seconds apart. The merge that made the nightly the sole publisher cancelled that night's nightly on its way in. Consequences visible right now on the `compatibility` branch:

- last data point is **2026-08-10T04:06**, before #2005 merged at 04:47
- `bql_runs`, the population field #2005 added, has **never been written** — every published point still reads "(not recorded)"

## Fix

Key the group on `github.event_name` instead of a literal:

| event | group before | group after |
|---|---|---|
| `pull_request` | `compatibility-<n>` | `compatibility-<n>` (unchanged) |
| `push` | `compatibility-nightly` | `compatibility-push` |
| `schedule` | `compatibility-nightly` | `compatibility-schedule` |
| `workflow_dispatch` | `compatibility-nightly` | `compatibility-workflow_dispatch` |

Push runs no longer write the branch at all after #2005, so the writer-vs-writer race this guard exists for is only schedule-vs-schedule, which distinct groups still cover. Pushes keep cancelling each other — the resource behavior they already had.

Verified the trigger list is exactly `push, pull_request, schedule, workflow_dispatch`, so there's no fifth event silently sharing a group.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
