### PR TITLE
perf(parser): compute the formatter alignment on demand, not on every parse

### DIFF
--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -200,7 +200,7 @@ pub fn handle_inlay_hints(
             // sits where `rledger format` *would* put the amount, which
             // may differ from where the current explicit amount renders.
             let num_text = amount.number.to_string();
-            let align = parse_result.alignment;
+            let align = parse_result.alignment();
             let field_pad = align.number_col.saturating_sub(end_col_chars).max(2);
             let justify_pad = align.number_width.saturating_sub(num_text.chars().count());
             let gap = field_pad + justify_pad;
@@ -859,7 +859,7 @@ mod tests {
         // Elided `Assets:Cash` is on line 2 (0-indexed).
         assert_eq!(h.position.line, 2);
 
-        let align = result.alignment;
+        let align = result.alignment();
         assert!(align.number_col > 0, "file should have an alignment column");
 
         // The number text must begin at the formatter's right-justified

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -292,7 +292,7 @@ fn fallback_cst_snap_edit(
     let (snap_cst, mut new_text) = if style.groups_anything() {
         format_node_range_grouped(&node, cst_range, style)?
     } else {
-        format_node_range_with_alignment(&node, cst_range, parse_result.alignment)?
+        format_node_range_with_alignment(&node, cst_range, parse_result.alignment())?
     };
 
     // CRLF preservation: `format_node_range` always emits LF (it

--- a/crates/rustledger-parser/fuzz/Cargo.lock
+++ b/crates/rustledger-parser/fuzz/Cargo.lock
@@ -441,6 +441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,12 +759,13 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+checksum = "14b574c58582fa59fa43a2feb6608b8744184659f08a2e0117e4b8224d95ed61"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
+ "memoffset",
  "rustc-hash 1.1.0",
  "text-size",
 ]
@@ -810,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "imbl",
  "jiff",
@@ -825,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "logos",
  "num_enum",

--- a/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
+++ b/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
@@ -70,8 +70,13 @@ fuzz_target!(|data: &[u8]| {
         green.has_leading_bom, red.has_leading_bom,
         "green vs red has_leading_bom diverged"
     );
+    // `alignment()` rather than the field: it is a lazily-computed `OnceLock`
+    // now. Asking here is what this target wants anyway — it must compare the
+    // VALUE the two paths produce, and forcing it on both is the only way to
+    // do that.
     assert_eq!(
-        green.alignment, red.alignment,
+        green.alignment(),
+        red.alignment(),
         "green vs red alignment diverged"
     );
 });

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -353,10 +353,12 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
     // `ParseResult::alignment` rustdoc for the cache contract;
     // the equivalence with a fresh `compute_alignment` call is
     // pinned by `parse_result_alignment_cache::*` (lib.rs tests).
-    let alignment = crate::cst::format::compute_alignment(
-        &source_file,
-        crate::cst::format::GroupingStyle::default(),
-    );
+    // NOT computed here: `compute_alignment` walks the tree through the red
+    // ast accessors, and rowan allocates a `Box<NodeData>` per red node with
+    // no recycling. Doing it eagerly charged every parse for a formatter pass
+    // it usually never reads — 5.7%-12.3% of instructions by workload. See
+    // `ParseResult::alignment`, which computes on first use and caches.
+    let alignment = std::sync::OnceLock::new();
 
     // Capture the green root before we drop `source_file`. `.green()`
     // borrows (`&GreenNodeData`), so promote to an owned `GreenNode`; it is

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -782,7 +782,7 @@ fn format_node_with_style(
     // debug_assert is a redundant no-op in release. External
     // direct callers of this entry point (FFI, future LSP
     // handlers calling `format_node_with_alignment` with a
-    // `parse_result.alignment` cache) get the panic in debug
+    // `parse_result.alignment()` cache) get the panic in debug
     // builds; in release, a wrong-kind `node` produces empty or
     // malformed output rather than panicking — acceptable for
     // a precondition that's guaranteed by the call's typed
@@ -4798,9 +4798,9 @@ mod tests {
         }
     }
 
-    /// The cached `ParseResult::alignment` value matches what
+    /// The cached [`crate::ParseResult::alignment`] value matches what
     /// `format_node` would compute on the parsed tree. End-to-end
-    /// regression: an LSP caller passing `parse_result.alignment`
+    /// regression: an LSP caller passing `parse_result.alignment()`
     /// to `format_node_with_alignment` produces the same output
     /// as the bare `format_node` (uncached path).
     #[test]

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -255,8 +255,8 @@ pub fn format_source_grouped(source: &str, style: GroupingStyle<'_>) -> String {
 ///
 /// In debug builds, panics on a `(parse_result, source)`
 /// length-mismatch via `debug_assert_eq!`. Release builds
-/// silently emit possibly-wrong output (the producer-only
-/// invariant is the caller's responsibility).
+/// silently emit possibly-wrong output (pairing `source` with the
+/// `parse_result` it came from is the caller's responsibility).
 #[must_use]
 pub fn format_source_with_parsed(parse_result: &crate::ParseResult, source: &str) -> String {
     // Parse-error fallback. See the function rustdoc for the
@@ -288,8 +288,7 @@ pub fn format_source_with_parsed(parse_result: &crate::ParseResult, source: &str
         "format_source_with_parsed called with a `source` whose length doesn't \
          match the CST stored in `parse_result`. The two arguments came from \
          different documents — the cache path will emit text for the wrong \
-         buffer. See `ParseResult::alignment` rustdoc for the producer-only \
-         invariant.",
+         buffer.",
     );
     format_node_with_alignment(&node, parse_result.alignment())
 }
@@ -4915,9 +4914,8 @@ mod tests {
     /// Mismatched-pair safety: in debug builds, passing a
     /// length-mismatched `(parse_result, source)` pair panics via
     /// the `debug_assert_eq!`. Release builds silently emit text
-    /// for the wrong buffer (the producer-only invariant is the
-    /// caller's responsibility, documented in
-    /// `ParseResult::alignment`).
+    /// for the wrong buffer — pairing the two arguments is the
+    /// caller's responsibility, per this function's rustdoc.
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "source` whose length doesn't match")]

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -291,7 +291,7 @@ pub fn format_source_with_parsed(parse_result: &crate::ParseResult, source: &str
          buffer. See `ParseResult::alignment` rustdoc for the producer-only \
          invariant.",
     );
-    format_node_with_alignment(&node, parse_result.alignment)
+    format_node_with_alignment(&node, parse_result.alignment())
 }
 
 /// Like [`format_source`], but returns the parse errors instead
@@ -4814,7 +4814,7 @@ mod tests {
         let node = parse_result.syntax_node();
         assert_eq!(
             format_node(&node),
-            format_node_with_alignment(&node, parse_result.alignment),
+            format_node_with_alignment(&node, parse_result.alignment()),
             "ParseResult::alignment must drive identical format output to format_node",
         );
     }

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -1327,7 +1327,7 @@ mod tests {
                     p.plugins.clone(),
                     format!("{:?}", p.warnings),
                     p.has_leading_bom,
-                    p.alignment,
+                    p.alignment(),
                 )
             };
             assert_eq!(

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -367,6 +367,7 @@ impl ParseResult {
     /// `OnceLock`, deliberately, not `OnceCell`: `ParseResult` is shared as
     /// `Arc<ParseResult>` across the LSP's threads and there is a
     /// compile-time assertion below that it stays `Send + Sync`.
+    ///
     /// # Panics
     ///
     /// Panics if `syntax_root` is not a `SOURCE_FILE`, matching
@@ -849,11 +850,12 @@ mod parse_result_alignment_cache {
         assert_eq!(
             result.alignment(),
             fresh,
-            "ParseResult::alignment cache diverged from a fresh \
-             compute_alignment call for {label}: cache = {:?}, fresh = {:?}. \
-             Either parse_via_cst forgot to call compute_alignment, or \
-             compute_alignment's semantics changed without refreshing \
-             the cache in the converter.",
+            "ParseResult::alignment() diverged from a fresh \
+             compute_alignment call for {label}: cached = {:?}, fresh = {:?}. \
+             The accessor and this test must agree on how the alignment is \
+             derived from the tree — most likely the accessor's \
+             `GroupingStyle` no longer matches the one used here, or \
+             compute_alignment's semantics changed.",
             result.alignment(),
             fresh,
         );

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -300,29 +300,23 @@ pub struct ParseResult {
     /// consume the cache to skip both the redundant parse and the
     /// redundant alignment walk.
     ///
-    /// **Producer-only cache invariant.** This field is populated
-    /// exactly once by `parse_via_cst`; the value is consistent with
-    /// the `directives` / `syntax_root` fields *at parse time*.
-    /// `ParseResult` exposes every cache input (`directives`,
-    /// `syntax_root`) as `pub`, so technically a consumer with a
-    /// `&mut ParseResult` can mutate one without refreshing the
-    /// other — leaving `alignment` stale. That is OUT-OF-CONTRACT
-    /// for this cache. Callers that mutate `ParseResult` directly
-    /// must either (a) refresh `alignment` by calling
-    /// `crate::format::compute_alignment(&SourceFile::cast(self.syntax_node()))`,
-    /// (b) avoid the `_with_alignment` formatter variants and use
-    /// the bare ones (which re-compute), or (c) treat the
-    /// `ParseResult` as immutable after construction (the common
-    /// case — the LSP wraps it in `Arc<ParseResult>`).
+    /// **Computed on first ask, then cached.** Nothing populates this at
+    /// parse time any more; the first call to [`ParseResult::alignment`]
+    /// computes it from `syntax_root` and every later call is free. Because
+    /// the value is derived from the tree WHEN ASKED rather than snapshotted
+    /// at parse time, the staleness hazard the old eager field carried — a
+    /// consumer mutating `directives` or `syntax_root` through their `pub`
+    /// handles and leaving a stale alignment behind — only exists if the
+    /// mutation happens after something already forced the cache.
     ///
     /// **Equivalence pinned.**
     /// `parse_result_alignment_cache::*` (7 fixtures) assert that
-    /// `parse(s).alignment` equals
+    /// `parse(s).alignment()` equals
     /// `compute_alignment(&SourceFile::cast(parse(s).syntax_node()).unwrap())`
-    /// across representative fixtures, so any future divergence
-    /// (a converter change that forgets to refresh the cache, a
-    /// `compute_alignment` change that breaks the contract)
-    /// fails CI.
+    /// across representative fixtures, so a `compute_alignment` change that
+    /// breaks the contract fails CI. `parse_leaves_the_alignment_uncomputed_until_asked`
+    /// separately pins that parsing does not force it — the value is the same
+    /// either way, so nothing else would notice the cost coming back.
     ///
     /// **Canonical-payload exclusion.** Excluded from
     /// [`__baseline_canonical_payload`] for the same reason as
@@ -373,19 +367,25 @@ impl ParseResult {
     /// `OnceLock`, deliberately, not `OnceCell`: `ParseResult` is shared as
     /// `Arc<ParseResult>` across the LSP's threads and there is a
     /// compile-time assertion below that it stays `Send + Sync`.
+    /// # Panics
+    ///
+    /// Panics if `syntax_root` is not a `SOURCE_FILE`, matching
+    /// [`crate::format::format_node_grouped`]. It always is — `parse_via_cst`
+    /// builds the root — and the alternative considered here, falling back to
+    /// `PostingAlignment::default()`, is worse than a panic: it would format
+    /// the whole file to the wrong columns while looking like it worked.
     #[must_use]
     pub fn alignment(&self) -> crate::format::PostingAlignment {
         *self.alignment.get_or_init(|| {
             use crate::cst::ast::AstNode as _;
-            let node = self.syntax_node();
-            crate::cst::ast::SourceFile::cast(node).map_or_else(
-                crate::format::PostingAlignment::default,
-                |sf| {
-                    crate::cst::format::compute_alignment(
-                        &sf,
-                        crate::cst::format::GroupingStyle::default(),
-                    )
-                },
+            // Precondition as in `format_node_grouped`, which panics on the
+            // same breach rather than guessing an alignment.
+            #[allow(clippy::expect_used)]
+            let source_file = crate::cst::ast::SourceFile::cast(self.syntax_node())
+                .expect("ParseResult::syntax_root is always a SOURCE_FILE");
+            crate::cst::format::compute_alignment(
+                &source_file,
+                crate::cst::format::GroupingStyle::default(),
             )
         })
     }

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -333,7 +333,8 @@ pub struct ParseResult {
     /// non-default alignment (i.e. essentially every real
     /// Beancount file). The exclusion is pinned by
     /// `canonical_payload_excludes_alignment`.
-    pub alignment: crate::format::PostingAlignment,
+    /// Lazily computed; see [`ParseResult::alignment`].
+    alignment: std::sync::OnceLock<crate::format::PostingAlignment>,
 }
 
 impl ParseResult {
@@ -349,6 +350,44 @@ impl ParseResult {
     #[must_use]
     pub fn syntax_node(&self) -> SyntaxNode {
         SyntaxNode::new_root(self.syntax_root.clone())
+    }
+
+    /// File-wide alignment columns the formatter would use, computed on
+    /// first call and cached.
+    ///
+    /// This used to be computed eagerly by every parse and stored as a
+    /// public field. `compute_alignment` walks the tree through the RED ast
+    /// accessors (`Posting::flag`, `Amount::is_arithmetic`, ...), and rowan
+    /// allocates a `Box<NodeData>` per red node with no recycling — so every
+    /// caller paid a full formatter pass whether or not it ever formatted
+    /// anything. Measured by ablation, it was 5.7%-12.3% of ALL instructions
+    /// depending on workload, and ~34% of the process's allocations.
+    ///
+    /// Only the formatter reads it (`format_source_with_parsed`, and through
+    /// it the LSP, `rledger format` and `doctor roundtrip`), so it is now
+    /// paid for by those callers alone. The caching contract they relied on
+    /// is unchanged: the first call computes, every later call is free, and
+    /// the value equals a fresh `compute_alignment` on the same tree — which
+    /// is what `parse_result_alignment_cache::*` pins.
+    ///
+    /// `OnceLock`, deliberately, not `OnceCell`: `ParseResult` is shared as
+    /// `Arc<ParseResult>` across the LSP's threads and there is a
+    /// compile-time assertion below that it stays `Send + Sync`.
+    #[must_use]
+    pub fn alignment(&self) -> crate::format::PostingAlignment {
+        *self.alignment.get_or_init(|| {
+            use crate::cst::ast::AstNode as _;
+            let node = self.syntax_node();
+            crate::cst::ast::SourceFile::cast(node).map_or_else(
+                crate::format::PostingAlignment::default,
+                |sf| {
+                    crate::cst::format::compute_alignment(
+                        &sf,
+                        crate::cst::format::GroupingStyle::default(),
+                    )
+                },
+            )
+        })
     }
 }
 
@@ -707,6 +746,49 @@ mod canonical_payload_excludes_alignment {
     use super::{__baseline_canonical_payload, parse};
     use crate::cst::format::PostingAlignment;
 
+    /// `parse` must NOT compute the alignment.
+    ///
+    /// This is the whole point of the change and nothing else asserts it: the
+    /// value is identical either way, so an eager computation would be
+    /// invisible to every other test while costing 7.6%-12.4% of the
+    /// program's instructions depending on workload.
+    ///
+    /// Checks the cache is empty after `parse`, that asking fills it, and
+    /// that the answer still equals a fresh `compute_alignment` on the same
+    /// tree.
+    #[test]
+    fn parse_leaves_the_alignment_uncomputed_until_asked() {
+        use crate::cst::ast::AstNode as _;
+
+        let src = "\
+2024-01-15 * \"Coffee\"
+  Assets:Bank  -5.00 USD
+  Expenses:Food
+";
+        let parsed = parse(src);
+        assert!(
+            parsed.alignment.get().is_none(),
+            "parse computed the alignment eagerly — that is the cost this \
+             change removed, and it is invisible in output because the value \
+             is the same either way",
+        );
+
+        let asked = parsed.alignment();
+        assert!(
+            parsed.alignment.get().is_some(),
+            "asking must populate the cache",
+        );
+
+        let fresh = crate::cst::format::compute_alignment(
+            &crate::cst::ast::SourceFile::cast(parsed.syntax_node()).expect("root casts"),
+            crate::cst::format::GroupingStyle::default(),
+        );
+        assert_eq!(
+            asked, fresh,
+            "the lazily-computed value must equal a fresh computation",
+        );
+    }
+
     #[test]
     fn mutating_alignment_does_not_change_canonical_payload() {
         let src = "\
@@ -715,14 +797,22 @@ mod canonical_payload_excludes_alignment {
   Expenses:Food
 ";
         let parsed = parse(src);
-        let mut mutated = parse(src);
+        let mutated = parse(src);
         // Synthesize a different PostingAlignment value: bump number_col
         // by 100. Real-world alignment would never be this wide
         // for the fixture, so we get a guaranteed-different cache.
-        mutated.alignment = PostingAlignment {
-            number_col: parsed.alignment.number_col + 100,
-            number_width: parsed.alignment.number_width + 7,
-        };
+        //
+        // `set` rather than assignment now that the cache is a `OnceLock`.
+        // It succeeds precisely because `parse` no longer fills it — which is
+        // the point of this change, so a failure here would mean the eager
+        // computation came back.
+        mutated
+            .alignment
+            .set(PostingAlignment {
+                number_col: parsed.alignment().number_col + 100,
+                number_width: parsed.alignment().number_width + 7,
+            })
+            .expect("parse must leave the alignment cache empty");
 
         let payload_original = __baseline_canonical_payload(&parsed);
         let payload_mutated = __baseline_canonical_payload(&mutated);
@@ -757,13 +847,15 @@ mod parse_result_alignment_cache {
             .expect("ParseResult::syntax_node() must be a SOURCE_FILE");
         let fresh = compute_alignment(&source_file, crate::cst::format::GroupingStyle::default());
         assert_eq!(
-            result.alignment, fresh,
+            result.alignment(),
+            fresh,
             "ParseResult::alignment cache diverged from a fresh \
              compute_alignment call for {label}: cache = {:?}, fresh = {:?}. \
              Either parse_via_cst forgot to call compute_alignment, or \
              compute_alignment's semantics changed without refreshing \
              the cache in the converter.",
-            result.alignment, fresh,
+            result.alignment(),
+            fresh,
         );
     }
 

--- a/crates/rustledger-parser/tests/green_red_properties.rs
+++ b/crates/rustledger-parser/tests/green_red_properties.rs
@@ -268,7 +268,7 @@ fn observables(r: &rustledger_parser::ParseResult) -> Vec<(&'static str, String)
         ("plugins", format!("{:?}", r.plugins)),
         ("warnings", format!("{:?}", r.warnings)),
         ("has_leading_bom", format!("{:?}", r.has_leading_bom)),
-        ("alignment", format!("{:?}", r.alignment)),
+        ("alignment", format!("{:?}", r.alignment())),
     ]
 }
 


### PR DESCRIPTION
**7.6%–12.4% fewer instructions depending on workload**, by not doing work most callers never read.

## The waste

`parse_via_cst_inner` computed `compute_alignment` eagerly into `ParseResult.alignment`. That walk goes through the **red** ast accessors (`Posting::flag`, `Amount::is_arithmetic`, …), and rowan allocates a `Box<NodeData>` per red node **with no recycling**. Every `rledger check`, every LSP diagnostic pass and every `load` paid for a full formatter pass whether or not it ever formatted anything.

dhat on `simple` shows the scale:

| | blocks | share |
|---|---|---|
| **RED `Box<NodeData>`** | 50,325 | **34.2% of all allocations** |
| GREEN node | 40,053 | |

The derived view cost more allocations than the green tree it derives from.

## The change

Only the formatter reads it — `format_source_with_parsed`, and through it LSP formatting, range-formatting and inlay hints, plus `doctor roundtrip`. The field becomes a `OnceLock` behind `ParseResult::alignment()`, so those callers pay and nobody else does. Their caching contract is unchanged: first call computes, later calls are free, and the value still equals a fresh `compute_alignment` — which `parse_result_alignment_cache::*` pins.

`OnceLock`, not `OnceCell`: `ParseResult` is shared as `Arc<ParseResult>` across the LSP's threads, and a compile-time assertion in that file requires `Send + Sync`.

## Measured — 2000 transactions per shape

| workload | main | lazy | |
|---|---|---|---|
| **simple** | 118,186,605 | 103,592,947 | **−12.35%** |
| multicurrency | 173,907,155 | 158,761,387 | −8.71% |
| tagged | 184,579,083 | 169,001,365 | −8.44% |
| investment | 207,113,683 | 191,351,889 | −7.61% |

Wall clock, `rledger check --no-cache`, 10k transactions, hyperfine 12 runs:

| | main | lazy | |
|---|---|---|---|
| simple | 132.5 ms | 121.2 ms | **1.09×** |
| investment | 414.7 ms | 395.4 ms | 1.05× |

Both binaries rebuilt from their current HEADs. Worth stating: the first run of that comparison reported **1.23×** against a main binary that predated #2056 by forty minutes — the win looked twice as large as it is.

## The test that matters

A new test pins the **laziness itself**. Nothing else can: the value is identical either way, so a reintroduced eager computation would be invisible to every other test while costing 7.6–12.4% of the program. Mutation-checked by restoring the eager call.

## How it was found

Three plausible explanations came first and **all were wrong**:

- the guarded `extract_*` passes — `simple` triggers none of them and still allocates 50k red nodes;
- top-level red iteration — the green fast path succeeds **1999/2000**;
- `fixup_directive_spans` — its `find` short-circuits at the first non-trivia token.

Only the dhat stacks named the real caller, and an ablation confirmed the size before any code was written. This is the first change in the series that #2055's workloads did *not* need to reveal — but they did size it correctly across shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG