### PR TITLE
fix(lsp): hover the account under the cursor, not its nearest ancestor

### DIFF
--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -102,19 +102,28 @@ fn get_account_info(
                 .is_some_and(|rest| rest.starts_with(':'))
     };
 
-    // The current file's directives go LAST so that on an equal-length tie
-    // (the same account opened in both places) `max_by_key` — which returns
-    // the last maximum — prefers the one the user is looking at.
+    // Rank the two sources explicitly and sort on `(specificity, source)`
+    // rather than leaning on `max_by_key`'s last-maximum-wins tie behavior.
+    // The tie is reachable and the choice matters: `LedgerState::directives`
+    // is the whole loaded ledger, which includes THIS file as loaded from
+    // disk, so when the same account is opened in both the buffer copy is the
+    // live one and the ledger copy may be stale by an unsaved edit.
+    const FROM_LEDGER: u8 = 0;
+    const FROM_BUFFER: u8 = 1;
     let open = ledger_directives
         .into_iter()
-        .chain(std::iter::once(parse_result.directives.as_slice()))
-        .flatten()
-        .filter_map(|sd| match &sd.value {
-            Directive::Open(open) if describes_account(open) => Some(open),
+        .map(|dirs| (FROM_LEDGER, dirs))
+        .chain(std::iter::once((
+            FROM_BUFFER,
+            parse_result.directives.as_slice(),
+        )))
+        .flat_map(|(source, dirs)| dirs.iter().map(move |sd| (source, sd)))
+        .filter_map(|(source, sd)| match &sd.value {
+            Directive::Open(open) if describes_account(open) => Some((source, open)),
             _ => None,
         })
-        .max_by_key(|open| open.account.as_ref().len())
-        .cloned();
+        .max_by_key(|(source, open)| (open.account.as_ref().len(), *source))
+        .map(|(_, open)| open.clone());
     let usage_count = count_account_usages(account, parse_result);
 
     if let Some(open) = open {
@@ -330,6 +339,12 @@ mod tests {
             "2014-01-01 open Assets:Bank\n",
         ));
 
+        for (name, pr) in [
+            ("parent_first", &parent_first),
+            ("child_first", &child_first),
+        ] {
+            assert!(pr.errors.is_empty(), "{name} must parse: {:?}", pr.errors);
+        }
         let a = get_account_info("Assets:Bank:Checking", &parent_first, None).expect("info");
         let b = get_account_info("Assets:Bank:Checking", &child_first, None).expect("info");
 
@@ -355,6 +370,7 @@ mod tests {
             "2020-01-01 open Expenses:Food USD\n",
             "2020-01-01 open Expenses:Food:Restaurant USD\n",
         ));
+        assert!(pr.errors.is_empty(), "fixture must parse: {:?}", pr.errors);
         let info = get_account_info("Expenses:Food:Restaurant", &pr, None).expect("info");
         assert!(
             info.contains("## Account: `Expenses:Food:Restaurant`"),
@@ -382,6 +398,7 @@ mod tests {
             "2020-01-01 open Assets:Bank\n",
             "2020-01-01 open Assets:Bank:Checking EUR\n",
         ));
+        assert!(pr.errors.is_empty(), "fixture must parse: {:?}", pr.errors);
         let info = get_account_info("Assets:Bank:Checking:Sub", &pr, None).expect("info");
 
         assert!(
@@ -417,6 +434,30 @@ mod tests {
         assert!(info.contains("**Currencies:** USD"), "got: {info}");
     }
 
+    /// On an EQUALLY specific match the buffer wins, not the loaded ledger.
+    /// `LedgerState::directives` includes this file as loaded from disk, so the
+    /// ledger's copy of the same `open` can be stale by an unsaved edit.
+    #[test]
+    fn test_account_info_prefers_buffer_over_stale_ledger_copy() {
+        // The buffer holds the edit the user just made — a later date and a USD
+        // constraint; the on-disk ledger still has the original line.
+        let buffer = parse("2024-02-01 open Assets:Bank:Checking USD\n");
+        let stale = parse("2014-01-01 open Assets:Bank:Checking\n");
+        assert!(buffer.errors.is_empty(), "{:?}", buffer.errors);
+        assert!(stale.errors.is_empty(), "{:?}", stale.errors);
+
+        let info = get_account_info("Assets:Bank:Checking", &buffer, Some(&stale.directives))
+            .expect("info");
+        assert!(
+            info.contains("**Opened:** 2024-02-01"),
+            "the live buffer's open must win: {info}"
+        );
+        assert!(
+            info.contains("**Currencies:** USD"),
+            "the live buffer's constraint must win: {info}"
+        );
+    }
+
     /// A sibling sharing a name prefix is not an ancestor. `Assets:Bank` is a
     /// string prefix of `Assets:Banking` but not its parent, so hovering
     /// `Assets:Banking` must not pick it up.
@@ -429,13 +470,15 @@ mod tests {
     #[test]
     fn test_account_info_ignores_prefix_sibling() {
         let pr = parse("2020-01-01 open Assets:Bank USD\n");
+        // Pin the fixture. An `is_none()` assertion is satisfied just as well
+        // by an `open` that failed to parse, so without this the test would go
+        // vacuous the moment account-name validation changed — exactly what
+        // made an earlier draft of the ancestor test above meaningless.
+        assert!(pr.errors.is_empty(), "fixture must parse: {:?}", pr.errors);
         // Nothing describes `Assets:Banking` and it is used nowhere, so there
         // is nothing to report at all.
-        assert!(
-            get_account_info("Assets:Banking", &pr, None).is_none(),
-            "got: {:?}",
-            get_account_info("Assets:Banking", &pr, None)
-        );
+        let info = get_account_info("Assets:Banking", &pr, None);
+        assert!(info.is_none(), "got: {info:?}");
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -77,39 +77,73 @@ pub fn handle_hover(
 
 /// Get information about an account.
 ///
-/// The `open` directive is looked up in the current file first, then in the
-/// cross-file `ledger_directives` (the loaded ledger) so an account opened in
-/// an `include`d file still shows its open date/currencies instead of a
-/// spurious "No `open` directive found".
+/// The `open` directive is looked up across the current file and the cross-file
+/// `ledger_directives` (the loaded ledger), so an account opened in an
+/// `include`d file still shows its open date/currencies instead of a spurious
+/// "No `open` directive found".
+///
+/// Several `open`s can describe the hovered account at once — a ledger may open
+/// a catch-all `Expenses:Food` as well as `Expenses:Food:Restaurant` — so the
+/// MOST SPECIFIC one is chosen rather than the first encountered. An exact
+/// `open` is the longest possible match and therefore always wins, whatever
+/// order the directives happen to appear in. Selecting positionally meant a
+/// parent declared before its child hijacked the child's popup, which is the
+/// norm in any alphabetically sorted account list (#2021).
 fn get_account_info(
     account: &str,
     parse_result: &ParseResult,
     ledger_directives: Option<&[Spanned<Directive>]>,
 ) -> Option<String> {
-    let matches_open = |open: &rustledger_core::Open| {
+    let describes_account = |open: &rustledger_core::Open| {
         let oa = open.account.as_ref();
         account == oa
             || account
                 .strip_prefix(oa)
                 .is_some_and(|rest| rest.starts_with(':'))
     };
-    let find_open = |dirs: &[Spanned<Directive>]| {
-        dirs.iter().find_map(|sd| match &sd.value {
-            Directive::Open(open) if matches_open(open) => Some(open.clone()),
+
+    // The current file's directives go LAST so that on an equal-length tie
+    // (the same account opened in both places) `max_by_key` — which returns
+    // the last maximum — prefers the one the user is looking at.
+    let open = ledger_directives
+        .into_iter()
+        .chain(std::iter::once(parse_result.directives.as_slice()))
+        .flatten()
+        .filter_map(|sd| match &sd.value {
+            Directive::Open(open) if describes_account(open) => Some(open),
             _ => None,
         })
-    };
-
-    let open =
-        find_open(&parse_result.directives).or_else(|| ledger_directives.and_then(find_open));
+        .max_by_key(|open| open.account.as_ref().len())
+        .cloned();
     let usage_count = count_account_usages(account, parse_result);
 
     if let Some(open) = open {
-        let mut info = format!("## Account: `{}`\n\n", open.account);
-        info.push_str(&format!("**Opened:** {}\n\n", open.date));
-        if !open.currencies.is_empty() {
-            let currencies: Vec<String> = open.currencies.iter().map(|c| c.to_string()).collect();
-            info.push_str(&format!("**Currencies:** {}\n\n", currencies.join(", ")));
+        // Always title with the account under the cursor. Titling with
+        // `open.account` was the visible half of #2021: an ancestor's name was
+        // presented as though it were the hovered account.
+        let mut info = format!("## Account: `{account}`\n\n");
+        let currencies: Vec<String> = open.currencies.iter().map(|c| c.to_string()).collect();
+        if open.account.as_ref() == account {
+            info.push_str(&format!("**Opened:** {}\n\n", open.date));
+            if !currencies.is_empty() {
+                info.push_str(&format!("**Currencies:** {}\n\n", currencies.join(", ")));
+            }
+        } else {
+            // Only an ancestor is declared. Attribute its date and currency
+            // constraint to it by name instead of letting them read as this
+            // account's own — and say so explicitly, so a missing
+            // `**Currencies:**` line is explained rather than just absent.
+            info.push_str(&format!(
+                "**Note:** no `open` for this account; nearest declared ancestor is `{}` (opened {})\n\n",
+                open.account, open.date
+            ));
+            if !currencies.is_empty() {
+                info.push_str(&format!(
+                    "**Currencies (from `{}`):** {}\n\n",
+                    open.account,
+                    currencies.join(", ")
+                ));
+            }
         }
         info.push_str(&format!(
             "**Used in:** {}",
@@ -279,6 +313,128 @@ mod tests {
         assert!(
             !cross.contains("No `open`"),
             "should not claim missing open: {cross}"
+        );
+    }
+
+    /// #2021: an exact `open` must win over an ancestor's, whichever is
+    /// declared first. The issue's own repro, run in both directive orders —
+    /// identical content, so both must produce identical hover text.
+    #[test]
+    fn test_account_info_prefers_exact_open_over_ancestor() {
+        let parent_first = parse(concat!(
+            "2014-01-01 open Assets:Bank\n",
+            "2014-01-01 open Assets:Bank:Checking USD\n",
+        ));
+        let child_first = parse(concat!(
+            "2014-01-01 open Assets:Bank:Checking USD\n",
+            "2014-01-01 open Assets:Bank\n",
+        ));
+
+        let a = get_account_info("Assets:Bank:Checking", &parent_first, None).expect("info");
+        let b = get_account_info("Assets:Bank:Checking", &child_first, None).expect("info");
+
+        assert_eq!(
+            a, b,
+            "declaration order must not change the hover text\n{a}\n---\n{b}"
+        );
+        // Pre-fix, `parent_first` produced "## Account: `Assets:Bank`" with no
+        // currencies — the ancestor's `open`, wearing the child's name.
+        assert!(a.contains("## Account: `Assets:Bank:Checking`"), "got: {a}");
+        assert!(a.contains("**Currencies:** USD"), "got: {a}");
+        assert!(
+            !a.contains("nearest declared ancestor"),
+            "an exact open is not an ancestor fallback: {a}"
+        );
+    }
+
+    /// The catch-all-parent shape from the issue, which is the norm in an
+    /// alphabetically sorted account list.
+    #[test]
+    fn test_account_info_exact_open_wins_for_sorted_catch_all_parent() {
+        let pr = parse(concat!(
+            "2020-01-01 open Expenses:Food USD\n",
+            "2020-01-01 open Expenses:Food:Restaurant USD\n",
+        ));
+        let info = get_account_info("Expenses:Food:Restaurant", &pr, None).expect("info");
+        assert!(
+            info.contains("## Account: `Expenses:Food:Restaurant`"),
+            "got: {info}"
+        );
+        // The title alone is not enough — it is now always the hovered
+        // account, so it stays right even if the WRONG open were selected.
+        // These pin the selection itself.
+        assert!(
+            !info.contains("nearest declared ancestor"),
+            "the exact open must be selected, not the catch-all parent: {info}"
+        );
+        assert!(info.contains("**Currencies:** USD"), "got: {info}");
+    }
+
+    /// With no exact `open`, the LONGEST ancestor is used — not the first —
+    /// the popup is still titled with the hovered account, and the ancestor's
+    /// facts are attributed to it rather than presented as this account's own.
+    #[test]
+    fn test_account_info_falls_back_to_longest_ancestor() {
+        // Two real ancestors, shallowest first, so a positional search picks
+        // `Assets:Bank`. (A single-segment `open Assets` does not parse, so it
+        // cannot be used as the decoy candidate here.)
+        let pr = parse(concat!(
+            "2020-01-01 open Assets:Bank\n",
+            "2020-01-01 open Assets:Bank:Checking EUR\n",
+        ));
+        let info = get_account_info("Assets:Bank:Checking:Sub", &pr, None).expect("info");
+
+        assert!(
+            info.contains("## Account: `Assets:Bank:Checking:Sub`"),
+            "titled with the hovered account: {info}"
+        );
+        assert!(
+            info.contains("nearest declared ancestor is `Assets:Bank:Checking`"),
+            "longest ancestor, and named as such: {info}"
+        );
+        assert!(
+            info.contains("**Currencies (from `Assets:Bank:Checking`):** EUR"),
+            "the constraint is attributed, not claimed: {info}"
+        );
+        assert!(
+            !info.contains("**Opened:**"),
+            "an ancestor's date is not this account's open date: {info}"
+        );
+    }
+
+    /// An exact `open` in an included file still beats an ancestor declared in
+    /// the file being edited — the selection is over both sources at once.
+    #[test]
+    fn test_account_info_exact_open_from_include_beats_local_ancestor() {
+        let pr = parse("2014-01-01 open Assets:Bank\n");
+        let inc = parse("2014-01-01 open Assets:Bank:Checking USD\n");
+        let info = get_account_info("Assets:Bank:Checking", &pr, Some(&inc.directives))
+            .expect("account info");
+        assert!(
+            info.contains("## Account: `Assets:Bank:Checking`"),
+            "got: {info}"
+        );
+        assert!(info.contains("**Currencies:** USD"), "got: {info}");
+    }
+
+    /// A sibling sharing a name prefix is not an ancestor. `Assets:Bank` is a
+    /// string prefix of `Assets:Banking` but not its parent, so hovering
+    /// `Assets:Banking` must not pick it up.
+    ///
+    /// The direction matters: the check asks whether the OPEN prefixes the
+    /// HOVERED account, so the decoy has to be the shorter of the two. An
+    /// earlier version of this test had them the other way round, where
+    /// `strip_prefix` returns `None` outright and the `:` boundary is never
+    /// reached — it could not fail.
+    #[test]
+    fn test_account_info_ignores_prefix_sibling() {
+        let pr = parse("2020-01-01 open Assets:Bank USD\n");
+        // Nothing describes `Assets:Banking` and it is used nowhere, so there
+        // is nothing to report at all.
+        assert!(
+            get_account_info("Assets:Banking", &pr, None).is_none(),
+            "got: {:?}",
+            get_account_info("Assets:Banking", &pr, None)
         );
     }
 


### PR DESCRIPTION
## What

`get_account_info` matched an `open` either exactly **or by ancestor prefix**, then took the **first** hit in directive order. A parent declared before its child therefore hijacked the child's popup, and the popup was titled from `open.account` rather than the hovered account — so the ancestor's name, date and currency constraint were all presented as the hovered account's own.

This picks the **most specific** `open` instead. An exact match is the longest possible one, so it always wins regardless of declaration order.

## Why it bites

Nothing exotic is required — `Expenses:Food` sorts before `Expenses:Food:Restaurant`, so it fires in any alphabetically sorted account list with a catch-all parent. Ledgers converted from GnuCash amplify it, since those emit a placeholder `open` for every intermediate node (the reporter's 178-account book had every 4-segment account reporting its 2-segment grandparent, and losing the `Currencies:` line as well).

## Changes

- **Selection is by specificity, not position.** `max_by_key` on the matched `open`'s account length. Exact beats ancestor; among ancestors the longest wins.
- **The search spans both sources at once.** Previously the current file was searched to exhaustion first, so a local ancestor beat an exact `open` in an `include`d file. Current-file directives are ordered last so an equal-length tie still favours the file being edited.
- **The popup is titled with the hovered account**, never `open.account`.
- **An ancestor's facts are attributed to it by name** when no exact `open` exists (`nearest declared ancestor is \`Assets:Bank\``, `**Currencies (from \`Assets:Bank\`):** …`) instead of reading as this account's own. That also explains a missing `**Currencies:**` line, which previously just vanished when the matched placeholder parent carried no constraint.

## How to test

The issue's file:

```beancount
2014-01-01 open Assets:Bank
2014-01-01 open Assets:Bank:Checking USD
2014-01-01 open Equity:Opening USD

2026-01-01 * "x" "y"
  Assets:Bank:Checking   1.00 USD
  Equity:Opening        -1.00 USD
```

Hover `Assets:Bank:Checking`. Driven over the real LSP protocol (`textDocument/hover` at line 5):

```
main @ 2973d28:   ## Account: `Assets:Bank`            (no Currencies line)
this branch:      ## Account: `Assets:Bank:Checking`   **Currencies:** USD
```

## Verification

- `cargo test --workspace --all-features`, `cargo +1.97.0 clippy --workspace --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo fmt --check` — all clean.
- Five new tests, each mutation-checked. Reverting selection to first-match kills three; titling from `open.account` kills the ancestor-attribution test; dropping the `:` boundary check kills the prefix-sibling test.
- Two of those tests were weak on first writing and were strengthened until they failed for the right reason: one asserted only the title, which is now always correct even when the wrong `open` is selected; the other used `open Assets` as a decoy candidate, which does not parse (single-segment account), so it had only one candidate and never exercised longest-vs-first at all.

Closes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
