### PR TITLE
chore(compat): register bean-query's render_commas gap as a Python divergence

### DIFF
--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -97,6 +97,163 @@ EMPTY_RESULT_WARNING_FRACTION = 0.5
 # Use `("path", "*")` to allowlist ALL queries on a file (e.g., when
 # the divergence is in a column projection that every query touches).
 KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
+    # `option "render_commas" "TRUE"` is honored by beancount and ignored by
+    # bean-query. These three fixtures set it; we emit `1,234,567.89 USD` and
+    # bean-query emits `1234567.89 USD`. Values are byte-identical once the
+    # separators are removed — this is purely thousands grouping.
+    #
+    # Verified rather than assumed, because registering the wrong side here
+    # would mask an rledger bug:
+    #   * `render_commas` is a real beancount option (`parser/options.py`),
+    #     defaulting to False.
+    #   * beancount CONSUMES it: `parser/grammar.py` does
+    #     `self.dcontext.set_commas(self.options["render_commas"])`.
+    #   * beancount's own printer honors it — `printer.format_entry` with that
+    #     dcontext renders `1,234,567.89 USD`.
+    #   * `render_commas` appears NOWHERE in beanquery's source; its renderer
+    #     never consults the ledger's dcontext for grouping.
+    #
+    # So beancount intends the option to produce separators and bean-query
+    # simply is not wired to it. We honor a documented option the user
+    # explicitly set; masking these keeps the metric from penalizing that.
+    # Pinned by `render_commas_applies_to_every_column_kind` and
+    # `beancount_output_honors_render_commas_like_format` in
+    # `crates/rustledger/src/cmd/query/output.rs`.
+    #
+    # Revisit if beanquery starts reading the option, at which point these
+    # pairs match again and the stale-mask gate fails the run.
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "balance-running-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "sum-position-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "first-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "last-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "balances-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "journal-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "journal-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "last-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "first-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "journal-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "journal-assets-at-cost",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "journal-assets-at-units",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "position-by-date",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "sum-number-by-currency",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_examples_example.beancount",
+        "weight-by-date",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "balance-running-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "balances-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "first-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "journal-assets-at-cost",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "journal-assets-at-units",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "last-balance-by-month",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "position-by-date",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "sum-number-by-currency",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "sum-position-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_minimizegains_example.beancount",
+        "weight-by-date",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "balance-running-assets",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "balances-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "journal-assets-at-cost",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "journal-assets-at-units",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "position-by-date",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "sum-number-by-currency",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "sum-position-by-account",
+    ),
+    (
+        "tests/compatibility/files/fava-investor/fava_investor_modules_tlh_example.beancount",
+        "weight-by-date",
+    ),
     # beancount/beanquery#275: position display truncates precision in
     # the ledger's display context. Affects any query that projects
     # `position` or sums it.


### PR DESCRIPTION
## What

33 pairs across three fava-investor fixtures differ **only by thousands separators**. The fixtures set `option "render_commas" "True"`; we emit `1,234,567.89 USD`, bean-query emits `1234567.89 USD`. Strip the separators and the rows are identical.

## Which side is wrong — verified, not assumed

Registering the wrong side would mask an rledger bug behind a flattering label, so I checked the mechanism rather than inferring from the symptom:

- `render_commas` is a **real beancount option** (`parser/options.py`), default `False`.
- beancount **consumes** it: `parser/grammar.py` does `self.dcontext.set_commas(self.options["render_commas"])`.
- beancount's **own printer honors it** — `printer.format_entry` with that dcontext renders `1,234,567.89 USD`.
- `render_commas` appears **nowhere in beanquery's source**; its renderer never consults the ledger's dcontext for grouping.

So beancount intends the option to produce separators, and bean-query simply isn't wired to it. We honor an option the user explicitly set.

That's why these go in the **Python** list — in contrast to the zerosum ordering divergence (#2040), where we deviate deliberately and I filed the entries under the **Rust** list on purpose so a future regression couldn't hide there.

## Nine pairs that looked like something else

The harness truncates its diff samples, and inserting separators shifts where truncation lands — so nine pairs *appear* to carry a non-comma difference. Comparing full output row by row (headers excluded, whitespace collapsed, separators stripped) shows all nine are comma-only too.

My first attempt at that check used `diff` over raw output and reported "REAL DIFFERENCE" for all nine. It was wrong: it compared the `SUM(position)` vs `SUM` column header and trailing whitespace, neither of which the harness compares. Worth recording, because acting on that first result would have left nine legitimate masks off — or worse, sent someone hunting a bug that isn't there.

## No code change

The behavior these masks depend on is already pinned by `render_commas_applies_to_every_column_kind` (#1892) and `beancount_output_honors_render_commas_like_format` (#1896). Both were mutation-checked here: making `render_commas_for` return `false` fails both. If beanquery ever starts reading the option, these pairs match again and the stale-mask gate fails the run.

## Verification

- Three fixtures: **9 real mismatches → 0** (51/51, +33 masked), no stale or dangling entries.
- `scripts/compat-bql-test.py --self-test` passes.
- Registry is surgical — 33 explicit `(file, query)` pins rather than a `("path", "*")` wildcard, so an unrelated regression on these files still surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
