### PR TITLE
perf(core): compute reductions from &self, so previewing stops copying

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -265,8 +265,42 @@ impl BookingEngine {
         // account more than once.
         let mut working_inventories: FxHashMap<rustledger_core::Account, Inventory> =
             FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
+        //
+        // Only accounts with MORE THAN ONE reducing posting need a working
+        // copy at all. The copy exists so a second posting on the same account
+        // sees what the first one took; with a single posting nothing ever
+        // reads the mutation back, and `Inventory::try_reduce` answers from
+        // `&self` without copying (it stopped being `self.clone().reduce(..)`
+        // in this same change).
+        //
+        // That matters because the copy is O(lots): the engine's stores are
+        // `PositionStore::Owned`, so a long-lived investment account copied
+        // its entire lot list on every transaction that touched it.
+        // `Position::clone` grew 104x for 10x the input on the `investment`
+        // profiling shape — the dominant superlinear term left in the
+        // pipeline.
+        //
+        // The gate below must stay in step with the reduction path's own
+        // gate (`Complete` units + a cost spec). If it ever drifts toward
+        // cloning MORE, the result is only wasted work; drifting toward
+        // cloning less would silently drop a second posting's view of the
+        // first, which is what `two_reducing_postings_on_one_account_*`
+        // pins.
+        let mut reducing_postings: FxHashMap<&rustledger_core::Account, usize> =
+            FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
         for posting in &txn.postings {
-            if let Some(inv) = self.inventories.get(&posting.account) {
+            if matches!(posting.units, Some(IncompleteAmount::Complete(_)))
+                && posting.cost.is_some()
+            {
+                *reducing_postings.entry(&posting.account).or_default() += 1;
+            }
+        }
+        for posting in &txn.postings {
+            if reducing_postings
+                .get(&posting.account)
+                .is_some_and(|n| *n > 1)
+                && let Some(inv) = self.inventories.get(&posting.account)
+            {
                 working_inventories
                     .entry(posting.account.clone())
                     .or_insert_with(|| inv.clone());
@@ -349,7 +383,10 @@ impl BookingEngine {
                 // This handles both:
                 // - Selling long positions (negative units, positive inventory)
                 // - Closing short positions (positive units, negative inventory)
-                if let Some(inv) = working_inventories.get_mut(&posting.account) {
+                if let Some(inv) = working_inventories
+                    .get(&posting.account)
+                    .or_else(|| self.inventories.get(&posting.account))
+                {
                     // Check if these units reduce existing cost-bearing inventory lots.
                     // Only positions with a cost basis are considered; simple (no-cost)
                     // positions are ignored to avoid misclassifying augmentations.
@@ -380,9 +417,21 @@ impl BookingEngine {
                         // out of the validator's input to avoid double-reporting against
                         // the validator's independent lot-matching pass.
                         // (`method` is resolved above next to the NONE-method gate.)
-                        let booking_result = inv
-                            .reduce(units, Some(cost_spec), method)
-                            .map_err(|e| convert_core_booking_error(e, &posting.account))?;
+                        // Mutate the working copy when we made one, so a
+                        // later posting on this account sees the reduction.
+                        // Otherwise preview against the live inventory:
+                        // nothing reads the mutation back, and this way
+                        // nothing was copied to produce it. Both call the
+                        // same planner inside `Inventory`.
+                        let booking_result = match working_inventories.get_mut(&posting.account) {
+                            Some(working) => working.reduce(units, Some(cost_spec), method),
+                            None => self.inventories[&posting.account].try_reduce(
+                                units,
+                                Some(cost_spec),
+                                method,
+                            ),
+                        }
+                        .map_err(|e| convert_core_booking_error(e, &posting.account))?;
                         {
                             // Check if multiple lots were matched
                             if booking_result.matched.len() > 1 {
@@ -2467,6 +2516,69 @@ mod tests {
     /// to remove. The third case is the one a naive guard gets wrong: the
     /// posting is tiny, but the account it lands in already sits at the
     /// ceiling, so the add still overflows.
+    /// Two reducing postings on the SAME account in one transaction: the
+    /// second must see what the first took.
+    ///
+    /// This is the case the working-copy clone exists for, and the only one
+    /// that still gets a copy — everything else previews against the live
+    /// inventory without copying. If the "does this account need a working
+    /// copy" gate ever drifts toward cloning less, both postings would match
+    /// against the full 10-unit lot and a 6+6 oversell would book cleanly.
+    ///
+    /// 10 AAPL held; sell 6 and 6 in one transaction. The second reduction
+    /// must fail on insufficient units.
+    #[test]
+    fn two_reducing_postings_on_one_account_see_each_other() {
+        let mut engine = BookingEngine::new();
+
+        let buy = Transaction::new(date(2024, 1, 1), "buy 10")
+            .with_synthesized_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(10), "AAPL")).with_cost(
+                    CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
+                        .with_currency("USD"),
+                ),
+            )
+            .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(-1000), "USD")));
+        engine.apply(&buy).expect("buy applies");
+
+        let oversell = Transaction::new(date(2024, 1, 2), "sell 6 then 6")
+            .with_synthesized_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(-6), "AAPL"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(-6), "AAPL"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(1200), "USD")));
+
+        let result = engine.book(&oversell);
+        assert!(
+            result.is_err(),
+            "6 + 6 against a 10-unit lot must fail: the second posting has to \
+             see the first one's reduction. Got {result:?}",
+        );
+
+        // And the control: 6 + 4 exactly drains the lot and must succeed.
+        let mut engine = BookingEngine::new();
+        engine.apply(&buy).expect("buy applies");
+        let exact = Transaction::new(date(2024, 1, 2), "sell 6 then 4")
+            .with_synthesized_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(-6), "AAPL"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(-4), "AAPL"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(1000), "USD")));
+        assert!(
+            engine.book(&exact).is_ok(),
+            "6 + 4 exactly drains the lot and must book",
+        );
+    }
+
     #[test]
     fn the_snapshot_is_skipped_only_when_overflow_is_impossible() {
         let mut engine = BookingEngine::new();

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -425,6 +425,10 @@ impl BookingEngine {
                         // same planner inside `Inventory`.
                         let booking_result = match working_inventories.get_mut(&posting.account) {
                             Some(working) => working.reduce(units, Some(cost_spec), method),
+                            // Indexing cannot panic here: reaching this arm
+                            // means the enclosing `if let` bound `inv` from
+                            // its `self.inventories` branch, so the account is
+                            // present.
                             None => self.inventories[&posting.account].try_reduce(
                                 units,
                                 Some(cost_spec),

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1057,6 +1057,56 @@ mod reduction_tests {
         Amount::new(d(-n), "STK")
     }
 
+    /// A cost-basis overflow part-way through a multi-lot reduction must leave
+    /// the inventory untouched.
+    ///
+    /// `reduce_ordered` states the rule itself — "a failed reduction must
+    /// leave the inventory untouched" — and enforced it for the sufficiency
+    /// check, which runs up front. The overflow check did NOT get the same
+    /// treatment: it lived inside the mutation loop, so a reduction that
+    /// overflowed on the third lot returned `Err` with the first two already
+    /// drained. The validator reduces against live `LedgerState` inventories,
+    /// so that partial drain corrupts every later balance assertion on the
+    /// account.
+    ///
+    /// Computing the whole plan before committing any of it makes the rule
+    /// hold for both checks by construction.
+    #[test]
+    fn an_overflowing_multi_lot_reduction_leaves_the_inventory_untouched() {
+        // Two lots whose combined cost basis cannot be represented: each is
+        // two thirds of the range, so the first accumulates fine and the sum
+        // overflows on the second.
+        let huge = Decimal::MAX / Decimal::from(3) * Decimal::from(2);
+        let mut inv = Inventory::new();
+        for day in 1..=2 {
+            let mut cost = Cost::new(huge, "USD");
+            cost.date = naive_date(2024, 1, day);
+            inv.add(Position::with_cost(Amount::new(Decimal::ONE, "AAPL"), cost))
+                .expect("lots fit individually");
+        }
+        let before: Vec<Position> = inv.positions().cloned().collect();
+        assert_eq!(before.len(), 2, "fixture must hold two distinct lots");
+
+        let err = inv
+            .reduce(
+                &Amount::new(Decimal::from(-2), "AAPL"),
+                Some(&CostSpec::default()),
+                BookingMethod::Fifo,
+            )
+            .expect_err("the combined cost basis overflows");
+        assert!(
+            matches!(err, super::BookingError::Overflow(_)),
+            "expected an overflow, got {err:?}",
+        );
+
+        let after: Vec<Position> = inv.positions().cloned().collect();
+        assert_eq!(
+            after, before,
+            "the failed reduction drained lots anyway — a partial mutation on \
+             the error path is what this pins",
+        );
+    }
+
     fn try_reduce(inv: &Inventory, units: &Amount, method: BookingMethod) -> super::BookingResult {
         inv.try_reduce(units, Some(&CostSpec::default()), method)
             .expect("reduction should succeed")

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -59,6 +59,24 @@ fn average_cost_from_positions(
     Ok(Some((total_cost / total_units, cost_currency.unwrap())))
 }
 
+/// A reduction computed from `&Inventory` but not yet applied.
+///
+/// The two variants mirror the two commit shapes the booking methods already
+/// had: the single-lot path maintains its caches incrementally, the multi-lot
+/// path rewrites lots and then rebuilds. Keeping them distinct means
+/// splitting preview from commit costs the commit path nothing.
+pub(super) enum ReductionPlan {
+    /// One lot reduced to `new_units`.
+    FromLot {
+        /// Index of the lot in `positions`.
+        idx: usize,
+        /// What that lot's units number becomes.
+        new_units: Decimal,
+    },
+    /// `(index, new units number)` pairs, applied in order.
+    Updates(SmallVec<[(usize, Decimal); 1]>),
+}
+
 impl Inventory {
     /// Try reducing positions without modifying the inventory.
     ///
@@ -91,7 +109,34 @@ impl Inventory {
         cost_spec: Option<&CostSpec>,
         method: BookingMethod,
     ) -> Result<BookingResult, BookingError> {
-        self.clone().reduce(units, cost_spec, method)
+        let spec = cost_spec.cloned().unwrap_or_default();
+
+        // Planned methods answer from `&self`. The rest still preview by
+        // cloning — correct, just O(lots). Converting them is mechanical and
+        // follows the same shape; these are simply not the ones the profiling
+        // shapes exercise.
+        if spec.merge {
+            return self.clone().reduce(units, cost_spec, method);
+        }
+        match method {
+            BookingMethod::Strict => self.plan_strict(units, &spec).map(|(r, _)| r),
+            BookingMethod::Fifo => self.plan_ordered(units, &spec, false).map(|(r, _)| r),
+            BookingMethod::Lifo => self.plan_ordered(units, &spec, true).map(|(r, _)| r),
+            BookingMethod::StrictWithSize
+            | BookingMethod::Hifo
+            | BookingMethod::Average
+            | BookingMethod::None => self.clone().reduce(units, cost_spec, method),
+        }
+    }
+
+    /// Apply a [`ReductionPlan`] produced by one of the `plan_*` methods.
+    fn commit_plan(&mut self, plan: &ReductionPlan, units: &Amount) {
+        match plan {
+            ReductionPlan::FromLot { idx, new_units } => {
+                self.commit_from_lot(*idx, units, *new_units);
+            }
+            ReductionPlan::Updates(updates) => self.commit_updates(updates),
+        }
     }
 
     /// STRICT booking: require exactly one matching lot, unless either:
@@ -132,6 +177,24 @@ impl Inventory {
         units: &Amount,
         spec: &CostSpec,
     ) -> Result<BookingResult, BookingError> {
+        let (result, plan) = self.plan_strict(units, spec)?;
+        self.commit_plan(&plan, units);
+        Ok(result)
+    }
+
+    /// The read-only half of [`Self::reduce_strict`].
+    ///
+    /// STRICT is a dispatcher: one match delegates to the single-lot path,
+    /// financially-interchangeable or wholly-consumed multi-matches fall back
+    /// to FIFO ordering, and anything else is ambiguous and mutates nothing.
+    /// This mirrors that dispatch by delegating to the same two planners the
+    /// mutating path uses. See [`Self::plan_from_lot`] for why the selection
+    /// logic must not be duplicated into `try_reduce`.
+    pub(super) fn plan_strict(
+        &self,
+        units: &Amount,
+        spec: &CostSpec,
+    ) -> Result<(BookingResult, ReductionPlan), BookingError> {
         let matching_indices: Vec<usize> = self
             .positions
             .iter()
@@ -152,7 +215,8 @@ impl Inventory {
             }),
             1 => {
                 let idx = matching_indices[0];
-                self.reduce_from_lot(idx, units)
+                let (result, new_units) = self.plan_from_lot(idx, units)?;
+                Ok((result, ReductionPlan::FromLot { idx, new_units }))
             }
             n => {
                 // Are the matched lots financially interchangeable? Two lots
@@ -174,7 +238,8 @@ impl Inventory {
                 });
 
                 if all_same_value {
-                    return self.reduce_ordered(units, spec, false);
+                    let (result, updates) = self.plan_ordered(units, spec, false)?;
+                    return Ok((result, ReductionPlan::Updates(updates)));
                 }
 
                 // Total match exception: if the reduction equals the sum of all
@@ -185,7 +250,8 @@ impl Inventory {
                     .map(|&i| self.positions[i].units.number.abs())
                     .sum();
                 if total_units == units.number.abs() {
-                    return self.reduce_ordered(units, spec, false);
+                    let (result, updates) = self.plan_ordered(units, spec, false)?;
+                    return Ok((result, ReductionPlan::Updates(updates)));
                 }
 
                 Err(BookingError::AmbiguousMatch {
@@ -399,6 +465,24 @@ impl Inventory {
         spec: &CostSpec,
         reverse: bool,
     ) -> Result<BookingResult, BookingError> {
+        let (result, updates) = self.plan_ordered(units, spec, reverse)?;
+        self.commit_updates(&updates);
+        Ok(result)
+    }
+
+    /// The read-only half of [`Self::reduce_ordered`]: pick the lots, check
+    /// sufficiency, and compute what would be matched — without touching a
+    /// single position.
+    ///
+    /// Returns the result alongside `(index, new units number)` pairs for the
+    /// caller to apply. See [`Self::plan_from_lot`] for why the split exists
+    /// and why the selection logic must not be duplicated into `try_reduce`.
+    pub(super) fn plan_ordered(
+        &self,
+        units: &Amount,
+        spec: &CostSpec,
+        reverse: bool,
+    ) -> Result<(BookingResult, SmallVec<[(usize, Decimal); 1]>), BookingError> {
         let mut remaining = units.number.abs();
         let mut matched: MatchedLots = SmallVec::new();
         let mut cost_basis = Decimal::ZERO;
@@ -458,12 +542,13 @@ impl Inventory {
             });
         }
 
+        let mut updates: SmallVec<[(usize, Decimal); 1]> = SmallVec::new();
         for idx in indices {
             if remaining.is_zero() {
                 break;
             }
 
-            let pos = &mut self.positions[idx];
+            let pos = &self.positions[idx];
             let available = pos.units.number.abs();
             let take = remaining.min(available);
 
@@ -484,25 +569,38 @@ impl Inventory {
             let (taken, _) = pos.split(take * pos.units.number.signum());
             matched.push(taken);
 
-            // Reduce the lot - modify in place to avoid cloning
+            // What the lot WOULD become. Recorded rather than applied so the
+            // preview path can run this same loop against `&self`.
             let reduction = if units.number.is_sign_negative() {
                 -take
             } else {
                 take
             };
-            pos.units.number += reduction;
+            updates.push((idx, pos.units.number + reduction));
 
             remaining -= take;
         }
 
-        // Clean up empty positions
+        Ok((
+            BookingResult {
+                matched,
+                cost_basis: cost_currency.map(|c| Amount::new(cost_basis, c)),
+            },
+            updates,
+        ))
+    }
+
+    /// Apply `(index, new units)` pairs from a plan, then restore the caches.
+    ///
+    /// `retain` + `rebuild_index` exactly as the fused `reduce_ordered` did —
+    /// the multi-lot path always paid an O(lots) cache rebuild, and changing
+    /// that is a separate question from removing the preview's clone.
+    fn commit_updates(&mut self, updates: &[(usize, Decimal)]) {
+        for &(idx, new_units) in updates {
+            self.positions[idx].units.number = new_units;
+        }
         self.positions.retain(|p| !p.is_empty());
         self.rebuild_index();
-
-        Ok(BookingResult {
-            matched,
-            cost_basis: cost_currency.map(|c| Amount::new(cost_basis, c)),
-        })
     }
 
     /// AVERAGE booking: merge all lots of the currency.
@@ -822,6 +920,30 @@ impl Inventory {
         idx: usize,
         units: &Amount,
     ) -> Result<BookingResult, BookingError> {
+        let (result, new_units) = self.plan_from_lot(idx, units)?;
+        self.commit_from_lot(idx, units, new_units);
+        Ok(result)
+    }
+
+    /// The read-only half of [`Self::reduce_from_lot`]: everything up to the
+    /// first mutation, returning what WOULD be matched plus the lot's new
+    /// units number.
+    ///
+    /// Split out so `try_reduce` can answer from `&self`. It used to be
+    /// `self.clone().reduce(..)`, which deep-copied every lot in the account
+    /// to preview a reduction that touches one of them — the dominant
+    /// superlinear term in the pipeline (`Position::clone` grew 104x for 10x
+    /// the input on the `investment` profiling shape).
+    ///
+    /// Selection logic lives HERE and only here; the mutating path calls this
+    /// too. That is deliberate — `try_reduce` duplicating `reduce`'s selection
+    /// is the exact drift that `try_reduce_equivalence` exists to police, and
+    /// it had already bitten once before that test was written.
+    pub(super) fn plan_from_lot(
+        &self,
+        idx: usize,
+        units: &Amount,
+    ) -> Result<(BookingResult, Decimal), BookingError> {
         let pos = &self.positions[idx];
         let available = pos.units.number.abs();
         let requested = units.number.abs();
@@ -850,17 +972,33 @@ impl Inventory {
         // Record matched
         let (matched, _) = pos.split(requested * pos.units.number.signum());
 
-        // Update the position
-        let currency = pos.units.currency.clone();
         // Python scale rule, same as `Inventory::add` — see
         // `crate::decimal::add_python_scale`. A reduction that brings a lot
         // through zero would otherwise drop the scale here while `add` kept
         // it, so the same lot would render differently depending on whether
         // it was last touched by an add or a reduce.
         let new_units = crate::decimal::add_python_scale(pos.units.number, units.number);
+
+        Ok((
+            BookingResult {
+                matched: smallvec![matched],
+                cost_basis,
+            },
+            new_units,
+        ))
+    }
+
+    /// The mutating half of [`Self::reduce_from_lot`], applying a
+    /// [`Self::plan_from_lot`] result.
+    ///
+    /// Keeps the incremental cache maintenance the single-lot path always
+    /// had: a full `rebuild_index` here would be O(lots) on the commit path
+    /// that this split is meant to keep cheap.
+    fn commit_from_lot(&mut self, idx: usize, units: &Amount, new_units: Decimal) {
+        let currency = self.positions[idx].units.currency.clone();
         let new_pos = Position {
             units: Amount::new(new_units, currency.clone()),
-            cost: pos.cost.clone(),
+            cost: self.positions[idx].cost.clone(),
         };
         self.positions[idx] = new_pos;
 
@@ -880,11 +1018,6 @@ impl Inventory {
                 }
             }
         }
-
-        Ok(BookingResult {
-            matched: smallvec![matched],
-            cost_basis,
-        })
     }
 }
 

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1027,13 +1027,16 @@ impl Inventory {
         //
         // NOT via the booking engine, whatever this comment used to say. Since
         // #2056 the store is a hybrid and `PositionStore::default()` is
-        // `Owned(Vec)`, so the engine's inventories are owned and the working
-        // copy `BookingEngine::book` takes is a DEEP O(lots) copy, not an
-        // imbl O(1) one. That mattered: the claim of an O(1) clone here is
-        // part of why the copy went unexamined. It is the dominant superlinear
-        // term left in the pipeline — `Position::clone` grows 104x for 10x the
-        // input on the `investment` profiling shape, via
-        // `Position::clone <- Inventory::clone <- BookingEngine::book`.
+        // `Owned(Vec)`, so the engine's inventories are owned and any copy of
+        // one is a DEEP O(lots) copy, not an imbl O(1) one. The claim of an
+        // O(1) clone here is part of why that copy went unexamined for so
+        // long: `Position::clone` was growing 104x for 10x the input on the
+        // `investment` profiling shape.
+        //
+        // `BookingEngine::book` no longer takes such a copy per transaction —
+        // it previews through `try_reduce`, which computes from `&self` via
+        // the `plan_*` halves in `booking.rs`, and copies only for an account
+        // with more than one reducing posting in the same transaction.
         //
         // Mutating a SHARED imbl `Vector` in place drives
         // `imbl-sized-chunks`' copy-on-write into a use-after-free of the

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1021,10 +1021,21 @@ impl Inventory {
         let spec = cost_spec.cloned().unwrap_or_default();
 
         // Force a uniquely-owned positions Vector before any reduction mutates
-        // it. `self.positions` is often structurally shared — the booking engine
-        // clones an account's inventory into a working copy via imbl's O(1)
-        // `clone` — and every reduction method below mutates it in place (via
-        // `IndexMut` / `retain`). Mutating a SHARED imbl `Vector` in place drives
+        // it. `self.positions` MAY be structurally shared — BQL snapshots build
+        // `Shared` stores via `Inventory::new_shared` — and every reduction
+        // method below mutates it in place (via `IndexMut` / `retain`).
+        //
+        // NOT via the booking engine, whatever this comment used to say. Since
+        // #2056 the store is a hybrid and `PositionStore::default()` is
+        // `Owned(Vec)`, so the engine's inventories are owned and the working
+        // copy `BookingEngine::book` takes is a DEEP O(lots) copy, not an
+        // imbl O(1) one. That mattered: the claim of an O(1) clone here is
+        // part of why the copy went unexamined. It is the dominant superlinear
+        // term left in the pipeline — `Position::clone` grows 104x for 10x the
+        // input on the `investment` profiling shape, via
+        // `Position::clone <- Inventory::clone <- BookingEngine::book`.
+        //
+        // Mutating a SHARED imbl `Vector` in place drives
         // `imbl-sized-chunks`' copy-on-write into a use-after-free of the
         // interned `Arc<str>` inside `Position` — heap corruption / SIGSEGV on
         // large ledgers with many lot reductions (found by the rich-workload

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1025,13 +1025,14 @@ impl Inventory {
         // `Shared` stores via `Inventory::new_shared` — and every reduction
         // method below mutates it in place (via `IndexMut` / `retain`).
         //
-        // NOT via the booking engine, whatever this comment used to say. Since
-        // #2056 the store is a hybrid and `PositionStore::default()` is
-        // `Owned(Vec)`, so the engine's inventories are owned and any copy of
-        // one is a DEEP O(lots) copy, not an imbl O(1) one. The claim of an
-        // O(1) clone here is part of why that copy went unexamined for so
-        // long: `Position::clone` was growing 104x for 10x the input on the
-        // `investment` profiling shape.
+        // The sharing comes from BQL, not from booking. Since #2056 the store
+        // is a hybrid and `PositionStore::default()` is `Owned(Vec)`, so the
+        // booking engine's inventories are owned and any copy of one is a
+        // DEEP O(lots) copy rather than an imbl O(1) one. This comment
+        // asserted the opposite until #2061, and that wrong claim is a good
+        // part of why the copy went unexamined for so long — `Position::clone`
+        // was growing 104x for 10x the input on the `investment` profiling
+        // shape.
         //
         // `BookingEngine::book` no longer takes such a copy per transaction —
         // it previews through `try_reduce`, which computes from `&self` via


### PR DESCRIPTION
`Inventory::try_reduce` was `self.clone().reduce(..)` — it deep-copied every lot in an account to preview a reduction touching one or two of them. `BookingEngine::book` then took its own working copy of each touched account's inventory, **per transaction**, for the same reason. Both are O(lots), lots accumulate, so booking grew superlinearly with ledger size.

## The change

Each affected method splits into a `plan_*` half computed from `&self` and a commit half that applies it:

| mutating | = | compute | + | commit |
|---|---|---|---|---|
| `reduce_from_lot` | | `plan_from_lot` | | `commit_from_lot` |
| `reduce_ordered` | | `plan_ordered` | | `commit_updates` |
| `reduce_strict` | | `plan_strict` | | `commit_plan` |

Selection logic lives in the `plan_*` half and **only** there — the mutating path calls it too. That's the point: `try_reduce` duplicating `reduce`'s selection is exactly the drift `try_reduce_equivalence` was written for, after it had already happened once.

STRICT_WITH_SIZE, HIFO, AVERAGE, NONE and the `{*}` merge operator still preview by cloning. Correct, just O(lots), and mechanical to convert when something needs it.

`book` now clones only for an account with **more than one** reducing posting in a transaction — the case where a second posting must see what the first took. With a single posting nothing reads the mutation back, so it previews against the live inventory and copies nothing.

## Measured

Cachegrind, both sides rebuilt at HEAD, base `a218920251`:

| workload | main | branch | delta |
|---|---|---|---|
| `investment` 2k | 182,434,646 | 161,811,594 | −11.30% |
| **`investment` 20k** | 7,651,077,174 | 5,784,989,413 | **−24.39%** |
| `simple` 20k | 2,251,393,629 | 2,251,388,486 | 0.00% |

`simple` is unchanged because it books no cost specs — which is the shape of the change: it removes work proportional to accumulated lots.

**Mechanism confirmed, not inferred.** `Position::clone` went from 1.30G instructions to 0.32G (−76%); `drop_glue::<Position>` from 5.3% to 1.8% of the run.

Scaling for 10× input improves **41.9× → 35.8×**. Still superlinear, and I want to be plain about that: the remaining terms are `is_reduced_by` — an O(lots) scan per posting, now the single largest at 9.0% — and the O(lots) `rebuild_index` on the commit path. Neither is touched here.

## Correctness

`two_reducing_postings_on_one_account_see_each_other` pins the case the working copy still exists for: 10 units held, 6 and 6 sold in one transaction must fail on insufficient units; 6 and 4 must succeed. Mutation-checked — removing the working copy entirely fails that test and the existing `test_multi_posting_crosses_lot_boundary`.

The `try_reduce_equivalence` proptest (`try_reduce(&inv, op) == reduce(&mut inv.clone(), op)`, every booking method, randomized inventories) passes throughout and is the main guard on the split.

## Also in here

Two commits correcting `reduce`'s `make_owned` comment, which claimed the booking engine's working copy was an imbl **O(1)** clone. That stopped being true at #2056 and is a good part of why the copy went unexamined — it was the one piece of evidence pointing the wrong way while I was chasing this. The second commit brings it up to date with the refactor.

Gates: `cargo test --workspace --all-features` (141 suites), `cargo +1.97.0 clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)