### PR TITLE
fix(core): make inventory coalescing independent of amount order

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -852,7 +852,12 @@ impl Inventory {
 
         // Update the position
         let currency = pos.units.currency.clone();
-        let new_units = pos.units.number + units.number;
+        // Python scale rule, same as `Inventory::add` — see
+        // `crate::decimal::add_python_scale`. A reduction that brings a lot
+        // through zero would otherwise drop the scale here while `add` kept
+        // it, so the same lot would render differently depending on whether
+        // it was last touched by an add or a reduce.
+        let new_units = crate::decimal::add_python_scale(pos.units.number, units.number);
         let new_pos = Position {
             units: Amount::new(new_units, currency.clone()),
             cost: pos.cost.clone(),
@@ -861,7 +866,7 @@ impl Inventory {
 
         // Update units cache incrementally (units.number is negative for reductions)
         if let Some(cached) = self.units_cache.get_mut(&currency) {
-            *cached += units.number;
+            *cached = crate::decimal::add_python_scale(*cached, units.number);
         }
 
         // Remove if empty and rebuild simple_index

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -732,8 +732,14 @@ impl Inventory {
             .get(&position.units.currency)
             .copied()
             .unwrap_or_default();
-        let new_cached = cached
-            .checked_add(position.units.number)
+        // Python `decimal` scale semantics, not raw `checked_add` — see
+        // `crate::decimal::add_python_scale`. `rust_decimal` returns the other
+        // operand untouched when one side is zero, so a running total that
+        // passes through zero drops its scale and everything added after it
+        // renders one scale narrower. That made a coalesced balance
+        // ORDER-DEPENDENT: the same postings in a different order produced
+        // `1` or `1.00` for the same money.
+        let new_cached = crate::decimal::checked_add_python_scale(cached, position.units.number)
             .ok_or_else(overflow)?;
 
         let merge_idx = position
@@ -743,11 +749,14 @@ impl Inventory {
             .flatten();
         let merged_units = merge_idx
             .map(|idx| {
-                self.positions[idx]
-                    .units
-                    .number
-                    .checked_add(position.units.number)
-                    .ok_or_else(overflow)
+                // Same rule as the units cache above — these two must agree,
+                // or `units()` and the position itself report different scales
+                // for the same currency.
+                crate::decimal::checked_add_python_scale(
+                    self.positions[idx].units.number,
+                    position.units.number,
+                )
+                .ok_or_else(overflow)
             })
             .transpose()?;
 
@@ -1599,6 +1608,62 @@ mod tests {
             .expect("fixture fits in Decimal");
         assert_eq!(inv.len(), 2); // Both lots kept
         assert_eq!(inv.units("AAPL"), dec!(0)); // Net units still zero
+    }
+
+    /// Coalescing must not make a balance depend on the order it was built in.
+    ///
+    /// `rust_decimal` returns the other operand untouched when one side is
+    /// zero, so a running total that passes through zero loses its scale and
+    /// every later addend renders one scale narrower. The two inventories
+    /// below hold the SAME multiset of amounts in a different order.
+    ///
+    /// Asserts on `to_string()`, not on `Decimal` equality: `==` compares
+    /// value and ignores scale (`dec!(1) == dec!(1.00)`), so a value-level
+    /// assertion here would pass against the bug it is pinning.
+    #[test]
+    fn coalescing_is_independent_of_the_order_amounts_arrive_in() {
+        // Passes through 0.00 (scale 2), then takes a scale-0 addend.
+        let zero_crossing_first = [dec!(-2.00), dec!(2.00), dec!(-1)];
+        // Same amounts, no zero crossing before the scale-0 addend.
+        let zero_crossing_last = [dec!(-1), dec!(-2.00), dec!(2.00)];
+
+        let build = |amounts: &[Decimal]| {
+            let mut inv = Inventory::new();
+            for n in amounts {
+                inv.add(Position::simple(Amount::new(*n, "USD")))
+                    .expect("fixture fits in Decimal");
+            }
+            inv
+        };
+
+        let a = build(&zero_crossing_first);
+        let b = build(&zero_crossing_last);
+
+        // The merged POSITION.
+        assert_eq!(
+            a.positions()
+                .next()
+                .expect("one position")
+                .units
+                .number
+                .to_string(),
+            "-1.00",
+            "a total that passed through zero must keep the widest scale",
+        );
+        assert_eq!(
+            b.positions()
+                .next()
+                .expect("one position")
+                .units
+                .number
+                .to_string(),
+            "-1.00",
+        );
+
+        // And the units CACHE, which is maintained separately and would
+        // otherwise disagree with the position it summarizes.
+        assert_eq!(a.units("USD").to_string(), "-1.00");
+        assert_eq!(b.units("USD").to_string(), "-1.00");
     }
 
     #[test]

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -882,17 +882,26 @@ impl Inventory {
         self.units_cache.clear();
 
         for (idx, pos) in self.positions.iter().enumerate() {
-            // Update units cache for all positions. `checked_add`, not `+=`:
+            // Update units cache for all positions. Checked, not `+=`:
             // `Decimal`'s `+` panics on overflow, and this runs over payloads.
+            //
+            // Must apply the SAME Python-scale rule as `add`, not a raw
+            // `checked_add`. `units_cache` is `#[serde(skip)]`, so this is the
+            // path that reconstructs it after a round-trip; if the two
+            // disagreed, an inventory built incrementally and the same
+            // inventory deserialized would report different scales for the
+            // same money — measured at `1.00` built vs `1` rebuilt, across
+            // three cost lots summing through zero. Pinned by
+            // `a_round_trip_reports_the_same_scale_as_incremental_adds`.
             let slot = self
                 .units_cache
                 .entry(pos.units.currency.clone())
                 .or_default();
-            *slot = slot
-                .checked_add(pos.units.number)
-                .ok_or_else(|| OverflowError {
+            *slot = crate::decimal::checked_add_python_scale(*slot, pos.units.number).ok_or_else(
+                || OverflowError {
                     currency: pos.units.currency.clone(),
-                })?;
+                },
+            )?;
 
             // Update simple_index only for positions without cost
             if pos.cost.is_none() {
@@ -1608,6 +1617,53 @@ mod tests {
             .expect("fixture fits in Decimal");
         assert_eq!(inv.len(), 2); // Both lots kept
         assert_eq!(inv.units("AAPL"), dec!(0)); // Net units still zero
+    }
+
+    /// A deserialized inventory must report the same scale as one built by
+    /// incremental `add`s.
+    ///
+    /// `units_cache` is `#[serde(skip)]`, so `try_rebuild_index_from` is what
+    /// reconstructs it after a round-trip. That rebuild re-sums the positions;
+    /// if it used a raw `checked_add` while `add` used the Python scale rule,
+    /// the two would part company the moment the running sum crossed zero —
+    /// the same money reporting `1.00` from one path and `1` from the other,
+    /// silently, depending only on whether it had been serialized.
+    ///
+    /// Needs COST-BEARING lots. Cost-less positions coalesce into a single
+    /// position, and one position cannot cross zero during the rebuild, so a
+    /// simpler fixture passes either way and pins nothing.
+    #[test]
+    fn a_round_trip_reports_the_same_scale_as_incremental_adds() {
+        let mut inv = Inventory::new();
+        let lots = [
+            (
+                dec!(2.00),
+                Cost::new(dec!(10.00), "USD").with_date(date(2024, 1, 1)),
+            ),
+            (
+                dec!(-2.00),
+                Cost::new(dec!(11.00), "USD").with_date(date(2024, 1, 2)),
+            ),
+            (
+                dec!(1),
+                Cost::new(dec!(12.00), "USD").with_date(date(2024, 1, 3)),
+            ),
+        ];
+        for (units, cost) in lots {
+            inv.add(Position::with_cost(Amount::new(units, "SH"), cost))
+                .expect("fixture fits in Decimal");
+        }
+
+        let built = inv.units("SH").to_string();
+        assert_eq!(built, "1.00", "the incrementally-built total");
+
+        let json = serde_json::to_string(&inv).expect("serializes");
+        let round_tripped: Inventory = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(
+            round_tripped.units("SH").to_string(),
+            built,
+            "a serde round-trip must not change the reported scale",
+        );
     }
 
     /// Coalescing must not make a balance depend on the order it was built in.

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -379,33 +379,6 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     ("tests/compatibility/files/beancount-v3/examples_simple_basic.beancount", "journal-assets"),
     ("tests/compatibility/files/beancount-v3/examples_simple_basic.beancount", "journal-assets-at-units"),
     ("tests/compatibility/files/beancount-v3/examples_simple_basic.beancount", "journal-assets-at-cost"),
-    # `sum-number-by-currency` display-scale mismatch on cost-spec
-    # interpolation fixtures: Python beanquery preserves arithmetic
-    # scale through SUM (`-1966.700` at scale 3); rledger's booking
-    # layer normalizes residuals to the input minimum scale and lands
-    # at scale 2 (`-1966.70`). The values are numerically equal — the
-    # difference is *display scale only*, surfaced as a textual diff
-    # because both tools intentionally preserve scale on `Value::Number`
-    # output (#1103 / #1106 / #1113).
-    #
-    # Root cause: cost-spec interpolation against `{}` lot-match against
-    # a `{{total}}` lot produces a residual whose scale depends on which
-    # intermediate value drives it. Python's intermediate stays at the
-    # buy-side scale 3; rledger's #1108 fix dropped intermediate scale
-    # to the input minimum (2) to stop 26-digit contamination — that
-    # fix was correct for the over-precision case but over-applies on
-    # these fixtures.
-    #
-    # Deep fix is continuation of #1108's pipeline scale-propagation
-    # work. Tracked under #1112 (kept open as the tracker — do not
-    # auto-close from this PR). Surgical pin (not "*") so any
-    # non-scale divergence on these fixtures stays surfaced.
-    #
-    # All three `non_default_capital_gains_journal` entries that used to sit
-    # here and below are gone: #2034's tolerance-quantization fix made that
-    # fixture match bean-query on every query. The two below still diverge —
-    # their residual is born inside a `{{total}}` lot match, which the
-    # tolerance rule does not reach.
     # `beancount_reds_plugins`' zerosum rewrites a matched posting by
     # REMOVING and RE-APPENDING it, so every rewritten posting lands last in
     # its transaction. We rewrite the account in place and keep the posting
@@ -434,8 +407,6 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     ("tests/regressions/issue-278.beancount", "journal-assets"),
     ("tests/regressions/issue-278.beancount", "journal-assets-at-cost"),
     ("tests/regressions/issue-278.beancount", "journal-assets-at-units"),
-    ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_invalid_journal.beancount", "sum-number-by-currency"),
-    ("tests/compatibility/files/beancount-import/testdata_source_healthequity_test_matching_journal.beancount", "sum-number-by-currency"),
 }
 
 


### PR DESCRIPTION
Follow-up to #2046, which fixed this defect in the query engine and documented this site as the remaining one.

## Problem

`Inventory::add` merges a same-key lot with a plain `checked_add`, and `rust_decimal` returns the other operand untouched when one side is zero. A running balance that passes through zero drops its scale, and every amount added after it renders one scale narrower.

The same postings in a different order give a different rendering of the same money:

| order | `NUMBER(SUM(position))` |
|---|---|
| `-2.00, 2.00, -1` | `-1` &nbsp;← total hits `0.00`, then loses the scale |
| `-1, -2.00, 2.00` | `-1.00` |

## Fix

**All four** arithmetic sites now use `checked_add_python_scale`:

| site | why it has to move too |
|---|---|
| `add` — merged position | the coalescing itself |
| `add` — units cache | maintained separately; must agree with the position it summarizes |
| `try_rebuild_index_from` | `units_cache` is `#[serde(skip)]`, so this rebuilds it after a round-trip |
| `reduce` — position and cache | a lot last touched by a reduce must render like one last touched by an add |

**The rebuild one matters most, and my first commit missed it.** Fixing only `add` put the two paths in disagreement — an inventory built incrementally and the same inventory deserialized reported *different scales for the same money*:

```
built     1.00
rebuilt   1        <- after the first commit, silently
```

Before that commit both said `1`, consistently wrong. So the partial fix introduced a **new** asymmetry, visible only across serialization — the kind that reaches an embedder rather than local CI. Caught in my own review pass, pinned by `a_round_trip_reports_the_same_scale_as_incremental_adds`.

## Performance

`add` is a per-posting hot path and the wall-clock benchmark reported +1.9%, which is one standard deviation on that harness and can't settle it. Deterministic instruction counts via cachegrind on the 10k-txn CI workload:

| | I refs |
|---|---|
| main | 857,111,720 |
| this branch | **861,245,476 (+0.48%)** |

Half a percent of the whole load→process pipeline, for an order-independent money type.

## Scope — measured, not assumed

**No compat movement from this fix — corrected.** I first claimed it improved compat by two pairs. It doesn't; **#2046 already fixed those two fixtures**, and my comparison had used a binary built before #2046 merged. Checked against main's own binary at `67a5edc7`:

```
bean-query    USD  -1966.700
main          USD  -1966.700   <- already matching, no inventory fix
this branch   USD  -1966.700
```

This PR is an **order-independence fix**; that is the whole of its case. `number(inventory)` doesn't exist in bean-query and every other surface renders through `DisplayContext` at per-currency precision, so the metric was never going to move.

## ⚠️ It does un-red main, though

`main`'s compat run is **failing right now** at `67a5edc7` and has been since #2046 merged — the two `KNOWN_RUST_DIVERGENCES` masks went stale there and I didn't remove them. `815adbd8b` in this PR removes them, which fixes that. That part is independent of the inventory change it happens to travel with.

**Why it wasn't caught pre-merge, which is systemic rather than a one-off:** PR compat runs use a **reduced corpus** (2,362 query pairs); main and the nightly use the full one (11,441). Neither `beancount-import` fixture is in the reduced set, so a mask going stale on a file outside it *cannot* surface until after merge. And `Run compatibility tests` isn't a required check, so nothing blocked it.

Not closing #1112 — it is the tracker for the wider scale-propagation work and other fixtures may still sit under it.

**No wire movement.** The FFI component parity suite passes with the debug wasm actually built — 26 tests in **91.41s**, not the 0.00s it reports when the artifact is missing and every test silently skips. That check matters here because rustfava pins `meta.hash` in its snapshots, so a serialization change would surface downstream rather than in local CI.

## Test

`coalescing_is_independent_of_the_order_amounts_arrive_in` builds the same multiset in both orders and asserts on `to_string()` — not `Decimal` equality, which compares value and ignores scale and would pass against the bug (the trap Copilot caught on #2046). It checks both the merged position and the units cache.

**Mutation-checked**: reverting either `checked_add_python_scale` call fails it with `left: "-1"`, `right: "-1.00"`.

Nothing else in the workspace suite moved — which is the point. This behavior had no test at all before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG


