### PR TITLE
fix(query): apply MAXWIDTH to JOURNAL's payee and narration

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -1025,20 +1025,29 @@ impl Executor<'_> {
                         // column without bound — the command exists to give a
                         // readable ledger view, and an 800-character memo
                         // defeats that.
-                        let shorten = |text: String, width: i64| -> Value {
-                            Self::maxwidth_on_values(&[Value::String(text), Value::Integer(width)])
-                                .unwrap_or_else(|_| Value::String(String::new()))
-                        };
-                        let row = vec![
-                            Value::Date(txn.date),
-                            Value::String(txn.flag.to_string()),
-                            shorten(
+                        // Propagate rather than substituting a fallback. The
+                        // arguments are fully controlled here — a string and a
+                        // width comfortably above the placeholder's own length
+                        // — so this cannot fail in practice; if it ever does,
+                        // that is a bug worth surfacing, not worth hiding
+                        // behind a silently emptied payee.
+                        let payee = Self::maxwidth_on_values(&[
+                            Value::String(
                                 txn.payee
                                     .as_ref()
                                     .map_or_else(String::new, ToString::to_string),
-                                JOURNAL_PAYEE_MAXWIDTH,
                             ),
-                            shorten(txn.narration.to_string(), JOURNAL_NARRATION_MAXWIDTH),
+                            Value::Integer(JOURNAL_PAYEE_MAXWIDTH),
+                        ])?;
+                        let narration = Self::maxwidth_on_values(&[
+                            Value::String(txn.narration.to_string()),
+                            Value::Integer(JOURNAL_NARRATION_MAXWIDTH),
+                        ])?;
+                        let row = vec![
+                            Value::Date(txn.date),
+                            Value::String(txn.flag.to_string()),
+                            payee,
+                            narration,
                             Value::String(posting.account.to_string()),
                             position_value,
                             Value::Inventory(Box::new(balance_for_row)),

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -42,6 +42,13 @@ impl AtMode {
     }
 }
 
+/// Widths `JOURNAL` applies to its payee and narration columns, matching
+/// beancount's `transform_journal` (`MAXWIDTH(payee, 48)` /
+/// `MAXWIDTH(narration, 80)`).
+const JOURNAL_PAYEE_MAXWIDTH: i64 = 48;
+/// See [`JOURNAL_PAYEE_MAXWIDTH`].
+const JOURNAL_NARRATION_MAXWIDTH: i64 = 80;
+
 impl Executor<'_> {
     /// Execute a SELECT query.
     pub(super) fn execute_select(&self, query: &SelectQuery) -> Result<QueryResult, QueryError> {
@@ -1010,15 +1017,28 @@ impl Executor<'_> {
                             AtMode::None | AtMode::Other => cumulative_balance.clone(),
                         };
 
+                        // `JOURNAL` is defined by beancount as a SELECT whose
+                        // payee and narration go through `MAXWIDTH`
+                        // (`beanquery/compiler.py::transform_journal`:
+                        // `MAXWIDTH(payee, 48)`, `MAXWIDTH(narration, 80)`).
+                        // Skipping it let a single long narration widen the
+                        // column without bound — the command exists to give a
+                        // readable ledger view, and an 800-character memo
+                        // defeats that.
+                        let shorten = |text: String, width: i64| -> Value {
+                            Self::maxwidth_on_values(&[Value::String(text), Value::Integer(width)])
+                                .unwrap_or_else(|_| Value::String(String::new()))
+                        };
                         let row = vec![
                             Value::Date(txn.date),
                             Value::String(txn.flag.to_string()),
-                            Value::String(
+                            shorten(
                                 txn.payee
                                     .as_ref()
                                     .map_or_else(String::new, ToString::to_string),
+                                JOURNAL_PAYEE_MAXWIDTH,
                             ),
-                            Value::String(txn.narration.to_string()),
+                            shorten(txn.narration.to_string(), JOURNAL_NARRATION_MAXWIDTH),
                             Value::String(posting.account.to_string()),
                             position_value,
                             Value::Inventory(Box::new(balance_for_row)),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -660,6 +660,65 @@ fn test_execute_journal_query() {
     assert!(!result.is_empty());
 }
 
+/// `JOURNAL` shortens payee and narration to the widths beancount defines.
+///
+/// `beanquery/compiler.py::transform_journal` builds the command as a SELECT
+/// over `MAXWIDTH(payee, 48)` and `MAXWIDTH(narration, 80)`. We selected the
+/// raw columns, so a single long memo widened the column without bound and
+/// pushed every later column off screen.
+///
+/// Asserts the widths and the `[...]` marker, not merely "shorter than the
+/// input" — the point is the specific 48/80 contract, and a test that only
+/// checked "was truncated somewhere" would pass with the wrong widths.
+#[test]
+fn test_journal_shortens_payee_and_narration_to_beancount_widths() {
+    let long_payee = "PAYEE ".repeat(20); // 120 chars
+    let long_narration = "NARRATION ".repeat(20); // 200 chars
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), long_narration.trim())
+                .with_payee(long_payee.trim())
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(1000), "USD"),
+                ))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1000), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets""#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+    assert_eq!(result.rows.len(), 1);
+
+    let cell = |i: usize| match &result.rows[0][i] {
+        Value::String(s) => s.clone(),
+        other => panic!("column {i} should be a string, got {other:?}"),
+    };
+    // Columns: date, flag, payee, narration, account, position, balance.
+    let (payee, narration) = (cell(2), cell(3));
+
+    assert!(
+        payee.len() <= 48,
+        "payee must fit MAXWIDTH(payee, 48), got {} chars: {payee}",
+        payee.len()
+    );
+    assert!(
+        narration.len() <= 80,
+        "narration must fit MAXWIDTH(narration, 80), got {} chars: {narration}",
+        narration.len()
+    );
+    assert!(payee.ends_with("[...]"), "payee marker: {payee}");
+    assert!(
+        narration.ends_with("[...]"),
+        "narration marker: {narration}"
+    );
+}
+
 /// Regression test for issue #955 (Bug 2): the JOURNAL `balance` column was
 /// per-account, but Python `bean-query` translates JOURNAL to a SELECT where
 /// `balance` is the cumulative inventory across every WHERE-filtered posting


### PR DESCRIPTION
## What

`JOURNAL` is **defined by beancount** as a SELECT whose payee and narration go through `MAXWIDTH` — `beanquery/compiler.py::transform_journal` builds `MAXWIDTH(payee, 48)` and `MAXWIDTH(narration, 80)`. Our `execute_journal` selected the raw columns, so neither was ever shortened.

That's a usability bug before it's a compat one: the command exists to give a readable ledger view, and a single 800-character memo widened the column without bound and pushed every later column off screen. On `parser-lima/examples_data_long_string.beancount` our narration column was 111 characters where bean-query's is 80.

`MAXWIDTH` itself was already implemented and already matched bean-query (Python `textwrap.shorten` semantics, `[...]` placeholder) — it simply wasn't wired into this command. I verified that standalone before touching anything, which is what narrowed it to the JOURNAL path.

## Impact

Over the **46 corpus files whose `JOURNAL` output changes**:

| | |
|---|---|
| Real mismatches | **108 → 18** |
| Effective match | 86% → 97% |
| Pair-by-pair | **90 fixed, 0 broken** |
| Error counts | no file changes |

I checked the pair-by-pair diff rather than trusting the net, since a net improvement can still hide a regression.

## Deliberately not fixed here

Visible in the same output: bean-query sizes each column to its **data** and truncates the header to fit — `flag` becomes `f`, `position` becomes `positio`, `MAXWIDTH(payee, 48)` becomes `M`. We pad the column so the header stays readable.

That accounts for most of the remaining 18 pairs. It's a presentation choice rather than a defect — arguably ours is the better one, since a column headed `f` tells the reader nothing — so it wants its own decision rather than being folded in here.

## Verification

- `cargo test --workspace --all-features`, `cargo +1.97.0 clippy --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo fmt --check` — all clean.
- 732-file corpus sweep with a `JOURNAL` query: 46 files change output, **0 change their error count**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG