### PR TITLE
chore(deps): bump rowan to 0.17, adapting to the green() signature change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2260,6 +2260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3261,12 +3270,13 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+checksum = "14b574c58582fa59fa43a2feb6608b8744184659f08a2e0117e4b8224d95ed61"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
+ "memoffset",
  "rustc-hash 1.1.0",
  "text-size",
 ]
@@ -3339,7 +3349,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4254,7 +4264,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5434,7 +5444,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ miette = { version = "7", features = ["fancy"] }
 logos = "0.16"
 # Lossless syntax tree (rust-analyzer's library). Used by
 # `rustledger-parser`'s CST module — see #1262.
-rowan = "0.16"
+rowan = "0.17"
 # Safe `repr(u16)` → enum conversion derive, used by `SyntaxKind`. Lets
 # rowan's `Language::kind_from_raw` be a one-line `try_from` instead of
 # a hand-rolled 70-arm match (rejected by the round-1 architecture

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -227,7 +227,7 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
                 let base =
                     u32::from(node.syntax().text_range().start()) as usize + bom_offset as usize;
                 let green_dir = if use_green {
-                    super::green::convert_transaction(&green, base)
+                    super::green::convert_transaction(green, base)
                 } else {
                     None
                 };
@@ -354,13 +354,15 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
         crate::cst::format::GroupingStyle::default(),
     );
 
-    // Capture the green root before we drop `source_file`. The
-    // `.green()` call returns a Cow so we promote to owned with
-    // `into_owned()`; the resulting `GreenNode` is reference-
-    // counted internally, cheap to clone, and `Send + Sync` -
-    // safe to stash in `Arc<ParseResult>` that the LSP shares
-    // across threads.
-    let syntax_root = source_file.syntax().green().into_owned();
+    // Capture the green root before we drop `source_file`. `.green()`
+    // borrows (`&GreenNodeData`), so promote to an owned `GreenNode`; it is
+    // reference-counted internally, cheap to clone, and `Send + Sync` — safe
+    // to stash in the `Arc<ParseResult>` the LSP shares across threads.
+    //
+    // `to_owned()`, not `into_owned()`: rowan 0.17 changed `green()` from
+    // returning `Cow<GreenNodeData>` to returning `&GreenNodeData`, so the
+    // promotion now goes through `ToOwned` instead of `Cow::into_owned`.
+    let syntax_root = source_file.syntax().green().to_owned();
 
     ParseResult {
         directives,

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -537,7 +537,7 @@ pub(super) fn walk_descendants(
             account_occurrences: Vec::new(),
         },
     };
-    w.walk(&root.green(), false);
+    w.walk(root.green(), false);
     w.result
 }
 

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -572,7 +572,7 @@ mod cached_syntax_root_matches_fresh_parse {
     fn assert_round_trip(label: &str, source: &str) {
         let parsed = parse(source);
         let (stripped, _bom) = crate::bom::strip_leading(source);
-        let fresh = parse_structured(stripped).green().into_owned();
+        let fresh = parse_structured(stripped).green().to_owned();
         assert_eq!(
             parsed.syntax_root, fresh,
             "cached syntax_root diverged from fresh parse_structured for {label}: \n\

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -652,7 +652,7 @@ version = "1.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rowan]]
-version = "0.16.1"
+version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rust_decimal]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -443,6 +443,10 @@ criteria = "safe-to-deploy"
 version = "0.9.11"
 criteria = "safe-to-deploy"
 
+[[exemptions.memoffset]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.miette]]
 version = "7.6.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Supersedes #2012, which failed **21 checks** — rowan 0.17 is a breaking change for us, not a drop-in bump.

## The break

`SyntaxNode::green()` changed signature:

```rust
// 0.16
pub fn green(&self) -> Cow<'_, GreenNodeData>
// 0.17
pub fn green(&self) -> &GreenNodeData
```

So `Cow::into_owned()` no longer applies:

```
error[E0599]: no method named `into_owned` found for reference `&GreenNodeData`
```

`GreenNodeData` implements `ToOwned` with `Owned = GreenNode`, so the promotion becomes `to_owned()`. Two call sites: the converter that stashes the green root into `ParseResult`, and the round-trip test that compares that stashed root against a fresh parse.

The same change made two borrows redundant — `&green` and `&root.green()` were passing a reference to a reference — which `clippy -D warnings` rejects.

The converter's comment described the `Cow` promotion, so it's updated rather than left explaining an API that no longer exists.

Also carries dependabot's `cargo-vet` exemption bump, which is why `supply-chain/config.toml` is in the diff.

## Verification

This is the CST library the whole parser is built on, so beyond the bump itself:

- `cargo test --workspace` — **138 suites, 0 failures**
- `cargo +1.97.0 clippy --workspace --all-targets` — clean
- `green_red_properties` — 3 passed
- the `syntax_root` round-trip guard passes: it re-parses and asserts the stashed green root equals a fresh `parse_structured`, which is precisely the invariant that would break if the tree diverged between converter capture and consumer access

That last one is the reason I didn't treat `into_owned` → `to_owned` as a mechanical substitution. `Cow::into_owned` on a `Borrowed` clones; `ToOwned::to_owned` on `&GreenNodeData` also clones. Same result, but the guard confirms it rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
