### PR TITLE
perf(parser): binary-search the span-fixup index, not a linear scan

### DIFF
--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -3612,6 +3612,17 @@ fn fixup_directive_spans(
         })
         .collect();
 
+    // `all_starts` is built from `children()`, i.e. siblings in document
+    // order, and sibling text ranges are disjoint and increasing — so it is
+    // sorted ascending on `raw_start` and every key is unique. The lookup
+    // below binary-searches on that.
+    debug_assert!(
+        all_starts.windows(2).all(|w| w[0].0 < w[1].0),
+        "all_starts must be strictly ascending by raw_start for the binary \
+         search below; sibling text ranges are disjoint and increasing, so a \
+         failure here means the enumeration is no longer document-ordered",
+    );
+
     let source_end: usize =
         (u32::from(source_file.syntax().text_range().end()) + bom_offset) as usize;
 
@@ -3632,7 +3643,20 @@ fn fixup_directive_spans(
         let node = &converted_nodes[i];
         let raw_start: usize = (u32::from(node.text_range().start()) + bom_offset) as usize;
         let node_end: usize = (u32::from(node.text_range().end()) + bom_offset) as usize;
-        if let Some(pos) = all_starts.iter().position(|(rs, _)| *rs == raw_start) {
+        // Binary search, NOT a linear `position()` scan. This loop runs once
+        // per directive over an `all_starts` that has one entry per
+        // directive, so a linear probe made span fixup O(N^2) in the
+        // directive count. Measured on the `simple` profiling shape: 10x the
+        // transactions cost 21.8x the instructions, and cachegrind put ~40%
+        // of a 20k-transaction run inside this one scan and its slice-iterator
+        // internals. It is invisible on small inputs, which is why it sat
+        // here — at 2k transactions the same scan is under 2%.
+        //
+        // Semantics are unchanged: keys are unique (see the debug_assert
+        // above), so where `position` found the sole match, `binary_search`
+        // finds the same one, and a miss still falls through to the
+        // defensive branch below rather than panicking.
+        if let Ok(pos) = all_starts.binary_search_by_key(&raw_start, |(rs, _)| *rs) {
             let start = all_starts[pos].1;
             let end = all_starts
                 .get(pos + 1)
@@ -3660,6 +3684,46 @@ fn fixup_directive_spans(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A directive's span ends at the next *input* directive's content start,
+    /// INCLUDING directives filtered out of the `ParseResult`
+    /// (`pushtag`/`poptag`/`pushmeta`/`popmeta`).
+    ///
+    /// This is the case that makes `all_starts` longer than `directives`, so
+    /// it is the one that breaks if the lookup ever stops keying on the CST
+    /// node's own start — e.g. "optimizing" the binary search into an index
+    /// into `directives`, which would end the `open` span at the transaction
+    /// instead of at the `pushtag` between them.
+    #[test]
+    fn spans_end_at_the_next_input_directive_even_when_it_is_filtered_out() {
+        let src = "2024-01-01 open Assets:Bank USD\n\
+                   pushtag #trip\n\
+                   2024-01-02 * \"a\"\n  Assets:Bank 1 USD\n  Assets:Other\n\
+                   poptag #trip\n\
+                   2024-01-03 close Assets:Bank\n";
+        let parsed = crate::parse(src);
+
+        let at = |needle: &str| src.find(needle).expect("fixture contains it");
+        let spans: Vec<(usize, usize)> = parsed
+            .directives
+            .iter()
+            .map(|d| (d.span.start, d.span.end))
+            .collect();
+
+        assert_eq!(
+            spans,
+            vec![
+                // `open` stops at `pushtag`, NOT at the transaction.
+                (0, at("pushtag")),
+                // the transaction stops at `poptag`, NOT at `close`.
+                (at("2024-01-02"), at("poptag")),
+                // the last directive runs to end of source.
+                (at("2024-01-03"), src.len()),
+            ],
+            "pushtag/poptag are filtered from `directives` but still bound the \
+             preceding directive's span",
+        );
+    }
 
     /// Match a `SyntaxError` by message prefix rather than by `Debug` output.
     /// The `Debug` rendering of `ParseErrorKind` can change without any

--- a/crates/rustledger-parser/tests/span_fixup_precondition.rs
+++ b/crates/rustledger-parser/tests/span_fixup_precondition.rs
@@ -1,0 +1,154 @@
+//! The precondition `fixup_directive_spans`' binary search rests on.
+//!
+//! It looks a directive up in `all_starts` by the CST node's own start
+//! offset. That list is built from `SourceFile::children()`, so it is sibling
+//! order — and the search is only equivalent to the linear `position()` scan
+//! it replaced if starts are strictly ascending and unique.
+//!
+//! They differ only if two sibling directives share a start, which requires a
+//! ZERO-WIDTH `Directive`-castable node. `position()` would have returned the
+//! first; `binary_search` returns an arbitrary one. Error recovery is where
+//! such a node could plausibly appear, so this hammers recovery paths rather
+//! than well-formed ledgers.
+//!
+//! The `debug_assert` in `fixup_directive_spans` covers the same ground in
+//! debug builds; this checks the condition DIRECTLY so a release-mode
+//! regression, or a change that removes the assert, still gets caught.
+
+use rustledger_parser::cst::ast::{AstNode as _, Directive};
+use rustledger_parser::parse;
+
+/// Returns a description of the first violation found, if any.
+fn violation(src: &str) -> Option<String> {
+    let parsed = parse(src);
+    let mut prev: Option<u32> = None;
+    for n in parsed.syntax_node().children() {
+        if !Directive::can_cast(n.kind()) {
+            continue;
+        }
+        let range = n.text_range();
+        let start: u32 = range.start().into();
+        if u32::from(range.len()) == 0 {
+            return Some(format!("zero-width {:?} at {start} in {src:?}", n.kind()));
+        }
+        if let Some(p) = prev
+            && start <= p
+        {
+            return Some(format!("start {start} not after {p} in {src:?}"));
+        }
+        prev = Some(start);
+    }
+    None
+}
+
+/// Deterministic LCG. Not `rand`: this must reproduce byte-for-byte on CI,
+/// and a failure has to be replayable from the seed alone.
+struct Lcg(u64);
+impl Lcg {
+    const fn next(&mut self) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (self.0 >> 33) as usize
+    }
+}
+
+#[test]
+fn directive_siblings_never_share_a_start() {
+    // Fragments chosen to end up mid-directive: bare keywords, unterminated
+    // strings, unbalanced braces, a BOM, and empties — the shapes that make
+    // the parser open a node and then recover.
+    const ATOMS: &[&str] = &[
+        "pushtag",
+        "poptag",
+        "pushmeta",
+        "popmeta",
+        "2024-01-01",
+        "open",
+        "close",
+        "*",
+        "\"",
+        "{",
+        "}",
+        "{{",
+        "}}",
+        "^a",
+        "#a",
+        "\n",
+        " ",
+        "\r\n",
+        "\u{feff}",
+        "",
+        ";x",
+        "custom",
+        "Assets:B",
+        "1 USD",
+        ":",
+        ",",
+        "balance",
+        "pad",
+        "price",
+        "@",
+        "@@",
+    ];
+
+    // Hand-picked cases first — the ones most likely to produce an empty node.
+    for src in [
+        "",
+        "\n",
+        "\n\n\n",
+        "pushtag",
+        "poptag\n",
+        "pushmeta",
+        "popmeta\n",
+        "2024-01-01",
+        "2024-01-01\n",
+        "2024-01-01 ",
+        "2024-01-01 open",
+        "2024-01-01 * \"",
+        "\u{feff}",
+        "\u{feff}\n\n",
+        "\r\n\r\n",
+        "*\n*\n*\n",
+        "{{{\n",
+        "pushtagpoptag\n",
+        "2024-01-012024-01-02\n",
+        "pushtag #a\npoptag #a\npushtag #b\npoptag #b\n",
+    ] {
+        assert!(violation(src).is_none(), "{}", violation(src).unwrap());
+    }
+
+    let mut rng = Lcg(0x2545_F491_4F6C_DD1D);
+    for _ in 0..20_000 {
+        let len = rng.next() % 12 + 1;
+        let src: String = (0..len).map(|_| ATOMS[rng.next() % ATOMS.len()]).collect();
+        assert!(violation(&src).is_none(), "{}", violation(&src).unwrap());
+    }
+}
+
+/// The check above is worthless if it cannot report a violation, and it
+/// cannot be shown to by feeding it real source — the whole point is that no
+/// input produces one. So feed the DETECTOR a sequence it must reject.
+#[test]
+fn the_violation_detector_can_actually_fail() {
+    // Same shape as `violation`'s loop, run over a hand-built sequence with a
+    // duplicate start. If this logic ever stops flagging that, the test above
+    // is asserting nothing.
+    let starts = [0u32, 10, 10, 20];
+    let mut prev: Option<u32> = None;
+    let mut flagged = false;
+    for start in starts {
+        if let Some(p) = prev
+            && start <= p
+        {
+            flagged = true;
+        }
+        prev = Some(start);
+    }
+    assert!(
+        flagged,
+        "the ascending check must reject a duplicate start; if it does not, \
+         `directive_siblings_never_share_a_start` proves nothing",
+    );
+}


### PR DESCRIPTION
`fixup_directive_spans` ran, once per directive, an `all_starts.iter().position(..)` over a list with one entry per directive. That is **O(N²)** in the directive count.

It is invisible at the sizes anything here was ever profiled at — under 2% of a 2,000-transaction run — and dominant at real ones: cachegrind puts ~40% of a 20,000-transaction `simple` run inside this scan and its slice-iterator internals.

## Measured

Both sides rebuilt at HEAD, base = `a218920251`:

| workload | main | branch | delta |
|---|---|---|---|
| `simple` 2k | 102,668,679 | 88,818,149 | −13.49% |
| **`simple` 20k** | 2,251,393,629 | 853,783,976 | **−62.08%** |
| `investment` 2k | 182,434,646 | 168,529,549 | −7.62% |
| **`investment` 20k** | 7,651,077,174 | 6,252,907,424 | **−18.27%** |

The scaling curve matters more than any single number. For **10× the input**:

| shape | main | branch |
|---|---|---|
| `simple` | 21.9× | **9.6× (linear)** |
| `investment` | 41.9× | 37.1× (still superlinear) |

`investment` stays superlinear because booking has its own, separate quadratic — `BookingEngine::book` deep-copies each touched account's entire position vector per transaction, so `Position::clone` grows 104× for 10× the input (callgrind chain: `Position::clone ← Inventory::clone ← BookingEngine::book`/`::apply`). **That is untouched here** and is the next thing to fix.

## The change

`all_starts` is built from `children()` — siblings in document order — so it is strictly ascending on `raw_start` and every key is unique. `binary_search_by_key` finds the same sole match `position` did, and a miss still falls through to the existing defensive branch rather than panicking. A `debug_assert` pins the ordering the search depends on.

## Test

The new test pins the case that makes this lookup non-trivial: a directive's span ends at the next **input** directive, including `pushtag`/`poptag`/`pushmeta`/`popmeta` ones that are filtered out of the `ParseResult`. That is exactly what makes `all_starts` longer than `directives`, and so what breaks if the lookup is ever "optimized" into an index into `directives` — the `open` span would then end at the transaction instead of at the `pushtag` between them.

Mutation-checked: applying that precise wrong refactor fails the new test and only that test.

Gates run locally: `cargo test --workspace --all-features`, `cargo +1.97.0 clippy -p rustledger-parser --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)