### PR TITLE
fix(pad): stop synthesized padding displacing unrelated same-date entries

### DIFF
--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -36,7 +36,7 @@ pub use interpolate::{
 };
 pub use pad::{
     PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,
-    merge_with_padding_owned, merge_with_padding_spanned, process_pads,
+    merge_with_padding_owned, merge_with_padding_spanned, pad_insertion_index, process_pads,
 };
 
 use bigdecimal::BigDecimal;

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -36,7 +36,7 @@ pub use interpolate::{
 };
 pub use pad::{
     PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,
-    merge_with_padding_spanned, process_pads,
+    merge_with_padding_owned, merge_with_padding_spanned, process_pads,
 };
 
 use bigdecimal::BigDecimal;

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -384,46 +384,65 @@ pub fn merge_with_padding_owned(directives: Vec<Directive>) -> Vec<Directive> {
 
     let result = process_pads(&directives);
 
-    // Place each synth immediately BEFORE the first Balance sharing its date,
-    // and otherwise at the END of its date group.
-    //
-    // Cost: one insert per synth into an already-sorted vector, so O(n x k)
-    // for k pads rather than the previous single O(n log n) pass. `pad` is
-    // used sparingly by construction — one per account per period — and the
-    // whole function early-returns on a ledger with none; the heaviest file
-    // in the compat corpus carries 12. If a ledger ever arrives with pads in
-    // the thousands, merge the (date-sorted) synths in one pass instead.
-    //
-    // The "before a same-date Balance" half is load-bearing: a `pad` and the
-    // `balance` it satisfies can share a date, and any consumer checking
-    // assertions mid-stream against this view must see the padding first.
-    //
-    // The "otherwise at the end" half is what stops the synth displacing
-    // UNRELATED same-date directives. Prepending it to the whole date group
-    // did that: on `ledger2beancount/tests_balance-assertion.beancount` a
-    // 2019-01-29 pad for `Assets:Test6` jumped ahead of an unrelated
-    // 2019-01-29 transaction for `Assets:Test5`, and every running balance
-    // from that row on was 500.00 USD out relative to bean-query, which
-    // orders the padding at the `pad` directive's own position.
     let mut merged: Vec<Directive> = directives;
     merged.sort_by_key(rustledger_core::Directive::date);
 
     for txn in result.padding_transactions {
-        let date = txn.date;
-        let insert_at = merged
-            .iter()
-            .position(|d| d.date() == date && matches!(d, Directive::Balance(_)))
-            .unwrap_or_else(|| {
-                // End of this date's group (or of the run, if it is last).
-                merged
-                    .iter()
-                    .rposition(|d| d.date() <= date)
-                    .map_or(0, |i| i + 1)
-            });
+        let insert_at = pad_insertion_index(merged.iter(), txn.date);
         merged.insert(insert_at, Directive::Transaction(txn));
     }
 
     merged
+}
+
+/// Where a synthesized padding transaction dated `date` belongs in an
+/// already date-sorted directive stream.
+///
+/// The rule: immediately BEFORE the first `Balance` sharing its date, and
+/// otherwise at the END of its date group.
+///
+/// The "before a same-date Balance" half is load-bearing: a `pad` and the
+/// `balance` it satisfies can share a date, and any consumer checking
+/// assertions mid-stream must see the padding first.
+///
+/// The "otherwise at the end" half is what stops the synth displacing
+/// UNRELATED same-date directives. Prepending it to the whole date group did
+/// that: on `ledger2beancount/tests_balance-assertion.beancount` a 2019-01-29
+/// pad for `Assets:Test6` jumped ahead of an unrelated 2019-01-29 transaction
+/// for `Assets:Test5`, and every running balance from that row on was
+/// 500.00 USD out relative to bean-query, which orders the padding at the
+/// `pad` directive's own position.
+///
+/// This is the single source of truth for pad placement. It is `pub` because
+/// the rule has three consumers with three different element types —
+/// [`merge_with_padding_owned`] over `Directive`,
+/// [`merge_with_padding_spanned`] over [`Spanned<Directive>`], and
+/// `rustledger-ffi-wasi`'s `expand_pads` over `(Directive, tag)` pairs, which
+/// carries parallel provenance tags and so cannot call either merge. All three
+/// once open-coded the rule; two of the copies were still prepending when this
+/// one changed. Compute the index here rather than re-deriving it.
+///
+/// Cost: one insert per synth into an already-sorted vector, so O(n x k) for
+/// k pads rather than a single O(n log n) pass. `pad` is used sparingly by
+/// construction — one per account per period — and callers early-return on a
+/// ledger with none; the heaviest file in the compat corpus carries 12. If a
+/// ledger ever arrives with pads in the thousands, merge the (date-sorted)
+/// synths in one pass instead.
+#[must_use]
+pub fn pad_insertion_index<'a, I>(sorted: I, date: NaiveDate) -> usize
+where
+    I: IntoIterator<Item = &'a Directive>,
+{
+    let mut end_of_group = 0;
+    for (index, directive) in sorted.into_iter().enumerate() {
+        if directive.date() == date && matches!(directive, Directive::Balance(_)) {
+            return index;
+        }
+        if directive.date() <= date {
+            end_of_group = index + 1;
+        }
+    }
+    end_of_group
 }
 
 /// Span-preserving variant of [`merge_with_padding`].
@@ -453,23 +472,13 @@ pub fn merge_with_padding_spanned(directives: &[Spanned<Directive>]) -> Vec<Span
 
     let result = process_pads(&plain);
 
-    // Same placement rule as the plain variant — see it for why the synth
-    // goes before a same-date Balance but after everything else on its date.
-    // Marked synthesized so they resolve to no source location.
+    // Placement via the shared [`pad_insertion_index`]. Marked synthesized so
+    // they resolve to no source location.
     let mut merged: Vec<Spanned<Directive>> = directives.to_vec();
     merged.sort_by_key(|s| s.value.date());
 
     for txn in result.padding_transactions {
-        let date = txn.date;
-        let insert_at = merged
-            .iter()
-            .position(|s| s.value.date() == date && matches!(s.value, Directive::Balance(_)))
-            .unwrap_or_else(|| {
-                merged
-                    .iter()
-                    .rposition(|s| s.value.date() <= date)
-                    .map_or(0, |i| i + 1)
-            });
+        let insert_at = pad_insertion_index(merged.iter().map(|s| &s.value), txn.date);
         merged.insert(insert_at, Spanned::synthesized(Directive::Transaction(txn)));
     }
 

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -376,6 +376,13 @@ pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
     // Place each synth immediately BEFORE the first Balance sharing its date,
     // and otherwise at the END of its date group.
     //
+    // Cost: one insert per synth into an already-sorted vector, so O(n x k)
+    // for k pads rather than the previous single O(n log n) pass. `pad` is
+    // used sparingly by construction — one per account per period — and the
+    // whole function early-returns on a ledger with none; the heaviest file
+    // in the compat corpus carries 12. If a ledger ever arrives with pads in
+    // the thousands, merge the (date-sorted) synths in one pass instead.
+    //
     // The "before a same-date Balance" half is load-bearing: a `pad` and the
     // `balance` it satisfies can share a date, and any consumer checking
     // assertions mid-stream against this view must see the padding first.

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -373,19 +373,37 @@ pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
 
     let result = process_pads(directives);
 
-    // Prepend synths so stable sort puts them BEFORE same-date originals.
-    // On a same-date pad+balance pair, the order is `[synth, pad, balance]`
-    // post-sort (synths start at the front of their date-group). This is
-    // important for any consumer that runs balance-assertion checks
-    // mid-stream against the merged view.
-    let mut merged: Vec<Directive> =
-        Vec::with_capacity(directives.len() + result.padding_transactions.len());
-    for txn in result.padding_transactions {
-        merged.push(Directive::Transaction(txn));
-    }
-    merged.extend(directives.iter().cloned());
-
+    // Place each synth immediately BEFORE the first Balance sharing its date,
+    // and otherwise at the END of its date group.
+    //
+    // The "before a same-date Balance" half is load-bearing: a `pad` and the
+    // `balance` it satisfies can share a date, and any consumer checking
+    // assertions mid-stream against this view must see the padding first.
+    //
+    // The "otherwise at the end" half is what stops the synth displacing
+    // UNRELATED same-date directives. Prepending it to the whole date group
+    // did that: on `ledger2beancount/tests_balance-assertion.beancount` a
+    // 2019-01-29 pad for `Assets:Test6` jumped ahead of an unrelated
+    // 2019-01-29 transaction for `Assets:Test5`, and every running balance
+    // from that row on was 500.00 USD out relative to bean-query, which
+    // orders the padding at the `pad` directive's own position.
+    let mut merged: Vec<Directive> = directives.to_vec();
     merged.sort_by_key(rustledger_core::Directive::date);
+
+    for txn in result.padding_transactions {
+        let date = txn.date;
+        let insert_at = merged
+            .iter()
+            .position(|d| d.date() == date && matches!(d, Directive::Balance(_)))
+            .unwrap_or_else(|| {
+                // End of this date's group (or of the run, if it is last).
+                merged
+                    .iter()
+                    .rposition(|d| d.date() <= date)
+                    .map_or(0, |i| i + 1)
+            });
+        merged.insert(insert_at, Directive::Transaction(txn));
+    }
 
     merged
 }
@@ -417,16 +435,25 @@ pub fn merge_with_padding_spanned(directives: &[Spanned<Directive>]) -> Vec<Span
 
     let result = process_pads(&plain);
 
-    // Prepend synth transactions (same ordering rationale as the plain variant)
-    // and mark them as synthesized so they resolve to no source location.
-    let mut merged: Vec<Spanned<Directive>> =
-        Vec::with_capacity(directives.len() + result.padding_transactions.len());
-    for txn in result.padding_transactions {
-        merged.push(Spanned::synthesized(Directive::Transaction(txn)));
-    }
-    merged.extend(directives.iter().cloned());
-
+    // Same placement rule as the plain variant — see it for why the synth
+    // goes before a same-date Balance but after everything else on its date.
+    // Marked synthesized so they resolve to no source location.
+    let mut merged: Vec<Spanned<Directive>> = directives.to_vec();
     merged.sort_by_key(|s| s.value.date());
+
+    for txn in result.padding_transactions {
+        let date = txn.date;
+        let insert_at = merged
+            .iter()
+            .position(|s| s.value.date() == date && matches!(s.value, Directive::Balance(_)))
+            .unwrap_or_else(|| {
+                merged
+                    .iter()
+                    .rposition(|s| s.value.date() <= date)
+                    .map_or(0, |i| i + 1)
+            });
+        merged.insert(insert_at, Spanned::synthesized(Directive::Transaction(txn)));
+    }
 
     merged
 }
@@ -710,6 +737,60 @@ mod tests {
         assert!(
             !is_synthesized_pad(&user_p),
             "user-written P-flag transaction must not be classified as synth",
+        );
+    }
+
+    #[test]
+    fn test_merge_with_padding_synth_does_not_displace_unrelated_same_date_entry() {
+        // A pad whose balance lands on a LATER date must not jump ahead of an
+        // unrelated transaction sharing the pad's date. Prepending synths to
+        // the whole date group did exactly that, and every running balance
+        // from that row on was off by the padding amount.
+        //
+        // This is the other half of the placement rule from
+        // `test_merge_with_padding_same_date_pad_balance_synth_comes_first`:
+        // with no same-date Balance to sit in front of, the synth belongs at
+        // the END of its date group, which is where bean-query puts it.
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Other")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            // Unrelated transaction, same date as the pad below.
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 2), "unrelated")
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Other",
+                        Amount::new(dec!(10), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-10), "USD"),
+                    )),
+            ),
+            Directive::Pad(Pad::new(date(2024, 1, 2), "Assets:Bank", "Equity:Opening")),
+            // Balance is on a LATER date, so there is no same-date Balance.
+            Directive::Balance(Balance::new(
+                date(2024, 1, 3),
+                "Assets:Bank",
+                Amount::new(dec!(1000), "USD"),
+            )),
+        ];
+
+        let merged = merge_with_padding(&directives);
+
+        let synth_idx = merged
+            .iter()
+            .position(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t)))
+            .expect("synth present");
+        let unrelated_idx = merged
+            .iter()
+            .position(
+                |d| matches!(d, Directive::Transaction(t) if t.narration.as_ref() == "unrelated"),
+            )
+            .expect("unrelated txn present");
+        assert!(
+            unrelated_idx < synth_idx,
+            "unrelated same-date txn (idx {unrelated_idx}) must precede the synth (idx {synth_idx})",
         );
     }
 

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -360,6 +360,17 @@ fn create_padding_transaction(
 /// re-applies them against an inventory that already includes the prior
 /// synth. A `debug_assert!` guards against this in dev builds.
 pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
+    merge_with_padding_owned(directives.to_vec())
+}
+
+/// [`merge_with_padding`] for a caller that already owns its directives.
+///
+/// Exists so consumers holding an owned `Vec` need not clone it a second time
+/// just to reach the canonical placement rule. `Ledger::balance_view` used to
+/// inline the merge for exactly that reason, and the copy drifted the moment
+/// the rule changed — this is the same saving without the duplicate.
+#[must_use]
+pub fn merge_with_padding_owned(directives: Vec<Directive>) -> Vec<Directive> {
     // Idempotence: input that already contains synth pad transactions has
     // been merged before (e.g. an embedder queries entries it loaded via
     // load-full, which merges pads — rustledger#1712). Re-running would
@@ -368,10 +379,10 @@ pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
         .iter()
         .any(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t)))
     {
-        return directives.to_vec();
+        return directives;
     }
 
-    let result = process_pads(directives);
+    let result = process_pads(&directives);
 
     // Place each synth immediately BEFORE the first Balance sharing its date,
     // and otherwise at the END of its date group.
@@ -394,7 +405,7 @@ pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
     // 2019-01-29 transaction for `Assets:Test5`, and every running balance
     // from that row on was 500.00 USD out relative to bean-query, which
     // orders the padding at the `pad` directive's own position.
-    let mut merged: Vec<Directive> = directives.to_vec();
+    let mut merged: Vec<Directive> = directives;
     merged.sort_by_key(rustledger_core::Directive::date);
 
     for txn in result.padding_transactions {

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -281,11 +281,18 @@ pub struct FileLoad {
 /// balance-computing consumers, preserving each directive's parallel tag
 /// (line, or line+file).
 ///
-/// Mirrors `Ledger::balance_view`: prepend the synthesized transactions —
-/// which have no source location, so they take `synth_tag` — then stable-sort
-/// the whole stream by date. Source-faithful callers skip this; only the
-/// `load`/`load-file` consumers that opt in (#1628) expand. The input must not
-/// already contain synth pad transactions (it is the raw load stream).
+/// Mirrors `Ledger::balance_view`, which merges via
+/// [`rustledger_booking::merge_with_padding_owned`]. This cannot call that
+/// directly: it carries a parallel tag per directive (line, or line+file), and
+/// a synth has no source location so it takes `synth_tag`. It therefore sorts
+/// the tagged pairs itself and places each synth at
+/// [`rustledger_booking::pad_insertion_index`] — the shared rule, not a second
+/// copy of it. An earlier copy here prepended the synths instead, and silently
+/// kept doing so after the shared rule changed.
+///
+/// Source-faithful callers skip this; only the `load`/`load-file` consumers
+/// that opt in (#1628) expand. The input must not already contain synth pad
+/// transactions (it is the raw load stream).
 #[must_use]
 pub fn expand_pads<T: Clone>(
     directives: Vec<Directive>,
@@ -294,11 +301,15 @@ pub fn expand_pads<T: Clone>(
 ) -> (Vec<Directive>, Vec<T>) {
     let pads = rustledger_booking::process_pads(&directives).padding_transactions;
     let mut pairs: Vec<(Directive, T)> = Vec::with_capacity(directives.len() + pads.len());
-    for txn in pads {
-        pairs.push((Directive::Transaction(txn), synth_tag.clone()));
-    }
     pairs.extend(directives.into_iter().zip(tags));
     pairs.sort_by_key(|(d, _)| d.date());
+
+    for txn in pads {
+        let insert_at =
+            rustledger_booking::pad_insertion_index(pairs.iter().map(|(d, _)| d), txn.date);
+        pairs.insert(insert_at, (Directive::Transaction(txn), synth_tag.clone()));
+    }
+
     pairs.into_iter().unzip()
 }
 
@@ -585,6 +596,58 @@ option \"operating_currency\" \"USD\"
             .filter(|d| matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t)))
             .count();
         assert_eq!(synth, 1, "expected exactly one synthesized Padding txn");
+    }
+
+    /// A ledger where a `pad` shares its date with an unrelated transaction.
+    ///
+    /// The existing tests cannot see the difference between prepending the
+    /// synth to its date group and placing it at the end: both leave the
+    /// stream globally date-sorted, and both synthesize exactly one Padding
+    /// txn. Only the relative order WITHIN 2024-01-20 tells them apart.
+    const SAME_DATE_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:SomeName USD
+2020-01-01 open Assets:Other USD
+2020-01-01 open Equity:Opening-balances
+2024-01-20 pad Assets:SomeName Equity:Opening-balances
+2024-01-20 * \"unrelated\"
+  Assets:Other  5 USD
+  Equity:Opening-balances
+2024-01-21 balance Assets:SomeName 42 USD
+";
+
+    #[test]
+    fn expand_pads_does_not_displace_unrelated_same_date_directives() {
+        let load = load_source(SAME_DATE_LEDGER);
+        let (expanded, lines) = expand_pads(load.directives, load.directive_lines, &0u32);
+
+        let synth_at = expanded
+            .iter()
+            .position(|d| matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t)))
+            .expect("fixture must synthesize a Padding txn");
+        let unrelated_at = expanded
+            .iter()
+            .position(|d| matches!(d, Directive::Transaction(t) if t.narration == "unrelated"))
+            .expect("fixture must keep the unrelated txn");
+
+        assert!(
+            synth_at > unrelated_at,
+            "the synthesized pad must sort AFTER the unrelated same-date \
+             transaction it does not concern (it went at index {synth_at}, \
+             the unrelated txn at {unrelated_at}); prepending it to the date \
+             group throws off every running balance from that row on",
+        );
+
+        // Tag alignment survives an INSERT, not just a sort. Placement moves
+        // directives relative to their tags if the two are ever updated out of
+        // step, and a wrong `filename`/`lineno` is silent — the stream still
+        // looks right.
+        let unrelated_line = lines[unrelated_at];
+        assert_eq!(
+            unrelated_line, 6,
+            "the unrelated txn must keep its own source line through expansion",
+        );
+        assert_eq!(lines[synth_at], 0, "a synth carries the synthesized tag");
     }
 }
 

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -216,27 +216,19 @@ impl Ledger {
     /// matters.
     #[must_use]
     pub fn balance_view(&self) -> Vec<Directive> {
-        let mut booked: Vec<Directive> = self.directives.iter().map(|s| s.value.clone()).collect();
+        let booked: Vec<Directive> = self.directives.iter().map(|s| s.value.clone()).collect();
 
-        // Inlined from `rustledger_booking::merge_with_padding` so
-        // `booked` is moved (not re-cloned via `to_vec()`).
-        // Algorithmically identical: prepend synth transactions, then
-        // stable-sort by date. Same-date pad+balance pairs land as
-        // `[synth, pad, balance]` because synths sit at the front of
-        // their date-group pre-sort.
+        // Call the canonical placement rule rather than re-deriving it.
+        // This used to inline the merge so `booked` could be moved instead of
+        // cloned a second time; `merge_with_padding_owned` gives the same
+        // saving without the copy. The copy had already drifted — it still
+        // prepended synths after the shared rule learned to place them
+        // relative to a same-date `Balance`.
         debug_assert!(
             !booked.iter().any(|d| matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t))),
             "balance_view called on a Ledger whose directives already contain synth pad transactions",
         );
-        let pad_result = rustledger_booking::process_pads(&booked);
-        let mut merged: Vec<Directive> =
-            Vec::with_capacity(booked.len() + pad_result.padding_transactions.len());
-        for txn in pad_result.padding_transactions {
-            merged.push(Directive::Transaction(txn));
-        }
-        merged.append(&mut booked);
-        merged.sort_by_key(rustledger_core::Directive::date);
-        merged
+        rustledger_booking::merge_with_padding_owned(booked)
     }
 }
 


### PR DESCRIPTION
## What

`merge_with_padding` prepended every synthesized padding transaction to the whole directive list before a date-only stable sort, so each synth led its date group.

That was **deliberate** — a `pad` and the `balance` it satisfies can share a date, and a consumer checking assertions mid-stream must see the padding first. But it's blunter than the requirement: leading the group also puts the synth ahead of entries that have nothing to do with it.

## The user-visible consequence

On `ledger2beancount/tests_balance-assertion.beancount`:

```beancount
2019-01-29 * "Balance assertion with metadata"   ← line 97
  Assets:Test5   10.00 EUR
2019-01-29 pad Assets:Test6 Equity:Adjustments   ← line 104
2019-01-30 balance Assets:Test6  500.00 USD
```

The `Assets:Test6` padding jumped ahead of the unrelated `Assets:Test5` transaction, and every running balance from that row on was **500.00 USD adrift** — we reported `987.00 USD` where bean-query reports `487.00 USD`, on a row that has nothing to do with the pad. bean-query orders the padding at the `pad` directive's own position, which is after the transaction here.

## Fix

Place each synth immediately before the first `Balance` sharing its date, and otherwise at the end of its date group. That keeps the requirement the old code was protecting while dropping the collateral reordering.

Both halves are pinned and **mutation-checked independently**:
- prepending again fails the new `..._does_not_displace_unrelated_same_date_entry`
- dropping the same-date-`Balance` rule fails the existing `..._synth_comes_first`

`merge_with_padding_spanned` carried the same prepend and is aligned.

## Verification

- **732-file corpus sweep:** exactly **one** file changes — the fixture above — and **no file changes its error count**. A pad-ordering change could have rippled widely; it doesn't.
- On that file the BQL harness goes **5 real mismatches → 1**, and the survivor is the unrelated `GBP 0` vs `GBP 0.00` scale difference.
- `cargo test --workspace --all-features`, `cargo +1.97.0 clippy --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo fmt --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG