### PR TITLE
perf(booking): undo what changed instead of copying what exists

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -1013,7 +1013,15 @@ impl BookingEngine {
         if !recording {
             return Ok(());
         }
+        // Deduplicated: a transaction with several postings on one account
+        // would otherwise re-enter `compact_if_sparse` for it, and compaction
+        // is O(slots) when it fires.
+        let mut committed: Vec<&rustledger_core::Account> = Vec::new();
         for posting in &txn.postings {
+            if committed.contains(&&posting.account) {
+                continue;
+            }
+            committed.push(&posting.account);
             if let Some(inv) = self.inventories.get_mut(&posting.account) {
                 if inv.undo_is_open() {
                     inv.commit_undo();

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -906,18 +906,24 @@ impl BookingEngine {
         let recording = self.rollback_needed(txn);
         let mut created: Vec<rustledger_core::Account> = Vec::new();
         if recording {
+            // Deduplicate the accounts FIRST, then open one log each.
+            //
+            // Skipping `begin_undo` when a log is already open would handle a
+            // repeated account too, but it would also silently adopt a log left
+            // over from an earlier transaction and roll back to the wrong
+            // point. `begin_undo` asserts it is not called twice; that
+            // assertion only does its job if this never calls it twice for a
+            // legitimate reason.
+            let mut touched: Vec<&rustledger_core::Account> = Vec::new();
             for posting in &txn.postings {
-                match self.inventories.get_mut(&posting.account) {
-                    Some(inv) => {
-                        if !inv.undo_is_open() {
-                            inv.begin_undo();
-                        }
-                    }
-                    None => {
-                        if !created.contains(&posting.account) {
-                            created.push(posting.account.clone());
-                        }
-                    }
+                if !touched.contains(&&posting.account) {
+                    touched.push(&posting.account);
+                }
+            }
+            for account in touched {
+                match self.inventories.get_mut(account) {
+                    Some(inv) => inv.begin_undo(),
+                    None => created.push(account.clone()),
                 }
             }
         }

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -807,9 +807,29 @@ impl BookingEngine {
                 return true;
             };
             let method = self.method_for(&posting.account);
-            self.inventories
-                .get(&posting.account)
-                .is_some_and(|inv| inv.is_booking_reduction(units, posting.cost.as_ref(), method))
+            if method == BookingMethod::None {
+                // NONE accumulates every posting as an augmentation and never
+                // matches a lot, so it cannot fail this way.
+                return false;
+            }
+            // Deliberately NOT `is_booking_reduction` against the CURRENT
+            // inventory. That asks whether this posting reduces something the
+            // account holds *now*, and a transaction can create the very lot a
+            // later posting then fails to reduce:
+            //
+            //     Assets:Stock   10 X {100.00 USD}
+            //     Assets:Stock  -20 X {100.00 USD}
+            //
+            // Against an empty account that answered "no reduction", so no
+            // rollback was prepared — and then the second posting failed and
+            // the engine hit its own "the guard is unsound" assertion, turning
+            // an ordinary bad ledger into a panic out of `rledger check`.
+            //
+            // Carrying a cost spec is what makes a posting able to reduce, and
+            // that does not depend on state, so it cannot be falsified by the
+            // transaction itself. Strictly more conservative: every posting
+            // this used to catch carries a cost spec too.
+            posting.cost.is_some() && units.number.is_sign_negative()
         })
     }
 

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -885,30 +885,58 @@ impl BookingEngine {
         // pays `Arc::make_mut` and copies a 64-`Position` chunk. Snapshotting
         // every transaction cost 2.4x heap churn and 6% CPU on the nightly
         // profile to guard a case needing values near 7.9e28 (#1897).
-        let snapshot: Option<FxHashMap<rustledger_core::Account, Option<Inventory>>> =
-            if self.rollback_needed(txn) {
-                let mut snap =
-                    FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
-                for posting in &txn.postings {
-                    snap.entry(posting.account.clone())
-                        .or_insert_with(|| self.inventories.get(&posting.account).cloned());
-                }
-                Some(snap)
-            } else {
-                None
-            };
-        let rollback =
-            |engine: &mut Self,
-             snapshot: FxHashMap<rustledger_core::Account, Option<Inventory>>| {
-                for (account, prior) in snapshot {
-                    match prior {
-                        Some(inv) => {
-                            engine.inventories.insert(account, inv);
-                        }
-                        None => {
-                            engine.inventories.remove(&account);
+        // Record what changes rather than copying what exists.
+        //
+        // This used to clone every touched account's `Inventory`, justified by
+        // a comment saying the positions were an `imbl::Vector` whose clone is
+        // O(1). That stopped being true at #2056, when booking's backing became
+        // owned — so the guard silently turned into an O(lots) copy per touched
+        // account per transaction, and grew into the largest superlinear term
+        // left in the pipeline. Ablating it was worth 56% of a
+        // 20,000-transaction `investment` run and took the curve from 19.4x to
+        // 9.9x per 10x of input.
+        //
+        // A reduction touches one or two lots; the undo log is proportional to
+        // that rather than to what the account holds.
+        //
+        // Accounts that do not exist yet are tracked separately: `apply` is the
+        // only thing that creates entries, and a failed transaction must leave
+        // no phantom empty inventory, which would change `into_inventories`'
+        // output.
+        let recording = self.rollback_needed(txn);
+        let mut created: Vec<rustledger_core::Account> = Vec::new();
+        if recording {
+            for posting in &txn.postings {
+                match self.inventories.get_mut(&posting.account) {
+                    Some(inv) => {
+                        if !inv.undo_is_open() {
+                            inv.begin_undo();
                         }
                     }
+                    None => {
+                        if !created.contains(&posting.account) {
+                            created.push(posting.account.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Roll back only the accounts this transaction touched, found through
+        // its postings rather than by sweeping every inventory the engine
+        // holds. `undo_is_open` guards the repeat visit when a transaction has
+        // two postings on one account.
+        let rollback =
+            |engine: &mut Self, txn: &Transaction, created: &[rustledger_core::Account]| {
+                for posting in &txn.postings {
+                    if let Some(inv) = engine.inventories.get_mut(&posting.account)
+                        && inv.undo_is_open()
+                    {
+                        inv.rollback_undo();
+                    }
+                }
+                for account in created {
+                    engine.inventories.remove(account);
                 }
             };
 
@@ -936,15 +964,35 @@ impl BookingEngine {
                 // nothing would be silent corruption — precisely the bug being
                 // fixed — so a violated guard must be loud rather than quiet.
                 assert!(
-                    snapshot.is_some(),
+                    recording,
                     "rollback_needed() returned false but posting application \
                      failed ({e}): the guard is unsound and the earlier \
                      postings of this transaction cannot be rolled back"
                 );
-                if let Some(snapshot) = snapshot {
-                    rollback(self, snapshot);
-                }
+                rollback(self, txn, &created);
                 return Err(e);
+            }
+        }
+
+        // Committed: drop the logs and compact the touched accounts.
+        // Compaction moved here from `reduce` because it renumbers slots, which
+        // an open undo log refers to — this is the one point where no log is
+        // open and no rollback can still be required.
+        //
+        // Skipped entirely when nothing was recorded. Only a reduction creates
+        // tombstones, `add` never does, and any reduction makes
+        // `rollback_needed` true — so `!recording` means this transaction left
+        // nothing to compact and nothing to commit. Without the guard, ledgers
+        // that never book a cost spec pay a per-posting map lookup for nothing.
+        if !recording {
+            return Ok(());
+        }
+        for posting in &txn.postings {
+            if let Some(inv) = self.inventories.get_mut(&posting.account) {
+                if inv.undo_is_open() {
+                    inv.commit_undo();
+                }
+                inv.compact_if_sparse();
             }
         }
         Ok(())

--- a/crates/rustledger-booking/tests/apply_precondition_test.rs
+++ b/crates/rustledger-booking/tests/apply_precondition_test.rs
@@ -317,3 +317,57 @@ fn a_failing_transaction_undoes_a_wildcard_merge() {
          -> {lots_after:?}",
     );
 }
+
+/// A transaction that CREATES the lot it then fails to reduce must report an
+/// error, not panic.
+///
+/// `rollback_needed` decides up front whether to prepare a rollback. It used
+/// to ask whether each posting reduces something the account holds *at that
+/// moment* — a question the transaction itself can falsify:
+///
+/// ```text
+///   Assets:Stock   10 X {100.00 USD}
+///   Assets:Stock  -20 X {100.00 USD}
+/// ```
+///
+/// Against an empty account that answered "no reduction", so nothing was
+/// prepared; the second posting then failed and `apply` hit its own "the guard
+/// is unsound" assertion. An ordinary bad ledger became a panic out of
+/// `rledger check`, on main as well as on this branch.
+///
+/// Carrying a cost spec is what makes a posting able to reduce, and that does
+/// not depend on state, so the transaction cannot falsify it.
+#[test]
+fn a_transaction_that_creates_and_then_oversells_a_lot_errors_rather_than_panicking() {
+    let mut engine = BookingEngine::with_method(BookingMethod::Strict);
+
+    let mut buy = Posting::new("Assets:Stock", amount("10", "X"));
+    buy.cost = Some(spec("100.00", "USD", 1));
+    let mut oversell = Posting::new("Assets:Stock", amount("-20", "X"));
+    oversell.cost = Some(spec("100.00", "USD", 1));
+
+    let txn = Transaction::new(date(1), "buy then oversell")
+        .with_synthesized_posting(buy)
+        .with_synthesized_posting(oversell);
+
+    let err = engine
+        .apply(&txn)
+        .expect_err("overselling the lot it just created must be an error");
+    assert!(
+        format!("{err:?}").contains("Insufficient") || format!("{err}").contains("not enough"),
+        "expected an insufficient-units error, got {err:?}",
+    );
+
+    // And the buy must have been rolled back with it: a rejected transaction
+    // leaves nothing behind.
+    let held: Vec<Decimal> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Stock")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| p.units.number)
+        .collect();
+    assert!(
+        held.is_empty(),
+        "the rejected transaction left its buy applied: {held:?}",
+    );
+}

--- a/crates/rustledger-booking/tests/apply_precondition_test.rs
+++ b/crates/rustledger-booking/tests/apply_precondition_test.rs
@@ -151,3 +151,169 @@ fn a_matching_reduction_still_applies() {
         .sum();
     assert_eq!(total, "16".parse::<Decimal>().unwrap(), "20 bought, 4 sold");
 }
+
+/// A failing transaction restores the reducing account's LOTS exactly, not
+/// merely its totals.
+///
+/// `a_failing_transaction_is_rolled_back_whole` checks the cash leg, which a
+/// rollback that restored totals but scrambled lots would still pass. That was
+/// adequate while `apply` snapshotted each touched account with
+/// `Inventory::clone` — restoring a whole copy cannot get the lots wrong.
+/// `apply` now records an undo log of only the slots it touched, so lot-level
+/// restoration is a real obligation rather than a free consequence, and it is
+/// asserted here.
+///
+/// The transaction reduces the SAME account twice: the first leg succeeds and
+/// mutates a lot, the second fails. That is the case where the log has to
+/// unwind more than one change, and where restoring only the last one would
+/// leave the account quietly short.
+#[test]
+fn a_failing_transaction_restores_every_lot_it_touched() {
+    let mut engine = engine_with_two_lots();
+
+    let lots_before: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+    assert_eq!(lots_before.len(), 2, "fixture holds two lots");
+
+    // Leg 1 matches the 150.00 lot and succeeds. Leg 2 asks for more of the
+    // 200.00 lot than it holds, so the transaction fails after leg 1 mutated.
+    let mut ok_leg = Posting::new("Assets:Broker", amount("-4", "AAPL"));
+    ok_leg.cost = Some(spec("150.00", "USD", 5));
+    let mut bad_leg = Posting::new("Assets:Broker", amount("-99", "AAPL"));
+    bad_leg.cost = Some(spec("200.00", "USD", 6));
+
+    let txn = Transaction::new(date(10), "one good leg, one impossible")
+        .with_synthesized_posting(ok_leg)
+        .with_synthesized_posting(bad_leg);
+
+    engine
+        .apply(&txn)
+        .expect_err("the second leg cannot be satisfied");
+
+    let lots_after: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+
+    assert_eq!(
+        lots_after, lots_before,
+        "the rejected transaction left the account's lots altered: the first \
+         leg's reduction was not undone",
+    );
+}
+
+/// Rollback must also undo a lot that was fully DRAINED and one that was
+/// ADDED before the failure.
+///
+/// The other rollback tests only mutate lots in place, so they exercise one of
+/// the three ways `apply` changes an inventory. Removing the recording from
+/// either of the other two — the removal of a drained lot, or the push of a
+/// new one — leaves every other test passing while a rejected transaction
+/// silently destroys a lot or leaves a phantom one behind.
+#[test]
+fn a_failing_transaction_undoes_drained_and_added_lots() {
+    let mut engine = engine_with_two_lots();
+
+    let lots_before: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+    assert_eq!(lots_before.len(), 2, "fixture holds two lots");
+
+    // Leg 1 drains the 150.00 lot entirely -> the lot is REMOVED.
+    let mut drain = Posting::new("Assets:Broker", amount("-10", "AAPL"));
+    drain.cost = Some(spec("150.00", "USD", 5));
+    // Leg 2 buys a new lot -> a slot is PUSHED.
+    let mut buy = Posting::new("Assets:Broker", amount("7", "AAPL"));
+    buy.cost = Some(spec("300.00", "USD", 11));
+    // Leg 3 cannot be satisfied, so the whole transaction is rejected.
+    let mut impossible = Posting::new("Assets:Broker", amount("-99", "AAPL"));
+    impossible.cost = Some(spec("200.00", "USD", 6));
+
+    let txn = Transaction::new(date(11), "drain, buy, then fail")
+        .with_synthesized_posting(drain)
+        .with_synthesized_posting(buy)
+        .with_synthesized_posting(impossible);
+
+    engine
+        .apply(&txn)
+        .expect_err("the third leg cannot be satisfied");
+
+    let lots_after: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+
+    assert_eq!(
+        lots_after, lots_before,
+        "a rejected transaction destroyed the drained lot or kept the added \
+         one: {lots_before:?} -> {lots_after:?}",
+    );
+}
+
+/// A `{*}` merge leg that is later rejected must give its lots back.
+///
+/// The merge path is the one that removes lots WITHOUT writing them first:
+/// `reduce_merge` drops every matched lot through `retain_slots`, where the
+/// other reduction paths zero a lot in place and only then remove it. On those,
+/// the in-place write is what captures the lot for the undo log, so dropping
+/// the capture in the removal path changes nothing — this is the case that
+/// tells the two apart, and without it a rejected `{*}` transaction silently
+/// destroys every lot it merged.
+#[test]
+fn a_failing_transaction_undoes_a_wildcard_merge() {
+    let mut engine = engine_with_two_lots();
+
+    let lots_before: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+    assert_eq!(lots_before.len(), 2, "fixture holds two lots to merge");
+
+    // Leg 1: `{*}` merges BOTH lots into one and reduces it — removing the
+    // originals outright.
+    let mut merge_leg = Posting::new("Assets:Broker", amount("-5", "AAPL"));
+    merge_leg.cost = Some(CostSpec {
+        number: None,
+        currency: None,
+        date: None,
+        label: None,
+        merge: true,
+    });
+    // Leg 2 cannot be satisfied, so the transaction is rejected.
+    let mut impossible = Posting::new("Assets:Broker", amount("-99", "AAPL"));
+    impossible.cost = Some(spec("200.00", "USD", 6));
+
+    let txn = Transaction::new(date(12), "merge then fail")
+        .with_synthesized_posting(merge_leg)
+        .with_synthesized_posting(impossible);
+
+    engine
+        .apply(&txn)
+        .expect_err("the second leg cannot be satisfied");
+
+    let lots_after: Vec<(Decimal, Option<Decimal>)> = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Broker")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| (p.units.number, p.cost.as_ref().map(|c| c.number)))
+        .collect();
+
+    assert_eq!(
+        lots_after, lots_before,
+        "the rejected merge destroyed the lots it consumed: {lots_before:?} \
+         -> {lots_after:?}",
+    );
+}

--- a/crates/rustledger-booking/tests/apply_rollback_properties.proptest-regressions
+++ b/crates/rustledger-booking/tests/apply_rollback_properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 44c7d8ebbf707011d82b285b37904d9331c7c8c6595b3e8b5799700ccd3772fb # shrinks to seed_costs = [103], legs = [Sell { units: 1, cost: 103 }]
+cc bb4e1af50b2061e490bb245eca5c723ad782ff8d5d0c00ff60d73f114562408e # shrinks to seed_costs = [100], legs = [Merge { units: 1 }]

--- a/crates/rustledger-booking/tests/apply_rollback_properties.rs
+++ b/crates/rustledger-booking/tests/apply_rollback_properties.rs
@@ -1,0 +1,169 @@
+//! Transaction-level rollback, under randomized failure.
+//!
+//! `booking_properties.rs` pins that a failed `Inventory::reduce` does not
+//! mutate. That is one posting. `apply` is the transaction: it can apply
+//! several postings and then fail on a later one, and must undo everything it
+//! already did.
+//!
+//! It used to do that by cloning each touched account before mutating, which
+//! cannot get the restoration wrong — restoring a whole copy is total by
+//! construction. It now records an undo log of the slots it writes, so
+//! completeness is a property of the recording hooks instead, and the hand-
+//! written cases only cover the interleavings someone thought of. These
+//! generate them.
+
+use proptest::prelude::*;
+use rustledger_booking::BookingEngine;
+use rustledger_core::{
+    Amount, BookingMethod, CostNumber, CostSpec, Decimal, NaiveDate, Posting, Transaction,
+    naive_date,
+};
+
+const CURRENCY: &str = "X";
+const COST_CURRENCY: &str = "USD";
+
+fn date(d: u32) -> NaiveDate {
+    naive_date(2024, 1, d.clamp(1, 28)).expect("valid date")
+}
+
+fn per_unit(cost: u32, day: u32) -> CostSpec {
+    CostSpec {
+        number: Some(CostNumber::PerUnit {
+            value: Decimal::from(cost),
+        }),
+        currency: Some(COST_CURRENCY.into()),
+        date: Some(date(day)),
+        label: None,
+        merge: false,
+    }
+}
+
+/// One posting in the generated transaction.
+#[derive(Debug, Clone)]
+enum Leg {
+    /// Add a new lot at this cost.
+    Buy { units: u32, cost: u32 },
+    /// Reduce against a lot at this cost, by this much.
+    Sell { units: u32, cost: u32 },
+    /// Reduce every lot into one and take from it.
+    Merge { units: u32 },
+}
+
+fn leg_strategy(costs: Vec<u32>) -> impl Strategy<Value = Leg> {
+    let c = costs.clone();
+    prop_oneof![
+        (1u32..20, prop::sample::select(costs)).prop_map(|(units, cost)| Leg::Buy { units, cost }),
+        (1u32..20, prop::sample::select(c)).prop_map(|(units, cost)| Leg::Sell { units, cost }),
+        (1u32..20).prop_map(|units| Leg::Merge { units }),
+    ]
+}
+
+/// The lots an account holds, as a comparable snapshot.
+fn holdings(engine: &BookingEngine) -> Vec<(Decimal, Option<Decimal>, Option<NaiveDate>)> {
+    engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Stock")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| {
+            (
+                p.units.number,
+                p.cost.as_ref().map(|c| c.number),
+                p.cost.as_ref().and_then(|c| c.date),
+            )
+        })
+        .collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(192))]
+
+    /// A transaction that fails part-way leaves the account EXACTLY as it was.
+    ///
+    /// The legs before the failure are randomized across all three shapes that
+    /// mutate an inventory differently — a buy pushes a slot, a sell writes a
+    /// lot in place or drains it, and `{*}` drops every matched lot at once —
+    /// so the undo log has to cover whatever combination comes up. The final
+    /// leg oversells by far more than the account can hold, which fails under
+    /// every booking method.
+    #[test]
+    fn a_failed_transaction_restores_the_account_exactly(
+        seed_costs in prop::collection::vec(100u32..104, 1..4),
+        legs in prop::collection::vec(leg_strategy((100u32..104).collect()), 0..5),
+    ) {
+        let mut engine = BookingEngine::with_method(BookingMethod::Fifo);
+
+        // Seed: one lot per cost, so sells have something to match.
+        for (i, cost) in seed_costs.iter().enumerate() {
+            let day = u32::try_from(i).unwrap_or(0) + 1;
+            let mut buy = Posting::new("Assets:Stock", Amount::new(Decimal::from(50), CURRENCY));
+            buy.cost = Some(per_unit(*cost, day));
+            let txn = Transaction::new(date(day), "seed")
+                .with_synthesized_posting(buy);
+            engine.apply(&txn).expect("seeding fits");
+        }
+
+        let before = holdings(&engine);
+
+        // The transaction: some legs, then one that cannot succeed.
+        let mut txn = Transaction::new(date(20), "randomized then doomed");
+        for (i, leg) in legs.iter().enumerate() {
+            let day = u32::try_from(i).unwrap_or(0) + 1;
+            let posting = match leg {
+                Leg::Buy { units, cost } => {
+                    let mut p = Posting::new(
+                        "Assets:Stock",
+                        Amount::new(Decimal::from(*units), CURRENCY),
+                    );
+                    p.cost = Some(per_unit(*cost, day));
+                    p
+                }
+                Leg::Sell { units, cost } => {
+                    let mut p = Posting::new(
+                        "Assets:Stock",
+                        Amount::new(-Decimal::from(*units), CURRENCY),
+                    );
+                    p.cost = Some(per_unit(*cost, day));
+                    p
+                }
+                Leg::Merge { units } => {
+                    let mut p = Posting::new(
+                        "Assets:Stock",
+                        Amount::new(-Decimal::from(*units), CURRENCY),
+                    );
+                    p.cost = Some(CostSpec {
+                        number: None,
+                        currency: None,
+                        date: None,
+                        label: None,
+                        merge: true,
+                    });
+                    p
+                }
+            };
+            txn = txn.with_synthesized_posting(posting);
+        }
+        let mut doomed = Posting::new(
+            "Assets:Stock",
+            Amount::new(Decimal::from(-100_000), CURRENCY),
+        );
+        doomed.cost = Some(CostSpec {
+            number: None,
+            currency: None,
+            date: None,
+            label: None,
+            merge: false,
+        });
+        txn = txn.with_synthesized_posting(doomed);
+
+        // Some generated prefixes fail before the doomed leg (an ambiguous
+        // match, an oversell of one lot). Either way the transaction is
+        // rejected, and either way the account must be untouched.
+        let result = engine.apply(&txn);
+        prop_assert!(result.is_err(), "the doomed leg must reject the transaction");
+        prop_assert_eq!(
+            holdings(&engine),
+            before,
+            "a rejected transaction changed the account",
+        );
+    }
+}

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -430,6 +430,12 @@ impl Slots {
     }
 
     /// Capture slot `i`'s current contents, if recording and not already held.
+    ///
+    /// The "already held" check is a linear scan. A transaction touches one or
+    /// two slots, where a scan beats hashing; the worst case is a `{*}` merge,
+    /// which records every matched lot and makes this O(k^2) in the lots
+    /// merged. That is bounded by one transaction and by an operation that is
+    /// rare, which is why it is not a set.
     fn record(&mut self, i: usize) {
         let Some(log) = self.undo.as_mut() else {
             return;
@@ -1158,6 +1164,19 @@ impl Inventory {
             !self.undo_open,
             "begin_undo called twice without commit or rollback",
         );
+        // Recording only exists on the owned backing. A shared inventory would
+        // set `undo_open` while capturing nothing, and rollback would then
+        // restore nothing while reporting success — silent corruption rather
+        // than a visible failure.
+        //
+        // Unreachable today: `BookingEngine` populates its map solely through
+        // `entry().or_default()`, which is owned, and accepts no inventory from
+        // outside. Asserted so it stays that way.
+        debug_assert!(
+            matches!(self.positions, PositionStore::Owned(_)),
+            "begin_undo on a shared inventory would record nothing and roll \
+             back nothing",
+        );
         self.undo_open = true;
         #[cfg(debug_assertions)]
         {
@@ -1774,11 +1793,23 @@ impl Inventory {
         // transaction. `compact_if_sparse` is called by the engine after a
         // transaction commits, which is the only moment no slot index is held
         // and no rollback can still be required.
-        // No assertion about the tombstone ratio here: a `{*}` merge legitimately
-        // tombstones every matched lot and pushes one merged lot, so dead slots
-        // CAN outnumber live ones mid-transaction. The deferral is bounded by
-        // the transaction — `apply` compacts on commit — and an earlier version
-        // of this assert fired on exactly that valid case.
+        // Compact here UNLESS a transaction is in flight. Compaction renumbers
+        // slots and an open undo log refers to them, so `apply` defers it to
+        // commit — but every other caller reduces without a log, and tying
+        // compaction to `apply` alone would leave those inventories growing a
+        // dead slot per closed lot forever.
+        //
+        // That is not hypothetical: the Late validator keeps its own
+        // inventories across transactions and calls `reduce` directly, so it
+        // would have accumulated one tombstone per sale for the life of the
+        // ledger and scanned all of them on every reduction.
+        //
+        // No assertion about the tombstone ratio: a `{*}` merge legitimately
+        // tombstones every matched lot and pushes one, so dead slots CAN
+        // outnumber live ones mid-transaction.
+        if !self.undo_open {
+            self.compact_if_sparse();
+        }
 
         // {*} merge operator: merge all lots into a single weighted-average-cost
         // lot before reducing, regardless of the account's booking method.
@@ -4710,11 +4741,11 @@ mod tests {
     /// toward "every lot this account ever held", which is far worse than the
     /// shifting it replaced.
     ///
-    /// Compaction is called at the COMMIT boundary — `BookingEngine::apply`
-    /// runs it once a transaction succeeds. It cannot run inside `reduce` any
-    /// more: it renumbers slots, and `apply` holds an undo log across the whole
-    /// transaction that refers to them. This test drives it the way the engine
-    /// does.
+    /// `reduce` compacts on its own whenever no undo log is open, which is the
+    /// case for every caller except a transaction in flight. This drives it
+    /// exactly as the Late validator does — no engine, no explicit call —
+    /// because that is the caller that would otherwise grow a dead slot per
+    /// closed lot for the life of the ledger.
     #[test]
     fn tombstones_are_compacted_rather_than_accumulating() {
         let mut inv = Inventory::new();
@@ -4735,8 +4766,6 @@ mod tests {
                 BookingMethod::Strict,
             )
             .expect("drains it again");
-            // What the engine does once the transaction commits.
-            inv.compact_if_sparse();
         }
         assert_eq!(inv.positions.len(), 0, "every lot was closed");
         assert!(

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -402,17 +402,43 @@ impl<'a> Iterator for PositionStoreIter<'a> {
 /// exactly the cost tombstones exist to avoid.
 #[derive(Debug, Clone, Default)]
 struct Slots {
-    slots: Vec<Option<Position>>,
+    entries: Vec<Option<Position>>,
     live: usize,
+    /// Prior contents of every slot this transaction has touched, so a failed
+    /// transaction can be undone without having copied the whole account.
+    ///
+    /// `None` while not recording. Recorded lazily and ONCE per slot — the
+    /// first write captures what to restore; later writes to the same slot are
+    /// already covered.
+    ///
+    /// Recording lives here, in the backing, rather than at the eleven call
+    /// sites that mutate positions. Those all funnel through this type's
+    /// primitives and the field is private, so covering the primitives is
+    /// complete by construction; covering call sites would be complete only
+    /// until someone adds a twelfth.
+    undo: Option<Vec<(usize, Option<Position>)>>,
 }
 
 impl Slots {
     fn from_live(positions: Vec<Position>) -> Self {
         let live = positions.len();
         Self {
-            slots: positions.into_iter().map(Some).collect(),
+            entries: positions.into_iter().map(Some).collect(),
             live,
+            undo: None,
         }
+    }
+
+    /// Capture slot `i`'s current contents, if recording and not already held.
+    fn record(&mut self, i: usize) {
+        let Some(log) = self.undo.as_mut() else {
+            return;
+        };
+        if log.iter().any(|(slot, _)| *slot == i) {
+            return;
+        }
+        let prior = self.entries.get(i).cloned().flatten();
+        log.push((i, prior));
     }
 
     /// Tombstone slot `i`, keeping `live` in step.
@@ -424,12 +450,13 @@ impl Slots {
     /// `live` count shows up later as a wrong compaction trigger with nothing
     /// pointing back here.
     fn set_dead(&mut self, i: usize) {
+        self.record(i);
         debug_assert!(
-            i < self.slots.len(),
+            i < self.entries.len(),
             "set_dead called with out-of-range slot {i} (of {})",
-            self.slots.len(),
+            self.entries.len(),
         );
-        if let Some(entry) = self.slots.get_mut(i)
+        if let Some(entry) = self.entries.get_mut(i)
             && entry.take().is_some()
         {
             self.live -= 1;
@@ -452,7 +479,7 @@ enum SlotIter<'a> {
 impl<'a> SlotIter<'a> {
     fn new(store: &'a PositionStore) -> Self {
         match store {
-            PositionStore::Owned(v) => Self::Owned(v.slots.iter().enumerate()),
+            PositionStore::Owned(v) => Self::Owned(v.entries.iter().enumerate()),
             PositionStore::Shared(v) => Self::Shared(v.iter().enumerate()),
         }
     }
@@ -509,7 +536,7 @@ impl PositionStore {
     /// invisible exactly as it was when removal shifted the vector.
     fn iter(&self) -> PositionStoreIter<'_> {
         match self {
-            Self::Owned(v) => PositionStoreIter::Owned(v.slots.iter().flatten()),
+            Self::Owned(v) => PositionStoreIter::Owned(v.entries.iter().flatten()),
             Self::Shared(v) => PositionStoreIter::Shared(v.iter()),
         }
     }
@@ -526,7 +553,7 @@ impl PositionStore {
     /// slot index, and what `push_slot` returns for the slot it fills.
     fn slot_count(&self) -> usize {
         match self {
-            Self::Owned(v) => v.slots.len(),
+            Self::Owned(v) => v.entries.len(),
             Self::Shared(v) => v.len(),
         }
     }
@@ -534,7 +561,7 @@ impl PositionStore {
     /// How many slots are tombstones.
     const fn dead(&self) -> usize {
         match self {
-            Self::Owned(v) => v.slots.len() - v.live,
+            Self::Owned(v) => v.entries.len() - v.live,
             Self::Shared(_) => 0,
         }
     }
@@ -545,7 +572,7 @@ impl PositionStore {
 
     fn get(&self, i: usize) -> Option<&Position> {
         match self {
-            Self::Owned(v) => v.slots.get(i).and_then(Option::as_ref),
+            Self::Owned(v) => v.entries.get(i).and_then(Option::as_ref),
             Self::Shared(v) => v.get(i),
         }
     }
@@ -562,7 +589,10 @@ impl PositionStore {
         let slot = self.slot_count();
         match self {
             Self::Owned(v) => {
-                v.slots.push(Some(p));
+                if let Some(log) = v.undo.as_mut() {
+                    log.push((slot, None));
+                }
+                v.entries.push(Some(p));
                 v.live += 1;
             }
             Self::Shared(v) => v.push_back(p),
@@ -586,13 +616,65 @@ impl PositionStore {
     fn retain(&mut self, mut f: impl FnMut(&Position) -> bool) {
         match self {
             Self::Owned(v) => {
-                for i in 0..v.slots.len() {
-                    if v.slots[i].as_ref().is_some_and(|p| !f(p)) {
+                for i in 0..v.entries.len() {
+                    if v.entries[i].as_ref().is_some_and(|p| !f(p)) {
                         v.set_dead(i);
                     }
                 }
             }
             Self::Shared(v) => v.retain(f),
+        }
+    }
+
+    /// Start recording an undo log, discarding any previous one.
+    fn begin_undo(&mut self) {
+        if let Self::Owned(v) = self {
+            v.undo = Some(Vec::new());
+        }
+    }
+
+    /// Stop recording and discard the log — the transaction committed.
+    fn commit_undo(&mut self) {
+        if let Self::Owned(v) = self {
+            v.undo = None;
+        }
+    }
+
+    /// Restore every slot the log captured, newest first, and stop recording.
+    ///
+    /// Newest first so that slots CREATED by this transaction are popped from
+    /// the end while they are still last. Forward order is not WRONG — each
+    /// slot is recorded once, and a created slot that cannot be popped is left
+    /// as a tombstone that compaction reclaims — but it leaves dead slots
+    /// behind for no reason. A mutation swapping the order therefore survives
+    /// the suite, and that is expected rather than a coverage gap.
+    fn rollback_undo(&mut self) {
+        let Self::Owned(v) = self else {
+            return;
+        };
+        let Some(log) = v.undo.take() else {
+            return;
+        };
+        for (slot, prior) in log.into_iter().rev() {
+            // The slot existed: put back exactly what was there. Otherwise it
+            // was created by this transaction (or was already a tombstone), so
+            // it must end up not-live — dropped entirely when it is the last
+            // one, so slot numbers do not drift upward across failed
+            // transactions.
+            if let Some(position) = prior {
+                if v.entries[slot].is_none() {
+                    v.live += 1;
+                }
+                v.entries[slot] = Some(position);
+            } else {
+                if v.entries[slot].is_some() {
+                    v.live -= 1;
+                }
+                v.entries[slot] = None;
+                if slot + 1 == v.entries.len() {
+                    v.entries.pop();
+                }
+            }
         }
     }
 
@@ -603,9 +685,9 @@ impl PositionStore {
     /// before planning, when nothing is held.
     fn compact_slots(&mut self) {
         if let Self::Owned(v) = self {
-            v.slots.retain(Option::is_some);
+            v.entries.retain(Option::is_some);
             debug_assert_eq!(
-                v.slots.len(),
+                v.entries.len(),
                 v.live,
                 "compaction must leave only live slots"
             );
@@ -629,8 +711,8 @@ impl PositionStore {
     fn retain_slots(&mut self, mut f: impl FnMut(usize, &Position) -> bool) {
         match self {
             Self::Owned(v) => {
-                for i in 0..v.slots.len() {
-                    if v.slots[i].as_ref().is_some_and(|p| !f(i, p)) {
+                for i in 0..v.entries.len() {
+                    if v.entries[i].as_ref().is_some_and(|p| !f(i, p)) {
                         v.set_dead(i);
                     }
                 }
@@ -661,7 +743,11 @@ impl PositionStore {
         if let Self::Shared(v) = self {
             let slots: Vec<Option<Position>> = v.iter().cloned().map(Some).collect();
             let live = slots.len();
-            *self = Self::Owned(Slots { slots, live });
+            *self = Self::Owned(Slots {
+                entries: slots,
+                live,
+                undo: None,
+            });
         }
     }
 }
@@ -677,7 +763,7 @@ impl std::ops::Index<usize> for PositionStore {
     /// have desynchronised, and a wrong-lot read is worse than a panic.
     fn index(&self, i: usize) -> &Position {
         match self {
-            Self::Owned(v) => v.slots[i]
+            Self::Owned(v) => v.entries[i]
                 .as_ref()
                 .expect("slot index names a live position, not a tombstone"),
             Self::Shared(v) => &v[i],
@@ -691,9 +777,14 @@ impl std::ops::IndexMut<usize> for PositionStore {
     /// As [`Index::index`](std::ops::Index::index).
     fn index_mut(&mut self, i: usize) -> &mut Position {
         match self {
-            Self::Owned(v) => v.slots[i]
-                .as_mut()
-                .expect("slot index names a live position, not a tombstone"),
+            Self::Owned(v) => {
+                // Capture BEFORE the caller writes through the returned
+                // reference — afterwards the prior value is gone.
+                v.record(i);
+                v.entries[i]
+                    .as_mut()
+                    .expect("slot index names a live position, not a tombstone")
+            }
             Self::Shared(v) => &mut v[i],
         }
     }
@@ -703,7 +794,11 @@ impl FromIterator<Position> for PositionStore {
     fn from_iter<I: IntoIterator<Item = Position>>(iter: I) -> Self {
         let slots: Vec<Option<Position>> = iter.into_iter().map(Some).collect();
         let live = slots.len();
-        Self::Owned(Slots { slots, live })
+        Self::Owned(Slots {
+            entries: slots,
+            live,
+            undo: None,
+        })
     }
 }
 
@@ -818,6 +913,15 @@ pub struct Inventory {
     /// Not serialized - rebuilt on demand, like the caches above.
     #[serde(skip)]
     cost_index: FxHashMap<CostKey, smallvec::SmallVec<[usize; 2]>>,
+    /// Whether an undo log is open. Not serialized; a transaction never spans
+    /// a round trip.
+    #[serde(skip)]
+    undo_open: bool,
+    /// Debug-only copy taken at `begin_undo`, compared against the restored
+    /// inventory to prove the log covered every mutation.
+    #[cfg(debug_assertions)]
+    #[serde(skip)]
+    undo_witness: Option<Box<Self>>,
 }
 
 /// What [`Inventory::cost_index`] groups lots by: the units they are held in,
@@ -955,6 +1059,9 @@ impl TryFrom<InventoryWire> for Inventory {
             simple_index: FxHashMap::default(),
             units_cache: FxHashMap::default(),
             cost_index: FxHashMap::default(),
+            undo_open: false,
+            #[cfg(debug_assertions)]
+            undo_witness: None,
         };
         // UNTRUSTED: the payload is input, not something this type produced, so
         // it may carry two cost-less lots for one currency — a state the
@@ -1003,6 +1110,117 @@ impl Inventory {
     #[must_use]
     pub fn position_list(&self) -> Vec<&Position> {
         self.positions.iter().collect()
+    }
+
+    /// Drop tombstones once they outnumber live lots, so slots stay within 2x
+    /// the real position count and iteration cannot degrade toward "every lot
+    /// this account ever held".
+    ///
+    /// Renumbers slots, so it must not run while an undo log is open or while
+    /// any caller holds a slot index. The engine calls it after a transaction
+    /// commits, which is the one moment both hold.
+    ///
+    /// Amortized: each compaction is O(slots) but halves them, so the cost per
+    /// removed lot is constant.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if an undo log is open.
+    pub fn compact_if_sparse(&mut self) {
+        debug_assert!(
+            !self.undo_open,
+            "compact_if_sparse would renumber slots the open undo log refers to",
+        );
+        if self.positions.dead() > self.positions.len() {
+            self.positions.compact_slots();
+            self.rebuild_index();
+        }
+    }
+
+    /// Begin recording an undo log so a failed transaction can be reverted
+    /// without having copied this inventory.
+    ///
+    /// `apply` used to snapshot every touched account with `Inventory::clone`.
+    /// That was written when the backing was `imbl::Vector` and the clone was
+    /// O(1); since #2056 booking's backing is owned, so it became O(lots) per
+    /// touched account per transaction — the largest superlinear term left in
+    /// the pipeline, worth 56% of a 20,000-transaction `investment` run.
+    ///
+    /// A reduction touches one or two lots. Recording those is proportional to
+    /// what changed instead of to what the account holds.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if a log is already open — nesting would make
+    /// "restore to the start" ambiguous.
+    pub fn begin_undo(&mut self) {
+        debug_assert!(
+            !self.undo_open,
+            "begin_undo called twice without commit or rollback",
+        );
+        self.undo_open = true;
+        #[cfg(debug_assertions)]
+        {
+            // The log is only as good as its coverage of the mutation paths.
+            // Recording lives in the backing's primitives, which is complete by
+            // construction today — this keeps it honest if that ever stops
+            // being true, at a cost paid only in debug builds.
+            self.undo_witness = Some(Box::new(self.clone_for_witness()));
+        }
+        self.positions.begin_undo();
+    }
+
+    /// Whether an undo log is currently open.
+    #[must_use]
+    pub const fn undo_is_open(&self) -> bool {
+        self.undo_open
+    }
+
+    /// Discard the log — the transaction committed.
+    pub fn commit_undo(&mut self) {
+        self.undo_open = false;
+        #[cfg(debug_assertions)]
+        {
+            self.undo_witness = None;
+        }
+        self.positions.commit_undo();
+    }
+
+    /// Restore this inventory to its state at [`Self::begin_undo`].
+    ///
+    /// Rebuilds the derived caches wholesale rather than unwinding them: this
+    /// is the failure path, so being obviously right beats being fast.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if the result differs from a witness copy taken
+    /// at `begin_undo` — that means a mutation path bypassed the log.
+    pub fn rollback_undo(&mut self) {
+        self.undo_open = false;
+        self.positions.rollback_undo();
+        self.rebuild_index();
+        #[cfg(debug_assertions)]
+        {
+            if let Some(witness) = self.undo_witness.take() {
+                let restored: Vec<&Position> = self.positions.iter().collect();
+                let expected: Vec<&Position> = witness.positions.iter().collect();
+                assert_eq!(
+                    restored, expected,
+                    "rollback did not restore the inventory: some mutation path \
+                     did not go through the backing's primitives, so the undo \
+                     log missed it",
+                );
+            }
+        }
+    }
+
+    /// A copy for the debug-only rollback witness.
+    #[cfg(debug_assertions)]
+    fn clone_for_witness(&self) -> Self {
+        let mut copy = self.clone();
+        copy.undo_witness = None;
+        copy.undo_open = false;
+        copy
     }
 
     /// Rewrite the positions wholesale, then rebuild every derived cache.
@@ -1551,18 +1769,16 @@ impl Inventory {
         // no shared chunk to corrupt.
         self.positions.make_owned();
 
-        // Drop tombstones once they outnumber live lots, so slots stay within
-        // 2x the real position count and iteration cannot degrade toward
-        // "every lot this account ever held". This is the ONLY place it can
-        // run: compaction renumbers slots, and here nothing holds one — the
-        // planners have not looked at the store yet.
-        //
-        // Amortized: each compaction is O(slots) but halves them, so the cost
-        // per removed lot is constant.
-        if self.positions.dead() > self.positions.len() {
-            self.positions.compact_slots();
-            self.rebuild_index();
-        }
+        // Compaction does NOT run here. It renumbers slots, which would
+        // invalidate an open undo log — and `apply` keeps one across the whole
+        // transaction. `compact_if_sparse` is called by the engine after a
+        // transaction commits, which is the only moment no slot index is held
+        // and no rollback can still be required.
+        // No assertion about the tombstone ratio here: a `{*}` merge legitimately
+        // tombstones every matched lot and pushes one merged lot, so dead slots
+        // CAN outnumber live ones mid-transaction. The deferral is bounded by
+        // the transaction — `apply` compacts on commit — and an earlier version
+        // of this assert fired on exactly that valid case.
 
         // {*} merge operator: merge all lots into a single weighted-average-cost
         // lot before reducing, regardless of the account's booking method.
@@ -4492,8 +4708,13 @@ mod tests {
     /// Without compaction a long-lived account accumulates one dead slot per
     /// closed lot, and every scan walks all of them — matching would degrade
     /// toward "every lot this account ever held", which is far worse than the
-    /// shifting it replaced. Compaction runs at the top of `reduce`, the one
-    /// point where no slot index is held.
+    /// shifting it replaced.
+    ///
+    /// Compaction is called at the COMMIT boundary — `BookingEngine::apply`
+    /// runs it once a transaction succeeds. It cannot run inside `reduce` any
+    /// more: it renumbers slots, and `apply` holds an undo log across the whole
+    /// transaction that refers to them. This test drives it the way the engine
+    /// does.
     #[test]
     fn tombstones_are_compacted_rather_than_accumulating() {
         let mut inv = Inventory::new();
@@ -4514,6 +4735,8 @@ mod tests {
                 BookingMethod::Strict,
             )
             .expect("drains it again");
+            // What the engine does once the transaction commits.
+            inv.compact_if_sparse();
         }
         assert_eq!(inv.positions.len(), 0, "every lot was closed");
         assert!(

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -417,6 +417,19 @@ struct Slots {
     /// complete by construction; covering call sites would be complete only
     /// until someone adds a twelfth.
     undo: Option<Vec<(usize, Option<Position>)>>,
+    /// Slots already captured in `undo`, for O(1) "have I recorded this?".
+    ///
+    /// This bounds the log's size and cost; it is not what makes rollback
+    /// correct. Restoring in reverse order already makes a duplicate entry
+    /// harmless, because the earliest capture is applied last. Removing this
+    /// therefore does not fail any test — it just lets the log grow.
+    ///
+    /// A linear scan of the log reads fine for a transaction touching one or
+    /// two slots, but `{*}` merge records every matched lot, which made
+    /// recording O(k^2) in the lots merged — a fresh quadratic inside the
+    /// change that removed one. Hashing a `usize` with `FxHash` is a couple of
+    /// instructions, so the common case loses nothing.
+    undo_seen: rustc_hash::FxHashSet<usize>,
 }
 
 impl Slots {
@@ -426,6 +439,7 @@ impl Slots {
             entries: positions.into_iter().map(Some).collect(),
             live,
             undo: None,
+            undo_seen: rustc_hash::FxHashSet::default(),
         }
     }
 
@@ -437,14 +451,16 @@ impl Slots {
     /// merged. That is bounded by one transaction and by an operation that is
     /// rare, which is why it is not a set.
     fn record(&mut self, i: usize) {
-        let Some(log) = self.undo.as_mut() else {
+        if self.undo.is_none() {
             return;
-        };
-        if log.iter().any(|(slot, _)| *slot == i) {
+        }
+        if !self.undo_seen.insert(i) {
             return;
         }
         let prior = self.entries.get(i).cloned().flatten();
-        log.push((i, prior));
+        if let Some(log) = self.undo.as_mut() {
+            log.push((i, prior));
+        }
     }
 
     /// Tombstone slot `i`, keeping `live` in step.
@@ -597,6 +613,7 @@ impl PositionStore {
             Self::Owned(v) => {
                 if let Some(log) = v.undo.as_mut() {
                     log.push((slot, None));
+                    v.undo_seen.insert(slot);
                 }
                 v.entries.push(Some(p));
                 v.live += 1;
@@ -636,6 +653,7 @@ impl PositionStore {
     fn begin_undo(&mut self) {
         if let Self::Owned(v) = self {
             v.undo = Some(Vec::new());
+            v.undo_seen.clear();
         }
     }
 
@@ -643,17 +661,26 @@ impl PositionStore {
     fn commit_undo(&mut self) {
         if let Self::Owned(v) = self {
             v.undo = None;
+            v.undo_seen.clear();
         }
     }
 
     /// Restore every slot the log captured, newest first, and stop recording.
     ///
-    /// Newest first so that slots CREATED by this transaction are popped from
-    /// the end while they are still last. Forward order is not WRONG — each
-    /// slot is recorded once, and a created slot that cannot be popped is left
-    /// as a tombstone that compaction reclaims — but it leaves dead slots
-    /// behind for no reason. A mutation swapping the order therefore survives
-    /// the suite, and that is expected rather than a coverage gap.
+    /// Newest first, for two reasons that are easy to conflate.
+    ///
+    /// The visible one: slots CREATED by this transaction are popped from the
+    /// end while they are still last, so failed transactions do not leave dead
+    /// slots behind. Forward order would merely leave tombstones that
+    /// compaction reclaims, so a mutation swapping the order survives the
+    /// suite — expected, not a coverage gap.
+    ///
+    /// The load-bearing one: reverse order is what makes a slot recorded MORE
+    /// THAN ONCE safe. The earliest capture holds the true prior value, and
+    /// reverse iteration applies it last, so it wins. `record` deduplicates, so
+    /// duplicates should not arise — but the two mechanisms are independent,
+    /// and dropping BOTH is what would corrupt a rollback. Changing this to
+    /// forward order is only safe while the deduplication holds.
     fn rollback_undo(&mut self) {
         let Self::Owned(v) = self else {
             return;
@@ -661,6 +688,7 @@ impl PositionStore {
         let Some(log) = v.undo.take() else {
             return;
         };
+        v.undo_seen.clear();
         for (slot, prior) in log.into_iter().rev() {
             // The slot existed: put back exactly what was there. Otherwise it
             // was created by this transaction (or was already a tombstone), so
@@ -753,6 +781,7 @@ impl PositionStore {
                 entries: slots,
                 live,
                 undo: None,
+                undo_seen: rustc_hash::FxHashSet::default(),
             });
         }
     }
@@ -804,6 +833,7 @@ impl FromIterator<Position> for PositionStore {
             entries: slots,
             live,
             undo: None,
+            undo_seen: rustc_hash::FxHashSet::default(),
         })
     }
 }


### PR DESCRIPTION
`apply` snapshotted every touched account with `Inventory::clone` before mutating, so a failed transaction could be rolled back. The comment justifying it said the positions were an `imbl::Vector` whose clone is O(1) — that stopped being true at **#2056**, when booking's backing became owned. The guard silently turned into an O(lots) copy per touched account per transaction and grew into the largest superlinear term left in the pipeline.

A reduction touches one or two lots. `apply` now records an undo log of the slots it actually writes.

## Measured

Cachegrind, both sides rebuilt at HEAD, base `f3ac855ca2`:

| workload | main | branch | delta |
|---|---|---|---|
| investment 2k | 136,693,394 | 122,452,140 | −10.42% |
| **investment 20k** | 2,650,674,155 | 1,209,849,439 | **−54.36%** |
| simple 20k | 860,854,747 | 863,447,163 | +0.30% |
| tagged 10k | 684,347,183 | 686,524,070 | +0.32% |

**Scaling for 10× input: 19.4× → 9.9×.** `investment` is now **linear**. An ablation removing the snapshot entirely measures 9.9× and −56.2%, so this captures 96% of what was available and the curve is flat rather than merely flatter.

The +0.3% on cost-spec-free shapes is real, not noise — the `undo_open` field plus the per-posting commit pass. That pass is skipped entirely when nothing was recorded: only reductions create tombstones, and any reduction makes `rollback_needed` true, so `!recording` means there is nothing to compact or commit.

## Why recording lives in the backing

Eleven call sites mutate positions across two files. Threading a log through each is how you miss one — and a missed site means rollback silently fails on an error path that is rare and hard to test.

They all funnel through `PositionStore`'s primitives, and the field is private, so hooking `IndexMut`, `push_slot` and `set_dead` is complete **by construction**. Hooking call sites would be complete only until someone adds a twelfth.

A debug-only witness copy taken at `begin_undo` is compared against the restored inventory, so a future mutation path that bypasses the log fails loudly in tests rather than corrupting a ledger.

**Compaction moved out of `reduce`** into `Inventory::compact_if_sparse`, called by `apply` on commit. Compaction renumbers slots and the undo log refers to them, so it cannot run mid-transaction — and commit is also the only moment no rollback can still be required.

## Verification

Four mutations run; **two survived**, and both exposed genuinely untested log paths that are now covered:

- **A lot fully DRAINED before the failure.** On the common paths the lot is zeroed through `IndexMut` first, which already records it, so removing `set_dead`'s capture changes nothing — *except* on `{*}` merge, which drops matched lots through `retain_slots` without writing them. That is the case that tells the two apart, and a rejected merge would otherwise destroy every lot it consumed.
- **A lot ADDED before the failure**, which would be left behind as a phantom.

The pre-existing `a_failing_transaction_is_rolled_back_whole` only checked the cash leg's total — adequate when rollback restored a whole copy, since that cannot get lots wrong. Lot-level restoration is now a real obligation, so it is asserted directly.

Restoring in reverse order pops created slots while they are still last; forward order is not wrong, only wasteful, so a mutation swapping it survives by design and the comment says so.

Also removes a `debug_assert` I added claiming tombstones cannot dominate while a log is open. A `{*}` merge tombstones every matched lot and pushes one, so they legitimately can — the assertion fired on valid input.

Gates: `cargo test --workspace --all-features` (142 suites), `cargo +1.97.0 clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)