### PR TITLE
test(compat): exclude a fixture neither tool can be compared on

### DIFF
--- a/tests/compatibility/exclusions.toml
+++ b/tests/compatibility/exclusions.toml
@@ -191,3 +191,32 @@ affected sub-segment so it starts with ASCII (e.g.,
 type (`Assets`, `Liabilities`, etc.), and the root segments in
 this file are already ASCII.
 """
+
+[[exclusions]]
+pattern = "fava-budget-freedom/example.beancount"
+reason = "Loads a Python plugin by module name, which rledger cannot execute"
+details = """
+The file loads `plugin "beancount_periodic.amortize"`, and rledger refuses it:
+
+    error[E8004]: Python plugin "beancount_periodic.amortize" is not supported
+    by module name; reference the file directly, e.g. plugin "/path/to/plugin.py".
+    The plugin sandbox cannot see the host venv, so the plugin must be
+    self-contained.
+
+That is a deliberate sandbox boundary, not a gap to close, so the two tools can
+never agree here: with `beancount_periodic` installed beancount amortizes and
+reports 34 entries while rledger reports 12.
+
+Until now the fixture was silently "passing" for the wrong reason. The plugin
+was not in the compat install list either, so beancount ALSO failed to load it
+— reporting the failed import on stderr and then exiting 0 with a partial
+ledger — and the two partial results agreed vacuously on several queries. #2013
+made that visible by flagging load errors as inconclusive.
+
+Installing the plugin would not fix it, it would invert it: beancount would run
+the amortization and rledger structurally cannot, turning four vacuous matches
+into four permanent mismatches. Excluding the fixture is the honest option,
+since neither tool can be compared against the other on it.
+
+This is the only fixture in the corpus that uses `beancount_periodic`.
+"""


### PR DESCRIPTION
**This PR changed direction after CI disproved my first attempt.** The original version added `beancount_periodic` to the compat install list; that was wrong, and the way it was wrong is the point.

## The fixture

`fava-budget-freedom/example.beancount` loads a Python plugin by module name, which rledger refuses by design:

```
error[E8004]: Python plugin "beancount_periodic.amortize" is not supported by
module name; reference the file directly. The plugin sandbox cannot see the
host venv, so the plugin must be self-contained.
```

That sandbox boundary is deliberate. So the two tools can **never** agree on this file: with `beancount_periodic` installed, beancount amortizes and reports 34 entries while rledger reports 12.

## Why installing the plugin makes it worse, not better

Without the plugin, **beancount also failed to load it** — reporting the import error on stderr and then exiting 0 with a partial ledger. Both sides were partial, and they agreed *vacuously* on four queries.

Installing it doesn't fix the comparison, it **inverts** it: beancount becomes whole, rledger structurally cannot, and four vacuous matches become four permanent mismatches. CI proved it — the first push failed with exactly those four pairs reported as regressed:

```
##[error]BQL compat regression: 4 (file, query) pair(s) that matched on the baseline now fail
  REGRESSED: count-by-currency | example.beancount
  REGRESSED: count-by-year-month | example.beancount
  REGRESSED: distinct-account | example.beancount
  REGRESSED: sum-position-by-account | example.beancount
```

They hadn't regressed. They had never validly passed.

## The fix

The fixture isn't comparable in either configuration, so it goes in `exclusions.toml` — which already carries entries of exactly this shape ("Uses beancount.plugins.unrealized removed in v3"). It's also the **only** fixture in the corpus using `beancount_periodic`, so nothing else wants the dependency.

## It only half works, and that is a separate bug

The exclusion takes effect in the **check** suite. It does **not** reach the BQL suite, and CI shows that plainly: the check step reports `Excluded (known limitations): 9`, and the BQL step then queries the fixture anyway and reports its load error.

The cause is that the BQL layer identifies fixtures by **bare filename**. Three fixtures are named `example.beancount`, `compat-check-results.jsonl` records the name rather than the path, and `find_file()` resolves it with `rglob` and takes the first match — which can be the excluded one. Filed as #2016, along with its other consequence: two of those three fixtures are never queried at all, so `Files queried` overstates coverage.

I am landing the exclusion anyway because it is correct on its own terms and improves the check suite. The BQL side needs #2016 fixed before it can take effect, and that is a coordinated change across `compat.yml` and `compat-bql-test.py` rather than something to bolt on here.

## Credit where due

#2013 is what made any of this visible. Before it, the partial-ledger comparison was silent — beancount exiting 0 after a failed import, and the suite treating the result as compatibility data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
