### PR TITLE
fix(booking): make inferred_tolerance_default actually quantize

### DIFF
--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -234,16 +234,21 @@ fn normalized_parts(quantum: Decimal) -> (u32, i64) {
 fn quantize_to_exponent(value: Decimal, exponent: i64) -> Option<Decimal> {
     if exponent <= 0 {
         let dp = u32::try_from(-exponent).ok()?;
-        // `round_dp` rounds DOWN to at most `dp` places but never pads up, so
-        // a value coarser than the grid came back unchanged: `(-100).round_dp(2)`
-        // is `-100`, not `-100.00`. Python's `quantize` lands the value ON the
-        // grid in both directions, which is what makes
-        // `option "inferred_tolerance_default" "USD:0.01"` observable at all —
-        // without the rescale the option parsed, threaded and reached this
-        // function, then changed nothing.
-        let mut rounded = value.round_dp(dp);
-        rounded.rescale(dp);
-        return Some(rounded);
+        // `rustledger_core::round_dp_python`, not a hand-rolled
+        // `round_dp` + `rescale`. Both differences from `round_dp` matter here
+        // and the canonical carries both:
+        //
+        //   * `round_dp` never pads UP, so a value coarser than the grid came
+        //     back unchanged — `(-100).round_dp(2)` is `-100`, not `-100.00`.
+        //     That is what left `option "inferred_tolerance_default"
+        //     "USD:0.01"` inert: it parsed, threaded, reached this function
+        //     and changed nothing.
+        //   * `round_dp` drops the SIGN when a small negative rounds to zero,
+        //     so a residual of `-0.004` on a 0.01 grid filled `0.00` where
+        //     Python fills `-0.00`. Quantized-to-zero fills are deliberately
+        //     kept (see the zero-residual prune below), so that is visible
+        //     output. Copilot's catch on #2052.
+        return Some(rustledger_core::round_dp_python(value, dp));
     }
     // Rounding to tens or coarser. Only reachable via a tolerance >= 0.5,
     // which needs `infer_tolerance_from_cost` on a high-priced commodity or
@@ -2386,6 +2391,44 @@ mod tests {
         // Without it, no tolerance applies to a scale-0 amount and the fill
         // keeps its natural scale — bean-query agrees here too.
         assert_eq!(fill(&crate::TolerancePolicy::default()), "-100");
+    }
+
+    /// A residual that rounds ONTO zero keeps its sign, as Python does.
+    ///
+    /// The grid lands `-0.004` on zero, and `round_dp` drops the sign there —
+    /// so a hand-rolled `round_dp` + `rescale` filled `0.00` where beancount
+    /// fills `-0.00`. Verified against beancount 3.2.3 on the same ledger.
+    /// Quantized-to-zero fills are deliberately kept (the prune below only
+    /// removes EXACTLY-zero residuals), so this is visible output, not an
+    /// internal detail. Copilot's catch on #2052 — and the reason this path
+    /// calls `rustledger_core::round_dp_python` rather than re-deriving it.
+    #[test]
+    fn a_residual_rounding_onto_zero_keeps_its_sign() {
+        let txn = Transaction::new(rustledger_core::naive_date(2018, 1, 1).unwrap(), "t")
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(100.004), "USD")))
+            .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(-100.000), "USD")))
+            .with_synthesized_posting(Posting::auto("Equity:O"));
+
+        let mut policy = crate::TolerancePolicy::default();
+        policy.defaults.insert("USD".to_string(), dec!(0.01));
+        let result =
+            crate::interpolate_with_tolerances(&txn, &policy.options()).expect("interpolates");
+
+        let filled = result
+            .transaction
+            .postings
+            .iter()
+            .find(|p| p.value.account == "Equity:O")
+            .and_then(|p| p.value.amount())
+            .expect("the elided posting is filled")
+            .number;
+
+        assert_eq!(
+            filled.to_string(),
+            "-0.00",
+            "a negative residual that rounds onto zero must keep its sign",
+        );
     }
 
     #[test]

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -234,7 +234,16 @@ fn normalized_parts(quantum: Decimal) -> (u32, i64) {
 fn quantize_to_exponent(value: Decimal, exponent: i64) -> Option<Decimal> {
     if exponent <= 0 {
         let dp = u32::try_from(-exponent).ok()?;
-        return Some(value.round_dp(dp));
+        // `round_dp` rounds DOWN to at most `dp` places but never pads up, so
+        // a value coarser than the grid came back unchanged: `(-100).round_dp(2)`
+        // is `-100`, not `-100.00`. Python's `quantize` lands the value ON the
+        // grid in both directions, which is what makes
+        // `option "inferred_tolerance_default" "USD:0.01"` observable at all —
+        // without the rescale the option parsed, threaded and reached this
+        // function, then changed nothing.
+        let mut rounded = value.round_dp(dp);
+        rounded.rescale(dp);
+        return Some(rounded);
     }
     // Rounding to tens or coarser. Only reachable via a tolerance >= 0.5,
     // which needs `infer_tolerance_from_cost` on a high-priced commodity or
@@ -2331,6 +2340,54 @@ mod tests {
     /// full decimal position too coarse. The step below is finer than the
     /// tightest grid in play (0.0001) and the range spans several multiples
     /// of the widest (0.01), so exact midpoints are sampled.
+    /// `option "inferred_tolerance_default"` must actually reach the
+    /// interpolated value.
+    ///
+    /// It parsed, threaded into `TolerancePolicy`, reached
+    /// `transaction_tolerances` (which returns `{USD: 0.01}` here) and passed
+    /// every guard in `round_interpolated` — and then changed nothing,
+    /// because `quantize_to_exponent` used `round_dp`, which rounds DOWN to
+    /// at most `dp` places and never pads up. `(-100).round_dp(2)` is `-100`.
+    /// So the whole option was silently inert end to end.
+    ///
+    /// beancount 3.2.3 on this ledger fills `-100.00`; without the option it
+    /// fills `-100`, and both tools agree in that case. Asserts on
+    /// `to_string()` because `Decimal`'s `==` cannot see the scale that is
+    /// the entire subject.
+    #[test]
+    fn an_inferred_tolerance_default_quantizes_the_interpolated_amount() {
+        let txn = Transaction::new(rustledger_core::naive_date(2018, 1, 1).unwrap(), "t")
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(100), "USD")))
+            .with_synthesized_posting(Posting::auto("Equity:O"));
+
+        let fill = |policy: &crate::TolerancePolicy| {
+            let result = crate::interpolate_with_tolerances(&txn, &policy.options())
+                .expect("fixture interpolates");
+            result
+                .transaction
+                .postings
+                .iter()
+                .find(|p| p.value.account == "Equity:O")
+                .and_then(|p| p.value.amount())
+                .expect("the elided posting is filled")
+                .number
+                .to_string()
+        };
+
+        let mut with_default = crate::TolerancePolicy::default();
+        with_default.defaults.insert("USD".to_string(), dec!(0.01));
+        assert_eq!(
+            fill(&with_default),
+            "-100.00",
+            "the option must land the fill on the 0.01 grid",
+        );
+
+        // Without it, no tolerance applies to a scale-0 amount and the fill
+        // keeps its natural scale — bean-query agrees here too.
+        assert_eq!(fill(&crate::TolerancePolicy::default()), "-100");
+    }
+
     #[test]
     fn rounding_error_never_exceeds_tolerance() {
         let quantum = dec!(0.01);

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -97,6 +97,40 @@ EMPTY_RESULT_WARNING_FRACTION = 0.5
 # Use `("path", "*")` to allowlist ALL queries on a file (e.g., when
 # the divergence is in a column projection that every query touches).
 KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
+    # A TOTAL annotation round-trips through a per-unit quotient in beancount
+    # and comes back with 28 digits of division noise; rledger uses the total
+    # the user wrote.
+    #
+    #   Assets:US:ETrade:CashEUR  110.00 EUR @@ 120.00 USD
+    #   Assets:US:BofA:Checking                 <- interpolated
+    #
+    #     py:  -120.0000000000000000000000000
+    #     rs:  -120.00
+    #
+    # beancount divides 120.00 / 110.00 to get a per-unit price
+    # (1.0909...  at context precision), then multiplies back by 110.00. The
+    # product cannot return to 120.00 exactly, so the residue is carried as
+    # trailing digits. rledger balances against the annotated total directly
+    # and lands on the authored value.
+    #
+    # Verified as one mechanism across all three pairs rather than assumed:
+    # `beangrow` and `fava-portfolio-returns` each hold exactly one `@@`, and
+    # `missing_prices` the `{{25.61 GBP, 2017-12-14}}` form of the same thing.
+    # In every case the two tools agree on the VALUE and on `cost_number`
+    # itself — only beancount's re-multiplied total carries the tail.
+    #
+    # Filed under the PYTHON list: the numbers are equal, the user wrote the
+    # total, and reproducing the noise would mean adopting a round-trip we do
+    # not perform. Revisit if beancount stops re-deriving the total.
+    ("tests/compatibility/files/beangrow/example_ledger.beancount", "sum-number-by-currency"),
+    (
+        "tests/compatibility/files/fava-portfolio-returns/example_example.beancount",
+        "sum-number-by-currency",
+    ),
+    (
+        "tests/compatibility/files/beancount-portfolio-alloc/tests_test_inputs_missing_prices.beancount",
+        "sum-number-by-currency",
+    ),
     # bean-query pads the amount INSIDE a cost brace, producing ragged output
     # that its own `Position.__str__` never emits:
     #


### PR DESCRIPTION
Found while checking the three "Python 28-digit noise" pairs. My earlier label for that bucket was half wrong, and the wrong half was the interesting one.

## An rledger bug hiding behind Python's noise

`beancount-portfolio-alloc/tests_test_inputs_missing_prices` carries **two** divergences, not one:

```
py: GBP  -25.61000000000000000000000000     <- genuinely Python's
py: USD -100000.00   rs: USD -100000        <- ours
```

The ledger sets `option "inferred_tolerance_default" "USD:0.01"`. Delete the option and both tools agree, so the option *is* the whole difference.

**It was inert end to end.** Parsed by the loader → threaded into `TolerancePolicy` → reaching `transaction_tolerances`, which returns `{USD: 0.01}` (confirmed by instrumenting) → passing every guard in `round_interpolated` (`digits=1, exp=-2`, both inside limits) → and then `quantize_to_exponent` called `round_dp(dp)`, which rounds **down** to at most `dp` places and never pads up. `(-100).round_dp(2)` is `-100`. The grid was never reached.

One line: rescale after rounding. Same defect as `round_dp_python` in #2050 — `round_dp` needs an explicit rescale to *be* a quantize.

The `exponent > 0` branch (tolerance ≥ 0.5, rounding to tens) is deliberately untouched: it divides, rounds to 0dp, multiplies back, and a negative scale isn't representable, so there's nothing to pad.

## Three Python divergences registered

All three "28-digit" pairs are **one mechanism**, verified rather than assumed: a TOTAL annotation that beancount round-trips through a per-unit quotient and multiplies back.

```
Assets:US:ETrade:CashEUR  110.00 EUR @@ 120.00 USD
Assets:US:BofA:Checking                 <- interpolated

  py:  -120.0000000000000000000000000
  rs:  -120.00
```

beancount divides `120.00 / 110.00` (1.0909… at context precision) then multiplies back by 110.00; the product can't return to 120.00 exactly. rledger balances against the annotated total directly. `beangrow` and `fava-portfolio-returns` each hold exactly one `@@`; `missing_prices` has the `{{25.61 GBP}}` form of the same thing. In every case both tools agree on the value **and** on `cost_number` — only beancount's re-derived total carries the tail.

## No cache bump — checked, not assumed

#2050 needed one because it changed **parse** output. This changes booking. The cache archives the raw parse result and `rustledger_loader::process` books and interpolates after *every* cache load. Verified twice: by reading the call order in `cmd/query/mod.rs`, and by populating a cache with the old binary and watching the new one still produce `-100.00`.

## Verification

**Corpus: 33 → 30 effective (98.82%)**, harness exit 0, no stale masks.

The code fix moves **zero** pairs on its own — which is exactly how it stayed hidden. The only fixture exercising the option also diverges on Python's noise, so the pair was red either way and the inert option was invisible behind it. Pinned by an end-to-end test instead, **mutation-checked**: dropping the rescale fails it with `left: "-100"`.

Full workspace tests, clippy 1.97, doc and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG