### PR TITLE
perf(parser): fold the node shape rules into the green walk

### DIFF
--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -109,9 +109,17 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
         top_level_comments,
         currency_occurrences,
         account_occurrences,
+        cost_brace_errors,
+        link_meta_errors,
+        custom_pushmeta_errors,
     } = if use_green {
         // Green-tree walk (no per-node red allocation); byte-identical to red.
-        super::green::walk_descendants(source_file.syntax(), bom_offset, collect_occurrences)
+        super::green::walk_descendants(
+            source_file.syntax(),
+            stripped,
+            bom_offset,
+            collect_occurrences,
+        )
     } else {
         walk_descendants_once(&source_file, bom_offset, collect_occurrences)
     };
@@ -137,32 +145,46 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
     comments.sort_by_key(|s| s.span.start);
     comments.dedup_by_key(|s| s.span.start);
     let mut errors = top_level_errors;
-    // Cost specs are always delimited by '{' (L_BRACE / L_DOUBLE_BRACE /
-    // L_BRACE_HASH all start with it). If the source has no '{' at all there can
-    // be no COST_SPEC node, so skip the whole-tree `descendants()` scan inside
-    // `extract_unclosed_cost_brace_errors` — it allocates a red `SyntaxNode` per
-    // node. Profiling flagged that scan as ~50k wasted allocations on
-    // cost-spec-free ledgers (the common case); the `contains('{')` guard is a
-    // memchr byte scan with no allocation. A '{' inside a string/comment only
-    // costs the (already-correct) full scan — never a false skip.
-    if stripped.contains('{') {
-        errors.extend(extract_unclosed_cost_brace_errors(
-            &source_file,
-            stripped,
-            bom_offset,
-        ));
-    }
-    // Same guard trick as above: no '^' in the source means no LINK token can
-    // exist, so the whole-tree scan is skipped on the common case.
-    if stripped.contains('^') {
-        errors.extend(extract_link_metadata_value_errors(&source_file, bom_offset));
-    }
-    // Ditto for the custom/pushmeta rules, which also care about '#'.
-    if stripped.contains('^') || stripped.contains('#') {
-        errors.extend(extract_custom_pushmeta_taglink_errors(
-            &source_file,
-            bom_offset,
-        ));
+    // Three per-node shape rules — unclosed cost braces, links as metadata
+    // values, tags/links as custom/pushmeta values — in a FIXED order that
+    // both paths below reproduce.
+    //
+    // Green folds them into `walk_descendants`, which already visits every
+    // node, so they cost a `match` per node and nothing else. Red still runs
+    // them as three standalone whole-tree `descendants()` scans, each behind a
+    // byte-scan guard (`contains('{')` and friends) that skips the scan when
+    // the source cannot contain the construct at all.
+    //
+    // The guards are what made this cost invisible for so long: they are free
+    // on a ledger with no '{', '^' or '#', which is exactly the `simple`
+    // profiling shape. Real ledgers have tags and cost specs, and there the
+    // three red scans measured 7.46% of all instructions on `tagged` and
+    // 2.15% on `investment` (cachegrind ablation, 10k txns). Green — the path
+    // every caller but the parity test takes — no longer pays any of it.
+    //
+    // The green path needs no guards: no '{' in the source means the parser
+    // built no COST_SPEC node, so the folded rule finds nothing to report.
+    if use_green {
+        errors.extend(cost_brace_errors);
+        errors.extend(link_meta_errors);
+        errors.extend(custom_pushmeta_errors);
+    } else {
+        if stripped.contains('{') {
+            errors.extend(extract_unclosed_cost_brace_errors(
+                &source_file,
+                stripped,
+                bom_offset,
+            ));
+        }
+        if stripped.contains('^') {
+            errors.extend(extract_link_metadata_value_errors(&source_file, bom_offset));
+        }
+        if stripped.contains('^') || stripped.contains('#') {
+            errors.extend(extract_custom_pushmeta_taglink_errors(
+                &source_file,
+                bom_offset,
+            ));
+        }
     }
     errors.extend(inline_errors);
     let warnings = Vec::new();
@@ -3112,6 +3134,23 @@ pub(super) struct DescendantsWalkResult {
     pub(super) top_level_comments: Vec<Spanned<String>>,
     pub(super) currency_occurrences: Vec<Spanned<Currency>>,
     pub(super) account_occurrences: Vec<Spanned<rustledger_core::Account>>,
+    /// The three per-node shape rules, kept in SEPARATE vecs rather than
+    /// merged into `inline_errors`.
+    ///
+    /// Two reasons. They are emitted at a different point in the error order
+    /// than the inline errors (see `parse_via_cst_inner`), and each vec stays
+    /// grouped the way its former standalone pass emitted it — document order
+    /// within a rule, rules in a fixed sequence. Merging them would interleave
+    /// the three by position, which no test pins today but which is
+    /// observable in every diagnostic list rledger prints.
+    ///
+    /// Populated only by the GREEN walker. The red walker leaves them empty
+    /// and `parse_via_cst_inner` calls the standalone `extract_*` functions
+    /// for that path instead — see the call site for why the fold is
+    /// green-only.
+    pub(super) cost_brace_errors: Vec<crate::ParseError>,
+    pub(super) link_meta_errors: Vec<crate::ParseError>,
+    pub(super) custom_pushmeta_errors: Vec<crate::ParseError>,
 }
 
 /// Fused single-pass visitor over `source_file`'s descendants -
@@ -3252,6 +3291,15 @@ fn walk_descendants_once(
         top_level_comments,
         currency_occurrences,
         account_occurrences,
+        // Red keeps the three shape rules as standalone `extract_*` passes;
+        // `parse_via_cst_inner` calls them for this path. Folding them in here
+        // too would need each token's IMMEDIATE parent kind, and this walk is
+        // a flat `descendants_with_tokens()` — recovering the parent means
+        // `t.parent()`, which allocates the very red `NodeData` the green fold
+        // exists to avoid.
+        cost_brace_errors: Vec::new(),
+        link_meta_errors: Vec::new(),
+        custom_pushmeta_errors: Vec::new(),
     }
 }
 

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -534,11 +534,14 @@ pub(super) fn convert_transaction(
 /// structurally), so the recursion can't blow the stack on adversarial input.
 pub(super) fn walk_descendants(
     root: &crate::SyntaxNode,
+    stripped: &str,
     bom_offset: u32,
     collect_occurrences: bool,
 ) -> DescendantsWalkResult {
     let mut w = DescendantsWalker {
         offset: bom_offset as usize,
+        bom_offset: bom_offset as usize,
+        stripped,
         preceded_by_ws: false,
         collect_occurrences,
         result: DescendantsWalkResult {
@@ -546,20 +549,31 @@ pub(super) fn walk_descendants(
             top_level_comments: Vec::new(),
             currency_occurrences: Vec::new(),
             account_occurrences: Vec::new(),
+            cost_brace_errors: Vec::new(),
+            link_meta_errors: Vec::new(),
+            custom_pushmeta_errors: Vec::new(),
         },
     };
     w.walk(root.green(), false);
     w.result
 }
 
-struct DescendantsWalker {
+struct DescendantsWalker<'a> {
     offset: usize,
+    /// `offset` starts at `bom_offset`, so subtracting this back out gives an
+    /// offset into `stripped` — which is what indexes `stripped` and what the
+    /// red passes hand to `first_cost_spec_defect` (the CST is built from
+    /// `stripped`, so red's `text_range()` is already stripped-relative).
+    bom_offset: usize,
+    /// Needed only to render a cost-spec defect message from the offending
+    /// source text, as `extract_unclosed_cost_brace_errors` does.
+    stripped: &'a str,
     preceded_by_ws: bool,
     collect_occurrences: bool,
     result: DescendantsWalkResult,
 }
 
-impl DescendantsWalker {
+impl DescendantsWalker<'_> {
     fn walk(&mut self, node: &rowan::GreenNodeData, in_error_node: bool) {
         use crate::SyntaxKind as K;
         for child in node.children() {
@@ -571,6 +585,10 @@ impl DescendantsWalker {
                     if super::ast::Directive::can_cast(kind) {
                         self.preceded_by_ws = false;
                     }
+                    // Before recursing: `self.offset` is `n`'s start byte, which is
+                    // what the per-node shape rules need. They only read `n`'s
+                    // IMMEDIATE children, so they cannot disturb the walk.
+                    self.node_shape_errors(n, kind);
                     self.walk(n, in_error_node || kind == K::ERROR_NODE);
                 }
                 NodeOrToken::Token(t) => {
@@ -581,6 +599,163 @@ impl DescendantsWalker {
                     self.token(kind, t.text(), start, len, in_error_node);
                 }
             }
+        }
+    }
+
+    /// The three per-node shape rules that used to be three SEPARATE
+    /// whole-tree red `descendants()` walks in `convert.rs`
+    /// (`extract_unclosed_cost_brace_errors`,
+    /// `extract_link_metadata_value_errors`,
+    /// `extract_custom_pushmeta_taglink_errors`).
+    ///
+    /// Each of those allocated a red `Box<NodeData>` per node visited, with no
+    /// recycling. Each carried a `stripped.contains(..)` byte-scan guard, so
+    /// they were free on a ledger with no `{`, `^` or `#` — but a `#` appears
+    /// in any tagged ledger and a `{` in any investment one, so real files paid
+    /// all three. Measured by ablation (cachegrind, 10k txns): 7.46% of ALL
+    /// instructions on the `tagged` workload shape and 2.15% on `investment`,
+    /// against 0.57% on `simple` — which is why an earlier profiling pass that
+    /// only looked at `simple` concluded these were not a hotspot.
+    ///
+    /// Folded in here they cost one `match` per node on a walk that already
+    /// visits every node, and the guards are gone: no `{` in the source means
+    /// the parser built no `COST_SPEC` node, so the rule finds nothing anyway.
+    ///
+    /// `self.offset` MUST be `node`'s start byte when this is called.
+    fn node_shape_errors(&mut self, node: &rowan::GreenNodeData, kind: crate::SyntaxKind) {
+        use crate::SyntaxKind as K;
+        match kind {
+            K::META_ENTRY => self.link_metadata_value_errors(node),
+            K::CUSTOM_DIRECTIVE => self.taglink_value_errors(node, true, "custom"),
+            K::PUSHMETA_DIRECTIVE => self.taglink_value_errors(node, false, "pushmeta"),
+            K::COST_SPEC => self.cost_spec_errors(node),
+            _ => {}
+        }
+    }
+
+    /// `node`'s immediate child tokens as `(kind, text, start, end)`, in
+    /// absolute (BOM-adjusted) byte offsets.
+    ///
+    /// The running offset advances over child NODES as well as tokens —
+    /// skipping their `text_len` would silently shift every span after the
+    /// first nested node.
+    fn child_tokens(
+        node: &rowan::GreenNodeData,
+        start: usize,
+    ) -> impl Iterator<Item = (crate::SyntaxKind, &str, usize, usize)> {
+        let mut offset = start;
+        node.children().filter_map(move |child| match child {
+            NodeOrToken::Node(n) => {
+                offset += usize::from(n.text_len());
+                None
+            }
+            NodeOrToken::Token(t) => {
+                let tok_start = offset;
+                offset += usize::from(t.text_len());
+                Some((
+                    crate::BeancountLanguage::kind_from_raw(t.kind()),
+                    t.text(),
+                    tok_start,
+                    offset,
+                ))
+            }
+        })
+    }
+
+    /// A link is not a valid metadata VALUE; beancount takes a tag here but
+    /// not a link. Mirrors `extract_link_metadata_value_errors`.
+    fn link_metadata_value_errors(&mut self, node: &rowan::GreenNodeData) {
+        for (kind, text, start, end) in Self::child_tokens(node, self.offset) {
+            if kind != crate::SyntaxKind::LINK {
+                continue;
+            }
+            self.result.link_meta_errors.push(crate::ParseError::new(
+                crate::ParseErrorKind::SyntaxError(format!(
+                    "a link ({text}) is not a valid metadata value; beancount \
+                     accepts a tag here but not a link",
+                )),
+                Span::new(start, end),
+            ));
+        }
+    }
+
+    /// Tags and links are not valid `custom` or `pushmeta` values (#1958), by
+    /// two DIFFERENT rules: `pushmeta` follows the metadata rule and rejects
+    /// only a link, `custom` rejects both. Mirrors
+    /// `extract_custom_pushmeta_taglink_errors` — see its rustdoc for why the
+    /// check cannot live in the shared `value_tokens_to_meta`.
+    fn taglink_value_errors(&mut self, node: &rowan::GreenNodeData, reject_tag: bool, what: &str) {
+        use crate::SyntaxKind as K;
+        for (kind, text, start, end) in Self::child_tokens(node, self.offset) {
+            let bad = match kind {
+                K::LINK => true,
+                K::TAG => reject_tag,
+                _ => false,
+            };
+            if !bad {
+                continue;
+            }
+            let noun = if kind == K::TAG { "tag" } else { "link" };
+            self.result
+                .custom_pushmeta_errors
+                .push(crate::ParseError::new(
+                    crate::ParseErrorKind::SyntaxError(format!(
+                        "a {noun} ({text}) is not a valid {what} value",
+                    )),
+                    Span::new(start, end),
+                ));
+        }
+    }
+
+    /// An opener with no closer, then the component-list shape rules.
+    /// Mirrors `extract_unclosed_cost_brace_errors`, including its ordering:
+    /// an unclosed spec reports ONLY the truncation, because a shape defect on
+    /// top of it would just be noise about the same truncation.
+    fn cost_spec_errors(&mut self, node: &rowan::GreenNodeData) {
+        use crate::SyntaxKind as K;
+        let mut has_opener = false;
+        let mut has_closer = false;
+        for (kind, _, _, _) in Self::child_tokens(node, self.offset) {
+            match kind {
+                K::L_BRACE | K::L_DOUBLE_BRACE | K::L_BRACE_HASH => has_opener = true,
+                K::R_BRACE | K::R_DOUBLE_BRACE => has_closer = true,
+                _ => {}
+            }
+        }
+        if has_opener && !has_closer {
+            let end = self.offset + usize::from(node.text_len());
+            self.result.cost_brace_errors.push(crate::ParseError::new(
+                crate::ParseErrorKind::SyntaxError(
+                    "unclosed cost specification: missing '}'".to_string(),
+                ),
+                Span::new(self.offset, end),
+            ));
+            return;
+        }
+
+        // `first_cost_spec_defect` is generic over the range payload and is
+        // THE shared rule — the red pass calls the same function, so the two
+        // paths cannot drift on what counts as a defect.
+        //
+        // Ranges here are stripped-relative (BOM subtracted back out): they
+        // index `stripped` below, exactly as red's `text_range()` does.
+        let bom = self.bom_offset;
+        let tokens = Self::child_tokens(node, self.offset)
+            .map(|(kind, _, start, end)| (kind, (start - bom)..(end - bom)));
+        if let Some((defect, range)) = super::cost_spec_shape::first_cost_spec_defect(tokens) {
+            // `get` rather than indexing: a non-char-boundary range must not
+            // panic the parser.
+            let message = match self.stripped.get(range.clone()) {
+                Some(text) => super::cost_spec_shape::cost_defect_message(defect, text),
+                None => format!(
+                    "malformed cost specification at bytes {}..{} ({defect:?})",
+                    range.start, range.end
+                ),
+            };
+            self.result.cost_brace_errors.push(crate::ParseError::new(
+                crate::ParseErrorKind::SyntaxError(message),
+                Span::new(range.start + bom, range.end + bom),
+            ));
         }
     }
 
@@ -1407,5 +1582,54 @@ mod negative_zero_tests {
             })
             .expect("one posting");
         assert_eq!(number.to_string(), "-12.34");
+    }
+}
+
+#[cfg(test)]
+mod child_tokens_offsets {
+    use super::DescendantsWalker;
+    use crate::SyntaxKind as K;
+    use rowan::{GreenNodeBuilder, Language as _};
+
+    /// `child_tokens` must advance its running offset over child NODES, not
+    /// just child tokens.
+    ///
+    /// Pinned on a hand-built green node because the real grammar cannot
+    /// currently produce one: `COST_SPEC`, `META_ENTRY`, `CUSTOM_DIRECTIVE`
+    /// and `PUSHMETA_DIRECTIVE` all have token-only children today — even a
+    /// parenthesized arithmetic cost component stays flat. So no source
+    /// fixture can reach this, and dropping the `n.text_len()` accumulation
+    /// passes the entire suite while silently shifting every span after the
+    /// first nested node. A grammar change that starts nesting here would
+    /// otherwise land the corruption with no test to catch it.
+    #[test]
+    fn a_child_node_advances_the_offset_for_later_tokens() {
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(crate::BeancountLanguage::kind_to_raw(K::COST_SPEC));
+        b.token(crate::BeancountLanguage::kind_to_raw(K::L_BRACE), "{");
+        // A nested node holding 7 bytes — the case the real grammar doesn't
+        // build today.
+        b.start_node(crate::BeancountLanguage::kind_to_raw(K::AMOUNT));
+        b.token(crate::BeancountLanguage::kind_to_raw(K::NUMBER), "100");
+        b.token(crate::BeancountLanguage::kind_to_raw(K::WHITESPACE), " ");
+        b.token(crate::BeancountLanguage::kind_to_raw(K::CURRENCY), "USD");
+        b.finish_node();
+        b.token(crate::BeancountLanguage::kind_to_raw(K::R_BRACE), "}");
+        b.finish_node();
+        let node = b.finish();
+
+        let got: Vec<_> = DescendantsWalker::child_tokens(&node, 0)
+            .map(|(kind, text, start, end)| (kind, text.to_string(), start, end))
+            .collect();
+
+        assert_eq!(
+            got,
+            vec![
+                (K::L_BRACE, "{".to_string(), 0, 1),
+                // 1 + 7 nested bytes = 8, NOT 1.
+                (K::R_BRACE, "}".to_string(), 8, 9),
+            ],
+            "the child AMOUNT node's 7 bytes must be counted",
+        );
     }
 }

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -588,6 +588,13 @@ impl DescendantsWalker<'_> {
                     // Before recursing: `self.offset` is `n`'s start byte, which is
                     // what the per-node shape rules need. They only read `n`'s
                     // IMMEDIATE children, so they cannot disturb the walk.
+                    //
+                    // NOT gated on `collect_occurrences`. That flag drops the
+                    // rename/references indices the LSP alone reads, and
+                    // `parse_without_occurrences` promises a result identical to
+                    // `parse`'s in every other respect — errors included. Gating
+                    // these here would silently strip diagnostics from the loader
+                    // and CLI, which take that path.
                     self.node_shape_errors(n, kind);
                     self.walk(n, in_error_node || kind == K::ERROR_NODE);
                 }

--- a/crates/rustledger-parser/tests/green_red_properties.proptest-regressions
+++ b/crates/rustledger-parser/tests/green_red_properties.proptest-regressions
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc e1ba4252b62b47395e83081c579c6fab5b34d28af694c2f279b2c94012a53342 # shrinks to source = "2024-01-01 * \"narration\"\n  Assets:Bank 1 USD {{1 USD}}\n"
-cc 6851060e30b6067d1314b381d2ad0e9aaead8a230e6bfbbc87f72db3801f5ebd # shrinks to source = "2024-01-01 * \"narration\"\n  Assets:Bank 1 USD {{1 USD}}\n"

--- a/crates/rustledger-parser/tests/green_red_properties.proptest-regressions
+++ b/crates/rustledger-parser/tests/green_red_properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e1ba4252b62b47395e83081c579c6fab5b34d28af694c2f279b2c94012a53342 # shrinks to source = "2024-01-01 * \"narration\"\n  Assets:Bank 1 USD {{1 USD}}\n"
+cc 6851060e30b6067d1314b381d2ad0e9aaead8a230e6bfbbc87f72db3801f5ebd # shrinks to source = "2024-01-01 * \"narration\"\n  Assets:Bank 1 USD {{1 USD}}\n"

--- a/crates/rustledger-parser/tests/green_red_properties.rs
+++ b/crates/rustledger-parser/tests/green_red_properties.rs
@@ -365,3 +365,112 @@ fn the_generator_reaches_well_formed_transactions() {
          already covers."
     );
 }
+
+/// Green and red must agree on the three per-node SHAPE rules — unclosed cost
+/// braces, a link used as a metadata value, and tags/links used as
+/// `custom`/`pushmeta` values.
+///
+/// These are pinned by hand rather than left to `ledger_source()` because the
+/// generator produces well-formed ledgers: it emits none of these three
+/// constructs, so the proptest above would report agreement without ever
+/// having compared one. The rules moved from three standalone red
+/// `descendants()` passes into the green walker, and the whole point of the
+/// move is that nothing observable changes — which is only worth asserting on
+/// inputs that actually trigger them.
+///
+/// Ordering is part of the contract: all cost errors, then all link-metadata
+/// errors, then all custom/pushmeta errors, each in document order. The last
+/// fixture puts all three in one file to pin the sequence, not just the set.
+#[test]
+fn green_equals_red_on_the_node_shape_rules() {
+    let fixtures: &[(&str, &str)] = &[
+        (
+            "unclosed cost brace",
+            "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {100 USD\n",
+        ),
+        (
+            "closed cost brace (control)",
+            "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {100 USD}\n  Assets:C\n",
+        ),
+        (
+            "empty cost component",
+            "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {100 USD,}\n  Assets:C\n",
+        ),
+        (
+            "link as metadata value",
+            "2024-01-01 * \"t\"\n  key: ^alink\n  Assets:B 1 USD\n  Assets:C\n",
+        ),
+        (
+            "tag as metadata value (valid)",
+            "2024-01-01 * \"t\"\n  key: #atag\n  Assets:B 1 USD\n  Assets:C\n",
+        ),
+        ("link in custom", "2024-01-01 custom \"budget\" ^alink\n"),
+        ("tag in custom", "2024-01-01 custom \"budget\" #atag\n"),
+        ("link in pushmeta", "pushmeta key: ^alink\n"),
+        ("tag in pushmeta (valid)", "pushmeta key: #atag\n"),
+        (
+            "all three rules in one file",
+            "2024-01-01 custom \"budget\" #atag ^alink\n\
+             pushmeta key: ^blink\n\
+             2024-01-03 * \"t\"\n  key: ^clink\n  Assets:B 1 AAPL {100 USD\n",
+        ),
+        // BOM: every span in these rules is BOM-adjusted, and the green walker
+        // derives its offsets differently from red (a running counter vs
+        // `text_range()`). An off-by-BOM would show up only here.
+        (
+            "BOM + all three",
+            "\u{feff}2024-01-01 custom \"budget\" ^alink\n\
+             2024-01-02 * \"t\"\n  key: ^blink\n  Assets:B 1 AAPL {100 USD\n",
+        ),
+        // A BOM with a CLOSED but malformed cost spec. The fixture above
+        // early-returns on the unclosed spec and never reaches the
+        // component-shape rule, which is the one path that indexes `stripped`
+        // and so is the only place a BOM offset can be double-counted. With
+        // only the unclosed fixture, dropping the BOM subtraction survived
+        // the whole suite.
+        (
+            "BOM + cost component shape",
+            "\u{feff}2024-01-01 * \"t\"\n  Assets:B 1 AAPL {100 USD,}\n  Assets:C\n",
+        ),
+    ];
+
+    for (label, source) in fixtures {
+        assert_eq!(
+            observables(&parse(source)),
+            observables(&parse_red_only(source)),
+            "green and red diverged on the {label} fixture",
+        );
+    }
+
+    // Self-check. Without it the assertions above pass against a parser that
+    // lost all three rules, because two empty error lists compare equal.
+    //
+    // Counting "any error" is NOT enough and was the first version's bug: a
+    // malformed fixture yields "unexpected input" and looks like it triggered
+    // the rule. The first `pushmeta` fixtures here were written with a leading
+    // date, which is invalid — the directive never parsed, no
+    // PUSHMETA_DIRECTIVE node was built, and a deliberate mutation making
+    // `pushmeta` reject tags went undetected. So match the RULES' messages.
+    let rule_hits = |needle: &str| {
+        fixtures
+            .iter()
+            .flat_map(|(_, s)| parse(s).errors)
+            .filter(|e| format!("{:?}", e.kind).contains(needle))
+            .count()
+    };
+    for (rule, needle, want) in [
+        ("unclosed cost brace", "unclosed cost specification", 2),
+        ("cost component shape", "cost-spec component", 1),
+        ("link as metadata value", "not a valid metadata value", 2),
+        ("custom value", "not a valid custom value", 3),
+        ("pushmeta value", "not a valid pushmeta value", 2),
+    ] {
+        let got = rule_hits(needle);
+        assert!(
+            got >= want,
+            "the {rule} rule fired {got} times across the fixtures, wanted at \
+             least {want} — these fixtures no longer exercise it, so this \
+             test is not comparing green against red on it",
+        );
+    }
+}

--- a/crates/rustledger-parser/tests/green_red_properties.rs
+++ b/crates/rustledger-parser/tests/green_red_properties.rs
@@ -370,13 +370,29 @@ fn the_generator_reaches_well_formed_transactions() {
 /// braces, a link used as a metadata value, and tags/links used as
 /// `custom`/`pushmeta` values.
 ///
-/// These are pinned by hand rather than left to `ledger_source()` because the
-/// generator produces well-formed ledgers: it emits none of these three
-/// constructs, so the proptest above would report agreement without ever
-/// having compared one. The rules moved from three standalone red
-/// `descendants()` passes into the green walker, and the whole point of the
-/// move is that nothing observable changes — which is only worth asserting on
-/// inputs that actually trigger them.
+/// Complementary to the proptest above, not a replacement. Which suite catches
+/// what was verified by running deliberate mutations, not assumed:
+///
+/// | deliberate mutation                    | fixtures | proptest |
+/// |----------------------------------------|----------|----------|
+/// | `pushmeta` wrongly rejects a tag       | catches  | misses   |
+/// | BOM not subtracted on the defect path  | catches  | misses   |
+/// | double-brace closer not recognized     | catches  | catches  |
+///
+/// The last row only reads that way because the proptest found it FIRST: the
+/// fixtures missed it until the two double-brace cases below were added. That
+/// is the argument for keeping both suites — neither was sufficient alone.
+///
+/// `ledger_source()` emits WELL-FORMED ledgers. It does generate cost specs —
+/// which is how it catches a broken `R_DOUBLE_BRACE` closer, since a valid
+/// `{{1 USD}}` then reports as unclosed — but it does not generate the
+/// MALFORMED constructs these rules exist to diagnose: an unclosed brace, a
+/// link where a metadata value belongs, a tag in a `custom`. On those the
+/// proptest compares two empty error lists and reports agreement without
+/// having exercised the rule at all.
+///
+/// So the double-brace cases below are pinned here too, rather than left to
+/// the generator to rediscover.
 ///
 /// Ordering is part of the contract: all cost errors, then all link-metadata
 /// errors, then all custom/pushmeta errors, each in document order. The last
@@ -391,6 +407,18 @@ fn green_equals_red_on_the_node_shape_rules() {
         (
             "closed cost brace (control)",
             "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {100 USD}\n  Assets:C\n",
+        ),
+        // `{{` / `}}` is a SEPARATE token pair from `{` / `}`, and treating
+        // only `}` as a closer makes this valid spec report as unclosed. The
+        // proptest catches that; these pin it without depending on the
+        // generator happening to emit a double-brace spec.
+        (
+            "closed double brace (control)",
+            "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {{100 USD}}\n  Assets:C\n",
+        ),
+        (
+            "unclosed double brace",
+            "2024-01-01 * \"t\"\n  Assets:B 1 AAPL {{100 USD\n",
         ),
         (
             "empty cost component",
@@ -459,7 +487,7 @@ fn green_equals_red_on_the_node_shape_rules() {
             .count()
     };
     for (rule, needle, want) in [
-        ("unclosed cost brace", "unclosed cost specification", 2),
+        ("unclosed cost brace", "unclosed cost specification", 3),
         ("cost component shape", "cost-spec component", 1),
         ("link as metadata value", "not a valid metadata value", 2),
         ("custom value", "not a valid custom value", 3),


### PR DESCRIPTION
Three error passes in `parse_via_cst_inner` — unclosed cost braces, a link used as a metadata value, tags/links used as `custom`/`pushmeta` values — each did its **own** whole-tree red `descendants()` walk. Red iteration allocates a `Box<NodeData>` per node with no recycling.

The green `DescendantsWalker` already visits every node and already tracks the byte offset, so the rules now cost one `match` per node on a walk that was happening anyway.

## Measured

Cachegrind, 10k txns, **both sides rebuilt at HEAD**:

| shape | main | this branch | delta | ablation ceiling |
|---|---|---|---|---|
| `tagged` | 1,109.08M | 1,030.42M | **−7.09%** | −7.46% |
| `investment` | 2,203.54M | 2,158.85M | **−2.03%** | −2.15% |
| `simple` | 784.36M | 779.73M | −0.59% | −0.57% |

The ceiling column is an ablation that deletes the three passes outright, so this captures ~95% of what is available. Supporting heap data (dhat): red `NodeData` was 48.6% of all allocation *blocks* on `tagged` — a block-count problem, not a byte one — and malloc/free is the single largest instruction bucket in the program there at 15.3%.

## Why it was invisible

Each pass carried a `stripped.contains(..)` byte-scan guard, so all three are free on a ledger with no `{`, `^` or `#` — which is exactly the `simple` profiling shape. An earlier profiling pass that looked only at `simple` concluded these were not a hotspot. But a `#` appears in any tagged ledger and a `{` in any investment one, so real files paid all three.

The green path needs no guards now: no `{` in the source means the parser built no `COST_SPEC` node, so the folded rule finds nothing to report.

## Scope

**Green only.** Red keeps the three standalone `extract_*` functions: folding them into its flat `descendants_with_tokens()` walk would need each token's immediate parent kind, and `t.parent()` allocates the very red node this change exists to avoid. Green is the path every caller but the parity test takes.

Error **order** is preserved exactly — three separate vecs extended in the old sequence, each in document order. `first_cost_spec_defect` stays the one shared rule both paths call, so they cannot drift on what counts as a defect.

## Tests

`green_equals_red_on_the_node_shape_rules` pins green against red on sources that actually trigger all three rules. The existing proptest could not: `ledger_source()` generates well-formed ledgers and emits none of these constructs, so it reported agreement without ever having compared one.

Five deliberate mutations were run against the suite and **all five are caught**. Two were *not* caught by the first version of the test, which is why it looks like it does:

- the `pushmeta` fixtures were written with a leading date, which is invalid — no `PUSHMETA_DIRECTIVE` node was built, and a mutation making `pushmeta` reject tags survived. The self-check now counts each **rule's own message** rather than "any error", which is what hid it.
- dropping the BOM subtraction on the cost-defect path survived, because the only BOM fixture had an *unclosed* spec, which returns before reaching the path that indexes `stripped`.

`a_child_node_advances_the_offset_for_later_tokens` pins the offset accumulation over child nodes on a hand-built green node. All four matching kinds have token-only children today — even a parenthesized arithmetic cost component stays flat — so no source fixture can reach it, and dropping the accumulation otherwise passes the entire suite.

Gates run locally: `cargo test --workspace --all-features`, `cargo +1.97.0 clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)