### PR TITLE
fix(query): give AVG Python's division scale rule

### DIFF
--- a/crates/rustledger-core/src/decimal.rs
+++ b/crates/rustledger-core/src/decimal.rs
@@ -84,10 +84,63 @@ pub fn checked_sub_python_scale(a: Decimal, b: Decimal) -> Option<Decimal> {
     Some(diff)
 }
 
+/// Divide with Python `decimal`'s scale rule.
+///
+/// Python defines an *ideal exponent* for division: `exp(a) - exp(b)`, i.e.
+/// an ideal SCALE of `scale(a) - scale(b)`. An exact quotient is reduced
+/// toward that scale but never below the scale exactness requires:
+///
+/// ```text
+///   0.00 / 4     ->  0.00     ideal 2, exact needs 0  -> 2
+///   7    / 2     ->  3.5      ideal 0, exact needs 1  -> 1
+///   1.00 / 2     ->  0.50     ideal 2, exact needs 1  -> 2
+///   1.000 / 8    ->  0.125    ideal 3, exact needs 3  -> 3
+/// ```
+///
+/// `rust_decimal` misses this in BOTH directions, so a pad-only fix would be
+/// half a fix:
+///
+/// * **Under**, on a zero dividend — the same zero shortcut behind
+///   [`add_python_scale`]. `0.00 / 4` gives `0`, dropping the scale.
+/// * **Over**, on an exact quotient — `7 / 2` gives `3.50`, one trailing
+///   zero more than the ideal exponent allows.
+///
+/// So the quotient is stripped to its minimal form and then padded up to the
+/// ideal scale; the two steps together land on Python's answer from either
+/// side. An inexact quotient (`1 / 3`) has no trailing zeros to strip and a
+/// scale far past the ideal, so both steps are no-ops and it is returned as
+/// `rust_decimal` computed it.
+///
+/// Returns `None` on divide-by-zero or overflow, matching
+/// `Decimal::checked_div` — BQL maps that to NULL rather than panicking.
+#[must_use]
+pub fn checked_div_python_scale(a: Decimal, b: Decimal) -> Option<Decimal> {
+    let quotient = a.checked_div(b)?;
+
+    // `scale()` is u32; the ideal can be negative (a coarser dividend than
+    // divisor), which simply means "no padding required".
+    let ideal_scale = i64::from(a.scale()) - i64::from(b.scale());
+
+    // Minimal form first: this is what removes the EXTRA trailing zero in
+    // `7 / 2 -> 3.50`. `normalize` never loses value.
+    let mut result = quotient.normalize();
+    let target = ideal_scale.max(i64::from(result.scale()));
+
+    // `rescale` takes u32 and is a no-op past the mantissa's capacity; the
+    // clamp keeps a pathological ideal from wrapping on the cast.
+    if let Ok(target) = u32::try_from(target)
+        && result.scale() < target
+    {
+        result.rescale(target);
+    }
+    Some(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+    use std::str::FromStr;
 
     /// The exact shape `rust_decimal` gets wrong: a zero operand's scale is
     /// dropped. Both orders, since its zero shortcut applies to either side.
@@ -164,6 +217,81 @@ mod tests {
 
         assert_eq!(python_like.to_string(), "0.00");
         assert_eq!(naive.to_string(), "0", "pins the pre-fix behavior");
+    }
+
+    /// Division scale, against Python `decimal`'s answers verbatim.
+    ///
+    /// Every expectation below was produced by running the case through
+    /// `CPython`'s `decimal` (3.13) rather than reasoned out — the ideal-exponent
+    /// rule is easy to state and easy to get subtly wrong, and a table of
+    /// hand-derived expectations would just encode the same misreading twice.
+    ///
+    /// Asserts on `to_string()`: `Decimal`'s `==` ignores scale, which is the
+    /// entire subject here.
+    #[test]
+    fn division_matches_python_decimal_scale() {
+        // (dividend, divisor, python's rendering)
+        let cases = [
+            // Zero dividend — `rust_decimal` drops the scale (gives `0`).
+            ("0.00", "4", "0.00"),
+            ("0.000", "3", "0.000"),
+            ("0.0", "7", "0.0"),
+            ("0.00", "2.0", "0.0"),
+            ("0.00", "1", "0.00"),
+            ("-0.00", "3", "0.00"), // see the sign note below
+            // Zero with no scale to keep.
+            ("0", "4", "0"),
+            // Exact quotients — `rust_decimal` OVER-pads `7 / 2` to `3.50`.
+            ("7", "2", "3.5"),
+            ("5", "4", "1.25"),
+            ("1.0", "2.00", "0.5"),
+            // Exact quotients both already agree on.
+            ("1.00", "2", "0.50"),
+            ("3.00", "3", "1.00"),
+            ("1.000", "8", "0.125"),
+            ("10.00", "4", "2.50"),
+            ("2.50", "5", "0.50"),
+            ("100.00", "8", "12.50"),
+            ("12.345", "5", "2.469"),
+            // Inexact: no trailing zeros to strip, scale far past the ideal,
+            // so the rule leaves `rust_decimal`'s result alone.
+            ("1", "3", "0.3333333333333333333333333333"),
+        ];
+
+        for (a, b, want) in cases {
+            let a = Decimal::from_str(a).expect("dividend parses");
+            let b = Decimal::from_str(b).expect("divisor parses");
+            let got = checked_div_python_scale(a, b).expect("no overflow");
+            assert_eq!(got.to_string(), want, "{a} / {b}");
+        }
+    }
+
+    /// One deliberate difference from the table's source: Python has a signed
+    /// zero (`Decimal("-0.00") / 3` is `-0.00`), `rust_decimal` does not — it
+    /// has a single zero, so the sign cannot be carried and `0.00` is the
+    /// closest representable answer. Pinned so the gap is a recorded fact
+    /// rather than a surprise; it is a pre-existing property of the type, not
+    /// something this rule introduces.
+    #[test]
+    fn negative_zero_is_unrepresentable_and_renders_unsigned() {
+        let neg_zero = Decimal::from_str("-0.00").expect("parses");
+        assert_eq!(neg_zero.to_string(), "0.00", "the type has no signed zero");
+        assert_eq!(
+            checked_div_python_scale(neg_zero, Decimal::from(3))
+                .expect("no overflow")
+                .to_string(),
+            "0.00",
+        );
+    }
+
+    /// Divide-by-zero is `None`, not a panic — BQL renders it NULL.
+    #[test]
+    fn division_by_zero_is_none() {
+        assert_eq!(
+            checked_div_python_scale(dec!(1.00), Decimal::ZERO),
+            None,
+            "div-by-zero must not panic",
+        );
     }
 
     /// The checked variants exist so BQL can map a value-range overflow to

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -68,7 +68,8 @@ pub use amount::{Amount, AmountParseError, AmountParseErrorReason, IncompleteAmo
 pub use calendar::{CalendarPeriod, quarter_index0};
 pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec};
 pub use decimal::{
-    add_python_scale, checked_add_python_scale, checked_sub_python_scale, sub_python_scale,
+    add_python_scale, checked_add_python_scale, checked_div_python_scale, checked_sub_python_scale,
+    sub_python_scale,
 };
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -522,20 +522,17 @@ impl<'a> Executor<'a> {
                             let val = self.evaluate_expr(&func.args[0], ctx)?;
                             match val {
                                 Value::Number(n) => {
-                                    // NOTE: deliberately plain `+=`, unlike
-                                    // SUM above. Fixing AVG needs a DIVISION
-                                    // scale rule too — `rust_decimal` drops
-                                    // the dividend's scale on `0.00 / 4` (it
-                                    // yields `0`, Python yields `0.00`), so
-                                    // the accumulator alone changes nothing
-                                    // observable here. Tracked separately;
-                                    // bean-query has no `avg(decimal)` at all,
-                                    // so there is no compat pin either way.
-                                    sum += n;
+                                    // Python scale semantics, same as SUM. The
+                                    // accumulator and the division below are
+                                    // one fix: #2046 landed this half alone,
+                                    // found it changed nothing observable
+                                    // because the division re-normalized, and
+                                    // reverted it rather than ship a half-fix.
+                                    sum = rustledger_core::add_python_scale(sum, n);
                                     count += 1;
                                 }
                                 Value::Integer(i) => {
-                                    sum += Decimal::from(i);
+                                    sum = rustledger_core::add_python_scale(sum, Decimal::from(i));
                                     count += 1;
                                 }
                                 Value::Null => {}
@@ -549,7 +546,21 @@ impl<'a> Executor<'a> {
                         if count == 0 {
                             Ok(Value::Null)
                         } else {
-                            Ok(Value::Number(sum / Decimal::from(count)))
+                            // Python's ideal-exponent rule — see
+                            // `rustledger_core::checked_div_python_scale`.
+                            // `rust_decimal` misses it in both directions:
+                            // `0.00 / 4` loses the scale, `7 / 2` gains a
+                            // trailing zero. `count` is non-zero here (the
+                            // branch above returns NULL otherwise), so the
+                            // `None` arm is unreachable in practice; map it to
+                            // NULL rather than panicking on a future change.
+                            Ok(
+                                rustledger_core::checked_div_python_scale(
+                                    sum,
+                                    Decimal::from(count),
+                                )
+                                .map_or(Value::Null, Value::Number),
+                            )
                         }
                     }
                     _ => {
@@ -975,20 +986,17 @@ impl<'a> Executor<'a> {
                                 self.evaluate_subquery_expr(&func.args[0], row, column_map)?;
                             match val {
                                 Value::Number(n) => {
-                                    // NOTE: deliberately plain `+=`, unlike
-                                    // SUM above. Fixing AVG needs a DIVISION
-                                    // scale rule too — `rust_decimal` drops
-                                    // the dividend's scale on `0.00 / 4` (it
-                                    // yields `0`, Python yields `0.00`), so
-                                    // the accumulator alone changes nothing
-                                    // observable here. Tracked separately;
-                                    // bean-query has no `avg(decimal)` at all,
-                                    // so there is no compat pin either way.
-                                    sum += n;
+                                    // Python scale semantics, same as SUM. The
+                                    // accumulator and the division below are
+                                    // one fix: #2046 landed this half alone,
+                                    // found it changed nothing observable
+                                    // because the division re-normalized, and
+                                    // reverted it rather than ship a half-fix.
+                                    sum = rustledger_core::add_python_scale(sum, n);
                                     count += 1;
                                 }
                                 Value::Integer(i) => {
-                                    sum += Decimal::from(i);
+                                    sum = rustledger_core::add_python_scale(sum, Decimal::from(i));
                                     count += 1;
                                 }
                                 Value::Null => {}
@@ -1002,7 +1010,21 @@ impl<'a> Executor<'a> {
                         if count == 0 {
                             Ok(Value::Null)
                         } else {
-                            Ok(Value::Number(sum / Decimal::from(count)))
+                            // Python's ideal-exponent rule — see
+                            // `rustledger_core::checked_div_python_scale`.
+                            // `rust_decimal` misses it in both directions:
+                            // `0.00 / 4` loses the scale, `7 / 2` gains a
+                            // trailing zero. `count` is non-zero here (the
+                            // branch above returns NULL otherwise), so the
+                            // `None` arm is unreachable in practice; map it to
+                            // NULL rather than panicking on a future change.
+                            Ok(
+                                rustledger_core::checked_div_python_scale(
+                                    sum,
+                                    Decimal::from(count),
+                                )
+                                .map_or(Value::Null, Value::Number),
+                            )
                         }
                     }
                     _ => {

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -376,7 +376,14 @@ impl Executor<'_> {
                 }
             }
             BinaryOperator::Mul => self.arithmetic_op(left, right, Decimal::checked_mul),
-            BinaryOperator::Div => self.arithmetic_op(left, right, Decimal::checked_div),
+            // Python's ideal-exponent rule, same as AVG — see
+            // `rustledger_core::checked_div_python_scale`. Unlike `avg`, this
+            // operator DOES exist in bean-query, so the divergence was
+            // user-visible on both sides: `0.00 / 4` rendered `0` against its
+            // `0.00`, and `7 / 2` rendered `3.50` against its `3.5`.
+            BinaryOperator::Div => {
+                self.arithmetic_op(left, right, rustledger_core::checked_div_python_scale)
+            }
             BinaryOperator::Mod => self.modulo_op(left, right),
         }
     }

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1917,3 +1917,39 @@ fn avg_follows_python_decimal_scale_in_both_directions() {
         "-56.555",
     );
 }
+
+/// BQL's `/` operator follows the same rule as AVG.
+///
+/// Unlike `avg(decimal)`, division DOES exist in bean-query, so this one is a
+/// compat surface and the divergence was user-visible in both directions:
+/// `0.00 / 4` rendered `0` against bean-query's `0.00`, and `7 / 2` rendered
+/// `3.50` against its `3.5`. Verified against bean-query 3.2.3 on each case
+/// below.
+///
+/// Leaving the operator on raw `checked_div` while AVG used the rule would
+/// have put two different answers for the same arithmetic in one engine.
+#[test]
+fn the_division_operator_matches_bean_query_scale() {
+    let directives = vec![Directive::Transaction(
+        Transaction::new(date(2024, 1, 2), "t")
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(-1), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(1), "USD"))),
+    )];
+
+    for (expr, want) in [
+        ("0.00 / 4", "0.00"),
+        ("0.000 / 3", "0.000"),
+        ("7 / 2", "3.5"),
+        ("1.00 / 2", "0.50"),
+        ("1 / 3", "0.3333333333333333333333333333"),
+    ] {
+        let mut executor = Executor::new(&directives);
+        let query = parse(&format!("SELECT {expr}")).unwrap();
+        let result = executor.execute(&query).unwrap();
+        let Value::Number(n) = &result.rows[0][0] else {
+            panic!("expected a Number for {expr}, got {:?}", result.rows[0][0]);
+        };
+        assert_eq!(n.to_string(), want, "{expr}");
+    }
+}

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1862,3 +1862,58 @@ fn sum_keeps_python_scale_when_the_running_total_passes_through_zero() {
         "SUM must keep the widest addend's scale (bean-query renders 0.00)",
     );
 }
+
+/// `AVG` follows Python `decimal` in both directions.
+///
+/// #2046 fixed AVG's accumulator, found it changed nothing observable
+/// because the division re-normalized the result, and reverted rather than
+/// ship a half-fix. The two halves land together here.
+///
+/// `rust_decimal` is wrong on each side of the ideal-exponent rule, so the
+/// fixture exercises both from one ledger:
+///
+/// * **Under** — the ungrouped average is `0.00 / 4`, which `rust_decimal`
+///   renders `0` (a zero dividend loses its scale).
+/// * **Over** — the per-account average is `-113.11 / 2`, which
+///   `rust_decimal` renders `-56.5550`, one trailing zero past what the
+///   ideal exponent allows.
+///
+/// Python gives `0.00` and `-56.555`; both were confirmed by running the
+/// arithmetic through `CPython`'s `decimal` rather than reasoned out.
+///
+/// Note this is NOT a compat pin: bean-query has no `avg(decimal)` at all
+/// (`no function matches "avg(decimal)"`), so nothing downstream forces the
+/// choice. It is here so AVG agrees with SUM and with `+` about the same
+/// arithmetic, and so the answer stops depending on addend order.
+#[test]
+fn avg_follows_python_decimal_scale_in_both_directions() {
+    let directives = vec![Directive::Transaction(
+        Transaction::new(date(2024, 1, 2), "one txn, four postings")
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(-111.11), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(111.11), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(-2), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(2), "USD"))),
+    )];
+
+    let render = |sql: &str, row: usize, col: usize| {
+        let mut executor = Executor::new(&directives);
+        let query = parse(sql).unwrap();
+        let result = executor.execute(&query).unwrap();
+        let Value::Number(n) = &result.rows[row][col] else {
+            panic!("expected a Number, got {:?}", result.rows[row][col]);
+        };
+        n.to_string()
+    };
+
+    // Under-padding: the running total passes through `0.00`, so a plain
+    // `+=` would leave `0` here and the division would keep it.
+    assert_eq!(render("SELECT AVG(number)", 0, 0), "0.00");
+
+    // Over-padding: `-113.11 / 2` is exactly `-56.555`. `rust_decimal`'s
+    // division alone yields `-56.5550`.
+    assert_eq!(
+        render("SELECT account, AVG(number) GROUP BY account", 0, 1),
+        "-56.555",
+    );
+}


### PR DESCRIPTION
#2046 fixed AVG's accumulator, found it changed nothing observable because the division re-normalized the result, and reverted rather than ship a half-fix that reads as complete. Both halves land together here.

## The rule

Python defines an **ideal exponent** for division — `exp(a) - exp(b)`, i.e. an ideal *scale* of `scale(a) - scale(b)`. An exact quotient is reduced toward that scale but never below what exactness requires.

`rust_decimal` misses it in **both** directions, which is why padding alone wasn't enough:

| | `rust_decimal` | Python | |
|---|---|---|---|
| `0.00 / 4` | `0` | `0.00` | **under** — the zero shortcut |
| `7 / 2` | `3.50` | `3.5` | **over** — one trailing zero too many |

`checked_div_python_scale` strips the quotient to minimal form, then pads up to the ideal scale. Together those land on Python's answer from either side. An inexact quotient (`1 / 3`) has no trailing zeros to strip and a scale far past the ideal, so both steps are no-ops.

## Observable through AVG, both directions, one ledger

```
SELECT AVG(number)                            0        ->  0.00
SELECT account, AVG(number) GROUP BY account  -56.5550 -> -56.555
```

The second is `-113.11 / 2`, exactly `-56.555`.

## Testing

The **18-case table test takes its expectations from CPython's `decimal` verbatim** rather than deriving them — the ideal-exponent rule is easy to state and easy to get subtly wrong, and hand-derived expectations would encode the same misreading twice. Asserts on `to_string()`, since `==` ignores scale.

**Mutation-checked both halves separately**, because either could coast on the other — reverting the accumulator fails it (`left: "0"`), and so does reverting the division.

Worth flagging: my first division mutation **silently didn't apply**. rustfmt had reflowed the block, so the patch string never matched and the test "passed" — which I'd have misread as "the test can't detect this". A mutation that doesn't mutate reports success. Re-ran it against the core function, where formatting can't interfere, and it fails correctly.

## Also: the `/` operator

Found reviewing this PR's own diff. `BinaryOperator::Div` was still on raw `Decimal::checked_div` while AVG used the new rule — two different answers for the same arithmetic in one engine, the exact half-fix shape this PR exists to close.

And unlike `avg(decimal)`, **`/` does exist in bean-query**, so this was a real compat divergence, in both directions:

| | rledger | bean-query |
|---|---|---|
| `0.00 / 4` | `0` | `0.00` |
| `7 / 2` | `3.50` | `3.5` |

Now byte-identical on `0.00 / 4`, `0.000 / 3`, `7 / 2`, `1.00 / 2` and `1 / 3`, verified against bean-query 3.2.3. Pinned by `the_division_operator_matches_bean_query_scale`, whose expectations come from running bean-query on each case.

## Merge order

This branch's compat run reports two stale masks. **They are not from this PR** — they are main's, stale since #2046 merged, and #2047 removes them. Merge #2047 first, then this rebases clean. (Detail in #2047: PR compat runs use a reduced 2,362-pair corpus while main uses the full 11,441, so a mask going stale outside the reduced set can't surface until after merge.)

## Scope

**Not a compat change.** bean-query has no `avg(decimal)` at all (`no function matches "avg(decimal)"`), so nothing downstream forces this. 2550 corpus pairs: **37 effective before and after, no regressions, no stale masks.** It's here so AVG agrees with SUM and `+` about the same arithmetic, and so the answer stops depending on addend order.

One recorded gap: Python has a signed zero (`-0.00 / 3` is `-0.00`), `rust_decimal` does not. Pinned as a fact rather than left to surprise someone — it's a property of the type, not something this rule introduces.

Independent of #2047 (different crates/paths); both branch from #2046.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
