### PR TITLE
fix(compat): do not compare against a partially loaded beancount ledger

### DIFF
--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -893,9 +893,15 @@ def main() -> int:
     # Per-query empty-result rate. A query that returns 0 rows on >50%
     # of files isn't actually being tested by the corpus and should
     # either be reformulated or paired with data that exercises it.
+    #
+    # Over `conclusive`, not `results`: a failed run has empty stdout, so it
+    # scores as `py_rows == 0 and rs_rows == 0` and would be indistinguishable
+    # from a query the corpus genuinely fails to exercise. A missing plugin or
+    # a timeout would then be reported as poor corpus coverage — the same
+    # mistake as folding those runs into the match rate, one metric over.
     empties_by_query: dict[str, int] = {}
     runs_by_query: dict[str, int] = {}
-    for r in results:
+    for r in conclusive:
         runs_by_query[r.query_name] = runs_by_query.get(r.query_name, 0) + 1
         if r.py_rows == 0 and r.rs_rows == 0:
             empties_by_query[r.query_name] = empties_by_query.get(r.query_name, 0) + 1

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -69,6 +69,11 @@ MIN_CORPUS_SIZE = 15
 # fuzz workflow uses.
 MAX_FILES = 150
 
+# beancount emits these on stderr and still exits 0, leaving the ledger short
+# of directives the fixture expects. Same expression as the one in
+# `verify-first-balance-divergence.py`, which documents the failure mode.
+_LOAD_ERROR = re.compile(r"Error importing|error importing|<load>:")
+
 # A query that returns 0 rows on more than this fraction of files isn't
 # really being tested by the corpus — flag it loudly so we know to add
 # data that exercises it.
@@ -569,6 +574,27 @@ def run_query(
         return ToolOutput(
             stdout=proc.stdout, failed=True, reason=f"rc={proc.returncode}: {head[:120]}"
         )
+    # Exit status alone is NOT enough for bean-query. beancount reports a
+    # failed plugin import as a load error on stderr and then exits 0 with a
+    # PARTIALLY LOADED ledger, so the comparison silently degrades to
+    # rledger-full against beancount-partial. That is not evidence of
+    # anything: every divergence it produces is an artifact of the missing
+    # plugin, and a fixture where both sides happen to come back empty is
+    # recorded as a match on no basis at all.
+    #
+    # This is not hypothetical. The corpus installs two third-party plugin
+    # sets (`beancount_reds_plugins`, `beancount-lazy-plugins`, see
+    # compat.yml), and running without them turns the four
+    # `beancount-lazy-plugins` valuation fixtures into ~58 confident
+    # mismatches that vanish once the plugins are present.
+    #
+    # `scripts/verify-first-balance-divergence.py` has guarded this since it
+    # was written; the harness that produces the published number did not.
+    for line in (proc.stderr or "").splitlines():
+        if _LOAD_ERROR.search(line):
+            return ToolOutput(
+                stdout=proc.stdout, failed=True, reason=f"load error: {line.strip()[:120]}"
+            )
     return ToolOutput(stdout=proc.stdout)
 
 
@@ -825,14 +851,29 @@ def main() -> int:
 
     # Tally. `total` counts file×query *runs*, not distinct corpus
     # queries; we expose both to make the CI summary unambiguous.
-    total = len(results)
-    matching = sum(1 for r in results if r.match)
+    # A run where either tool failed proves nothing, so it must not be
+    # averaged into the match rate. Counting it as a mismatch (which is what
+    # `match=False` does) quietly converts an environment problem — a missing
+    # third-party plugin, a timeout — into a lower compatibility number, and
+    # the number is the thing people read.
+    #
+    # Excluding them silently would trade one blind spot for another, so
+    # they are also surfaced as a CI annotation. Deliberately a warning and
+    # not a hard failure: in CI the corpus plugins ARE installed (compat.yml),
+    # so a load error there means the install broke and is worth shouting
+    # about — but a timeout lands in this same bucket, and failing the suite
+    # on a slow runner would make it flaky for a reason unrelated to
+    # compatibility.
+    inconclusive = [r for r in results if r.py_failed or r.rs_failed]
+    conclusive = [r for r in results if not (r.py_failed or r.rs_failed)]
+    total = len(conclusive)
+    matching = sum(1 for r in conclusive if r.match)
     known_py = sum(
-        1 for r in results
+        1 for r in conclusive
         if not r.match and _is_known_python_divergence(r)
     )
     known_rs = sum(
-        1 for r in results
+        1 for r in conclusive
         if not r.match and _is_known_rust_divergence(r)
     )
     known_div = known_py + known_rs
@@ -877,6 +918,25 @@ def main() -> int:
     )
     print(f"Runs tested:         {total}  (file × query)")
     print(f"Runs matching:       {matching}")
+    if inconclusive:
+        print(
+            f"Inconclusive:        {len(inconclusive)} run(s) where a tool failed "
+            f"— EXCLUDED from the rates below"
+        )
+        for r in inconclusive[:5]:
+            reason = r.py_failure or r.rs_failure or "?"
+            print(f"    {r.file} | {r.query_name}: {reason[:96]}")
+        load_errs = [r for r in inconclusive
+                     if "load error" in (r.py_failure or r.rs_failure or "")]
+        if load_errs:
+            files = sorted({r.file for r in load_errs})
+            print(
+                f"::warning::{len(load_errs)} run(s) across {len(files)} fixture(s) "
+                f"could not be compared because a tool reported a load error and "
+                f"still exited 0 — usually a missing third-party corpus plugin. "
+                f"Those runs are excluded from the match rates. Files: "
+                f"{', '.join(files[:5])}"
+            )
     print(f"Raw match:           {matching}/{total} ({raw_pct}%)  [nothing masked]")
     print(f"Known Python diffs:  {known_py}")
     print(f"Known Rust diffs:    {known_rs}")

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -1081,10 +1081,19 @@ def main() -> int:
                 if b.get("match"):
                     baseline_passing.add((b.get("file"), b.get("query_name")))
 
+        # A run where a tool failed is NOT a regression — it is an absence of
+        # evidence, the same reasoning `stale_divergence_entries` already
+        # applies. Without this, making load errors visible would itself fire
+        # the gate: a pair that "matched" only because beancount loaded a
+        # partial ledger and both sides came back empty is a FALSE match, and
+        # honestly reclassifying it as inconclusive would be reported as a
+        # regression it never was.
         regressed = [
             r
             for r in results
-            if not r.match and (r.file, r.query_name) in baseline_passing
+            if not r.match
+            and not (r.py_failed or r.rs_failed)
+            and (r.file, r.query_name) in baseline_passing
         ]
         if regressed:
             print()


### PR DESCRIPTION
## What this fixes

beancount reports a failed plugin import as a load error **on stderr and then exits 0**, with a ledger missing everything that plugin would have produced. `run_query` only checked the exit status, so the harness compared **rledger-full against beancount-partial** and recorded every resulting difference as a compatibility mismatch.

`scripts/verify-first-balance-divergence.py` has guarded this since it was written, and its docstring says exactly why — *"that is not evidence of anything"*. The harness that produces the published number did not.

## How it surfaced

I was chasing what looked like a genuine near-zero residual bug. The four `beancount-lazy-plugins` valuation fixtures had rledger and beancount disagreeing about a `1e-7` residue **in opposite directions** — rledger keeping `0.0000001` where beancount had `0.00` on one fixture, and an empty inventory where beancount had `0.0000001` on another. That is precisely the shape of a real rounding bug.

It wasn't one. The plugin wasn't installed locally, so beancount was valuing nothing at all. With it installed, `tests_data_cool_fund_example` **agrees exactly**.

## Changes

- `run_query` treats a load error on stderr as a failure, reusing the same expression as the verifier script.
- The tally **excludes** runs where either tool failed rather than counting them as mismatches. A failed run proves nothing, and folding it into the rate silently converts an environment problem into a lower compatibility number — the number people actually read.

## Measured

On those four fixtures, plugins deliberately absent:

| | runs | flagged | counted as mismatch |
|---|---|---|---|
| before | 68 | 0 | **58** |
| after | 34 conclusive | 34 inconclusive | 0 from the failures |

With the plugins present, as CI installs them (`compat.yml` lines 94–95), all 68 runs are conclusive and nothing is excluded — so this changes nothing about the number CI reports today. It changes what happens the day a plugin install breaks.

## Why a warning and not a gate

Inconclusive runs are surfaced as a CI annotation, deliberately not a hard failure. In CI the plugins are installed, so a load error means the install broke and is worth shouting about — but a **timeout** lands in the same bucket, and failing the suite on a slow runner would make it flaky for a reason unrelated to compatibility.

## Note on what remains

With the plugins present, 36 of those 68 fund-fixture runs still mismatch. That is real, and it is mostly decimal rendering plus a genuine `1e-7` difference between rledger's native `valuation` plugin and the Python original. That's a fidelity gap in a third-party plugin reimplementation, not a core engine bug — worth its own issue, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
