### PR TITLE
fix(plugin): valuation sell must move the lot by what it posted

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -576,7 +576,13 @@ fn process_fifo_sell(
                 span: None,
             });
 
-            state.total_units -= lot.units;
+            // Same reasoning as the partial branch: the posting reported
+            // `rounded_units`, so that is what leaves the running total. With
+            // the partial branch fixed, `lot.units` is already at
+            // `MAPPED_CURRENCY_PRECISION` and this is a no-op — but it keeps
+            // the two branches saying the same thing, and it is still correct
+            // for a lot carrying more precision than the posting can express.
+            state.total_units -= rounded_units;
             remaining -= lot_value_at_current_price;
             state.lots.remove(0);
         } else {
@@ -620,8 +626,19 @@ fn process_fifo_sell(
                 span: None,
             });
 
-            lot.units -= units_to_sell;
-            state.total_units -= units_to_sell;
+            // Decrement by what was POSTED, not by the unrounded quotient.
+            //
+            // The posting above reports `rounded_units`; decrementing the lot
+            // by the full-precision `units_to_sell` lets the plugin's idea of
+            // the lot drift below the balance the ledger actually shows. The
+            // drift is at most 1e-7 per partial sell and is invisible until a
+            // later full sell posts `lot.units` — by then already short — and
+            // leaves a residual position that should not exist (#2018).
+            //
+            // The buy path has always done it this way: it rounds once and
+            // uses that single value for both the lot and the posting.
+            lot.units -= rounded_units;
+            state.total_units -= rounded_units;
             remaining = Decimal::ZERO;
         }
     }
@@ -810,6 +827,84 @@ mod tests {
         assert_eq!(config.account, "Assets:Fund");
         assert_eq!(config.currency, "FUND_USD");
         assert_eq!(config.pnl_account, "Income:Fund:PnL");
+    }
+
+    /// A partial sell must move the lot by exactly what it posted, so a later
+    /// full sell closes the lot to zero instead of leaving a phantom residual.
+    ///
+    /// Regression for #2018. `units_to_sell` is `remaining / price`, which can
+    /// carry more precision than `MAPPED_CURRENCY_PRECISION`; the posting is
+    /// rounded but the lot used to be decremented by the unrounded quotient.
+    /// The gap is at most 1e-7 per partial sell and is invisible until the
+    /// close-out posts a lot balance that is already short.
+    ///
+    /// The numbers mirror `tests_data_some_fund_example.beancount`: 500 units
+    /// bought at 1, then sold at a price that does not divide evenly, then the
+    /// remainder sold. Before the fix the two postings summed to -500.0000000
+    /// against a 500 lot only because the lot had silently shrunk; beancount's
+    /// plugin posts -374.9999999 and -125.0000001.
+    #[test]
+    fn partial_sell_leaves_no_phantom_residual() {
+        let mut state = AccountState::new(AccountConfig {
+            account: "Assets:Fund:Total".to_string(),
+            currency: "FUND_USD".to_string(),
+            pnl_account: "Income:Fund:PnL".to_string(),
+        });
+        state.lots.push(CostLot {
+            units: Decimal::from(500),
+            cost_per_unit: Decimal::ONE,
+            date: "2024-01-10".to_string(),
+        });
+        state.total_units = Decimal::from(500);
+        // 1200/1125 — the price that produces a non-terminating quotient.
+        state.last_price = Decimal::from(1200) / Decimal::from(1125);
+
+        let posted = |ps: &[PostingData]| -> Decimal {
+            ps.iter()
+                .filter(|p| p.account == "Assets:Fund:Total")
+                .filter_map(|p| p.units.as_ref())
+                .map(|a| a.number.parse::<Decimal>().expect("posted units parse"))
+                .sum()
+        };
+
+        let (first, _) = process_fifo_sell(
+            &mut state,
+            Decimal::from(400),
+            "Assets:Fund:Total",
+            "USD",
+            &None,
+            &[],
+        );
+        let sold_first = posted(&first);
+
+        // Sell everything that remains, at whatever price.
+        let remaining_value = state.total_units * state.last_price;
+        let (second, _) = process_fifo_sell(
+            &mut state,
+            remaining_value,
+            "Assets:Fund:Total",
+            "USD",
+            &None,
+            &[],
+        );
+        let sold_second = posted(&second);
+
+        assert_eq!(
+            sold_first + sold_second,
+            Decimal::from(-500),
+            "the two sells must dispose of exactly the 500 units bought; a \
+             shortfall here is the #2018 residual"
+        );
+        assert!(
+            state.lots.is_empty(),
+            "the lot should be gone, found {:?}",
+            state.lots
+        );
+        assert_eq!(
+            state.total_units,
+            Decimal::ZERO,
+            "running total must close to zero, not to a 1e-7 remainder"
+        );
     }
 
     #[test]

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -1262,12 +1262,25 @@ def main() -> int:
         # partial ledger and both sides came back empty is a FALSE match, and
         # honestly reclassifying it as inconclusive would be reported as a
         # regression it never was.
+        # A pair registered as a DELIBERATE divergence is likewise not a
+        # regression. Registering one is the act of saying "these two are
+        # expected to differ, and here is which side is wrong"; if the gate
+        # ignored that, the registries could never absorb a newly-created
+        # divergence and the only way to land a fix that makes us diverge
+        # ON PURPOSE would be to bypass the gate entirely.
+        #
+        # This does not blunt the gate, because the exemption is paired: an
+        # entry whose pair starts MATCHING again fails the run via
+        # `stale_divergence_entries` above, so a registration cannot outlive
+        # the divergence it documents and quietly cover a later regression on
+        # the same pair.
         regressed = [
             r
             for r in results
             if not r.match
             and not (r.py_failed or r.rs_failed)
             and (r.file, r.query_name) in baseline_passing
+            and not _is_known_divergence(r)
         ]
         if regressed:
             print()

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -103,6 +103,48 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
     ("tests/compatibility/files/beancount-import/testdata_source_generic_importer_test_invalid_journal.beancount", "*"),
     # DisplayContext common vs max precision (#724)
     ("tests/compatibility/files/beancount-import/testdata_source_ofx_test_fidelity_journal.beancount", "*"),
+    # The valuation plugin strands a 1e-7 phantom position on a fully-withdrawn
+    # fund, and beancount's copy of it keeps that phantom where ours no longer
+    # does (#2018).
+    #
+    # Both implementations used to leave it. rledger's now closes the fund to
+    # exactly zero, so these pairs report `0.0000001 COOL_FUND_USD` /
+    # `SOME_FUND_USD` on the Python side and an empty inventory on ours. The
+    # ledgers say "withdraw all" and the cash legs are exact, so zero is the
+    # right answer and the mismatch is Python's.
+    #
+    # Verified against beancount 3.2.3 + beancount_lazy_plugins by dumping both
+    # plugins' synthesized postings: they agree on 6 of the 7, and diverge only
+    # on the final lot, which beancount under-sells by 1e-7. Per-posting table
+    # in #2018.
+    #
+    # Surgical rather than a `"*"` wildcard: only queries that project a
+    # position or a balance can see this, and pinning the whole file would mask
+    # an unrelated regression on the other queries.
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount",
+        "balances-by-account",
+    ),
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount",
+        "journal-assets-at-units",
+    ),
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount",
+        "last-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount",
+        "position-by-date",
+    ),
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount",
+        "sum-position-by-account",
+    ),
+    (
+        "tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount",
+        "balances-by-account",
+    ),
     # beancount/beanquery#279 used to be pinned here, 56 fixtures of it. It is
     # not masked any more because it is no longer a divergence: the corpus query
     # now selects `LAST(balance)` alongside `FIRST(balance)`, which forces


### PR DESCRIPTION
The valuation plugin decremented a lot by the **unrounded** quantity while posting the **rounded** one, so its idea of the lot drifted below the balance the ledger showed. A later full sell then posted the already-short figure and stranded a phantom `1e-7` position on a fund the ledger says was fully withdrawn.

```rust
let units_to_sell = remaining / current_price;   // unrounded quotient
let rounded_units = round_down(units_to_sell, MAPPED_CURRENCY_PRECISION);
postings.push(... -rounded_units ...);           // POSTED rounded
lot.units -= units_to_sell;                      // DECREMENTED unrounded  <-- drift
```

The buy path always did it correctly — rounds once, uses that value for both the lot and the posting. This makes the sell path agree.

## I checked which side is right, rather than assuming

This branch was parked because it "cost 6 compat mismatches". With a local **beancount 3.2.3 + beancount_lazy_plugins** install I could finally dump both plugins' synthesized postings and compare:

| lot | beancount | rledger (fixed) |
|---|---|---|
| `{1}` | `500.0000000 − 374.9999999 − 125.0000001` = **0** | same = **0** |
| `{0.8}` | `625.0000000 − 625.0000000` = **0** | same = **0** |
| `{1.0666…}` | `656.2500000 − 656.2499999` = **+1e-7** | `656.25 − 656.25` = **0** |

They agree on **6 of the 7 postings** and diverge only on the final lot, which beancount under-sells by 1e-7.

```console
$ SELECT SUM(number) WHERE currency = 'SOME_FUND_USD'
  beancount        1E-7
  rledger (fixed)  0.0000000
```

The ledgers say `; withdraw all` and their cash legs are exact, so **zero is the right answer and the residual is Python's.** Same result on `cool_fund_example`.

## This corrects the issue as filed

#2018 says beancount "closes that lot to exactly zero" and we don't. Half right: beancount closes the `{1}` lot exactly and we didn't — but it strands the same 1e-7 in the *last* lot instead. **Before this fix both implementations produced the phantom, just in different lots**, which is why it looked like agreement on the totals and why it took a per-posting dump to see.

## The 6 mismatches are registered, not absorbed

Per the compatibility policy's "we don't copy bugs we can fix" bucket, the six pairs go into `KNOWN_PYTHON_DIVERGENCES` with the evidence. Surgical pins rather than a `"*"` wildcard — only queries projecting a position or balance can see this, and pinning the files whole would mask unrelated regressions on their other queries.

Effective match on the eight lazy-plugin fixtures: **48/85 → 49/85**. Raw goes 48 → 42, which is the metric becoming honest about which side is wrong.

## What I tried and dropped

The same "use what you posted" reasoning applies to the PnL, which is also computed from `units_to_sell` before rounding. I implemented it and **reverted it**: it moved the total from `-299.9999998999…` to `-299.9999998933…`, neither of which is the true `-300`, and `rledger check` is clean either way because the fixture's 1e-8 tolerance absorbs both. Principled but unevidenced, so it is not in this PR. Worth its own look if the PnL drift ever matters — beancount gets `-300.00000001`, closer than either of ours.

## Verification

- Full workspace suite green; clippy `1.97.0` and fmt clean
- Regression test in `valuation.rs` pins that a partial sell moves the lot by exactly what it posted
- Rebased onto current `main` — the old base predated #2019, so its `compat-bql-test.py` still resolved fixtures by bare name and silently found nothing when handed a path

Closes #2018
