### PR TITLE
chore(deps): accept the bitmaps unmaintained advisory, drop a dead one

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,12 +20,20 @@ yanked = "warn"
 # parent crate isn't actionable today. Re-audit when the upstream crate
 # either resumes maintenance or gets a replacement we can adopt.
 ignore = [
-  # `paste` (proc-macro), pulled in transitively by `ferrolearn-bayes`
-  # via `faer` / `gemm`. Project is unmaintained but the code is stable
-  # and small. No drop-in replacement exists with the same macro
-  # surface. Re-evaluate when faer drops the dep or when a fork
-  # supersedes paste.
-  "RUSTSEC-2024-0436",
+  # `bitmaps`, reached only as `bitmaps <- imbl <- rustledger-core`.
+  # Archived by its owner on 2026-05-03; the advisory is `unmaintained`,
+  # not a vulnerability, and there is no known defect to be exposed to.
+  #
+  # Not actionable from here. `imbl` (the maintained fork of `im`) is
+  # itself current at 7.0.1 with no release that drops the dep, and
+  # `bitmaps` is its internal chunk bitmap - not a type we hold or pass
+  # around, so we cannot swap it for `fixedbitset` / `bitvec` without
+  # replacing `imbl` itself. `imbl` backs `Inventory`'s persistent maps,
+  # so that is a data-structure change, not a dependency bump.
+  #
+  # Re-audit when `imbl` releases a version without `bitmaps`, or if this
+  # advisory is ever upgraded from `unmaintained` to a vulnerability.
+  "RUSTSEC-2026-0247",
 ]
 
 # rand 0.8.x (via cap-rand/wasmtime-wasi) uses thread_rng which is


### PR DESCRIPTION
`Cargo Deny` — and the `quality` gate that aggregates it — went red on **RUSTSEC-2026-0247**: `bitmaps` was archived by its owner on 2026-05-03.

```
error[unmaintained]: bitmaps is unmaintained
   ┌─ Cargo.lock:30:1
   │ bitmaps 3.2.1 ━━━ unmaintained advisory detected
```

## Why this is an ignore rather than a fix

The only path is `bitmaps ← imbl ← rustledger-core` — one edge, nothing feature-gated.

- `imbl` (the maintained fork of `im`) is **already current at 7.0.1**; there is no release that drops the dep.
- `bitmaps` is `imbl`'s *internal chunk bitmap*, not a type we hold or pass around — so the advisory's suggested `fixedbitset` / `bitvec` can't be swapped in at our level. Adopting one means replacing `imbl` itself, which backs `Inventory`'s persistent maps. That's a data-structure change, not a dependency bump.
- The advisory is **`unmaintained`, not a vulnerability**. There's no known defect and no exposure to weigh against that cost.

Ignored with the revisit condition written down: when `imbl` ships without `bitmaps`, or if this is ever upgraded from `unmaintained` to a vulnerability.

## Also removes a dead ignore

`RUSTSEC-2024-0436` (`paste`) is gone. Its comment describes a `ferrolearn-bayes` → `faer` → `gemm` chain that no longer exists — `paste` has **zero** entries in `Cargo.lock`, and cargo-deny was already warning `no crate matched advisory criteria`. An ignore that outlives its cause is a mask waiting to silently absorb a future advisory on the same ID.

## What I deliberately left alone

The three `bans` / `licenses` warnings in the same file. They don't fail the check, and the `rand` one is a trap worth naming:

```
warning[unnecessary-skip]: skip 'rand' applied to a crate with only one version
```

…while `Cargo.lock` holds **three** `rand` entries. cargo-deny resolves per-target against `graph.targets`, so "only one version" is true for the configured targets and false for the lockfile. Deleting that skip on the strength of the warning would convert a warning into a failure the moment the check runs against a target set that sees the duplicates. Same reasoning for `equator` / `equator-macro`.

## Result

```
advisories ok, bans ok, licenses ok, sources ok
```

The ignore is a specific RUSTSEC ID, so it can mask exactly this one advisory and nothing else.
