### PR TITLE
fix: identify compat fixtures by path, not bare filename

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -301,6 +301,13 @@ jobs:
 
           @dataclass
           class FileResult:
+              # Repo-relative PATH, not a bare filename. Four basenames collide
+              # in the corpus (3x example.beancount, 3x example_example.beancount,
+              # 2x data_sample.beancount, 2x accounts.beancount), so a bare name
+              # is not an identity: it made `previous_results` below silently drop
+              # all but one file per collision, let `exclusions.toml` leak (an
+              # excluded path re-entered the BQL suite under a surviving twin's
+              # name), and left 6 files never queried at all. See #2016.
               file: str
               category: str
               # Check comparison
@@ -339,7 +346,9 @@ jobs:
           def test_file(file_path: Path) -> FileResult:
               """Test a single file - designed to run in parallel."""
               category = get_category(file_path)
-              result = FileResult(file=file_path.name, category=category)
+              # TEST_DIRS are repo-relative and the job runs from the repo root,
+              # so str(file_path) is already the repo-relative path.
+              result = FileResult(file=str(file_path), category=category)
 
               # === Python parsing ===
               python_accounts = set()
@@ -564,6 +573,15 @@ jobs:
           json_parse_failures = [r for r in results if r.rust_json_parse_failed]
 
           # === Regression detection ===
+          # Keyed by `file`, a repo-relative path since #2016. It used to be a
+          # bare name and `previous_results` is a dict, so each of the four
+          # colliding basenames kept only ONE entry — the other fixtures were
+          # compared against an unrelated file's history, or dropped entirely.
+          #
+          # The first run after #2016 sees a name-keyed baseline, so no key
+          # matches and nothing is flagged (a missing key means "new", not
+          # "regressed"). One cycle of reduced sensitivity, then the published
+          # baseline is path-keyed and the comparison is exact.
           previous_file = Path(".github/badges/previous-check-results.jsonl")
           regressions = []
           if previous_file.exists() and previous_file.stat().st_size > 0:

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -295,7 +295,7 @@ def _stale_registry_entries(
 def bare_name_registry_entries(
     registries: list[tuple[str, set[tuple[str, str]]]] | None = None,
 ) -> list[tuple[str, str]]:
-    """Registry keys written as a bare filename instead of a repo-relative path.
+    r"""Registry keys written as a bare filename instead of a repo-relative path.
 
     Since #2016 a fixture's identity is its path. A bare name is not merely
     unidiomatic here — it silently NEVER MATCHES any run, so the mask it was
@@ -307,6 +307,12 @@ def bare_name_registry_entries(
     on disk, so it cannot silently skip on a machine where the fixtures were
     never downloaded — which is exactly how the stale/dangling check degrades.
     Typo'd *paths* are a different failure and are caught by the dangling check.
+
+    `/` is the only separator accepted, deliberately. Run keys are POSIX
+    (`str(file_path)` on a Linux runner), so a key written with `\` separators
+    could never match one either, and flagging it here is the correct outcome —
+    treating `\` as a separator would make this guard go SILENT on exactly the
+    kind of unmatchable key it exists to catch.
     """
     if registries is None:
         registries = [
@@ -434,9 +440,26 @@ def _run_self_test() -> int:
     check(dirty == [("T", "bare.beancount")], f"bare-name key must be flagged, got {dirty}")
     clean = bare_name_registry_entries([("T", {("tests/x/ok.beancount", "q2")})])
     check(clean == [], f"path-keyed registry must be clean, got {clean}")
+    # A `\`-separated key can't match a POSIX run key either, so it must be
+    # flagged, not excused. Pins the reasoning in the docstring against a
+    # future "portability" edit that would silently disarm the guard.
+    backslash = bare_name_registry_entries(
+        [("T", {(r"tests\x\a.beancount", "q1")})]
+    )
+    check(
+        backslash == [("T", r"tests\x\a.beancount")],
+        f"backslash-separated key must be flagged, got {backslash}",
+    )
     # And the real registries this script ships with must be path-keyed.
     live = bare_name_registry_entries()
     check(live == [], f"shipped registries must be path-keyed, got {live}")
+
+    # --- find_file must not escape the corpus root (#2019 review) ---
+    for escape in ("/etc/passwd", "../outside.beancount", "tests/../../outside.beancount"):
+        check(
+            find_file(escape, DEFAULT_TEST_DIRS) is None,
+            f"find_file must reject {escape!r} rather than resolve outside REPO_ROOT",
+        )
 
     if failures:
         for m in failures:
@@ -763,6 +786,16 @@ def find_file(name_or_path: str, test_dirs: list[Path]) -> Path | None:
     `sorted()` (not `matches[0]` on an arbitrary walk order) so that even the
     legacy path is reproducible across machines and runs.
     """
+    # Reject absolute paths and `..` before touching the filesystem.
+    # `REPO_ROOT / "/etc/passwd"` is `/etc/passwd` — pathlib lets an absolute
+    # operand replace the base entirely — and `..` walks out the same way. The
+    # entries we generate are always relative and clean, but `--files-from` also
+    # accepts a downloaded baseline artifact, and silently querying a file
+    # outside the corpus is the same "this is not the file it claims to be"
+    # failure this function exists to remove.
+    if os.path.isabs(name_or_path) or ".." in name_or_path.split("/"):
+        return None
+
     direct = REPO_ROOT / name_or_path
     if direct.is_file():
         return direct
@@ -846,8 +879,9 @@ def main() -> int:
             "name never matches a run, so the mask silently does nothing."
         )
         for name, file in bare:
-            print(f"  BARE NAME [{name}]: {file!r} — use its path, e.g. "
-                  f"'tests/compatibility/files/<project>/{file}'")
+            print(f"  NOT A PATH [{name}]: {file!r} — use a repo-relative path "
+                  f"with '/' separators, e.g. "
+                  f"'tests/compatibility/files/<project>/{Path(file).name}'")
         return 1
 
     queries = load_corpus(args.corpus)

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -83,21 +83,26 @@ EMPTY_RESULT_WARNING_FRACTION = 0.5
 # These don't count against compat percentage. See referenced beanquery
 # issues for context.
 #
-# Keyed by `(filename, query_name)`. A bare filename used to be enough,
-# but with a 13-query corpus a single broken file would silently mask up
-# to 12 unrelated regressions on that same file. The query_name pin
+# Keyed by `(repo_relative_path, query_name)`. A bare filename used to be
+# enough, but with a 13-query corpus a single broken file would silently mask
+# up to 12 unrelated regressions on that same file. The query_name pin
 # makes the allowlist surgical: only the specific query that's known to
 # diverge is excused.
 #
-# Use `("filename", "*")` to allowlist ALL queries on a file (e.g., when
+# The key is a PATH, not a basename: four basenames collide in the corpus, so a
+# name-keyed mask would excuse every twin sharing that name (#2016). Entries are
+# stale/dangling-checked at runtime, so a mistyped path surfaces as a dangling
+# warning rather than a silent no-op mask.
+#
+# Use `("path", "*")` to allowlist ALL queries on a file (e.g., when
 # the divergence is in a column projection that every query touches).
 KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
     # beancount/beanquery#275: position display truncates precision in
     # the ledger's display context. Affects any query that projects
     # `position` or sums it.
-    ("testdata_source_generic_importer_test_invalid_journal.beancount", "*"),
+    ("tests/compatibility/files/beancount-import/testdata_source_generic_importer_test_invalid_journal.beancount", "*"),
     # DisplayContext common vs max precision (#724)
-    ("testdata_source_ofx_test_fidelity_journal.beancount", "*"),
+    ("tests/compatibility/files/beancount-import/testdata_source_ofx_test_fidelity_journal.beancount", "*"),
     # beancount/beanquery#279 used to be pinned here, 56 fixtures of it. It is
     # not masked any more because it is no longer a divergence: the corpus query
     # now selects `LAST(balance)` alongside `FIRST(balance)`, which forces
@@ -124,8 +129,8 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
 # whose pair now MATCHES bean-query fails the run, so a mask can't outlive the
 # divergence it documents and then absorb a real regression on the same pair.
 #
-# Keyed by `(filename, query_name)` with the same surgical-pin semantics
-# as `KNOWN_PYTHON_DIVERGENCES`. Counted as "known" for the effective
+# Keyed by `(repo_relative_path, query_name)` with the same surgical-pin
+# semantics as `KNOWN_PYTHON_DIVERGENCES`. Counted as "known" for the effective
 # match percentage (the values are correct — only display scale differs),
 # but tracked as a distinct category so future bookkeeping stays honest.
 KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
@@ -150,9 +155,9 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     # work. Tracked under #1112 (kept open as the tracker — do not
     # auto-close from this PR). Surgical pin (not "*") so any
     # non-scale divergence on these fixtures stays surfaced.
-    ("testdata_source_healthequity_test_invalid_journal.beancount", "sum-number-by-currency"),
-    ("testdata_source_healthequity_test_matching_journal.beancount", "sum-number-by-currency"),
-    ("testdata_source_ofx_test_non_default_capital_gains_journal.beancount", "sum-number-by-currency"),
+    ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_invalid_journal.beancount", "sum-number-by-currency"),
+    ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_matching_journal.beancount", "sum-number-by-currency"),
+    ("tests/compatibility/files/beancount-import/testdata_source_ofx_test_non_default_capital_gains_journal.beancount", "sum-number-by-currency"),
 }
 
 
@@ -287,6 +292,35 @@ def _stale_registry_entries(
     return stale, dangling
 
 
+def bare_name_registry_entries(
+    registries: list[tuple[str, set[tuple[str, str]]]] | None = None,
+) -> list[tuple[str, str]]:
+    """Registry keys written as a bare filename instead of a repo-relative path.
+
+    Since #2016 a fixture's identity is its path. A bare name is not merely
+    unidiomatic here — it silently NEVER MATCHES any run, so the mask it was
+    meant to apply quietly does nothing and the divergence it documents shows
+    up as a mismatch (or, worse, a mask intended for one file gets written in a
+    form that could only ever have excused a twin).
+
+    The check is purely syntactic (`"/" in key`) on purpose: it needs no corpus
+    on disk, so it cannot silently skip on a machine where the fixtures were
+    never downloaded — which is exactly how the stale/dangling check degrades.
+    Typo'd *paths* are a different failure and are caught by the dangling check.
+    """
+    if registries is None:
+        registries = [
+            ("KNOWN_PYTHON_DIVERGENCES", KNOWN_PYTHON_DIVERGENCES),
+            ("KNOWN_RUST_DIVERGENCES", KNOWN_RUST_DIVERGENCES),
+        ]
+    bare: list[tuple[str, str]] = []
+    for name, registry in registries:
+        for file, _query in registry:
+            if "/" not in file:
+                bare.append((name, file))
+    return sorted(bare)
+
+
 def stale_divergence_entries(
     results: "list[QueryRun]",
 ) -> "tuple[list[tuple[str, tuple[str, str]]], list[tuple[str, tuple[str, str]]]]":
@@ -390,6 +424,19 @@ def _run_self_test() -> int:
         ("T", ("c.beancount", "*")) not in stale_w,
         "a file with one diverging query keeps its wildcard live",
     )
+
+    # --- bare-name registry guard (#2016) ---
+    # Both directions, because a guard only ever shown reporting "clean" is
+    # indistinguishable from one that is wired up wrong and always says clean.
+    dirty = bare_name_registry_entries(
+        [("T", {("bare.beancount", "q1"), ("tests/x/ok.beancount", "q2")})]
+    )
+    check(dirty == [("T", "bare.beancount")], f"bare-name key must be flagged, got {dirty}")
+    clean = bare_name_registry_entries([("T", {("tests/x/ok.beancount", "q2")})])
+    check(clean == [], f"path-keyed registry must be clean, got {clean}")
+    # And the real registries this script ships with must be path-keyed.
+    live = bare_name_registry_entries()
+    check(live == [], f"shipped registries must be path-keyed, got {live}")
 
     if failures:
         for m in failures:
@@ -679,6 +726,10 @@ def load_valid_files(check_results: Path) -> list[str]:
 
     BQL diffs against an empty postings table aren't meaningful — both
     tools return zero rows trivially. Only test files with real data.
+
+    Returns repo-relative paths (the check step records `file` as a path since
+    #2016). Order is preserved, and paths are unique by construction, so the
+    caller's `--max-files` budget now counts files rather than names.
     """
     files: list[str] = []
     if not check_results.exists():
@@ -698,10 +749,31 @@ def load_valid_files(check_results: Path) -> list[str]:
     return files
 
 
-def find_file(filename: str, test_dirs: list[Path]) -> Path | None:
+def find_file(name_or_path: str, test_dirs: list[Path]) -> Path | None:
+    """Resolve a check-results `file` entry to a path on disk.
+
+    `file` is a repo-relative PATH (see the `FileResult` rationale in
+    `.github/workflows/compat.yml`), so the common case is a direct hit and
+    involves no globbing at all. That directness is the point: the previous
+    `rglob(name) -> matches[0]` made identity filesystem-order dependent, and
+    four basenames collide in the corpus (#2016).
+
+    The glob is kept only as a fallback for a BARE name, which is what a
+    baseline artifact published before #2016 contains. It is deliberately
+    `sorted()` (not `matches[0]` on an arbitrary walk order) so that even the
+    legacy path is reproducible across machines and runs.
+    """
+    direct = REPO_ROOT / name_or_path
+    if direct.is_file():
+        return direct
+    if "/" in name_or_path:
+        # A path that does not exist is a genuine miss; do not fall back to
+        # globbing its basename, which would resolve to a DIFFERENT file that
+        # merely shares the name — exactly the bug this function stopped having.
+        return None
     for d in test_dirs:
         if d.exists():
-            matches = list(d.rglob(filename))
+            matches = sorted(d.rglob(name_or_path))
             if matches:
                 return matches[0]
     return None
@@ -762,6 +834,22 @@ def main() -> int:
     if args.self_test:
         return _run_self_test()
 
+    # Static gate, before any work: a bare-name registry key can never match a
+    # run, so it is a mask that does nothing. Fail fast rather than let the run
+    # report the divergence it was supposed to excuse.
+    bare = bare_name_registry_entries()
+    if bare:
+        print(
+            f"::error::{len(bare)} deliberate-divergence registry "
+            f"entr{'y' if len(bare) == 1 else 'ies'} keyed by bare filename. "
+            "Fixtures are identified by repo-relative path since #2016; a bare "
+            "name never matches a run, so the mask silently does nothing."
+        )
+        for name, file in bare:
+            print(f"  BARE NAME [{name}]: {file!r} — use its path, e.g. "
+                  f"'tests/compatibility/files/<project>/{file}'")
+        return 1
+
     queries = load_corpus(args.corpus)
     print(f"Corpus: {len(queries)} queries from {args.corpus.name}")
 
@@ -774,13 +862,11 @@ def main() -> int:
 
     test_dirs = DEFAULT_TEST_DIRS
 
-    # Resolve basenames → real paths BEFORE prioritization. The
-    # `--files-from` JSONL stores `file_path.name` (basename only —
-    # see `.github/workflows/compat.yml` `FileResult(file=...)`), so
-    # we can't tell from the basename alone whether a fixture lives
-    # under `plugins/` or anywhere else. Resolving first lets us
-    # prioritize on the resolved path and also surfaces collisions
-    # via `find_file`'s logic.
+    # Resolve to real paths BEFORE prioritization: `is_plugin_fixture` below
+    # needs the path's directory segments, which the entry alone doesn't
+    # guarantee is on disk. Since #2016 the `--files-from` JSONL stores a
+    # repo-relative path (see `FileResult` in `.github/workflows/compat.yml`),
+    # so this is a direct existence check rather than a basename glob.
     resolved: list[tuple[str, Path]] = []
     unresolved: list[str] = []
     for filename in valid:
@@ -1069,6 +1155,12 @@ def main() -> int:
     # out of the run (its file no longer qualifies) is NOT counted, only a real
     # true→false flip is. This is the gate that would have caught the JOURNAL
     # regression (90→12 matches) that previously merged unblocked.
+    #
+    # The pair key's file component became a repo-relative path in #2016. The
+    # first run after that change compares against a name-keyed baseline, so no
+    # pair matches and nothing is gated — by the same "dropped pairs don't
+    # count" rule above. One cycle of reduced sensitivity, then the published
+    # baseline is path-keyed too.
     if args.baseline and args.baseline.exists():
         baseline_passing = set()
         with open(args.baseline) as f:


### PR DESCRIPTION
## What

Fixtures in the compatibility suite are now identified by **repo-relative path** instead of bare filename.

`compat-check-results.jsonl` recorded `file` as a basename, and `compat-bql-test.py` resolved it with `rglob(name)` → `matches[0]`. Four basenames collide in the corpus:

| basename | copies |
|---|---|
| `example.beancount` | 3 (`pinto-reports`, `fava-budget-freedom`, `fava-envelope`) |
| `example_example.beancount` | 3 (`fava-dashboards`, `fava-portfolio-returns`, `fava-portfolio-summary`) |
| `data_sample.beancount` | 2 (`gnucash-to-beancount`, `henriquebastos-gnucash`) |
| `accounts.beancount` | 2 (`beanbot`, `donearm-ledger`) |

Ten files on disk resolved to four, and *which* four was filesystem-order dependent.

## Why it matters

Two consequences are from #2016; the third turned up while fixing it.

1. **`exclusions.toml` did not reach the BQL suite.** Exclusions are path-keyed and applied in the check step, but a surviving twin put the shared *name* into the results and the glob resolved it back to an excluded file. 2 of the 10 exclusions are leakable this way — and a `sorted()` glob lands on `fava-budget-freedom/example.beancount`, which is one of them. This is exactly what #2014 observed.
1. **Six files were never queried**, while `Files queried: N` counted names and reported full coverage.
1. **The check step's own regression detection was affected too** — `previous_results[prev["file"]]` is a dict, so each collision group kept one entry and the rest were compared against an unrelated file's history or dropped. Silent, and it predates the BQL suite entirely.

## How

- `FileResult.file` is now `str(file_path)`. `TEST_DIRS` are already repo-relative and the job runs from the repo root, so no extra plumbing.
- `find_file` resolves the path directly. A path that does not exist returns `None` rather than falling back to its basename — that fallback *is* the bug. A bare name still resolves, via a now-`sorted()` glob, purely so a pre-#2016 baseline artifact stays readable.
- `KNOWN_*_DIVERGENCES` keys move to paths. All five live in `tests/compatibility/files/beancount-import/` and none collide, so it is mechanical.
- New `bare_name_registry_entries` gate: a bare-name key is a mask that can never match, so it fails the run. The check is syntactic (`"/" in key`) on purpose — it needs no corpus on disk and so cannot silently skip on a machine where fixtures were never downloaded, which is how the stale/dangling check degrades to a warning.

## Verification

Against the real corpus:

```
10 colliding fixtures on disk
resolve by NAME (old): 4 distinct -> 6 never queried
resolve by PATH (new): 10 distinct -> 0 never queried
every path round-trips exactly: True
nonexistent path -> None (no basename fallback): True
legacy bare name still resolves (old baselines): True
```

A full selection run over those ten reports `Testing against 10 files`.

**The new gate is sabotage-verified in both directions.** Reverting one registry key to its bare name:

```
self-test FAIL: shipped registries must be path-keyed, got
  [('KNOWN_PYTHON_DIVERGENCES', 'testdata_source_ofx_test_fidelity_journal.beancount')]
::error::1 deliberate-divergence registry entry keyed by bare filename.
```

Both go green again on restore. The self-test asserts the flagged case, the clean case, *and* that the shipped registries are clean.

## Expected: one quiet cycle on the baseline gates

Both baselines (`previous-check-results.jsonl`, `previous-bql-results.jsonl`) are name-keyed, so after this lands no pair matches and nothing is flagged. A missing key already means "new", not "regressed", so this **cannot produce a false failure** — only reduced sensitivity for one run, until the next publish writes path-keyed baselines. Documented at both gates.

Also expect `Files queried` to rise by 6 and the BQL run count with it.

Closes #2016
