### PR TITLE
chore(deps): bump ureq to 3.4.0 and allow the base64 duplicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,11 +4677,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "cookie_store",
  "flate2",
  "log",
@@ -4691,11 +4697,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -5121,7 +5127,7 @@ version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",

--- a/deny.toml
+++ b/deny.toml
@@ -99,6 +99,7 @@ deny = [
 # Audited 2026-05 via `cargo deny check bans`.
 skip = [
   { crate = "addr2line" },        # gimli's, vs backtrace's
+  { crate = "base64" },           # 0.22 (wasmtime-internal-cache) vs 0.23 (ureq/ureq-proto)
   { crate = "bitflags" },         # 1.x via wasmtime stack, 2.x elsewhere
   { crate = "block-buffer" },     # digest 0.9 vs 0.10
   { crate = "cpufeatures" },      # transitive sha2 skew

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -99,6 +99,10 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.base64]]
+version = "0.23.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.bigdecimal]]
 version = "0.4.10"
 criteria = "safe-to-deploy"
@@ -856,11 +860,11 @@ version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ureq]]
-version = "3.3.0"
+version = "3.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ureq-proto]]
-version = "0.6.0"
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.utf8-zero]]


### PR DESCRIPTION
Completes #2071. Follow-up to #2079, which took the other three crates in that group and deliberately held this one back.

## Why the bump was blocked

`ureq` 3.4.0 moves to `base64` 0.23, while `wasmtime-internal-cache` 47.0.3 still pins 0.22:

```
$ cargo tree -i base64@0.22.1 --workspace --depth 1
base64 v0.22.1
└── wasmtime-internal-cache v47.0.3

$ cargo tree -i base64@0.23.1 --workspace --depth 1
base64 v0.23.1
├── ureq v3.4.0
└── ureq-proto v0.6.1
```

So the duplicate-crate ban fires and #2071 has been red since it opened. Neither side is ours to move: waiting it out means waiting for a wasmtime release, which here is its own coordinated event (`wasmtime` and `wasmtime-wasi` bump in lockstep), and until then every future `ureq` bump is blocked on the same error.

## Why a skip is the consistent answer

The list already carries 24 entries of exactly this shape, five naming the wasmtime stack:

```toml
{ crate = "bitflags" },      # 1.x via wasmtime stack, 2.x elsewhere
{ crate = "hashbrown" },     # 3 versions: stdlib's, wasmtime's, our deps
{ crate = "io-lifetimes" },  # wasmtime 47 (cap-std 4.x) drags a 2nd version
{ crate = "toml" },          # wasmtime cache vs our config parsing
{ crate = "getrandom" },     # 0.2 (via ring/rustls/ureq TLS stack) vs 0.3 vs 0.4
```

That last one already records the ring/rustls/**ureq** TLS stack as a legitimate source of skew. This is the same skew one crate over.

`base64` is a pure-Rust leaf crate — no C linkage, no global state, no cross-version types crossing an API boundary — so two copies cost compile time and a little binary size, not correctness. No advisory is involved either: `cargo deny check` reports `advisories ok` with or without the bump, so this is about unblocking future bumps rather than urgency.

## Verification

Checked in both directions rather than trusting the CI message:

| lockfile | deny.toml | result |
|---|---|---|
| ureq 3.4.0 | no skip | `bans FAILED` — `found 2 duplicate entries for crate 'base64'` |
| ureq 3.4.0 | skip added | `advisories ok, bans ok, licenses ok, sources ok` |

Plus: 143 test suites green — including the 181 price-source tests, which are what actually exercise `ureq` (`rledger price` sources: coinbase, quandl, coincap, yahoo, ecb) — and clippy (1.97.0) / fmt / doc clean.

`supply-chain/` exemptions for `base64` 0.23.1, `ureq` 3.4.0 and `ureq-proto` 0.6.1 are left to `Cargo Vet Auto`.

## Noted, not changed

`cargo deny` also emits two stale-config warnings that predate this PR: `equator-macro` is an *unmatched* skip, and `rand` is now *unnecessary* (one version left). Worth a cleanup, but those warnings are resolution-dependent, so removing either wants a check across other feature/target combinations first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr