### PR TITLE
perf(core): tombstone removed lots and index them by cost

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -197,9 +197,18 @@ impl Inventory {
     ) -> Result<(BookingResult, ReductionPlan), BookingError> {
         // Candidates from the cost index when the spec names a per-unit cost,
         // otherwise every lot — a spec without one can match anything. Both
-        // arms apply the SAME predicate, so the index only narrows what is
-        // examined; it never decides a match, and a stale or missing entry
-        // costs correctness nothing that the predicate would not catch.
+        // arms apply the SAME predicate, so the index never decides a match;
+        // it only narrows what the predicate is run on.
+        //
+        // That asymmetry is the whole safety argument, and it only runs one
+        // way. A STALE entry is harmless: it names a tombstone or a lot that
+        // no longer matches, and the predicate discards it. A MISSING entry is
+        // NOT: the lot is never offered to the predicate at all, so a
+        // reduction that should have matched it reports no matching lot or
+        // books as an augmentation and duplicates the position. Index
+        // maintenance is therefore a correctness obligation, not an
+        // optimization — `draining_a_lot_removes_it_from_the_cost_index` and
+        // the `add`/rebuild mutations are what hold it.
         let matching_indices: Vec<usize> = match self.cost_candidates(units, spec) {
             Some(slots) => slots
                 .into_iter()

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -195,17 +195,39 @@ impl Inventory {
         units: &Amount,
         spec: &CostSpec,
     ) -> Result<(BookingResult, ReductionPlan), BookingError> {
-        let matching_indices: Vec<usize> = self
-            .positions
-            .iter_slots()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.can_reduce(units)
-                    && p.matches_cost_spec(spec)
-            })
-            .map(|(i, _)| i)
-            .collect();
+        // Candidates from the cost index when the spec names a per-unit cost,
+        // otherwise every lot — a spec without one can match anything. Both
+        // arms apply the SAME predicate, so the index only narrows what is
+        // examined; it never decides a match, and a stale or missing entry
+        // costs correctness nothing that the predicate would not catch.
+        let matching_indices: Vec<usize> = match self.cost_candidates(units, spec) {
+            Some(slots) => slots
+                .into_iter()
+                .filter(|i| {
+                    // `get`, not `[]`: indexing a tombstone panics, and a
+                    // stale entry must not be able to crash on user data. With
+                    // `get` it is merely a wasted candidate, which the
+                    // predicate discards anyway.
+                    self.positions.get(*i).is_some_and(|p| {
+                        p.units.currency == units.currency
+                            && !p.is_empty()
+                            && p.can_reduce(units)
+                            && p.matches_cost_spec(spec)
+                    })
+                })
+                .collect(),
+            None => self
+                .positions
+                .iter_slots()
+                .filter(|(_, p)| {
+                    p.units.currency == units.currency
+                        && !p.is_empty()
+                        && p.can_reduce(units)
+                        && p.matches_cost_spec(spec)
+                })
+                .map(|(i, _)| i)
+                .collect(),
+        };
 
         match matching_indices.len() {
             0 => Err(BookingError::NoMatchingLot {
@@ -1005,6 +1027,7 @@ impl Inventory {
         // Remove if empty, then repair `simple_index`.
         if self.positions[idx].is_empty() {
             self.sign_index_bump(idx, -1);
+            self.cost_index_remove(idx);
             self.positions.remove(idx);
 
             // Removing shifts every later position down one, so the stored
@@ -1019,29 +1042,18 @@ impl Inventory {
             // nothing at all; it grew 164x for 10x the input on the
             // `investment` profiling shape.
             //
-            // The removed lot CAN be the cost-less lot this map names: an
-            // empty cost spec matches a cost-less position
-            // (`matches_cost_spec`: `(None, true) => true`), so STRICT selects
-            // one and drains it. An earlier version of this asserted the
-            // opposite and handled only the shift, which left the map pointing
-            // at a removed index — the next cost-less `add` then merged into a
-            // lot that was no longer there, or indexed past the end. Caught in
-            // review on #2063; pinned by
-            // `removing_a_cost_less_lot_drops_its_index_entry`.
+            // Nothing shifted: removal leaves a tombstone, so every
+            // surviving lot keeps its slot. Only the entry naming the removed
+            // lot has to go — and it CAN name it, because an empty cost spec
+            // matches a cost-less position (`matches_cost_spec`:
+            // `(None, true) => true`), so STRICT can select and drain one.
             //
-            // One pass: drop the entry naming the removed lot, shift the rest.
-            // (`>` vs `>=` here is an equivalent mutation — the `== idx` arm
-            // returns first, so no entry equal to `idx` ever reaches it. A
-            // mutation swapping them survives, and that is not a gap.)
-            self.simple_index.retain(|_, stored| {
-                if *stored == idx {
-                    return false;
-                }
-                if *stored > idx {
-                    *stored -= 1;
-                }
-                true
-            });
+            // Before tombstones this also decremented the later entries to
+            // follow the shift. Keeping that now would renumber indices that
+            // did not move, pointing `add`'s merge at a tombstone — which is
+            // exactly what `removing_a_lot_repairs_the_index_of_a_later_cost_less_lot`
+            // caught.
+            self.simple_index.retain(|_, stored| *stored != idx);
         }
     }
 }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -4708,4 +4708,92 @@ mod tests {
             .expect("a snapshot with no cost index must fall back to scanning");
         assert_eq!(result.matched.len(), 1);
     }
+
+    /// Tombstones must not reach the wire, and a round trip must come back
+    /// dense.
+    ///
+    /// Every other round-trip test builds its inventory with `add` alone, so
+    /// none of them has a tombstone in it — the sparse backing was entirely
+    /// untested through serde. It matters twice over: the wire format is
+    /// pinned by downstream snapshots, and a leaked `null` would both break
+    /// them and deserialize into a lot that does not exist.
+    #[test]
+    fn a_drained_lot_does_not_reach_the_wire() {
+        let mut inv = Inventory::new();
+        for units in [dec!(10), dec!(20)] {
+            inv.add(Position::with_cost(
+                Amount::new(units, "AAPL"),
+                Cost::new(units * dec!(10), "USD"),
+            ))
+            .expect("fits");
+        }
+        inv.reduce(
+            &Amount::new(dec!(-10), "AAPL"),
+            Some(
+                &CostSpec::empty()
+                    .with_number(crate::CostNumber::PerUnit { value: dec!(100) })
+                    .with_currency("USD"),
+            ),
+            BookingMethod::Strict,
+        )
+        .expect("drains the first lot");
+        assert_eq!(
+            inv.positions.slot_count(),
+            2,
+            "the fixture must actually hold a tombstone, or this proves nothing",
+        );
+        assert_eq!(inv.positions.len(), 1, "one live lot");
+
+        let json = serde_json::to_string(&inv).expect("serializes");
+        // Check the positions ARRAY, not the whole string: `Cost`'s optional
+        // `date` and `label` serialize as `null` legitimately, so a bare
+        // "contains null" search reports a leak that is not there.
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let wire_positions = parsed
+            .get("positions")
+            .and_then(serde_json::Value::as_array)
+            .expect("positions is an array");
+        assert_eq!(
+            wire_positions.len(),
+            1,
+            "the wire must carry only the live lot, not the tombstone: {json}",
+        );
+        assert!(
+            !wire_positions.iter().any(serde_json::Value::is_null),
+            "a tombstone leaked onto the wire as a null element: {json}",
+        );
+
+        let round_tripped: Inventory = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(
+            round_tripped.positions.slot_count(),
+            1,
+            "the round trip must come back dense, not carrying the hole",
+        );
+        assert_eq!(round_tripped.positions.len(), 1);
+        assert_eq!(round_tripped.units("AAPL"), dec!(20));
+        assert_eq!(
+            round_tripped
+                .positions()
+                .next()
+                .expect("one lot")
+                .units
+                .number,
+            dec!(20),
+        );
+
+        // The rebuilt caches must work: the surviving lot is still bookable.
+        let mut round_tripped = round_tripped;
+        round_tripped
+            .reduce(
+                &Amount::new(dec!(-20), "AAPL"),
+                Some(
+                    &CostSpec::empty()
+                        .with_number(crate::CostNumber::PerUnit { value: dec!(200) })
+                        .with_currency("USD"),
+                ),
+                BookingMethod::Strict,
+            )
+            .expect("the deserialized lot is reachable");
+        assert_eq!(round_tripped.units("AAPL"), dec!(0));
+    }
 }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -346,8 +346,23 @@ impl std::error::Error for AccountedBookingError {}
 #[derive(Debug, Clone)]
 enum PositionStore {
     /// Contiguous — booking's working representation.
-    Owned(Vec<Position>),
-    /// Structurally shared — BQL's snapshot representation.
+    ///
+    /// SPARSE: a slot holding `None` is a lot a reduction drained and removed.
+    /// Removing by shifting renumbers every later lot, and lot indices have to
+    /// survive removals for a cost-keyed match index to be possible at all.
+    /// Tombstoning makes removal O(1) and leaves every other slot untouched.
+    ///
+    /// `None` is NOT the same as a zero-unit position. A zero-unit lot is live
+    /// and visible — cost-less lots can merge through zero — and
+    /// [`Inventory::len`] is documented as counting them. A tombstone is a lot
+    /// that is GONE. Encoding one as the other would make drained lots visible
+    /// to `Serialize`, the FFI and wasm converters, the account validator and
+    /// `report balances`, and would change what `currency_accounts` sees when
+    /// it branches on `inv.len() == 1` to match Python.
+    Owned(Slots),
+    /// Structurally shared — BQL's snapshot representation, and dense: BQL
+    /// clones snapshots but never books against them, so it has no removals to
+    /// keep indices stable across.
     Shared(Vector<Position>),
 }
 
@@ -358,7 +373,7 @@ enum PositionStore {
 /// a heap allocation and a dynamic dispatch on paths this change exists to
 /// make cheaper. Copilot's catch on #2056.
 enum PositionStoreIter<'a> {
-    Owned(std::slice::Iter<'a, Position>),
+    Owned(std::iter::Flatten<std::slice::Iter<'a, Option<Position>>>),
     Shared(imbl::vector::Iter<'a, Position, imbl::shared_ptr::DefaultSharedPtr>),
 }
 
@@ -380,9 +395,79 @@ impl<'a> Iterator for PositionStoreIter<'a> {
     }
 }
 
+/// The sparse backing: slots plus the number that are live.
+///
+/// `live` is maintained rather than counted because `len`, `is_empty` and the
+/// compaction trigger all run per reduction, and an O(slots) scan there is
+/// exactly the cost tombstones exist to avoid.
+#[derive(Debug, Clone, Default)]
+struct Slots {
+    slots: Vec<Option<Position>>,
+    live: usize,
+}
+
+impl Slots {
+    fn from_live(positions: Vec<Position>) -> Self {
+        let live = positions.len();
+        Self {
+            slots: positions.into_iter().map(Some).collect(),
+            live,
+        }
+    }
+
+    fn set_dead(&mut self, i: usize) {
+        if let Some(entry) = self.slots.get_mut(i)
+            && entry.take().is_some()
+        {
+            self.live -= 1;
+        }
+    }
+}
+
+/// Iterator over [`PositionStore`] yielding each live position with its SLOT
+/// index — the index [`std::ops::Index`] accepts, not a running count.
+///
+/// A stack-allocated enum for the same reason as [`PositionStoreIter`]: this
+/// runs inside every reduction and must not box.
+enum SlotIter<'a> {
+    Owned(std::iter::Enumerate<std::slice::Iter<'a, Option<Position>>>),
+    Shared(
+        std::iter::Enumerate<imbl::vector::Iter<'a, Position, imbl::shared_ptr::DefaultSharedPtr>>,
+    ),
+}
+
+impl<'a> SlotIter<'a> {
+    fn new(store: &'a PositionStore) -> Self {
+        match store {
+            PositionStore::Owned(v) => Self::Owned(v.slots.iter().enumerate()),
+            PositionStore::Shared(v) => Self::Shared(v.iter().enumerate()),
+        }
+    }
+}
+
+impl<'a> Iterator for SlotIter<'a> {
+    type Item = (usize, &'a Position);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Owned(i) => {
+                // Skip tombstones, but keep the REAL slot number of what we do
+                // yield: that number is what comes back through `Index`.
+                for (slot, entry) in i.by_ref() {
+                    if let Some(position) = entry {
+                        return Some((slot, position));
+                    }
+                }
+                None
+            }
+            Self::Shared(i) => i.next(),
+        }
+    }
+}
+
 impl Default for PositionStore {
     fn default() -> Self {
-        Self::Owned(Vec::new())
+        Self::Owned(Slots::default())
     }
 }
 
@@ -401,20 +486,43 @@ impl PositionStore {
     ///
     /// [`Index`]: std::ops::Index
     fn iter_slots(&self) -> impl Iterator<Item = (usize, &Position)> {
-        self.iter().enumerate()
+        // Real slot numbers, skipping tombstones — NOT a running count of live
+        // positions. The reduction paths hand these back to `Index`.
+        SlotIter::new(self)
     }
 
+    /// Live positions, dropping tombstones. This is what `Serialize`, the FFI
+    /// converters and every external consumer see, so a drained lot stays
+    /// invisible exactly as it was when removal shifted the vector.
     fn iter(&self) -> PositionStoreIter<'_> {
         match self {
-            Self::Owned(v) => PositionStoreIter::Owned(v.iter()),
+            Self::Owned(v) => PositionStoreIter::Owned(v.slots.iter().flatten()),
             Self::Shared(v) => PositionStoreIter::Shared(v.iter()),
         }
     }
 
+    /// Number of LIVE positions. Tombstones are not positions.
     fn len(&self) -> usize {
         match self {
-            Self::Owned(v) => v.len(),
+            Self::Owned(v) => v.live,
             Self::Shared(v) => v.len(),
+        }
+    }
+
+    /// Number of slots, live or not — the exclusive upper bound on a valid
+    /// slot index, and what `push_slot` returns for the slot it fills.
+    fn slot_count(&self) -> usize {
+        match self {
+            Self::Owned(v) => v.slots.len(),
+            Self::Shared(v) => v.len(),
+        }
+    }
+
+    /// How many slots are tombstones.
+    const fn dead(&self) -> usize {
+        match self {
+            Self::Owned(v) => v.slots.len() - v.live,
+            Self::Shared(_) => 0,
         }
     }
 
@@ -424,29 +532,70 @@ impl PositionStore {
 
     fn get(&self, i: usize) -> Option<&Position> {
         match self {
-            Self::Owned(v) => v.get(i),
+            Self::Owned(v) => v.slots.get(i).and_then(Option::as_ref),
             Self::Shared(v) => v.get(i),
         }
     }
 
     fn push(&mut self, p: Position) {
+        self.push_slot(p);
+    }
+
+    /// Append a position, returning the slot index it landed in.
+    ///
+    /// The slot is `slot_count()`, not `len()`: with tombstones present those
+    /// differ, and `simple_index` stores slots.
+    fn push_slot(&mut self, p: Position) -> usize {
+        let slot = self.slot_count();
         match self {
-            Self::Owned(v) => v.push(p),
+            Self::Owned(v) => {
+                v.slots.push(Some(p));
+                v.live += 1;
+            }
             Self::Shared(v) => v.push_back(p),
         }
+        slot
     }
 
-    fn remove(&mut self, i: usize) -> Position {
+    /// Remove the position in slot `i`, leaving a tombstone behind so no other
+    /// slot is renumbered.
+    fn remove(&mut self, i: usize) {
         match self {
-            Self::Owned(v) => v.remove(i),
-            Self::Shared(v) => v.remove(i),
+            Self::Owned(v) => v.set_dead(i),
+            Self::Shared(v) => {
+                v.remove(i);
+            }
         }
     }
 
-    fn retain(&mut self, f: impl FnMut(&Position) -> bool) {
+    /// Drop positions failing `f`. On the sparse backing they become
+    /// tombstones, so no surviving lot is renumbered.
+    fn retain(&mut self, mut f: impl FnMut(&Position) -> bool) {
         match self {
-            Self::Owned(v) => v.retain(f),
+            Self::Owned(v) => {
+                for i in 0..v.slots.len() {
+                    if v.slots[i].as_ref().is_some_and(|p| !f(p)) {
+                        v.set_dead(i);
+                    }
+                }
+            }
             Self::Shared(v) => v.retain(f),
+        }
+    }
+
+    /// Physically drop tombstones, renumbering the slots that remain.
+    ///
+    /// INVALIDATES every slot index, so callers must hold none and must
+    /// rebuild anything keyed by slot. Reductions never span this: it runs
+    /// before planning, when nothing is held.
+    fn compact_slots(&mut self) {
+        if let Self::Owned(v) = self {
+            v.slots.retain(Option::is_some);
+            debug_assert_eq!(
+                v.slots.len(),
+                v.live,
+                "compaction must leave only live slots"
+            );
         }
     }
 
@@ -465,12 +614,24 @@ impl PositionStore {
     ///
     /// [`Index`]: std::ops::Index
     fn retain_slots(&mut self, mut f: impl FnMut(usize, &Position) -> bool) {
-        let mut slot = 0;
-        self.retain(|position| {
-            let keep = f(slot, position);
-            slot += 1;
-            keep
-        });
+        match self {
+            Self::Owned(v) => {
+                for i in 0..v.slots.len() {
+                    if v.slots[i].as_ref().is_some_and(|p| !f(i, p)) {
+                        v.set_dead(i);
+                    }
+                }
+            }
+            // Dense: a running count IS the slot number here.
+            Self::Shared(v) => {
+                let mut slot = 0;
+                v.retain(|position| {
+                    let keep = f(slot, position);
+                    slot += 1;
+                    keep
+                });
+            }
+        }
     }
 
     /// Switch to contiguous storage, cloning if not already `Owned`.
@@ -485,25 +646,41 @@ impl PositionStore {
     /// then contiguous instead of an RRB walk.
     fn make_owned(&mut self) {
         if let Self::Shared(v) = self {
-            *self = Self::Owned(v.iter().cloned().collect());
+            let slots: Vec<Option<Position>> = v.iter().cloned().map(Some).collect();
+            let live = slots.len();
+            *self = Self::Owned(Slots { slots, live });
         }
     }
 }
 
 impl std::ops::Index<usize> for PositionStore {
     type Output = Position;
+    /// # Panics
+    ///
+    /// Panics if `i` names a tombstone. Every index in circulation comes from
+    /// [`PositionStore::iter_slots`] or [`PositionStore::push_slot`], which
+    /// only ever report live slots, and no reduction removes a lot and then
+    /// re-reads it — so reaching a tombstone means slot numbers and the store
+    /// have desynchronised, and a wrong-lot read is worse than a panic.
     fn index(&self, i: usize) -> &Position {
         match self {
-            Self::Owned(v) => &v[i],
+            Self::Owned(v) => v.slots[i]
+                .as_ref()
+                .expect("slot index names a live position, not a tombstone"),
             Self::Shared(v) => &v[i],
         }
     }
 }
 
 impl std::ops::IndexMut<usize> for PositionStore {
+    /// # Panics
+    ///
+    /// As [`Index::index`](std::ops::Index::index).
     fn index_mut(&mut self, i: usize) -> &mut Position {
         match self {
-            Self::Owned(v) => &mut v[i],
+            Self::Owned(v) => v.slots[i]
+                .as_mut()
+                .expect("slot index names a live position, not a tombstone"),
             Self::Shared(v) => &mut v[i],
         }
     }
@@ -511,7 +688,9 @@ impl std::ops::IndexMut<usize> for PositionStore {
 
 impl FromIterator<Position> for PositionStore {
     fn from_iter<I: IntoIterator<Item = Position>>(iter: I) -> Self {
-        Self::Owned(iter.into_iter().collect())
+        let slots: Vec<Option<Position>> = iter.into_iter().map(Some).collect();
+        let live = slots.len();
+        Self::Owned(Slots { slots, live })
     }
 }
 
@@ -528,7 +707,9 @@ impl Serialize for PositionStore {
 
 impl<'de> Deserialize<'de> for PositionStore {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::Owned(Vec::<Position>::deserialize(deserializer)?))
+        Ok(Self::Owned(Slots::from_live(Vec::<Position>::deserialize(
+            deserializer,
+        )?)))
     }
 }
 
@@ -609,6 +790,36 @@ pub struct Inventory {
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
     units_cache: FxHashMap<crate::Currency, CurrencyStats>,
+    /// Cost-bearing lots grouped by what a cost spec matches them on, so a
+    /// reduction naming an explicit per-unit cost finds its candidates instead
+    /// of comparing against every lot.
+    ///
+    /// That comparison was the last superlinear term in the pipeline:
+    /// `CostSpec::matches` ran once per lot per reduction and grew 111x for
+    /// 10x the input. Slots are stable across removals — that is what the
+    /// tombstoned backing buys — so the lists stay valid until compaction,
+    /// which rebuilds them.
+    ///
+    /// Only lots WITH a cost appear. A spec that names no per-unit cost still
+    /// scans, because it can match anything.
+    /// Not serialized - rebuilt on demand, like the caches above.
+    #[serde(skip)]
+    cost_index: FxHashMap<CostKey, smallvec::SmallVec<[usize; 2]>>,
+}
+
+/// What [`Inventory::cost_index`] groups lots by: the units they are held in,
+/// and the per-unit cost a spec would name to select them.
+type CostKey = (crate::Currency, Decimal, crate::Currency);
+
+/// The key for `position`, if it carries a cost.
+fn cost_key(position: &Position) -> Option<CostKey> {
+    position.cost.as_ref().map(|cost| {
+        (
+            position.units.currency.clone(),
+            cost.number,
+            cost.currency.clone(),
+        )
+    })
 }
 
 /// Everything cached per currency: the running unit total, and the per-bucket
@@ -727,9 +938,10 @@ impl TryFrom<InventoryWire> for Inventory {
     /// deserialization error.
     fn try_from(wire: InventoryWire) -> Result<Self, Self::Error> {
         let mut inv = Self {
-            positions: PositionStore::Owned(wire.positions.into_iter().collect()),
+            positions: PositionStore::Owned(Slots::from_live(wire.positions.into_iter().collect())),
             simple_index: FxHashMap::default(),
             units_cache: FxHashMap::default(),
+            cost_index: FxHashMap::default(),
         };
         // UNTRUSTED: the payload is input, not something this type produced, so
         // it may carry two cost-less lots for one currency — a state the
@@ -780,40 +992,22 @@ impl Inventory {
         self.positions.iter().collect()
     }
 
-    /// Get mutable access to the underlying positions, contiguously.
+    /// Rewrite the positions wholesale, then rebuild every derived cache.
     ///
-    /// Forces the contiguous backing first, so the caller gets a real
-    /// `&mut Vec<Position>` with O(1) indexing and amortized O(1) push. If
-    /// the inventory was using the structurally-shared backing — the BQL
-    /// snapshot representation, see [`Inventory::new_shared`] — that
-    /// conversion costs O(M) once and any sharing with earlier snapshots is
-    /// dropped for THIS inventory; the snapshots themselves are unaffected.
+    /// Replaces the old `positions_mut`, which handed out `&mut Vec<Position>`
+    /// directly. That is no longer possible — the backing is sparse, so the
+    /// vector holds `Option<Position>` alongside a live count, and a caller
+    /// writing through it could desync that count with no way to notice.
+    /// It also left `units_cache` and `simple_index` describing the OLD
+    /// contents, which this rebuilds for you.
     ///
-    /// (The backing enum is private, so this deliberately describes it in
-    /// prose rather than linking: a public doc cannot intra-doc-link a
-    /// private item, and `cargo doc -D warnings` rejects it.)
-    ///
-    /// **Caches are the caller's problem here.** Mutating positions through
-    /// this handle leaves `units_cache` — both the running totals and the
-    /// sign counts — and `simple_index` describing the OLD contents. Those
-    /// drive `units()`, the reduction-vs-augmentation decision in
-    /// `is_reduced_by`, and cost-less merging in `add` respectively.
-    ///
-    /// [`Self::compact`] rebuilds all of them, but note that it ALSO drops
-    /// every empty position on the way through. If the caller deliberately
-    /// left a zero-unit lot in place, compacting to refresh the caches will
-    /// silently remove it — so that is a semantic change, not just a cache
-    /// refresh.
-    ///
-    /// Debug builds catch a missed rebuild through `is_reduced_by`'s
-    /// consistency assertion; release builds silently book against a stale
-    /// view.
-    pub fn positions_mut(&mut self) -> &mut Vec<Position> {
-        self.positions.make_owned();
-        match &mut self.positions {
-            PositionStore::Owned(v) => v,
-            PositionStore::Shared(_) => unreachable!("make_owned just ran"),
-        }
+    /// Pre-1.0 break: the closure sees a dense `Vec<Position>` with tombstones
+    /// already dropped, and whatever it leaves becomes the inventory.
+    pub fn modify_positions(&mut self, f: impl FnOnce(&mut Vec<Position>)) {
+        let mut dense: Vec<Position> = self.positions.iter().cloned().collect();
+        f(&mut dense);
+        self.positions = PositionStore::Owned(Slots::from_live(dense));
+        self.rebuild_index();
     }
 
     /// An inventory whose positions are structurally SHARED.
@@ -1193,17 +1387,23 @@ impl Inventory {
                 return Ok(());
             }
             // No existing position - add new one and index it
-            let idx = self.positions.len();
-            self.simple_index
-                .insert(position.units.currency.clone(), idx);
-            self.positions.push(position);
+            // `push_slot`, not `len()`: with tombstones present the live
+            // count is not the slot the lot lands in, and `simple_index`
+            // stores slots.
+            let currency = position.units.currency.clone();
+            let idx = self.positions.push_slot(position);
+            self.simple_index.insert(currency, idx);
             return Ok(());
         }
 
         // For positions with cost, just add as a new lot.
         // This is O(1) and keeps all lots separate, matching Python beancount behavior.
         // Lot aggregation for display purposes is handled separately in query output.
-        self.positions.push(position);
+        let key = cost_key(&position);
+        let slot = self.positions.push_slot(position);
+        if let Some(key) = key {
+            self.cost_index.entry(key).or_default().push(slot);
+        }
         Ok(())
     }
 
@@ -1211,13 +1411,44 @@ impl Inventory {
     ///
     /// Called with `-1` before changing or removing a lot and `+1` after, so
     /// a sign flip lands in the right bucket.
+    /// Drop `idx` from [`Self::cost_index`]. Called wherever a lot is
+    /// tombstoned, since the slot stays valid but the lot is gone.
+    pub(super) fn cost_index_remove(&mut self, idx: usize) {
+        let Some(key) = self.positions.get(idx).and_then(cost_key) else {
+            return;
+        };
+        if let Some(slots) = self.cost_index.get_mut(&key) {
+            slots.retain(|slot| *slot != idx);
+            if slots.is_empty() {
+                self.cost_index.remove(&key);
+            }
+        }
+    }
+
+    /// Slots that could satisfy `spec` for `units`, or `None` when the spec
+    /// names no per-unit cost and therefore every lot is a candidate.
+    ///
+    /// Returned ascending so callers see the same order a scan would.
+    fn cost_candidates(&self, units: &Amount, spec: &CostSpec) -> Option<Vec<usize>> {
+        let number = spec.number.and_then(|n| n.per_unit())?;
+        let currency = spec.currency.clone()?;
+        let mut slots = self
+            .cost_index
+            .get(&(units.currency.clone(), number, currency))
+            .cloned()
+            .unwrap_or_default()
+            .to_vec();
+        slots.sort_unstable();
+        Some(slots)
+    }
+
     pub(super) fn sign_index_bump(&mut self, idx: usize, delta: i32) {
         // All three call sites pass an index they just read or wrote, so this
         // is defensive only. Returning rather than panicking keeps a future
         // caller's off-by-one out of the panic path; the counts then disagree
         // with a scan, which `is_reduced_by`'s assertion reports in debug.
         debug_assert!(
-            idx < self.positions.len(),
+            idx < self.positions.slot_count(),
             "sign_index_bump called with out-of-range index {idx}",
         );
         let Some(position) = self.positions.get(idx) else {
@@ -1299,6 +1530,19 @@ impl Inventory {
         // no shared chunk to corrupt.
         self.positions.make_owned();
 
+        // Drop tombstones once they outnumber live lots, so slots stay within
+        // 2x the real position count and iteration cannot degrade toward
+        // "every lot this account ever held". This is the ONLY place it can
+        // run: compaction renumbers slots, and here nothing holds one — the
+        // planners have not looked at the store yet.
+        //
+        // Amortized: each compaction is O(slots) but halves them, so the cost
+        // per removed lot is constant.
+        if self.positions.dead() > self.positions.len() {
+            self.positions.compact_slots();
+            self.rebuild_index();
+        }
+
         // {*} merge operator: merge all lots into a single weighted-average-cost
         // lot before reducing, regardless of the account's booking method.
         if spec.merge {
@@ -1345,8 +1589,12 @@ impl Inventory {
     fn try_rebuild_index_from(&mut self, source: CacheSource) -> Result<(), OverflowError> {
         self.simple_index.clear();
         self.units_cache.clear();
+        self.cost_index.clear();
 
         for (idx, pos) in self.positions.iter_slots() {
+            if let Some(key) = cost_key(pos) {
+                self.cost_index.entry(key).or_default().push(idx);
+            }
             // Update units cache for all positions. Checked, not `+=`:
             // `Decimal`'s `+` panics on overflow, and this runs over payloads.
             //
@@ -2867,8 +3115,12 @@ mod tests {
 
         // Inventory should have a single merged lot with 15 remaining @ 155
         assert_eq!(inv.positions.len(), 1);
-        assert_eq!(inv.positions[0].units.number, dec!(15));
-        let cost = inv.positions[0].cost.as_ref().expect("should have cost");
+        // Through the iterator, not a raw slot: the merged lot is appended
+        // after the tombstoned originals, and the iterator is what every
+        // consumer sees.
+        let merged = inv.positions().next().expect("one merged lot");
+        assert_eq!(merged.units.number, dec!(15));
+        let cost = merged.cost.as_ref().expect("should have cost");
         assert_eq!(cost.number, dec!(155));
     }
 
@@ -2946,7 +3198,10 @@ mod tests {
 
         assert_eq!(result.cost_basis, Some(Amount::new(dec!(450), "USD")));
         assert_eq!(inv.positions.len(), 1);
-        assert_eq!(inv.positions[0].units.number, dec!(7));
+        // Iterator, not a raw slot: the merged lot is appended after the
+        // tombstoned originals.
+        let merged = inv.positions().next().expect("one merged lot");
+        assert_eq!(merged.units.number, dec!(7));
     }
 
     #[test]
@@ -2981,8 +3236,11 @@ mod tests {
 
         assert_eq!(result.cost_basis, Some(Amount::new(dec!(900), "USD")));
         assert_eq!(inv.positions.len(), 1);
-        assert_eq!(inv.positions[0].units.number, dec!(24));
-        let cost = inv.positions[0].cost.as_ref().expect("should have cost");
+        // Iterator, not a raw slot: the merged lot is appended after the
+        // tombstoned originals.
+        let merged = inv.positions().next().expect("one merged lot");
+        assert_eq!(merged.units.number, dec!(24));
+        let cost = merged.cost.as_ref().expect("should have cost");
         assert_eq!(cost.number, dec!(150));
     }
 
@@ -3948,16 +4206,25 @@ mod tests {
     /// matching lot — booking a sale as a purchase and duplicating the lot,
     /// which is the #875-class bug this predicate exists to prevent.
     ///
-    /// So the unbuilt case falls back to the scan. This is the only test that
-    /// reaches that branch: every other route into `is_reduced_by` goes
-    /// through `add` or a rebuild, both of which populate the cache.
+    /// So the unbuilt case falls back to the scan.
+    ///
+    /// The cache is cleared DIRECTLY here. It used to be reached through
+    /// `positions_mut`, which handed out the position vector and left the
+    /// caches describing the old contents — that accessor is gone, and its
+    /// replacement `modify_positions` rebuilds them, so no public API produces
+    /// this state any more. The fallback stays because `units_cache` is
+    /// `#[serde(skip)]` and answering "not a reduction" for an inventory that
+    /// plainly holds a matching lot is the unsafe direction; this constructs
+    /// the state the only way left, and says so.
     #[test]
     fn an_unbuilt_cache_falls_back_to_the_scan_rather_than_answering_no() {
         let mut inv = Inventory::new();
-        inv.positions_mut().push(Position::with_cost(
+        inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(100), "USD"),
-        ));
+        ))
+        .expect("fits");
+        inv.units_cache.clear();
         assert!(
             inv.units_cache.is_empty(),
             "the fixture must reach `is_reduced_by` with an unbuilt cache, or \
@@ -3993,15 +4260,18 @@ mod tests {
         ));
     }
 
-    /// Removing a drained lot shifts every later position down one, and
-    /// `simple_index` stores POSITIONS BY INDEX — so a cost-less lot sitting
-    /// after the removed one must have its stored index repaired.
+    /// A cost-less lot sitting after a removed one keeps working.
     ///
-    /// Get this wrong and `add` merges a later cost-less deposit into the
-    /// wrong lot, or indexes past the end. Nothing else in the suite covers
-    /// it: it needs a cost-bearing lot and a cost-less lot in the same
-    /// inventory, with the cost-bearing one removed first, and inventories in
-    /// most tests hold only one kind.
+    /// Removal used to shift every later position down one, so `simple_index`
+    /// — which stores positions BY INDEX — had to be repaired to follow the
+    /// shift. With tombstones nothing moves, so the entry must be left exactly
+    /// where it is; repairing it now would point `add`'s merge at the wrong
+    /// slot. Same test, opposite mechanism, and the consequence it guards is
+    /// unchanged: a later cost-less deposit must MERGE rather than duplicate.
+    ///
+    /// Nothing else in the suite covers it: it needs a cost-bearing lot and a
+    /// cost-less lot in the same inventory, with the cost-bearing one removed
+    /// first, and inventories in most tests hold only one kind.
     #[test]
     fn removing_a_lot_repairs_the_index_of_a_later_cost_less_lot() {
         let mut inv = Inventory::new();
@@ -4020,7 +4290,7 @@ mod tests {
         );
 
         // Drain the cost-bearing lot. STRICT takes the single-lot commit path,
-        // which removes in place rather than rebuilding.
+        // which tombstones the slot in place.
         inv.reduce(
             &Amount::new(dec!(-10), "AAPL"),
             Some(&CostSpec::default()),
@@ -4030,8 +4300,8 @@ mod tests {
 
         assert_eq!(
             inv.simple_index.get(&crate::Currency::new("USD")),
-            Some(&0),
-            "the cost-less lot moved to index 0 and the index must follow it",
+            Some(&1),
+            "the cost-less lot did not move, so its stored slot must not change",
         );
 
         // The consequence a stale index actually has: this must MERGE into the
@@ -4136,5 +4406,143 @@ mod tests {
             "iter_slots must visit every live position",
         );
         assert_eq!(seen, 6, "fixture must hold six lots, two of them equal");
+    }
+
+    /// The point of tombstoning: removing a lot must not renumber the lots
+    /// after it.
+    ///
+    /// Shifting was what made a cost-keyed match index impossible — every
+    /// removal invalidated every later index. This is the property the whole
+    /// sparse backing exists to provide, so it is asserted directly rather
+    /// than inferred from something downstream.
+    #[test]
+    fn a_removal_does_not_renumber_the_lots_after_it() {
+        let mut inv = Inventory::new();
+        for units in [dec!(10), dec!(20), dec!(30)] {
+            inv.add(Position::with_cost(
+                Amount::new(units, "AAPL"),
+                Cost::new(units * dec!(10), "USD"),
+            ))
+            .expect("fits");
+        }
+        let before: Vec<usize> = inv.positions.iter_slots().map(|(slot, _)| slot).collect();
+        assert_eq!(before, vec![0, 1, 2], "fixture must fill three slots");
+
+        // Drain the MIDDLE lot, so a shift would move the one after it.
+        inv.reduce(
+            &Amount::new(dec!(-20), "AAPL"),
+            Some(
+                &CostSpec::empty()
+                    .with_number(crate::CostNumber::PerUnit { value: dec!(200) })
+                    .with_currency("USD"),
+            ),
+            BookingMethod::Strict,
+        )
+        .expect("drains the middle lot");
+
+        let after: Vec<(usize, Decimal)> = inv
+            .positions
+            .iter_slots()
+            .map(|(slot, p)| (slot, p.units.number))
+            .collect();
+        assert_eq!(
+            after,
+            vec![(0, dec!(10)), (2, dec!(30))],
+            "the surviving lots must keep the slots they had; slot 1 is now a \
+             tombstone and slot 2 must NOT have become slot 1",
+        );
+        assert_eq!(inv.positions.len(), 2, "two live lots");
+        assert_eq!(inv.positions.slot_count(), 3, "three slots, one dead");
+    }
+
+    /// Tombstones must not pile up without bound.
+    ///
+    /// Without compaction a long-lived account accumulates one dead slot per
+    /// closed lot, and every scan walks all of them — matching would degrade
+    /// toward "every lot this account ever held", which is far worse than the
+    /// shifting it replaced. Compaction runs at the top of `reduce`, the one
+    /// point where no slot index is held.
+    #[test]
+    fn tombstones_are_compacted_rather_than_accumulating() {
+        let mut inv = Inventory::new();
+        for i in 0..50u32 {
+            let cost = Decimal::from(100 + i);
+            inv.add(Position::with_cost(
+                Amount::new(dec!(1), "AAPL"),
+                Cost::new(cost, "USD"),
+            ))
+            .expect("fits");
+            inv.reduce(
+                &Amount::new(dec!(-1), "AAPL"),
+                Some(
+                    &CostSpec::empty()
+                        .with_number(crate::CostNumber::PerUnit { value: cost })
+                        .with_currency("USD"),
+                ),
+                BookingMethod::Strict,
+            )
+            .expect("drains it again");
+        }
+        assert_eq!(inv.positions.len(), 0, "every lot was closed");
+        assert!(
+            inv.positions.slot_count() <= 4,
+            "50 open-and-close cycles left {} slots; compaction is not running, \
+             and every later scan pays for all of them",
+            inv.positions.slot_count(),
+        );
+    }
+
+    /// Draining a lot must take it out of the cost index.
+    ///
+    /// A stale entry is not merely wasteful: the slot it names is a tombstone,
+    /// and it would be handed to the reduction path as a candidate. The lookup
+    /// tolerates that by design, but the index still has to be maintained —
+    /// otherwise the lists grow without bound as lots close, and the whole
+    /// point of the index erodes. Asserted directly, because the tolerant
+    /// lookup means no behavioral test can see the difference.
+    #[test]
+    fn draining_a_lot_removes_it_from_the_cost_index() {
+        let spec = || {
+            CostSpec::empty()
+                .with_number(crate::CostNumber::PerUnit { value: dec!(100) })
+                .with_currency("USD")
+        };
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(100), "USD"),
+        ))
+        .expect("fits");
+        assert_eq!(inv.cost_index.len(), 1, "the lot is indexed");
+
+        inv.reduce(
+            &Amount::new(dec!(-10), "AAPL"),
+            Some(&spec()),
+            BookingMethod::Strict,
+        )
+        .expect("drains the lot");
+
+        assert!(
+            inv.cost_index.is_empty(),
+            "the drained lot is still indexed: {:?}",
+            inv.cost_index,
+        );
+
+        // And the same cost can be re-used afterwards without tripping over
+        // the old slot — the case a stale entry would reach.
+        inv.add(Position::with_cost(
+            Amount::new(dec!(5), "AAPL"),
+            Cost::new(dec!(100), "USD"),
+        ))
+        .expect("fits");
+        let result = inv
+            .reduce(
+                &Amount::new(dec!(-5), "AAPL"),
+                Some(&spec()),
+                BookingMethod::Strict,
+            )
+            .expect("re-buying at the same cost and selling must work");
+        assert_eq!(result.matched.len(), 1);
+        assert_eq!(inv.positions.len(), 0);
     }
 }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -415,7 +415,20 @@ impl Slots {
         }
     }
 
+    /// Tombstone slot `i`, keeping `live` in step.
+    ///
+    /// Out of range is a caller bug, not a condition: slot indices come from
+    /// `iter_slots` or `push_slot` and are internal throughout. It cannot
+    /// panic in release — silently skipping is better than aborting on a
+    /// ledger — but it must not pass unnoticed in a test run, or a desynced
+    /// `live` count shows up later as a wrong compaction trigger with nothing
+    /// pointing back here.
     fn set_dead(&mut self, i: usize) {
+        debug_assert!(
+            i < self.slots.len(),
+            "set_dead called with out-of-range slot {i} (of {})",
+            self.slots.len(),
+        );
         if let Some(entry) = self.slots.get_mut(i)
             && entry.take().is_some()
         {
@@ -4544,5 +4557,72 @@ mod tests {
             .expect("re-buying at the same cost and selling must work");
         assert_eq!(result.matched.len(), 1);
         assert_eq!(inv.positions.len(), 0);
+    }
+
+    /// `modify_positions` hands over a DENSE vector and rebuilds every cache.
+    ///
+    /// It replaced `positions_mut`, which returned the backing vector
+    /// directly. Two promises to keep: the closure must never see tombstones
+    /// (the sparse backing is an implementation detail), and everything
+    /// derived — units totals, the cost-less merge index, the cost index and
+    /// the sign counts — must describe what the closure left, not what was
+    /// there before. The old accessor kept none of that, which its own docs
+    /// warned about.
+    #[test]
+    fn modify_positions_hands_over_a_dense_vector_and_rebuilds_the_caches() {
+        let mut inv = Inventory::new();
+        for units in [dec!(10), dec!(20)] {
+            inv.add(Position::with_cost(
+                Amount::new(units, "AAPL"),
+                Cost::new(units * dec!(10), "USD"),
+            ))
+            .expect("fits");
+        }
+        // Drain the first lot so a tombstone exists before the handover.
+        inv.reduce(
+            &Amount::new(dec!(-10), "AAPL"),
+            Some(
+                &CostSpec::empty()
+                    .with_number(crate::CostNumber::PerUnit { value: dec!(100) })
+                    .with_currency("USD"),
+            ),
+            BookingMethod::Strict,
+        )
+        .expect("drains the first lot");
+        assert_eq!(inv.positions.slot_count(), 2, "one live lot, one tombstone");
+
+        inv.modify_positions(|positions| {
+            assert_eq!(
+                positions.len(),
+                1,
+                "the closure must see only live lots; tombstones are ours, not \
+                 the caller's",
+            );
+            positions.push(Position::simple(Amount::new(dec!(5), "USD")));
+        });
+
+        // Every derived structure now describes what the closure left.
+        assert_eq!(inv.units("USD"), dec!(5), "units_cache rebuilt");
+        assert_eq!(inv.units("AAPL"), dec!(20));
+        assert_eq!(inv.positions.len(), 2);
+
+        // simple_index rebuilt: a further cost-less add MERGES.
+        inv.add(Position::simple(Amount::new(dec!(2), "USD")))
+            .expect("fits");
+        assert_eq!(inv.positions.len(), 2, "merged rather than appended");
+        assert_eq!(inv.units("USD"), dec!(7));
+
+        // cost_index rebuilt: the surviving lot is still findable by its cost.
+        inv.reduce(
+            &Amount::new(dec!(-20), "AAPL"),
+            Some(
+                &CostSpec::empty()
+                    .with_number(crate::CostNumber::PerUnit { value: dec!(200) })
+                    .with_currency("USD"),
+            ),
+            BookingMethod::Strict,
+        )
+        .expect("the surviving lot is still reachable through the cost index");
+        assert_eq!(inv.units("AAPL"), dec!(0));
     }
 }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1443,6 +1443,14 @@ impl Inventory {
     ///
     /// Returned ascending so callers see the same order a scan would.
     fn cost_candidates(&self, units: &Amount, spec: &CostSpec) -> Option<Vec<usize>> {
+        // An empty index means it was never built for this inventory — a
+        // shared snapshot, or one that has not been rebuilt since. Scanning is
+        // always correct, and answering from an index that is missing entries
+        // is NOT: the lot would never reach the predicate. Falling back keeps
+        // the only failure mode the harmless one.
+        if self.cost_index.is_empty() {
+            return None;
+        }
         let number = spec.number.and_then(|n| n.per_unit())?;
         let currency = spec.currency.clone()?;
         let mut slots = self
@@ -1604,8 +1612,19 @@ impl Inventory {
         self.units_cache.clear();
         self.cost_index.clear();
 
+        // The cost index is for BOOKING, and only the owned backing books.
+        //
+        // Not a micro-optimization: `Inventory` derives `Clone` and BQL clones
+        // a shared snapshot ONCE PER OUTPUT ROW (`running_balance.clone()` in
+        // the executor). This map holds roughly an entry per distinct cost, so
+        // building it for shared inventories would put O(lots) back into every
+        // per-row clone — the O(rows x lots) blow-up that #1086 is about and
+        // that the shared backing exists to avoid. Snapshots keep an empty map
+        // and clone it for free.
+        let index_costs = matches!(self.positions, PositionStore::Owned(_));
+
         for (idx, pos) in self.positions.iter_slots() {
-            if let Some(key) = cost_key(pos) {
+            if index_costs && let Some(key) = cost_key(pos) {
                 self.cost_index.entry(key).or_default().push(idx);
             }
             // Update units cache for all positions. Checked, not `+=`:
@@ -4624,5 +4643,69 @@ mod tests {
         )
         .expect("the surviving lot is still reachable through the cost index");
         assert_eq!(inv.units("AAPL"), dec!(0));
+    }
+
+    /// A shared snapshot must not carry the cost index.
+    ///
+    /// `Inventory` derives `Clone`, and BQL clones a shared running balance
+    /// ONCE PER OUTPUT ROW — the executor says so directly above the call.
+    /// The shared backing makes the positions O(1) to clone, which is what
+    /// #1086 needed; a per-inventory map holding roughly an entry per distinct
+    /// cost would put O(lots) straight back into every one of those clones and
+    /// undo it.
+    ///
+    /// Nothing else in the suite would notice: the index is invisible in
+    /// results, and no instruction profile here runs BQL. So it is asserted
+    /// directly, on the representation.
+    #[test]
+    fn a_shared_snapshot_carries_no_cost_index() {
+        let mut shared = Inventory::new_shared();
+        for units in [dec!(10), dec!(20), dec!(30)] {
+            shared
+                .add(Position::with_cost(
+                    Amount::new(units, "AAPL"),
+                    Cost::new(units * dec!(10), "USD"),
+                ))
+                .expect("fits");
+        }
+        shared.rebuild_index();
+        assert!(
+            shared.cost_index.is_empty(),
+            "a shared snapshot built an index of {} entries; every per-row \
+             clone now pays for it",
+            shared.cost_index.len(),
+        );
+
+        // The owned backing — the one that books — still gets it.
+        let mut owned = Inventory::new();
+        for units in [dec!(10), dec!(20), dec!(30)] {
+            owned
+                .add(Position::with_cost(
+                    Amount::new(units, "AAPL"),
+                    Cost::new(units * dec!(10), "USD"),
+                ))
+                .expect("fits");
+        }
+        assert_eq!(
+            owned.cost_index.len(),
+            3,
+            "the owned backing must still index its lots, or the fast path is \
+             dead everywhere",
+        );
+
+        // And a snapshot still books CORRECTLY, by scanning: an inventory with
+        // no index must never answer "no matching lot" for a lot it holds.
+        let result = shared
+            .reduce(
+                &Amount::new(dec!(-20), "AAPL"),
+                Some(
+                    &CostSpec::empty()
+                        .with_number(crate::CostNumber::PerUnit { value: dec!(200) })
+                        .with_currency("USD"),
+                ),
+                BookingMethod::Strict,
+            )
+            .expect("a snapshot with no cost index must fall back to scanning");
+        assert_eq!(result.matched.len(), 1);
     }
 }


### PR DESCRIPTION
Lot matching was the last superlinear term: every reduction compared its cost spec against **every** lot — 25.1% of a 20,000-transaction `investment` run, growing **111×** for 10× the input. Answering that from an index needs lot indices that survive removals, which needs removal to stop shifting.

`PositionStore::Owned` is now sparse — `Vec<Option<Position>>` plus a live count — so removing a lot leaves a tombstone and renumbers nothing. On top of that, `cost_index` groups cost-bearing lots by (units currency, per-unit cost, cost currency), and `plan_strict` takes its candidates from there when the spec names an explicit per-unit cost.

## Measured

Cachegrind, both sides rebuilt at HEAD, base `9ef20d85ed`:

| workload | main | branch | delta |
|---|---|---|---|
| investment 2k | 137,583,909 | 136,706,645 | −0.64% |
| **investment 20k** | 3,152,823,895 | 2,650,810,136 | **−15.92%** |
| simple 20k | 859,095,775 | 860,837,918 | +0.20% |

Scaling for 10× input improves **22.9× → 19.4×** — the first time this curve has moved rather than just the constant on it.

**The two halves only work together, and that is measured rather than assumed.** With tombstones alone the same workload was **+14.47%** and the curve got *worse* (25.4×), because scans walk up to twice the slots for nothing. The index is what pays for them. I built it in that order and measured the intermediate state deliberately.

## Design decisions worth reviewing

**The tombstone is an explicit `None`, not a zero-unit position.** A zero-unit lot is live and visible — cost-less lots merge through zero — and `Inventory::len` is documented as counting them, with `currency_accounts` branching on `inv.len() == 1` to match Python. Encoding one as the other would have changed that plugin, `Serialize`, the FFI and wasm converters, the account validator and `report balances`.

**Compaction** runs at the top of `reduce` — the one point where no slot index is held — once tombstones outnumber live lots, so slots stay within 2× the real count and a long-lived account cannot degrade toward "every lot it ever held". `Slots` carries its live count because `len`, `is_empty` and that trigger all run per reduction and must not scan.

**Candidate lookup uses `get`, not indexing**: a stale entry names a tombstone, and indexing one panics. With `get` it is a wasted candidate the predicate discards. Both arms apply the *same* predicate, so the index only narrows what is examined — it never decides a match.

## Breaks and behavior changes

- **`positions_mut` is gone.** It handed out `&mut Vec<Position>`, which the sparse backing cannot produce, and writing through it could desync the live count. `modify_positions` takes a closure, hands it a dense vector with tombstones already dropped, and rebuilds every derived cache afterwards — which also fixes the stale-cache footgun its own docs warned about. Pre-1.0 break; no in-tree callers.
- **`commit_from_lot` no longer shifts `simple_index`.** Nothing moves now, so shifting would renumber entries that did not — caught by `removing_a_lot_repairs_the_index_of_a_later_cost_less_lot`, which was written for the opposite mechanism and now pins this one.
- Three `reduce_merge` tests asserted `positions[0]`; the merged lot is appended after the tombstoned originals, so they now read through the iterator, which is what every consumer sees.

## Verification

Six mutations, all caught: no compaction; removal shifting again; the index returning no candidates; a drained lot left indexed; `add` not indexing; the rebuild skipping the index.

The drained-lot case needed a test asserting the index *directly* — the tolerant lookup means no behavioral test can see the difference, and I only found the gap because the mutation survived.

New tests: `a_removal_does_not_renumber_the_lots_after_it` (the property the whole design exists to provide), `tombstones_are_compacted_rather_than_accumulating`, `draining_a_lot_removes_it_from_the_cost_index`.

Gates: `cargo test --workspace --all-features` (142 suites), `cargo +1.97.0 clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)