### PR TITLE
fix(core): render a naked Decimal with Python's scientific notation

### DIFF
--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -916,7 +916,13 @@ impl DisplayContext {
         const PYTHON_DECIMAL_PRECISION: u32 = 28;
         let capped = Self::cap_significant_digits(number, PYTHON_DECIMAL_PRECISION);
         let formatted = Self::to_scientific_string(capped);
-        if self.render_commas {
+        // No thousands separators on the exponential form. `add_commas`
+        // groups from the right of the integer part, and an exponent has no
+        // decimal point to shield it — `0E-14` came back `0E,-14` and `1E-7`
+        // came back `1,E-7`. A scientific mantissa is one digit before the
+        // point by construction, so there is never a group to insert anyway.
+        // Copilot's catch on #2053.
+        if self.render_commas && !formatted.contains('E') {
             Self::add_commas(&formatted)
         } else {
             formatted
@@ -2143,6 +2149,37 @@ mod custom_directive_precision_tests {
         let mut plain = DisplayContext::new();
         plain.set_fixed_precision("USD", 2);
         assert!(!plain.for_surface(OutputSurface::Human).render_commas());
+    }
+
+    /// `render_commas` must not corrupt the exponential form.
+    ///
+    /// `add_commas` groups from the right of the integer part, and an
+    /// exponent has no decimal point to shield it: `0E-14` became `0E,-14`
+    /// and `1E-7` became `1,E-7`. Only `1.234E-7` survived, because the `.`
+    /// split happened to protect it — which is why this pins the bare-mantissa
+    /// forms specifically.
+    #[test]
+    fn render_commas_leaves_scientific_notation_alone() {
+        use std::str::FromStr;
+
+        let mut ctx = DisplayContext::new();
+        ctx.set_render_commas(true);
+
+        for (input, want) in [
+            ("0E-14", "0E-14"),
+            ("1E-7", "1E-7"),
+            ("-1E-7", "-1E-7"),
+            ("1234E-10", "1.234E-7"),
+        ] {
+            let value = Decimal::from_str(input).expect("parses");
+            assert_eq!(ctx.format_default(value), want, "input {input}");
+        }
+
+        // And commas still apply to the plain form.
+        assert_eq!(
+            ctx.format_default(Decimal::from_str("1234567.89").unwrap()),
+            "1,234,567.89",
+        );
     }
 
     /// `format_default` follows Python's `to-scientific-string`.

--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -915,12 +915,69 @@ impl DisplayContext {
         // fractional digits = 28 total).
         const PYTHON_DECIMAL_PRECISION: u32 = 28;
         let capped = Self::cap_significant_digits(number, PYTHON_DECIMAL_PRECISION);
-        let formatted = capped.to_string();
+        let formatted = Self::to_scientific_string(capped);
         if self.render_commas {
             Self::add_commas(&formatted)
         } else {
             formatted
         }
+    }
+
+    /// Render a `Decimal` the way Python's `Decimal.__str__` does.
+    ///
+    /// The spec's `to-scientific-string` switches to exponential notation
+    /// when the ADJUSTED exponent is below -6, and uses plain notation
+    /// otherwise:
+    ///
+    /// ```text
+    ///   0.000001   adj  -6  ->  0.000001
+    ///   0.0000001  adj  -7  ->  1E-7
+    ///   0E-14      adj -14  ->  0E-14
+    /// ```
+    ///
+    /// `rust_decimal`'s `Display` is always plain, so a naked Decimal column
+    /// diverged from bean-query on anything that far below zero: a zero at
+    /// scale 14 rendered `0.00000000000000` against bean-query's `0E-14`.
+    ///
+    /// The adjusted exponent is `-scale + digits - 1`, and Python counts a
+    /// zero coefficient as one digit — which is why a plain `0` (scale 0)
+    /// stays `0` while `0E-14` goes exponential.
+    ///
+    /// Only the naked-Decimal path uses this. Amount cells keep their
+    /// per-currency rendering, which bean-query also prints plainly.
+    fn to_scientific_string(number: Decimal) -> String {
+        let scale = i64::from(number.scale());
+        let mantissa = number.mantissa().unsigned_abs();
+        let digits = if mantissa == 0 {
+            1
+        } else {
+            i64::from(mantissa.ilog10()) + 1
+        };
+        // Spec: `adjusted = exponent + digits - 1`, with `exponent = -scale`.
+        let adjusted = digits - scale - 1;
+        if adjusted > -7 {
+            return number.to_string();
+        }
+
+        let sign = if number.is_sign_negative() { "-" } else { "" };
+        if mantissa == 0 {
+            // Python prints a zero's exponent as its own exponent.
+            return format!("{sign}0E-{scale}");
+        }
+
+        // Strip trailing zeros into the exponent, then place the decimal
+        // point after the first significant digit.
+        let all = mantissa.to_string();
+        let significant = all.trim_end_matches('0');
+        let trailing = (all.len() - significant.len()) as i64;
+        let exponent = -scale + trailing + (significant.len() as i64 - 1);
+        let coefficient = if significant.len() == 1 {
+            significant.to_string()
+        } else {
+            format!("{}.{}", &significant[..1], &significant[1..])
+        };
+        let exp_sign = if exponent < 0 { "-" } else { "+" };
+        format!("{sign}{coefficient}E{exp_sign}{}", exponent.abs())
     }
 
     /// Round `number` to at most `max_sig` significant digits, matching
@@ -2086,5 +2143,58 @@ mod custom_directive_precision_tests {
         let mut plain = DisplayContext::new();
         plain.set_fixed_precision("USD", 2);
         assert!(!plain.for_surface(OutputSurface::Human).render_commas());
+    }
+
+    /// `format_default` follows Python's `to-scientific-string`.
+    ///
+    /// Expectations produced by running each case through `CPython`'s
+    /// `decimal` (3.13) rather than derived — the switch point is easy to
+    /// state and easy to get off by one. `1E+2` is excluded from the round
+    /// trip because `rust_decimal` cannot hold a positive exponent; every
+    /// other case is a value it can represent.
+    #[test]
+    fn format_default_matches_python_decimal_str() {
+        use std::str::FromStr;
+
+        let ctx = DisplayContext::new();
+        for (input, want) in [
+            ("0E-14", "0E-14"),
+            ("0E-7", "0E-7"),
+            ("0E-6", "0.000000"),
+            ("0", "0"),
+            ("0.00", "0.00"),
+            ("1E-7", "1E-7"),
+            ("0.0000001", "1E-7"),
+            ("0.000001", "0.000001"),
+            ("0.00001", "0.00001"),
+            ("1.5E-9", "1.5E-9"),
+            ("-1E-7", "-1E-7"),
+            ("1234E-10", "1.234E-7"),
+            ("1E-28", "1E-28"),
+            ("0.1", "0.1"),
+            ("123.456", "123.456"),
+        ] {
+            let value = Decimal::from_str(input).expect("parses");
+            assert_eq!(ctx.format_default(value), want, "input {input}");
+        }
+    }
+
+    /// The switch is on the ADJUSTED exponent, not the scale, so a value with
+    /// enough significant digits stays plain even at a deep scale.
+    #[test]
+    fn the_notation_switch_follows_the_adjusted_exponent() {
+        use std::str::FromStr;
+
+        let ctx = DisplayContext::new();
+        // scale 7 but adjusted -1: plain.
+        assert_eq!(
+            ctx.format_default(Decimal::from_str("0.1234567").unwrap()),
+            "0.1234567"
+        );
+        // scale 7, adjusted -7: exponential.
+        assert_eq!(
+            ctx.format_default(Decimal::from_str("0.0000001").unwrap()),
+            "1E-7"
+        );
     }
 }

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -395,6 +395,38 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
 # match percentage (the values are correct — only display scale differs),
 # but tracked as a distinct category so future bookkeeping stays honest.
 KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
+    # `capital_gains_classifier` RECOMPUTES the gain upstream; we reclassify
+    # the posting that was already interpolated.
+    #
+    #   Assets:Brokerage  -100 ORNG {1 USD} @ 1.50 USD
+    #   Assets:Bank        150 USD
+    #   Income:Capital-Gains            <- interpolated to -50
+    #
+    #     py:  USD 0.00        rs:  USD 0
+    #
+    # The values are equal; only the scale differs, and it comes from the
+    # upstream plugin's own arithmetic. `long_short.py` computes
+    # `gain = (cost.number - price.number) * abs(units.number)` — here
+    # `(1 - 1.50) * 100`, where `0.50` carries scale 2 — then REMOVES the
+    # original gains postings and appends new ones holding that product. It
+    # reconciles the product against the interpolated residual only if the
+    # difference exceeds the transaction tolerance, redistributing the excess
+    # proportionally.
+    #
+    # rledger keeps the interpolated number, which is the residual that
+    # actually balances the transaction, and changes only the account. That
+    # is the classifier's stated job, and it cannot drift from the balance
+    # the way a recomputation can — upstream needs the tolerance check
+    # precisely because its product may not equal the residual.
+    #
+    # Filed under the RUST list even though the behavior is deliberate: we
+    # are the side whose output differs from bean-query, and a flattering
+    # label would let a future genuine regression on this pair hide. Revisit
+    # if the plugin stops substituting its own product.
+    (
+        "tests/compatibility/files/reds-plugins/beancount_reds_plugins_capital_gains_classifier_example.long_short.beancount",
+        "sum-number-by-currency",
+    ),
     # Posting ORDER after an elided posting is split across two currencies.
     # On `examples_simple_basic.beancount`:
     #


### PR DESCRIPTION
Closes the last two **actionable** compat pairs. Everything remaining is the documented `rust_decimal` ceiling.

> Stacked on #2052 — review that first; this PR's base will retarget to `main` when it merges.

## The rule

Python's `Decimal.__str__` (the spec's `to-scientific-string`) switches to exponential notation when the **adjusted** exponent is below −6:

| value | adjusted | Python |
|---|---|---|
| `0.000001` | −6 | `0.000001` |
| `0.0000001` | −7 | `1E-7` |
| `0E-14` | −14 | `0E-14` |

`rust_decimal`'s `Display` is always plain, so a naked Decimal column diverged on anything that far below zero — a zero at scale 14 rendered `0.00000000000000` where bean-query gives `0E-14`.

**The rule is not about zeros.** `0.0000001` renders `1E-7` too. The hledger fixture only exposed the zero case, so a fix written to that symptom would have been half a rule. The table test covers both sides of the switch, plus a value with scale 7 but adjusted −1 that stays plain.

Expectations came from running each case through CPython rather than being derived from the spec text. **Mutation-checked**: reverting to `to_string` fails with `left: "0.00000000000000"`.

Only the naked-Decimal path changes — Amount cells keep per-currency rendering, which bean-query also prints plainly.

### How this nearly got missed

On a branch stacked before #2051, the fixture *still* showed the plain form: the #988 currency hint intercepted `SUM(number) GROUP BY currency` before `format_default` ever ran. The fix was correct the whole time and completely invisible. Rebasing onto #2051 made it observable — worth knowing when a change looks like a no-op.

## The last non-ceiling pair, registered

`capital_gains_classifier` **recomputes** the gain upstream rather than reclassifying:

```python
gain = (p.cost.number - p.price.number) * abs(p.units.number)   # (1 - 1.50) * 100
```

`0.50` carries the scale. The plugin then removes the interpolated gains posting and appends its own product, reconciling to the original only when the difference exceeds tolerance.

rledger keeps the interpolated number — the residual that actually balances the transaction — and changes only the account. Values identical; only the scale of upstream's product differs. Filed under `KNOWN_RUST_DIVERGENCES` because **we** are the side differing from bean-query output, so a future genuine regression on that pair can't hide behind a flattering label.

## Result

**Corpus: 30 → 23 effective (99.10%)**, harness exit 0, no stale masks.

**All 23 remaining pairs are `beancount-lazy-plugins` decimal-ceiling cases** — the documented floor. There is no actionable BQL gap left.

Full workspace tests, clippy 1.97, doc and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG