### PR TITLE
docs(plugin): record zerosum posting-order as a deliberate deviation

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/zerosum.rs
+++ b/crates/rustledger-plugin/src/native/plugins/zerosum.rs
@@ -282,7 +282,32 @@ impl NativePlugin for ZerosumPlugin {
                 }
             }
 
-            // Now update the matched postings to use the target account
+            // Update the matched postings to use the target account, IN PLACE.
+            //
+            // Deliberate divergence from `beancount_reds_plugins`, whose
+            // `account_replace` does:
+            //
+            //     new_posting = posting._replace(account=new_account)
+            //     txn.postings.remove(posting)
+            //     txn.postings.append(new_posting)
+            //
+            // — moving every rewritten posting to the END of the transaction.
+            // That reordering is incidental to mutating a Python list while
+            // iterating it (the caller has to `break` and reprocess because,
+            // in its own words, "this entry's postings changes under us"), not
+            // a property anyone chose. It silently destroys the order the user
+            // wrote, which is the only thing posting order carries.
+            //
+            // Rewriting the account in place keeps that order. The values,
+            // accounts and signs are identical either way, so nothing
+            // downstream depends on the difference — only rendered posting
+            // order differs, which is why the four affected pairs on
+            // `tests/regressions/issue-278.beancount` are registered in
+            // `KNOWN_RUST_DIVERGENCES` (see `scripts/compat-bql-test.py`)
+            // rather than chased.
+            //
+            // Revisit if upstream ever makes the ordering intentional, or if a
+            // consumer starts deriving meaning from posting position.
             for (txn_i, post_i) in &matched {
                 if let DirectiveData::Transaction(ref mut txn) = directives[*txn_i].data
                     && *post_i < txn.postings.len()
@@ -534,6 +559,91 @@ mod tests {
             }
         }
         assert!(found_matched, "Should have matched postings");
+    }
+
+    /// A matched posting is rewritten IN PLACE — its position in the
+    /// transaction does not change.
+    ///
+    /// `beancount_reds_plugins` removes and re-appends the posting, so every
+    /// rewritten posting ends up last. That is incidental to mutating a list
+    /// while iterating it, not a chosen property, and it discards the order
+    /// the user wrote. We keep the order; accounts and amounts are identical
+    /// either way.
+    ///
+    /// The two transactions put the zerosum leg at DIFFERENT positions —
+    /// first in one, last in the other — so the test distinguishes "kept in
+    /// place" from "moved to the end", which a single transaction with the
+    /// leg already last could not.
+    ///
+    /// Pinned because it is the observable behind four registered entries in
+    /// `KNOWN_RUST_DIVERGENCES` for `tests/regressions/issue-278.beancount`.
+    /// If this flips, those entries go stale and the compat run fails — the
+    /// intended coupling.
+    #[test]
+    fn test_matched_posting_keeps_its_position() {
+        let plugin = ZerosumPlugin;
+        let config = r"{
+            'zerosum_accounts': {
+                'Assets:ZeroSum:Transfers': ('Assets:ZeroSum-Matched:Transfers', 30)
+            }
+        }";
+
+        // `create_transfer_txn` writes `from` first with the NEGATED amount
+        // and `to` second, so this puts the zerosum leg first in one txn
+        // (at -100) and second in the other (at +100) — they cancel.
+        let input = PluginInput {
+            directives: vec![
+                create_transfer_txn(
+                    "2024-01-01",
+                    "Assets:ZeroSum:Transfers",
+                    "Assets:Bank",
+                    "100.00",
+                    "USD",
+                ),
+                create_transfer_txn(
+                    "2024-01-03",
+                    "Assets:Investment",
+                    "Assets:ZeroSum:Transfers",
+                    "100.00",
+                    "USD",
+                ),
+            ],
+            options: PluginOptions {
+                operating_currencies: vec!["USD".to_string()],
+                title: None,
+                ..Default::default()
+            },
+            config: Some(config.to_string()),
+        };
+
+        let input_dirs = input.directives.clone();
+        let output = plugin.process(input);
+        assert_eq!(output.errors.len(), 0);
+        let directives = materialize_ops(&input_dirs, &output);
+
+        let accounts: Vec<Vec<String>> = directives
+            .iter()
+            .filter_map(|d| match &d.data {
+                DirectiveData::Transaction(t) => {
+                    Some(t.postings.iter().map(|p| p.account.clone()).collect())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(accounts.len(), 2, "both transactions survive");
+
+        // Rewritten, but each still where it was written. Upstream's
+        // remove/append would make BOTH of these last.
+        assert_eq!(
+            accounts[0],
+            vec!["Assets:ZeroSum-Matched:Transfers", "Assets:Bank"],
+            "leg written FIRST must stay first"
+        );
+        assert_eq!(
+            accounts[1],
+            vec!["Assets:Investment", "Assets:ZeroSum-Matched:Transfers"],
+            "leg written SECOND must stay second"
+        );
     }
 
     #[test]

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -203,6 +203,34 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     # fixture match bean-query on every query. The two below still diverge —
     # their residual is born inside a `{{total}}` lot match, which the
     # tolerance rule does not reach.
+    # `beancount_reds_plugins`' zerosum rewrites a matched posting by
+    # REMOVING and RE-APPENDING it, so every rewritten posting lands last in
+    # its transaction. We rewrite the account in place and keep the posting
+    # where the user wrote it.
+    #
+    # This is a DELIBERATE deviation, and the only one on these pairs: the
+    # accounts, amounts and signs are byte-identical — bean-query and rledger
+    # emit the same two rows in the opposite order, nothing more. Upstream's
+    # ordering is incidental to mutating a list mid-iteration (its loop has to
+    # `break` and reprocess because "this entry's postings changes under us"),
+    # not a property anyone chose, and it discards the only information
+    # posting order carries: what the user wrote.
+    #
+    # Filed under the RUST list rather than the Python one on purpose. We are
+    # the side that differs from bean-query's output, and putting a deviation
+    # we think is an improvement into the Python bucket would let a future
+    # genuine rledger regression on these pairs hide behind a flattering
+    # label.
+    #
+    # Pinned in `test_matched_posting_keeps_its_position`
+    # (`rustledger-plugin/src/native/plugins/zerosum.rs`); if that flips,
+    # these go stale and the run fails. Revisit if upstream makes the
+    # ordering intentional, or if a consumer starts deriving meaning from
+    # posting position.
+    ("tests/regressions/issue-278.beancount", "balance-running-assets"),
+    ("tests/regressions/issue-278.beancount", "journal-assets"),
+    ("tests/regressions/issue-278.beancount", "journal-assets-at-cost"),
+    ("tests/regressions/issue-278.beancount", "journal-assets-at-units"),
     ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_invalid_journal.beancount", "sum-number-by-currency"),
     ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_matching_journal.beancount", "sum-number-by-currency"),
 }

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -223,8 +223,8 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     # label.
     #
     # Pinned in `test_matched_posting_keeps_its_position`
-    # (`rustledger-plugin/src/native/plugins/zerosum.rs`); if that flips,
-    # these go stale and the run fails. Revisit if upstream makes the
+    # (`crates/rustledger-plugin/src/native/plugins/zerosum.rs`); if that
+    # flips, these go stale and the run fails. Revisit if upstream makes the
     # ordering intentional, or if a consumer starts deriving meaning from
     # posting position.
     ("tests/regressions/issue-278.beancount", "balance-running-assets"),


### PR DESCRIPTION
## Finding: there is no bug here

I went in expecting to fix the four BQL divergences on `tests/regressions/issue-278.beancount`. They are all the same two rows swapped — bean-query and rledger emit **identical accounts, amounts and signs**, in opposite order:

```
py: 2024-01-17 * Transfer received  Assets:Bank:Savings 1000 USD  |  Assets:ZSA-Matched:Transfer -1000 USD
rs: 2024-01-17 * Transfer received  Assets:ZSA-Matched:Transfer -1000 USD  |  Assets:Bank:Savings 1000 USD
```

## Why ours is the better order

`beancount_reds_plugins`' zerosum rewrites a matched posting like this:

```python
def account_replace(txn, posting, new_account):
    new_posting = posting._replace(account=new_account)
    txn.postings.remove(posting)
    txn.postings.append(new_posting)
```

Every rewritten posting therefore lands **last** in its transaction. That is incidental to mutating a Python list mid-iteration — the caller has to `break` and reprocess because, in its own words, *"this entry's postings changes under us"* — not a property anyone chose. It discards the only information posting order carries: what the user wrote.

We rewrite the account in place and keep the position. Given "correctness above compatibility", that is the behavior to keep.

## So this PR changes no behavior

It records the decision, so the next person to look doesn't spend an afternoon rediscovering that the numbers already agree:

- **Comment at the rewrite site** naming upstream's `account_replace`, why we don't copy it, and the revisit condition.
- **`test_matched_posting_keeps_its_position`** pins it. The two transactions put the zerosum leg at *different* positions — first in one, last in the other — so it distinguishes "kept in place" from "moved to the end". A single transaction with the leg already last could not, and my first draft had exactly that hole. Mutation-checked against an upstream-emulating remove/append.
- **Four entries in `KNOWN_RUST_DIVERGENCES`.**

## On the registry bucket

Filed under the **Rust** list, not the Python one, deliberately. We are the side that differs from bean-query's output, and putting a deviation we believe is an improvement into the Python bucket would let a future genuine rledger regression on these pairs hide behind a flattering label. The registry's stale-check couples the entries to the test: if the plugin ever starts reordering, the pairs match again, the entries go stale, and the run fails.

## Verification

- Harness on that fixture: **4 real mismatches → 0** (17/17, +5 masked), no stale or dangling entries.
- **No behavior change**: 732-file corpus sweep shows 0 query and 0 error-count diffs, and `rledger check` output is byte-identical across every fixture in `tests/regressions/`.
- `cargo test --workspace --all-features`, `cargo +1.97.0 clippy --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo fmt --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
