### PR TITLE
test(compat): give five corpus queries a total order key

### DIFF
--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -40,7 +40,7 @@ preserve_order = true
 
 [[query]]
 name = "count-by-currency"
-query = "SELECT currency, COUNT(*) AS count GROUP BY currency ORDER BY count DESC LIMIT 5"
+query = "SELECT currency, COUNT(*) AS count GROUP BY currency ORDER BY count DESC, currency LIMIT 5"
 preserve_order = true
 
 # ----------------------------------------------------------------------
@@ -59,7 +59,7 @@ preserve_order = true
 
 [[query]]
 name = "balance-running-assets"
-query = "SELECT date, account, balance WHERE account ~ '^Assets' ORDER BY date LIMIT 10"
+query = "SELECT date, account, balance WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
 notes = "Cumulative running balance over WHERE-filtered postings (#929)"
 preserve_order = true
 
@@ -106,18 +106,18 @@ preserve_order = true
 
 [[query]]
 name = "position-by-date"
-query = "SELECT date, account, position WHERE account ~ '^Assets' ORDER BY date LIMIT 10"
+query = "SELECT date, account, position WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
 preserve_order = true
 
 [[query]]
 name = "weight-by-date"
-query = "SELECT date, account, weight WHERE account ~ '^Assets' ORDER BY date LIMIT 10"
+query = "SELECT date, account, weight WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
 notes = "Weight = cost-basis-converted balancing amount; differs from position only on cost-bearing postings"
 preserve_order = true
 
 [[query]]
 name = "cost-basis-fields"
-query = "SELECT account, cost_number, cost_currency WHERE cost_number IS NOT NULL ORDER BY account LIMIT 10"
+query = "SELECT account, cost_number, cost_currency WHERE cost_number IS NOT NULL ORDER BY account, cost_number, cost_currency LIMIT 10"
 notes = "Exposes the cost-bearing branch of position handling"
 preserve_order = true
 

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -59,7 +59,7 @@ preserve_order = true
 
 [[query]]
 name = "balance-running-assets"
-query = "SELECT date, account, balance WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
+query = "SELECT date, account, balance WHERE account ~ '^Assets' ORDER BY date, account, lineno LIMIT 10"
 notes = "Cumulative running balance over WHERE-filtered postings (#929)"
 preserve_order = true
 
@@ -106,18 +106,18 @@ preserve_order = true
 
 [[query]]
 name = "position-by-date"
-query = "SELECT date, account, position WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
+query = "SELECT date, account, position WHERE account ~ '^Assets' ORDER BY date, account, lineno LIMIT 10"
 preserve_order = true
 
 [[query]]
 name = "weight-by-date"
-query = "SELECT date, account, weight WHERE account ~ '^Assets' ORDER BY date, account LIMIT 10"
+query = "SELECT date, account, weight WHERE account ~ '^Assets' ORDER BY date, account, lineno LIMIT 10"
 notes = "Weight = cost-basis-converted balancing amount; differs from position only on cost-bearing postings"
 preserve_order = true
 
 [[query]]
 name = "cost-basis-fields"
-query = "SELECT account, cost_number, cost_currency WHERE cost_number IS NOT NULL ORDER BY account, cost_number, cost_currency LIMIT 10"
+query = "SELECT account, cost_number, cost_currency WHERE cost_number IS NOT NULL ORDER BY account, cost_number, cost_currency, lineno LIMIT 10"
 notes = "Exposes the cost-bearing branch of position handling"
 preserve_order = true
 


### PR DESCRIPTION
Five corpus queries sorted on a **non-unique key** and then applied `LIMIT`, so which rows survived the cut was whichever the implementation happened to emit first. Comparing that between two tools compares an implementation detail, not compatibility.

| query | before | after |
|---|---|---|
| `balance-running-assets` | `ORDER BY date` | `ORDER BY date, account, lineno` |
| `position-by-date` | `ORDER BY date` | `ORDER BY date, account, lineno` |
| `weight-by-date` | `ORDER BY date` | `ORDER BY date, account, lineno` |
| `count-by-currency` | `ORDER BY count DESC` | `ORDER BY count DESC, currency` |
| `cost-basis-fields` | `ORDER BY account` | `ORDER BY account, cost_number, cost_currency, lineno` |

`distinct-account` already sorts on a `DISTINCT` column and needed nothing. The three `JOURNAL` queries compare ordered output with no `ORDER BY` at all, but `JOURNAL` has no sort clause to give it, and their divergence is posting order after multi-currency interpolation — a separate question.

## Measured, and smaller than the defect suggests

On the 44 corpus fixtures that currently mismatch on these five queries: **128 mismatches → 123**. Five.

Worth stating plainly rather than dressing up: a non-total sort under `LIMIT` was a real source of nondeterminism, but a small one. The remaining 123 breaks down as 35 value differences, 33 row-count differences, 30 rendering differences, 25 structural.

## The value is that the comparison now means something

`tests_balance-assertion` is the case that motivated this. Two postings share `2019-01-29` and `LIMIT 10` cut through the tie:

```
before   rledger: 2019-01-29  Assets:Test6  40.00 EUR  987.00 USD
         bean-q:  2019-01-29  Assets:Test5  50.00 EUR  487.00 USD
```

Different *account* — pure tie-break, no information. With the total key both tools now select `Test5`:

```
after    rledger: 2019-01-29  Assets:Test5  50.00 EUR  987.00 USD
         bean-q:  2019-01-29  Assets:Test5  50.00 EUR  487.00 USD
```

Same row, and the difference is now visible for what it is: the **balance column**, `987.00` against `487.00`. That divergence was there all along, hidden behind the ordering noise. It's a running-balance difference and it's real.

So this doesn't move the percentage much. It converts a class of "mismatch" that carried no information into either agreement or a genuine finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG