### PR TITLE
fix(query): give decimal addition Python's scale semantics

### DIFF
--- a/crates/rustledger-core/src/decimal.rs
+++ b/crates/rustledger-core/src/decimal.rs
@@ -1,0 +1,163 @@
+//! Decimal arithmetic with Python `decimal` scale semantics.
+//!
+//! `rust_decimal` and Python's `decimal` agree on the VALUE of a sum but not
+//! always on its SCALE, and BQL renders a naked decimal at its intrinsic scale
+//! (bean-query's `DecimalRenderer` pads for alignment only — it never
+//! quantizes). So a scale difference is a visible output difference.
+//!
+//! Python's rule for `+`/`-` is that an exact result carries
+//! `max(scale(a), scale(b))`:
+//!
+//! ```text
+//!   Decimal("0.00") + Decimal("1")  ==  Decimal("1.00")
+//! ```
+//!
+//! `rust_decimal` matches that for ordinary operands (`2.00 + 1 == 3.00`) but
+//! not when one side is ZERO: its addition returns the other operand
+//! unchanged, so the zero's scale is discarded and `0.00 + 1 == 1`.
+//!
+//! That makes an accumulation order-dependent, which is how it surfaced. A
+//! `SUM` over `-1, 1, -111.11, 111.11, -2, 2` passes through `0.00` at the
+//! fourth term; the `-2` that follows then resets the running total to scale
+//! 0 and the query prints `0` where bean-query prints `0.00`. Move the
+//! fractional pair last and the same multiset prints `0.00` — same value,
+//! same inputs, different rendering.
+
+use rust_decimal::Decimal;
+
+/// Add two decimals with Python `decimal`'s scale rule.
+///
+/// The value is `a + b` either way; this only restores the scale
+/// `rust_decimal` drops when an operand is zero (see the module docs). The
+/// result is padded UP to `max(scale(a), scale(b))` and never truncated, so
+/// it cannot lose significant digits.
+///
+/// Rescaling is best-effort: `Decimal::rescale` is a no-op when the target
+/// scale would overflow the 96-bit mantissa (a value near `Decimal::MAX` at
+/// high scale). Such a value cannot be represented at that scale at all, so
+/// there is nothing to restore and the unrescaled sum is the best available
+/// answer — the same one we returned before this function existed.
+#[must_use]
+pub fn add_python_scale(a: Decimal, b: Decimal) -> Decimal {
+    let mut sum = a + b;
+    let target = a.scale().max(b.scale());
+    if sum.scale() < target {
+        sum.rescale(target);
+    }
+    sum
+}
+
+/// Subtract with Python `decimal`'s scale rule — see [`add_python_scale`].
+#[must_use]
+pub fn sub_python_scale(a: Decimal, b: Decimal) -> Decimal {
+    let mut diff = a - b;
+    let target = a.scale().max(b.scale());
+    if diff.scale() < target {
+        diff.rescale(target);
+    }
+    diff
+}
+
+/// Overflow-checked [`add_python_scale`].
+///
+/// `None` on value-range overflow, matching `Decimal::checked_add` — BQL maps
+/// that to NULL rather than panicking, so the checked form is what the
+/// expression evaluator needs.
+#[must_use]
+pub fn checked_add_python_scale(a: Decimal, b: Decimal) -> Option<Decimal> {
+    let mut sum = a.checked_add(b)?;
+    let target = a.scale().max(b.scale());
+    if sum.scale() < target {
+        sum.rescale(target);
+    }
+    Some(sum)
+}
+
+/// Overflow-checked [`sub_python_scale`] — see [`checked_add_python_scale`].
+#[must_use]
+pub fn checked_sub_python_scale(a: Decimal, b: Decimal) -> Option<Decimal> {
+    let mut diff = a.checked_sub(b)?;
+    let target = a.scale().max(b.scale());
+    if diff.scale() < target {
+        diff.rescale(target);
+    }
+    Some(diff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    /// The exact shape `rust_decimal` gets wrong: a zero operand's scale is
+    /// dropped. Both orders, since its zero shortcut applies to either side.
+    #[test]
+    fn a_zero_operand_keeps_its_scale() {
+        assert_eq!(add_python_scale(dec!(0.00), dec!(1)), dec!(1.00));
+        assert_eq!(add_python_scale(dec!(1), dec!(0.00)), dec!(1.00));
+        assert_eq!(sub_python_scale(dec!(0.00), dec!(1)), dec!(-1.00));
+        assert_eq!(sub_python_scale(dec!(1), dec!(0.00)), dec!(1.00));
+    }
+
+    /// `assert_eq!` on `Decimal` compares VALUE, not scale — `dec!(1)` and
+    /// `dec!(1.00)` are equal to it. Every assertion above would therefore
+    /// pass against plain `+`, which is the bug. Assert on the rendered
+    /// string, which is what the divergence is actually about.
+    #[test]
+    fn scale_is_asserted_on_the_rendering_not_the_value() {
+        assert_eq!(dec!(1), dec!(1.00), "precondition: == ignores scale");
+
+        assert_eq!(add_python_scale(dec!(0.00), dec!(1)).to_string(), "1.00");
+        assert_eq!((dec!(0.00) + dec!(1)).to_string(), "1", "the bug itself");
+    }
+
+    /// Ordinary operands already behaved; the fix must not disturb them.
+    #[test]
+    fn non_zero_operands_are_unchanged() {
+        for (a, b, want) in [
+            (dec!(2.00), dec!(1), "3.00"),
+            (dec!(1), dec!(2.00), "3.00"),
+            (dec!(2.50), dec!(2.50), "5.00"),
+            (dec!(111.11), dec!(-111.11), "0.00"),
+            (dec!(1), dec!(2), "3"),
+        ] {
+            assert_eq!(add_python_scale(a, b).to_string(), want, "{a} + {b}");
+        }
+    }
+
+    /// Padding is upward only — a result that already carries more scale than
+    /// either operand (impossible for `+`, but the guard is what makes that
+    /// true) keeps it, and no significant digit is ever dropped.
+    #[test]
+    fn never_truncates() {
+        assert_eq!(add_python_scale(dec!(0.5), dec!(0.25)).to_string(), "0.75");
+        assert_eq!(
+            add_python_scale(dec!(0), dec!(1.2345)).to_string(),
+            "1.2345"
+        );
+    }
+
+    /// The running-total shape from the compat corpus: passing through zero
+    /// mid-accumulation must not reset the scale for the terms that follow.
+    #[test]
+    fn accumulating_through_zero_keeps_the_widest_scale() {
+        let terms = [
+            dec!(-1),
+            dec!(1),
+            dec!(-111.11),
+            dec!(111.11),
+            dec!(-2),
+            dec!(2),
+        ];
+
+        let mut python_like = Decimal::ZERO;
+        let mut naive = Decimal::ZERO;
+        for t in terms {
+            python_like = add_python_scale(python_like, t);
+            naive += t;
+        }
+
+        assert_eq!(python_like.to_string(), "0.00");
+        assert_eq!(naive.to_string(), "0", "pins the pre-fix behavior");
+    }
+}

--- a/crates/rustledger-core/src/decimal.rs
+++ b/crates/rustledger-core/src/decimal.rs
@@ -91,24 +91,29 @@ mod tests {
 
     /// The exact shape `rust_decimal` gets wrong: a zero operand's scale is
     /// dropped. Both orders, since its zero shortcut applies to either side.
+    ///
+    /// Asserts on `to_string()`, NOT on `Decimal` equality. `==` compares
+    /// value and ignores scale — `dec!(1) == dec!(1.00)` — so an
+    /// `assert_eq!(add_python_scale(..), dec!(1.00))` here would pass against
+    /// a plain `a + b` and pin nothing. That is exactly what this test looked
+    /// like when Copilot caught it on #2046; the rendered form is the whole
+    /// subject of the divergence, so it is what gets asserted.
     #[test]
     fn a_zero_operand_keeps_its_scale() {
-        assert_eq!(add_python_scale(dec!(0.00), dec!(1)), dec!(1.00));
-        assert_eq!(add_python_scale(dec!(1), dec!(0.00)), dec!(1.00));
-        assert_eq!(sub_python_scale(dec!(0.00), dec!(1)), dec!(-1.00));
-        assert_eq!(sub_python_scale(dec!(1), dec!(0.00)), dec!(1.00));
+        assert_eq!(add_python_scale(dec!(0.00), dec!(1)).to_string(), "1.00");
+        assert_eq!(add_python_scale(dec!(1), dec!(0.00)).to_string(), "1.00");
+        assert_eq!(sub_python_scale(dec!(0.00), dec!(1)).to_string(), "-1.00");
+        assert_eq!(sub_python_scale(dec!(1), dec!(0.00)).to_string(), "1.00");
     }
 
-    /// `assert_eq!` on `Decimal` compares VALUE, not scale — `dec!(1)` and
-    /// `dec!(1.00)` are equal to it. Every assertion above would therefore
-    /// pass against plain `+`, which is the bug. Assert on the rendered
-    /// string, which is what the divergence is actually about.
+    /// The trap the test above avoids, pinned so it cannot silently return:
+    /// `Decimal`'s `==` cannot see a scale difference, and the raw operator
+    /// really does drop it.
     #[test]
-    fn scale_is_asserted_on_the_rendering_not_the_value() {
-        assert_eq!(dec!(1), dec!(1.00), "precondition: == ignores scale");
-
-        assert_eq!(add_python_scale(dec!(0.00), dec!(1)).to_string(), "1.00");
+    fn decimal_equality_cannot_see_the_bug_but_rendering_can() {
+        assert_eq!(dec!(1), dec!(1.00), "== ignores scale");
         assert_eq!((dec!(0.00) + dec!(1)).to_string(), "1", "the bug itself");
+        assert_eq!(add_python_scale(dec!(0.00), dec!(1)).to_string(), "1.00");
     }
 
     /// Ordinary operands already behaved; the fix must not disturb them.
@@ -159,5 +164,51 @@ mod tests {
 
         assert_eq!(python_like.to_string(), "0.00");
         assert_eq!(naive.to_string(), "0", "pins the pre-fix behavior");
+    }
+
+    /// The checked variants exist so BQL can map a value-range overflow to
+    /// NULL instead of panicking (`rust_decimal` panics on raw `+`). That
+    /// path had no test — the one behavior the checked form is FOR.
+    #[test]
+    fn checked_variants_return_none_on_overflow() {
+        assert_eq!(checked_add_python_scale(Decimal::MAX, Decimal::MAX), None);
+        assert_eq!(checked_sub_python_scale(Decimal::MIN, Decimal::MAX), None);
+
+        // And still compute the ordinary case, with the scale rule applied.
+        assert_eq!(
+            checked_add_python_scale(dec!(0.00), dec!(1))
+                .expect("no overflow")
+                .to_string(),
+            "1.00"
+        );
+        assert_eq!(
+            checked_sub_python_scale(dec!(1), dec!(0.00))
+                .expect("no overflow")
+                .to_string(),
+            "1.00"
+        );
+    }
+
+    /// The rescale step must never corrupt a value it cannot widen.
+    ///
+    /// A sum near `Decimal::MAX` has no room for extra fractional digits, so
+    /// the requested scale is unreachable. `Decimal::rescale` is documented
+    /// to leave the value alone in that case rather than truncating, and this
+    /// pins that we depend on it: if it ever became saturating or truncating,
+    /// the failure mode is a silently WRONG money value rather than a panic
+    /// or an error, which nothing else here would catch.
+    ///
+    /// Verified against the real type rather than assumed — `MAX.rescale(2)`
+    /// is a no-op returning `79228162514264337593543950335`.
+    #[test]
+    fn rescale_beyond_capacity_preserves_the_value() {
+        let near_max = Decimal::MAX - Decimal::ONE;
+        let sum = add_python_scale(near_max, dec!(0.00));
+
+        assert_eq!(
+            sum, near_max,
+            "a value too large to carry the target scale must keep its VALUE",
+        );
+        assert_eq!(sum.to_string(), near_max.to_string());
     }
 }

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -44,6 +44,7 @@
 pub mod amount;
 pub mod calendar;
 pub mod cost;
+pub mod decimal;
 pub mod directive;
 pub mod display_context;
 pub mod extract;
@@ -66,6 +67,9 @@ mod kani_proofs;
 pub use amount::{Amount, AmountParseError, AmountParseErrorReason, IncompleteAmount};
 pub use calendar::{CalendarPeriod, quarter_index0};
 pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec};
+pub use decimal::{
+    add_python_scale, checked_add_python_scale, checked_sub_python_scale, sub_python_scale,
+};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -522,6 +522,15 @@ impl<'a> Executor<'a> {
                             let val = self.evaluate_expr(&func.args[0], ctx)?;
                             match val {
                                 Value::Number(n) => {
+                                    // NOTE: deliberately plain `+=`, unlike
+                                    // SUM above. Fixing AVG needs a DIVISION
+                                    // scale rule too — `rust_decimal` drops
+                                    // the dividend's scale on `0.00 / 4` (it
+                                    // yields `0`, Python yields `0.00`), so
+                                    // the accumulator alone changes nothing
+                                    // observable here. Tracked separately;
+                                    // bean-query has no `avg(decimal)` at all,
+                                    // so there is no compat pin either way.
                                     sum += n;
                                     count += 1;
                                 }
@@ -966,6 +975,15 @@ impl<'a> Executor<'a> {
                                 self.evaluate_subquery_expr(&func.args[0], row, column_map)?;
                             match val {
                                 Value::Number(n) => {
+                                    // NOTE: deliberately plain `+=`, unlike
+                                    // SUM above. Fixing AVG needs a DIVISION
+                                    // scale rule too — `rust_decimal` drops
+                                    // the dividend's scale on `0.00 / 4` (it
+                                    // yields `0`, Python yields `0.00`), so
+                                    // the accumulator alone changes nothing
+                                    // observable here. Tracked separately;
+                                    // bean-query has no `avg(decimal)` at all,
+                                    // so there is no compat pin either way.
                                     sum += n;
                                     count += 1;
                                 }

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -331,11 +331,21 @@ impl<'a> Executor<'a> {
                                     has_positions = true;
                                 }
                                 Value::Number(n) => {
-                                    total_number += n;
+                                    // Python scale semantics, not `+=` — see
+                                    // `rustledger_core::add_python_scale`. A
+                                    // running total that passes through zero
+                                    // otherwise drops its scale and the column
+                                    // renders `0` where bean-query renders
+                                    // `0.00`.
+                                    total_number =
+                                        rustledger_core::add_python_scale(total_number, n);
                                     has_numbers = true;
                                 }
                                 Value::Integer(i) => {
-                                    total_number += Decimal::from(i);
+                                    total_number = rustledger_core::add_python_scale(
+                                        total_number,
+                                        Decimal::from(i),
+                                    );
                                     has_numbers = true;
                                 }
                                 Value::Null => {}
@@ -820,11 +830,21 @@ impl<'a> Executor<'a> {
                                     has_positions = true;
                                 }
                                 Value::Number(n) => {
-                                    total_number += n;
+                                    // Python scale semantics, not `+=` — see
+                                    // `rustledger_core::add_python_scale`. A
+                                    // running total that passes through zero
+                                    // otherwise drops its scale and the column
+                                    // renders `0` where bean-query renders
+                                    // `0.00`.
+                                    total_number =
+                                        rustledger_core::add_python_scale(total_number, n);
                                     has_numbers = true;
                                 }
                                 Value::Integer(i) => {
-                                    total_number += Decimal::from(i);
+                                    total_number = rustledger_core::add_python_scale(
+                                        total_number,
+                                        Decimal::from(i),
+                                    );
                                     has_numbers = true;
                                 }
                                 Value::Null => {}

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -890,7 +890,25 @@ impl<'a> Executor<'a> {
                             if &pos.units.currency != first_currency {
                                 return Ok(Value::Null);
                             }
-                            total += pos.units.number;
+                            // Python scale rule, same as SUM — see
+                            // `rustledger_core::add_python_scale`. This walks
+                            // a multi-lot inventory (cost-bearing lots are not
+                            // coalesced), so it is a real accumulation and
+                            // gets the same rule rather than a second
+                            // convention.
+                            //
+                            // Honest scope note: I could not construct a
+                            // ledger where THIS loop's zero-crossing is
+                            // observable — booking rejects the reductions that
+                            // would produce one. The `0` vs `0.00` difference
+                            // visible from `NUMBER(SUM(position))` on a
+                            // single-currency ledger comes from further
+                            // upstream, where `Inventory::add` coalesces
+                            // same-key lots with a plain `checked_add` and
+                            // drops the scale there. That is a
+                            // `rustledger-core` change touching every balance
+                            // surface, so it is deliberately NOT in this PR.
+                            total = rustledger_core::add_python_scale(total, pos.units.number);
                         }
                         Ok(Value::Number(total))
                     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -897,17 +897,18 @@ impl<'a> Executor<'a> {
                             // gets the same rule rather than a second
                             // convention.
                             //
-                            // Honest scope note: I could not construct a
-                            // ledger where THIS loop's zero-crossing is
-                            // observable — booking rejects the reductions that
-                            // would produce one. The `0` vs `0.00` difference
-                            // visible from `NUMBER(SUM(position))` on a
-                            // single-currency ledger comes from further
-                            // upstream, where `Inventory::add` coalesces
-                            // same-key lots with a plain `checked_add` and
-                            // drops the scale there. That is a
-                            // `rustledger-core` change touching every balance
-                            // surface, so it is deliberately NOT in this PR.
+                            // Scope note, so this is not mistaken for a fix of
+                            // the visible symptom: no ledger is known that
+                            // makes THIS loop's own zero-crossing observable —
+                            // booking rejects the reductions that would build
+                            // one. The `0` vs `0.00` that `NUMBER(SUM(position))`
+                            // does show on a single-currency ledger comes from
+                            // further upstream, where `Inventory::add`
+                            // coalesces same-key lots with a plain
+                            // `checked_add` and drops the scale there. Fixing
+                            // that is a `rustledger-core` change read by every
+                            // balance surface (reports, FFI, BQL) and wants its
+                            // own compat sweep.
                             total = rustledger_core::add_python_scale(total, pos.units.number);
                         }
                         Ok(Value::Number(total))

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -349,10 +349,14 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    // `checked_add` so a value-range overflow yields NULL (like
+                    // Checked so a value-range overflow yields NULL (like
                     // div-by-zero — see `arithmetic_op`) instead of panicking;
                     // `rust_decimal` panics on raw `+`/`-`/`*` overflow.
-                    _ => self.arithmetic_op(left, right, Decimal::checked_add),
+                    //
+                    // Python scale semantics, so `0.00 + 1` is `1.00` as
+                    // bean-query renders it, not `1` — the same rule SUM
+                    // accumulates by. See `rustledger_core::add_python_scale`.
+                    _ => self.arithmetic_op(left, right, rustledger_core::checked_add_python_scale),
                 }
             }
             BinaryOperator::Sub => {
@@ -368,7 +372,7 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    _ => self.arithmetic_op(left, right, Decimal::checked_sub),
+                    _ => self.arithmetic_op(left, right, rustledger_core::checked_sub_python_scale),
                 }
             }
             BinaryOperator::Mul => self.arithmetic_op(left, right, Decimal::checked_mul),

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1819,3 +1819,46 @@ fn test_expr_references_column_walks_window_over_clause() {
         "OVER (ORDER BY balance + amount) must be detected"
     );
 }
+
+/// `SUM` must carry Python `decimal`'s scale, including across a running
+/// total that passes through zero.
+///
+/// The postings below sum to exactly zero, and one pair is scale-2 while the
+/// rest are scale-0. Python renders `0.00`; pre-fix rledger rendered `0`,
+/// because `rust_decimal`'s addition returns the other operand unchanged when
+/// one side is zero and so discarded the accumulated scale as soon as the
+/// scale-0 terms that FOLLOW the fractional pair were added.
+///
+/// Order is the whole point — the scale-0 pair must come last. With the
+/// fractional pair last the naive accumulation happens to end at scale 2 and
+/// the test passes against the bug. Verified by reordering: move the `-2/2`
+/// pair before the `111.11` pair and this test no longer distinguishes the
+/// fix from `+=`.
+#[test]
+fn sum_keeps_python_scale_when_the_running_total_passes_through_zero() {
+    let directives = vec![Directive::Transaction(
+        Transaction::new(date(2024, 1, 1), "mixed scales")
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(-111.11), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(111.11), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(-2), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(2), "USD"))),
+    )];
+
+    let mut executor = Executor::new(&directives);
+    let query = parse("SELECT currency, SUM(number) GROUP BY currency").unwrap();
+    let result = executor.execute(&query).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let Value::Number(sum) = &result.rows[0][1] else {
+        panic!("expected a Number, got {:?}", result.rows[0][1]);
+    };
+
+    // Assert the RENDERING: `Decimal`'s `==` ignores scale, so comparing
+    // against `dec!(0.00)` would pass against the bug it is pinning.
+    assert_eq!(
+        sum.to_string(),
+        "0.00",
+        "SUM must keep the widest addend's scale (bean-query renders 0.00)",
+    );
+}

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -1600,9 +1600,22 @@ mod tests {
             .split_whitespace()
             .last()
             .unwrap_or_else(|| panic!("expected non-empty data row; got: {data_row:?}"));
+        // `0.000`, not `0.00`. The fixture's addends are `5.00, -5.00,
+        // 0.000, 0.0`, so Python's sum carries the widest scale — 3 — and
+        // bean-query's `DecimalRenderer` prints a decimal at its intrinsic
+        // scale without ever quantizing. Measured against bean-query 3.2.3
+        // on this exact ledger:
+        //
+        //     py: USD  0.000
+        //
+        // This assertion previously read `0.00`, describing the pre-fix
+        // accumulation: `rust_decimal`'s addition discards a zero operand's
+        // scale, so the running total collapsed to 2dp and the #988 hint
+        // padded it back to USD's 2dp. That agreed with neither bean-query
+        // nor the arithmetic. See `rustledger_core::add_python_scale`.
         assert_eq!(
-            sum_cell, "0.00",
-            "SUM cell should be quantized to USD's 2dp; row was {data_row:?}, raw output:\n{text}"
+            sum_cell, "0.000",
+            "SUM cell should carry the widest addend's scale; row was {data_row:?}, raw output:\n{text}"
         );
     }
 
@@ -1675,9 +1688,11 @@ mod tests {
             .find(|l| l.contains("USD"))
             .unwrap_or_else(|| panic!("expected USD data row; raw output:\n{text}"));
         let sum_cell = data_row.split_whitespace().last().expect("non-empty row");
+        // Same fixture, same reasoning as the explicit-GROUP BY test above:
+        // bean-query renders `0.000` here.
         assert_eq!(
-            sum_cell, "0.00",
-            "implicit GROUP BY should quantize same as explicit; got {sum_cell:?} \
+            sum_cell, "0.000",
+            "implicit GROUP BY should render the same as explicit; got {sum_cell:?} \
              in row {data_row:?}\n full output:\n{text}"
         );
     }


### PR DESCRIPTION
## Problem

`rust_decimal`'s addition returns the other operand unchanged when one side is zero, discarding the zero's scale:

```
0.00 + 1  ==  1        (rust_decimal)
0.00 + 1  ==  1.00     (Python decimal)
```

BQL renders a naked decimal at its **intrinsic scale** — bean-query's `DecimalRenderer` pads for alignment and never quantizes — so that scale is directly visible in query output.

The consequence is worse than a rendering difference. A `SUM` whose running total passes through zero loses its scale for every term that follows, making the result **order-dependent**:

| addends | rendered |
|---|---|
| `-1, 1, -111.11, 111.11, -2, 2` | `0` |
| `-1, 1, -2, 2, -111.11, 111.11` | `0.00` |

Same multiset, same value, different output.

## Fix

Adds `rustledger_core::add_python_scale` (plus `sub` and checked variants): the value is unchanged, the result is padded **up** to `max(scale(a), scale(b))` and never truncated.

Applied to both SUM accumulators, BQL's binary `+`/`-`, and `NUMBER(inventory)` — so SUM and `+` no longer disagree about the same arithmetic.

**Not every decimal accumulator in the crate**, deliberately. Two were found and left alone, each documented at its site:

- **AVG** keeps plain `+=`. Its accumulator was fixed, and the fix turned out to change nothing observable: `rust_decimal` drops the scale on the **division** too (`0.00 / 4` yields `0`, Python yields `0.00`), so AVG needs a division rule as well. Reverted rather than ship a half-fix that reads as complete. bean-query has no `avg(decimal)` at all — it raises `no function matches "avg(decimal)"` — so there is no compat pin either way.
- **`Inventory::add`** coalesces same-key lots with a plain `checked_add` and has the identical defect. It lives in `rustledger-core` and is read by every balance surface (reports, FFI, BQL), so it wants its own compat sweep rather than riding along here.

## Two #988 tests were asserting the wrong thing

Both pin a SUM of `5.00, -5.00, 0.000, 0.0`. I built that exact ledger and asked bean-query 3.2.3:

```
py:     USD  0.000
rs:     USD  0.00     <- before this PR
```

Python's sum carries the widest addend's scale. The old `0.00` described the bug — the accumulation collapsed to 2dp and the #988 currency hint padded it back to USD's tracked precision, agreeing with neither bean-query nor the arithmetic. Both corrected, with the measurement recorded at the assertion site.

## Verification

- **Corpus**: 2550 query pairs, effective gap **42 → 37, zero regressions**. Most of that delta is #2045 (this branch's base); the scale fix itself accounts for `display-precision-most-common`. The operator half moves no corpus pair (no corpus query uses `+`) and is verified directly against bean-query on `0.00 + 1`, `1 + 0.00`, `0.00 - 1`, `1 - 0.00`, `2.00 + 1`, `2.50 + 2.50`, `1 + 2` — all now byte-identical.
- **Mutation-checked**: the query-level test fails with `left: "0"` when the accumulator is reverted to `+=`. The unit tests assert on `to_string()`, not `Decimal` equality — `assert_eq!(dec!(1), dec!(1.00))` passes, so a value-level assertion would be vacuous here, and one test pins that explicitly.
- Full workspace tests, clippy 1.97, `cargo doc -D warnings`, fmt — all clean.

## Not addressed here

The remaining `-900` vs `-900.00` pairs are the #988 hint padding **up**, which bean-query never does. That hint also serves #1023 (PIVOT column names), so removing it needs its own measurement against both issues' original cases rather than riding along with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
