### PR TITLE
fix(plugin): match Python's rounding modes in the valuation plugin

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -770,15 +770,36 @@ fn parse_valuation_amount(value: &MetaValueData) -> Option<(Decimal, String)> {
 }
 
 /// Round up with given precision.
+/// Python `decimal`'s `ROUND_UP`: away from zero, NOT toward +infinity.
+///
+/// The upstream plugin rounds a cash INFLOW with `ROUND_UP` and an OUTFLOW
+/// with `ROUND_DOWN` (`valuation/__init__.py`), so the fund never credits
+/// more units than the cash bought. `ceil`/`floor` agree with Python for
+/// positive values and are exactly INVERTED for negative ones, which is the
+/// outflow path — so an outflow of `-6000/11` rounded to `-545.4545455`
+/// here against beancount's `-545.4545454`.
+///
+/// That one digit is the whole of the "1E-7 residue" this fixture is known
+/// for: beancount's three legs sum to `0.0000001` because of its own
+/// truncation, and rledger's summed to zero. It is not a `rust_decimal`
+/// precision limit — these are ten-digit values.
 fn round_up(value: Decimal, decimals: u32) -> Decimal {
     let scale = Decimal::new(1, decimals);
-    (value / scale).ceil() * scale
+    let scaled = value / scale;
+    // Away from zero.
+    let rounded = if value.is_sign_negative() {
+        scaled.floor()
+    } else {
+        scaled.ceil()
+    };
+    rounded * scale
 }
 
 /// Round down with given precision.
+/// Python `decimal`'s `ROUND_DOWN`: toward zero — see [`round_up`].
 fn round_down(value: Decimal, decimals: u32) -> Decimal {
     let scale = Decimal::new(1, decimals);
-    (value / scale).floor() * scale
+    (value / scale).trunc() * scale
 }
 
 /// Format a decimal number, stripping trailing zeros.
@@ -792,11 +813,16 @@ fn format_decimal(d: Decimal) -> String {
 }
 
 /// Format a decimal with fixed precision (for synthetic amounts).
+/// Render at EXACTLY `decimals` places, matching Python's
+/// `round(Decimal, decimals)`.
+///
+/// This used to `trim_end_matches('0')`, which does the opposite of what its
+/// own comment claimed ("keep at least 7 decimal places") — it stripped every
+/// trailing zero, so an inflow of `1000` emitted `1000` where beancount emits
+/// `1000.0000000`. The values were equal; the scale was not, and the scale is
+/// what the position and its cost render at.
 fn format_decimal_fixed(d: Decimal, decimals: u32) -> String {
-    let scaled = d.round_dp(decimals);
-    let s = format!("{:.1$}", scaled, decimals as usize);
-    // Trim trailing zeros but keep at least 7 decimal places for consistency
-    s.trim_end_matches('0').to_string()
+    format!("{:.1$}", d.round_dp(decimals), decimals as usize)
 }
 
 #[cfg(test)]
@@ -909,20 +935,41 @@ mod tests {
 
     #[test]
     fn test_round_up() {
+        // `ROUND_UP` is AWAY FROM ZERO, not toward +infinity. The two agree on
+        // positives, which is all this test covered while the helper used
+        // `ceil` — so the direction could be wrong for negatives with the
+        // suite green. Reference values from CPython's `decimal`.
         let value = Decimal::new(12_345_678, 8); // 0.12345678
-        let rounded = round_up(value, 7);
-        assert!(rounded >= value);
-        // 0.12345678 rounded up to 7 decimals = 0.1234568
-        assert_eq!(rounded, Decimal::new(1_234_568, 7));
+        assert_eq!(round_up(value, 7), Decimal::new(1_234_568, 7));
+        assert!(round_up(value, 7) >= value, "positives grow");
+
+        let negative = Decimal::new(-12_345_678, 8); // -0.12345678
+        assert_eq!(
+            round_up(negative, 7),
+            Decimal::new(-1_234_568, 7),
+            "away from zero, so a negative gets MORE negative",
+        );
+        // Deliberately not `>= negative`: that assertion encodes the
+        // toward-+infinity reading this helper is not.
+        assert!(round_up(negative, 7).abs() >= negative.abs());
     }
 
     #[test]
     fn test_round_down() {
+        // `ROUND_DOWN` is TOWARD ZERO — see `test_round_up`. This is the
+        // direction the sell path takes, and the one that made the
+        // `cool_fund` close-out differ from beancount in the last digit.
         let value = Decimal::new(12_345_678, 8); // 0.12345678
-        let rounded = round_down(value, 7);
-        assert!(rounded <= value);
-        // 0.12345678 rounded down to 7 decimals = 0.1234567
-        assert_eq!(rounded, Decimal::new(1_234_567, 7));
+        assert_eq!(round_down(value, 7), Decimal::new(1_234_567, 7));
+        assert!(round_down(value, 7) <= value, "positives shrink");
+
+        let negative = Decimal::new(-12_345_678, 8); // -0.12345678
+        assert_eq!(
+            round_down(negative, 7),
+            Decimal::new(-1_234_567, 7),
+            "toward zero, so a negative gets LESS negative",
+        );
+        assert!(round_down(negative, 7).abs() <= negative.abs());
     }
 
     #[test]

--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -933,6 +933,37 @@ mod tests {
         );
     }
 
+    /// `format_decimal_fixed` renders EXACTLY `decimals` places.
+    ///
+    /// It used to `trim_end_matches('0')` — the opposite of its own comment —
+    /// so an inflow of `1000` emitted `1000` where beancount emits
+    /// `1000.0000000`. Asserts the full string, not a prefix or a length:
+    /// the failure mode was a SHORTER rendering of an equal value, which a
+    /// `starts_with` or a parse-and-compare would both accept.
+    #[test]
+    fn format_decimal_fixed_pads_to_exactly_the_requested_places() {
+        assert_eq!(
+            format_decimal_fixed(Decimal::new(1000, 0), 7),
+            "1000.0000000"
+        );
+        assert_eq!(format_decimal_fixed(Decimal::new(0, 0), 7), "0.0000000");
+        // Already at 7dp: unchanged.
+        assert_eq!(
+            format_decimal_fixed(Decimal::new(5_454_545_454, 7), 7),
+            "545.4545454"
+        );
+        // More precision than asked for: rounded to exactly 7.
+        assert_eq!(
+            format_decimal_fixed(Decimal::new(54_545_454_549, 8), 7),
+            "545.4545455"
+        );
+        // Negative keeps its sign and its padding.
+        assert_eq!(
+            format_decimal_fixed(Decimal::new(-1000, 0), 7),
+            "-1000.0000000"
+        );
+    }
+
     #[test]
     fn test_round_up() {
         // `ROUND_UP` is AWAY FROM ZERO, not toward +infinity. The two agree on

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -395,6 +395,59 @@ KNOWN_PYTHON_DIVERGENCES: set[tuple[str, str]] = {
 # match percentage (the values are correct — only display scale differs),
 # but tracked as a distinct category so future bookkeeping stays honest.
 KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
+    # `beancount_lazy_plugins`' valuation plugin leaves a phantom lot behind;
+    # we deliberately do not, per #2018.
+    #
+    # Upstream posts a ROUNDED quantity but accumulates the UNROUNDED one:
+    #
+    #     modified_posting = ... round_down(total_in_mapped_currency, 7) ...
+    #     balances[posting.account] += total_in_mapped_currency   # unrounded
+    #
+    # The two drift by up to 1e-7 per partial sell. On `cool_fund_example`
+    # that makes the final close-out post `-545.4545454` against our
+    # `-545.4545455`, and beancount finishes holding `0.0000001
+    # COOL_FUND_USD` in an account the user emptied.
+    #
+    # Replaying the plugin's own arithmetic in CPython reproduces beancount
+    # exactly, unrounded balance and all — so this is upstream's behavior, not
+    # an accident of anyone's decimal type. It is NOT the `rust_decimal`
+    # ceiling either: these are ten-digit values, and the residue is born from
+    # the rounding policy rather than from precision running out. (The genuine
+    # ceiling case is `tests_data_output_some_fund_output`, a different file.)
+    #
+    # rledger decrements the lot by what it POSTED. That is #2018, closed:
+    # decrementing by the unrounded quotient let our idea of the lot drift
+    # below the balance the ledger shows, and a later full close-out then
+    # posted a short lot and left exactly the kind of residual position seen
+    # here. Matching upstream would reintroduce it.
+    #
+    # Filed under the RUST list because we are the side whose output differs
+    # from bean-query. Pinned per (file, query) rather than with `"*"`: only
+    # 22 of the 51 runs across these three files diverge, and a blanket mask
+    # would swallow a future regression on the other 29. Revisit if upstream
+    # starts accumulating the rounded quantity.
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "balance-running-assets"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "first-balance-by-month"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "journal-assets"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "sum-number-by-currency"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "balance-running-assets"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "balances-by-account"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "first-balance-by-month"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "journal-assets"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "journal-assets-at-cost"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "journal-assets-at-units"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "last-balance-by-month"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "position-by-date"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "prices-from-plugin-by-date"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "sum-position-by-account"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_output_cool_fund_output.beancount", "weight-by-date"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "first-balance-by-month"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "journal-assets"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "journal-assets-at-units"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "last-balance-by-month"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "sum-number-by-currency"),
+    ("tests/compatibility/files/beancount-lazy-plugins/tests_data_some_fund_example.beancount", "sum-position-by-account"),
+
     # `capital_gains_classifier` RECOMPUTES the gain upstream; we reclassify
     # the posting that was already interpolated.
     #

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -423,9 +423,14 @@ KNOWN_RUST_DIVERGENCES: set[tuple[str, str]] = {
     #
     # Filed under the RUST list because we are the side whose output differs
     # from bean-query. Pinned per (file, query) rather than with `"*"`: only
-    # 22 of the 51 runs across these three files diverge, and a blanket mask
-    # would swallow a future regression on the other 29. Revisit if upstream
-    # starts accumulating the rounded quantity.
+    # 21 of the 51 runs across these three files diverge (11 + 6 + 4), and a
+    # blanket mask would swallow a future regression on the other 30. Revisit
+    # if upstream starts accumulating the rounded quantity.
+    #
+    # It was 22 until `output_cool_fund_output`'s `sum-number-by-currency`
+    # started matching: that file is the plugin's captured OUTPUT, so it
+    # carries the residue as literal data and only ever differed in notation,
+    # which #2053 fixed. The stale-mask gate caught the leftover entry.
     ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "balance-running-assets"),
     ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "first-balance-by-month"),
     ("tests/compatibility/files/beancount-lazy-plugins/tests_data_cool_fund_example.beancount", "journal-assets"),


### PR DESCRIPTION
Two bugs in rledger's port of `beancount_lazy_plugins`' valuation plugin, plus registry entries for the part we diverge on deliberately.

**Takes the BQL compat suite to 0 effective mismatches.**

## Bug 1 — the rounding helpers went the wrong way on negatives

```rust
fn round_up(v, d)   { (v / scale).ceil()  * scale }   // toward +∞
fn round_down(v, d) { (v / scale).floor() * scale }   // toward −∞
```

Python's `ROUND_UP` is **away from zero**; `ROUND_DOWN` is **toward zero**. The two readings agree on positives and are exactly inverted on negatives — and both existing tests used only positive values, so the direction could be wrong with the suite green.

Both tests now carry negative cases with CPython reference values. Their old `rounded >= value` / `<= value` assertions are **removed**: those encode the toward-±∞ reading these helpers are not, and would have been false for the negatives. Mutation-checked — restoring `ceil`/`floor` fails both with the exact digits.

## Bug 2 — the formatter did the opposite of its own comment

```rust
// Trim trailing zeros but keep at least 7 decimal places for consistency
s.trim_end_matches('0').to_string()
```

An inflow of `1000` emitted `1000` where beancount emits `1000.0000000`. Values equal, scale not — and the scale is what the position and its cost render at.

## The rest is deliberate — #2018

Upstream posts a **rounded** quantity but accumulates the **unrounded** one:

```python
modified_posting = ... round_down(total_in_mapped_currency, 7) ...
balances[posting.account] += total_in_mapped_currency   # unrounded
```

Replaying that arithmetic in CPython reproduces beancount exactly — including the `0.0000001 COOL_FUND_USD` it is left holding in an account the user emptied. rledger decrements the lot by what it **posted**; that is #2018, closed, and matching upstream would reintroduce the phantom residual that issue was filed for.

**This bucket is not the `rust_decimal` ceiling** — worth stating plainly, because it was repeated as fact for a while (including by me). These are ten-digit values and the residue comes from a rounding policy. The genuine ceiling case is `tests_data_output_some_fund_output`, a different file that already matches.

21 entries, pinned per (file, query) rather than `"*"`: only 21 of the 51 runs across those three files diverge, and a blanket mask would swallow a regression on the other 30.

## Result

```
runs 2550   raw mismatches 170   EFFECTIVE 0   (100.00%)
harness exit 0, no stale masks
```

Full workspace tests, clippy 1.97, doc and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG