### PR TITLE
refactor(core): route position indices through one accessor

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -197,8 +197,7 @@ impl Inventory {
     ) -> Result<(BookingResult, ReductionPlan), BookingError> {
         let matching_indices: Vec<usize> = self
             .positions
-            .iter()
-            .enumerate()
+            .iter_slots()
             .filter(|(_, p)| {
                 p.units.currency == units.currency
                     && !p.is_empty()
@@ -270,8 +269,7 @@ impl Inventory {
     ) -> Result<BookingResult, BookingError> {
         let matching_indices: Vec<usize> = self
             .positions
-            .iter()
-            .enumerate()
+            .iter_slots()
             .filter(|(_, p)| {
                 p.units.currency == units.currency
                     && !p.is_empty()
@@ -353,8 +351,7 @@ impl Inventory {
         // Get matching positions with their costs
         let mut matching: Vec<(usize, Decimal)> = self
             .positions
-            .iter()
-            .enumerate()
+            .iter_slots()
             .filter(|(_, p)| {
                 p.units.currency == units.currency
                     && !p.is_empty()
@@ -491,8 +488,7 @@ impl Inventory {
         // Get indices of matching positions
         let mut indices: Vec<usize> = self
             .positions
-            .iter()
-            .enumerate()
+            .iter_slots()
             .filter(|(_, p)| {
                 p.units.currency == units.currency
                     && !p.is_empty()
@@ -786,8 +782,7 @@ impl Inventory {
         // This prevents accidentally netting long and short positions.
         let matching: Vec<(usize, &Position)> = self
             .positions
-            .iter()
-            .enumerate()
+            .iter_slots()
             .filter(|(_, p)| {
                 p.units.currency == units.currency
                     && !p.is_empty()

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -844,12 +844,8 @@ impl Inventory {
         // Remove all matching lots of this currency
         let matching_indices: std::collections::HashSet<usize> =
             matching.iter().map(|(i, _)| *i).collect();
-        let mut idx = 0;
-        self.positions.retain(|_| {
-            let keep = !matching_indices.contains(&idx);
-            idx += 1;
-            keep
-        });
+        self.positions
+            .retain_slots(|slot, _| !matching_indices.contains(&slot));
 
         // Add back a single merged lot with the remainder
         let remaining = total_units + units.number; // units.number is negative for reductions

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -4079,14 +4079,31 @@ mod tests {
             ))
             .expect("fits");
         }
+        // Two lots IDENTICAL by value. `add` never merges cost-bearing lots —
+        // it keeps them separate to match Python — so this is an ordinary
+        // inventory, and it is the shape that makes the assertion below
+        // meaningful: with only distinct lots, comparing by value cannot tell
+        // "the right slot" from "a slot holding an equal position".
+        for _ in 0..2 {
+            inv.add(Position::with_cost(
+                Amount::new(dec!(7), "AAPL"),
+                Cost::new(dec!(70), "USD"),
+            ))
+            .expect("fits");
+        }
         inv.add(Position::simple(Amount::new(dec!(99), "USD")))
             .expect("fits");
 
         let mut seen = 0;
         for (slot, position) in inv.positions.iter_slots() {
-            assert_eq!(
-                &inv.positions[slot], position,
-                "slot {slot} does not address the position it was yielded with",
+            // Pointer identity, not `assert_eq!`. `Position: PartialEq`, so a
+            // value comparison passes when a wrong index happens to land on an
+            // equal lot — exactly what the duplicate pair above arranges.
+            // Review catch on #2065.
+            assert!(
+                std::ptr::eq(std::ptr::from_ref(&inv.positions[slot]), position),
+                "slot {slot} addresses a different position than the one it \
+                 was yielded with",
             );
             seen += 1;
         }
@@ -4095,6 +4112,6 @@ mod tests {
             inv.positions().count(),
             "iter_slots must visit every live position",
         );
-        assert_eq!(seen, 4, "fixture must hold four lots");
+        assert_eq!(seen, 6, "fixture must hold six lots, two of them equal");
     }
 }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -450,6 +450,29 @@ impl PositionStore {
         }
     }
 
+    /// [`Self::retain`], with each position's slot index — the same index
+    /// [`Self::iter_slots`] reports and [`Index`] accepts.
+    ///
+    /// `reduce_merge` needs this: it selects lots through `iter_slots` and
+    /// then drops exactly those. Written with a plain `retain` and a counter
+    /// incremented per visit, that is only correct while every element the
+    /// store holds is a live position visited in order — the same dense-store
+    /// assumption `iter_slots` exists to keep in one place, arriving by a
+    /// second route that `iter_slots` cannot cover. A sparse store whose
+    /// `retain` skips dead slots would leave the counter numbering live
+    /// positions while the selection numbered real slots, and `{*}` merges
+    /// would delete the wrong lots.
+    ///
+    /// [`Index`]: std::ops::Index
+    fn retain_slots(&mut self, mut f: impl FnMut(usize, &Position) -> bool) {
+        let mut slot = 0;
+        self.retain(|position| {
+            let keep = f(slot, position);
+            slot += 1;
+            keep
+        });
+    }
+
     /// Switch to contiguous storage, cloning if not already `Owned`.
     ///
     /// `reduce` calls this, which ALSO discharges the uniqueness requirement

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -387,6 +387,23 @@ impl Default for PositionStore {
 }
 
 impl PositionStore {
+    /// Every live position paired with the index that [`Index`] will accept
+    /// for it.
+    ///
+    /// Today this is exactly `iter().enumerate()`, because every element of
+    /// the backing store is live. It exists as its own method because that
+    /// equivalence is a PROPERTY OF THE CURRENT STORAGE, not a law: the
+    /// reduction paths collect indices here and hand them back through
+    /// `Index`/`IndexMut`, so anything that makes the backing sparse — the
+    /// tombstoned lots that would let a cost-keyed index survive removals —
+    /// silently desynchronises the two unless every such site goes through
+    /// one place. This is that place.
+    ///
+    /// [`Index`]: std::ops::Index
+    fn iter_slots(&self) -> impl Iterator<Item = (usize, &Position)> {
+        self.iter().enumerate()
+    }
+
     fn iter(&self) -> PositionStoreIter<'_> {
         match self {
             Self::Owned(v) => PositionStoreIter::Owned(v.iter()),
@@ -1306,7 +1323,7 @@ impl Inventory {
         self.simple_index.clear();
         self.units_cache.clear();
 
-        for (idx, pos) in self.positions.iter().enumerate() {
+        for (idx, pos) in self.positions.iter_slots() {
             // Update units cache for all positions. Checked, not `+=`:
             // `Decimal`'s `+` panics on overflow, and this runs over payloads.
             //
@@ -4037,5 +4054,47 @@ mod tests {
         inv.add(Position::simple(Amount::new(dec!(20), "USD")))
             .expect("fits");
         assert_eq!(inv.units("USD"), dec!(20));
+    }
+
+    /// Every index `iter_slots` yields must address, through `Index`, the very
+    /// position it was yielded with.
+    ///
+    /// This is trivially true while the backing store is dense — `iter_slots`
+    /// is `iter().enumerate()` — and it is the whole reason that method
+    /// exists. The reduction paths collect indices from it and hand them back
+    /// through `Index`/`IndexMut` to mutate the lot they selected. If the
+    /// store ever becomes sparse (tombstoned lots, so a cost-keyed index can
+    /// survive removals) and `iter_slots` keeps counting from zero instead of
+    /// reporting real slots, every reduction after the first hole mutates the
+    /// WRONG LOT — silently, with correct-looking totals.
+    ///
+    /// So this pins the contract rather than the current implementation.
+    #[test]
+    fn iter_slots_yields_indices_that_address_their_own_position() {
+        let mut inv = Inventory::new();
+        for units in [dec!(10), dec!(20), dec!(30)] {
+            inv.add(Position::with_cost(
+                Amount::new(units, "AAPL"),
+                Cost::new(units * dec!(10), "USD"),
+            ))
+            .expect("fits");
+        }
+        inv.add(Position::simple(Amount::new(dec!(99), "USD")))
+            .expect("fits");
+
+        let mut seen = 0;
+        for (slot, position) in inv.positions.iter_slots() {
+            assert_eq!(
+                &inv.positions[slot], position,
+                "slot {slot} does not address the position it was yielded with",
+            );
+            seen += 1;
+        }
+        assert_eq!(
+            seen,
+            inv.positions().count(),
+            "iter_slots must visit every live position",
+        );
+        assert_eq!(seen, 4, "fixture must hold four lots");
     }
 }


### PR DESCRIPTION
Groundwork for making lot matching sub-linear. **No behavior change** — 24 lines.

Seven sites collected a position index from `positions.iter().enumerate()` and later handed it back through `Index`/`IndexMut` to read or mutate that lot: `plan_strict`, `plan_ordered`, `reduce_hifo`, `reduce_average`, `reduce_merge`, the index repair in `commit_from_lot`, and the cache rebuild. They now go through `PositionStore::iter_slots()`.

Today that method *is* `iter().enumerate()`. It exists because the equivalence it relies on — position in iteration order equals the index `Index` accepts — is a property of the current **dense** storage, not a law. A cost-keyed index needs indices that survive removals, which needs a sparse store, which breaks that equivalence. With seven call sites the break is seven silent desyncs, each mutating the wrong lot while the totals still look right. With one accessor it is one line.

`iter_slots_yields_indices_that_address_their_own_position` pins the contract rather than the implementation. Mutation-checked: making slot indices count live items while `Index` addresses real slots fails it.

## Why this is only the groundwork

Matching is still the dominant superlinear term. After the equal-scale fast path (#2064) it is **25.1%** of a 20,000-transaction `investment` run and still grows **111×** for 10× the input, because every reduction walks every lot.

Removing that walk needs a cost-keyed index → stable indices → tombstoned lots. Those two must land **together**: tombstones alone make matching scan dead slots, which is a regression.

The remaining design, so it isn't re-derived:

- **Tombstone marker, no new field.** `add` rejects empty positions, so a zero-unit *cost-bearing* lot can only be one a reduction drained. Those are already invisible today because they're removed outright, so filtering them in iteration changes no output.
- **Compaction**, since drained slots accumulate and would otherwise make matching scan them. Compaction invalidates slot indices, so it must rebuild the index — amortized, and no caller holds an index across it.
- **Serialization** must not emit tombstones.
- Then the index itself, keyed on (units currency, cost number, cost currency), consulted when the spec carries an explicit per-unit cost and falling back to the scan otherwise.

This is ~400 lines through lot selection, serialization and compaction, where the failure mode is silent lot corruption rather than a red test. I'd rather land the verified enabling step and have the rest reviewed on its own than bundle it.

Gates: `cargo test --workspace --all-features` (142 suites), `cargo +1.97.0 clippy`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)