### PR TITLE
fix(booking): apply a transaction's reductions before its augmentations

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -1068,7 +1068,46 @@ impl BookingEngine {
         let mut touched: rustc_hash::FxHashSet<&rustledger_core::Account> =
             rustc_hash::FxHashSet::default();
 
-        for posting in &txn.postings {
+        // Apply this transaction's cost-bearing REDUCTIONS before its other
+        // postings (#2070).
+        //
+        // `book` decides every posting against the inventory as it stood before
+        // the transaction, threaded with that transaction's earlier reductions
+        // and NOTHING else — the same rule beancount's `book_reductions`
+        // follows, for the same reason it states: an augmentation's cost may
+        // still need interpolation, so it is not a resolvable position yet.
+        //
+        // `apply` mutated in posting order, so a buy earlier in the transaction
+        // was already in the account when a later reduction ran. For a spec
+        // naming a concrete lot that changes nothing — the lot is found either
+        // way. For the two that RE-DERIVE a pool, `AVERAGE` and `{*}`, it moves
+        // the pool, and the engine then disagreed with the journal about cost
+        // basis. Silently: `book_apply_agreement` shrinks it to holding 40 @
+        // 100, then buying 1 @ 101 and `{*}`-selling 1 in one transaction.
+        //
+        // Classifying against the PRE-transaction inventory (rather than
+        // threading, as `book` does) decides ORDER only. `apply_posting`
+        // classifies each posting itself against live state, so a posting
+        // sorted into the wrong bucket still does the right thing; and the
+        // disagreement can only run one way, since threading removes units and
+        // so can only make a posting look less like a reduction. Reductions
+        // keep their relative order, which is what a second reduction on one
+        // account depends on.
+        let (mut ordered, rest): (Vec<_>, Vec<_>) = txn.postings.iter().partition(|posting| {
+            posting.cost.is_some()
+                && posting.amount().is_some_and(|units| {
+                    self.inventories.get(&posting.account).is_some_and(|inv| {
+                        inv.is_booking_reduction(
+                            units,
+                            posting.cost.as_ref(),
+                            self.method_for(&posting.account),
+                        )
+                    })
+                })
+        });
+        ordered.extend(rest);
+
+        for posting in ordered {
             // EVERY posting failure aborts the transaction and rolls back —
             // overflow and failed reduction alike (#1987).
             //

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -1093,8 +1093,20 @@ impl BookingEngine {
         // so can only make a posting look less like a reduction. Reductions
         // keep their relative order, which is what a second reduction on one
         // account depends on.
-        let (mut ordered, rest): (Vec<_>, Vec<_>) = txn.postings.iter().partition(|posting| {
-            posting.cost.is_some()
+        // Classified ONCE, into a bitmask rather than two vectors: a
+        // transaction has a handful of postings, and this path is hot enough
+        // that #2061/#2067 exist to keep allocations out of it.
+        //
+        // `apply_posting` asks the same predicate again, which is not waste to
+        // eliminate: it asks about LIVE state, deliberately, so that a posting
+        // reclassifies as the transaction proceeds. This asks about the
+        // pre-transaction state, which is the question `book` answered. Sharing
+        // one answer between them would reintroduce the divergence. The call is
+        // a hash lookup either way — `is_reduced_by` has read per-currency sign
+        // counts since #2062, not scanned positions.
+        let mut reduces: u64 = 0;
+        for (i, posting) in txn.postings.iter().enumerate().take(64) {
+            let is_reduction = posting.cost.is_some()
                 && posting.amount().is_some_and(|units| {
                     self.inventories.get(&posting.account).is_some_and(|inv| {
                         inv.is_booking_reduction(
@@ -1103,11 +1115,20 @@ impl BookingEngine {
                             self.method_for(&posting.account),
                         )
                     })
-                })
-        });
-        ordered.extend(rest);
+                });
+            if is_reduction {
+                reduces |= 1 << i;
+            }
+        }
+        // A transaction with more than 64 postings keeps source order beyond
+        // the 64th. Ordering is an optimization of WHICH state a re-derived
+        // pool sees, not a correctness requirement for the postings themselves,
+        // so degrading to source order is safe — and `apply_posting` still
+        // classifies each posting itself.
+        let reduces_first = (0..txn.postings.len()).filter(|i| *i < 64 && reduces & (1 << i) != 0);
+        let then_the_rest = (0..txn.postings.len()).filter(|i| *i >= 64 || reduces & (1 << i) == 0);
 
-        for posting in ordered {
+        for posting in reduces_first.chain(then_the_rest).map(|i| &txn.postings[i]) {
             // EVERY posting failure aborts the transaction and rolls back —
             // overflow and failed reduction alike (#1987).
             //

--- a/crates/rustledger-booking/tests/apply_precondition_test.rs
+++ b/crates/rustledger-booking/tests/apply_precondition_test.rs
@@ -663,3 +663,70 @@ fn a_buy_and_a_merge_sale_in_one_transaction_is_not_a_mismatch() {
         .apply(&booked.transaction)
         .expect("the buy moved the pool; that is the engine's own ordering, not a bad ledger");
 }
+
+/// A buy earlier in the transaction does not move the pool a later reduction
+/// draws from (#2070).
+///
+/// `book` decides against the inventory as it stood before the transaction
+/// (threaded with earlier reductions only), so it books this sale at the
+/// pre-transaction average of 100. `apply` used to have the buy in the account
+/// already, so `{*}` re-derived a pool of 110 and drained 5 at that — leaving
+/// the engine holding 1650 of basis where the journal recorded 1700.
+///
+/// The property test `book_apply_agreement` generalizes this; this pins the
+/// arithmetic in a form that names the numbers.
+#[test]
+fn a_buy_earlier_in_the_transaction_does_not_move_the_pool() {
+    let mut engine = BookingEngine::with_method(BookingMethod::Strict);
+
+    let mut seed = Posting::new("Assets:Stock", amount("10", "X"));
+    seed.cost = Some(spec("100.00", "USD", 1));
+    engine
+        .apply(&Transaction::new(date(1), "buy lot 1").with_synthesized_posting(seed))
+        .expect("the seed buy applies");
+
+    let mut buy = Posting::new("Assets:Stock", amount("10", "X"));
+    buy.cost = Some(spec("120.00", "USD", 2));
+    let mut sell = Posting::new("Assets:Stock", amount("-5", "X"));
+    sell.cost = Some(CostSpec {
+        number: None,
+        currency: None,
+        date: None,
+        label: None,
+        merge: true,
+    });
+    let txn = Transaction::new(date(2), "buy and merge-sell together")
+        .with_synthesized_posting(buy)
+        .with_synthesized_posting(sell);
+
+    let booked = engine.book(&txn).expect("the transaction books");
+    let booked_reduction = booked
+        .transaction
+        .postings
+        .iter()
+        .find(|p| p.amount().is_some_and(|u| u.number.is_sign_negative()))
+        .and_then(|p| p.cost.as_ref())
+        .and_then(|c| c.number)
+        .and_then(|n| n.per_unit())
+        .expect("the reduction carries a booked cost");
+    assert_eq!(
+        booked_reduction,
+        "100".parse::<Decimal>().expect("literal parses"),
+        "booking draws from the pre-transaction pool, as beancount does",
+    );
+
+    engine.apply(&booked.transaction).expect("applies");
+
+    let basis: Decimal = engine
+        .inventories()
+        .filter(|(account, _)| account.as_str() == "Assets:Stock")
+        .flat_map(|(_, inv)| inv.positions())
+        .map(|p| p.units.number * p.cost.as_ref().map_or(Decimal::ZERO, |c| c.number))
+        .sum();
+    assert_eq!(
+        basis,
+        "1700".parse::<Decimal>().expect("literal parses"),
+        "the engine must hold what the booked postings add up to \
+         (1000 + 1200 - 500), not the 1650 a re-derived pool produces",
+    );
+}

--- a/crates/rustledger-booking/tests/book_apply_agreement.proptest-regressions
+++ b/crates/rustledger-booking/tests/book_apply_agreement.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f95d469cec5dc2e9c0331eacf9cefb527a47e7c93c414beac86004121ad2ed1a # shrinks to method = Fifo, seeds = [101, 100], txns = [[SellAny { units: 1 }, SellMerged { units: 1 }]]
+cc 61f050b17b5d2a81402e4ba07450ba82b8d2b0fdb42819db83be9e9970182303 # shrinks to method = Strict, seeds = [100], txns = [[Buy { units: 1, cost: 101 }, SellMerged { units: 1 }]]

--- a/crates/rustledger-booking/tests/book_apply_agreement.rs
+++ b/crates/rustledger-booking/tests/book_apply_agreement.rs
@@ -14,8 +14,8 @@
 //! must agree on, and stays silent about the representation itself.
 //!
 //! Every existing suite passed while the divergence shipped, so treat a clean
-//! run here as meaningful only alongside `the_detector_can_report_dirty`, which
-//! pins that the comparison fails on the known-bad shape.
+//! run here as meaningful only alongside `the_comparison_can_report_dirty`,
+//! which pins that the comparison itself can report a disagreement.
 
 use proptest::prelude::*;
 use rustledger_booking::BookingEngine;
@@ -199,9 +199,10 @@ fn run(method: BookingMethod, seeds: &[u32], txns: &[Vec<Leg>]) -> (Totals, Tota
         buy.cost = Some(per_unit(*cost));
         let txn = Transaction::new(date(u32::try_from(i).unwrap_or(0) + 1), "seed")
             .with_synthesized_posting(buy);
-        if engine.apply(&txn).is_ok() {
-            add_booked_postings(&mut journal, &txn);
-        }
+        engine
+            .apply(&txn)
+            .expect("seed buys are fixtures and always apply");
+        add_booked_postings(&mut journal, &txn);
     }
 
     for (i, legs) in txns.iter().enumerate() {
@@ -209,12 +210,18 @@ fn run(method: BookingMethod, seeds: &[u32], txns: &[Vec<Leg>]) -> (Totals, Tota
         for leg in legs {
             txn = txn.with_synthesized_posting(posting_for(leg));
         }
+        // An unbookable transaction is a different failure and says nothing
+        // about this invariant, so it is skipped. A transaction that BOOKED and
+        // then failed to apply is not skipped: `apply`'s precondition is booked
+        // input, and `book` just produced it, so that combination is itself a
+        // defect and must not be swallowed into a vacuous pass.
         let Ok(booked) = engine.book(&txn) else {
             continue;
         };
-        if engine.apply(&booked.transaction).is_ok() {
-            add_booked_postings(&mut journal, &booked.transaction);
-        }
+        engine
+            .apply(&booked.transaction)
+            .expect("a transaction that booked must apply");
+        add_booked_postings(&mut journal, &booked.transaction);
     }
 
     (journal, engine_totals(&engine))

--- a/crates/rustledger-booking/tests/book_apply_agreement.rs
+++ b/crates/rustledger-booking/tests/book_apply_agreement.rs
@@ -1,0 +1,305 @@
+//! The engine's holdings must equal the sum of the booked postings (#2070).
+//!
+//! `book` and `apply` are two derivations of the same quantity. `book` decides
+//! what each posting does and writes that into the posting; `apply` re-runs
+//! `Inventory::reduce` and decides again, against state that has moved on. When
+//! the cost spec names a concrete lot the two land on the same answer, which is
+//! why the disagreement went unnoticed — the merging paths (`AVERAGE`, `{*}`)
+//! re-derive a pool instead, and a lot added earlier in the SAME transaction
+//! moves it.
+//!
+//! The invariant compares units and cost basis, not lot structure: ADR-0007
+//! deliberately lets the engine pool while the journal keeps per-lot costs, and
+//! pooling preserves both totals. So this asserts only what both representations
+//! must agree on, and stays silent about the representation itself.
+//!
+//! Every existing suite passed while the divergence shipped, so treat a clean
+//! run here as meaningful only alongside `the_detector_can_report_dirty`, which
+//! pins that the comparison fails on the known-bad shape.
+
+use proptest::prelude::*;
+use rustledger_booking::BookingEngine;
+use rustledger_core::{
+    Amount, BookingMethod, CostNumber, CostSpec, Decimal, NaiveDate, Posting, Transaction,
+    naive_date,
+};
+use std::collections::BTreeMap;
+
+const CURRENCY: &str = "X";
+const COST_CURRENCY: &str = "USD";
+const ACCOUNT: &str = "Assets:Stock";
+
+fn date(d: u32) -> NaiveDate {
+    naive_date(2024, 1, d.clamp(1, 28)).expect("valid date")
+}
+
+fn per_unit(cost: u32) -> CostSpec {
+    CostSpec {
+        number: Some(CostNumber::PerUnit {
+            value: Decimal::from(cost),
+        }),
+        currency: Some(COST_CURRENCY.into()),
+        date: None,
+        label: None,
+        merge: false,
+    }
+}
+
+const fn empty_spec() -> CostSpec {
+    CostSpec {
+        number: None,
+        currency: None,
+        date: None,
+        label: None,
+        merge: false,
+    }
+}
+
+fn merge_spec() -> CostSpec {
+    CostSpec {
+        merge: true,
+        ..empty_spec()
+    }
+}
+
+/// `(units, cost basis)` per commodity, the two quantities both
+/// representations must agree on.
+type Totals = BTreeMap<String, (Decimal, Decimal)>;
+
+/// What the ENGINE holds.
+fn engine_totals(engine: &BookingEngine) -> Totals {
+    let mut out = Totals::new();
+    for (account, inv) in engine.inventories() {
+        if account.as_str() != ACCOUNT {
+            continue;
+        }
+        for p in inv.positions() {
+            let e = out
+                .entry(p.units.currency.to_string())
+                .or_insert((Decimal::ZERO, Decimal::ZERO));
+            e.0 += p.units.number;
+            e.1 += p.units.number * p.cost.as_ref().map_or(Decimal::ZERO, |c| c.number);
+        }
+    }
+    out
+}
+
+/// What the JOURNAL says — the booked postings, summed.
+///
+/// This is what BQL aggregates and what `print` shows, so it is the ledger's
+/// record of what happened. Accumulating it is deliberately dumb: no matching,
+/// no re-derivation, just addition.
+fn add_booked_postings(totals: &mut Totals, txn: &Transaction) {
+    for posting in &txn.postings {
+        if posting.account.as_str() != ACCOUNT {
+            continue;
+        }
+        let Some(units) = posting.amount() else {
+            continue;
+        };
+        let cost = posting
+            .cost
+            .as_ref()
+            .and_then(|c| c.number)
+            .and_then(|n| n.per_unit())
+            .unwrap_or(Decimal::ZERO);
+        let e = totals
+            .entry(units.currency.to_string())
+            .or_insert((Decimal::ZERO, Decimal::ZERO));
+        e.0 += units.number;
+        e.1 += units.number * cost;
+    }
+}
+
+/// Basis equality, ignoring the residue a weighted average cannot represent.
+///
+/// A pooled cost like `7939/79` does not terminate, so the engine stores it
+/// rounded on the remainder while the journal keeps the un-rounded sum of what
+/// was booked. They then differ in the last digits of `rust_decimal`'s 28 —
+/// inherent to per-unit average costing, not a decision the two halves disagree
+/// about, and it is what this predicate exists to ignore.
+///
+/// The tolerance is far below anything the divergence this file hunts produces:
+/// #2070's shape is off by 50 whole units of cost currency, which is roughly
+/// twenty orders of magnitude above this bar. Widening it further would start
+/// masking real disagreement, so it stays pinned to representation error.
+fn within_rounding_residue(a: Decimal, b: Decimal) -> bool {
+    let scale = a.abs().max(b.abs()).max(Decimal::ONE);
+    let tolerance = scale
+        * Decimal::from_str_exact("0.00000000000000000001").expect("literal is a valid decimal");
+    (a - b).abs() <= tolerance
+}
+
+/// One posting in a generated transaction.
+#[derive(Debug, Clone)]
+enum Leg {
+    Buy {
+        units: u32,
+        cost: u32,
+    },
+    /// Reduce naming an explicit lot cost.
+    SellAt {
+        units: u32,
+        cost: u32,
+    },
+    /// Reduce with a bare `{}` — the booking method picks the lot.
+    SellAny {
+        units: u32,
+    },
+    /// Reduce through a `{*}` merge.
+    SellMerged {
+        units: u32,
+    },
+}
+
+fn leg_strategy() -> impl Strategy<Value = Leg> {
+    prop_oneof![
+        (1u32..12, 100u32..104).prop_map(|(units, cost)| Leg::Buy { units, cost }),
+        (1u32..8, 100u32..104).prop_map(|(units, cost)| Leg::SellAt { units, cost }),
+        (1u32..8).prop_map(|units| Leg::SellAny { units }),
+        (1u32..8).prop_map(|units| Leg::SellMerged { units }),
+    ]
+}
+
+fn posting_for(leg: &Leg) -> Posting {
+    match leg {
+        Leg::Buy { units, cost } => {
+            let mut p = Posting::new(ACCOUNT, Amount::new(Decimal::from(*units), CURRENCY));
+            p.cost = Some(per_unit(*cost));
+            p
+        }
+        Leg::SellAt { units, cost } => {
+            let mut p = Posting::new(ACCOUNT, Amount::new(-Decimal::from(*units), CURRENCY));
+            p.cost = Some(per_unit(*cost));
+            p
+        }
+        Leg::SellAny { units } => {
+            let mut p = Posting::new(ACCOUNT, Amount::new(-Decimal::from(*units), CURRENCY));
+            p.cost = Some(empty_spec());
+            p
+        }
+        Leg::SellMerged { units } => {
+            let mut p = Posting::new(ACCOUNT, Amount::new(-Decimal::from(*units), CURRENCY));
+            p.cost = Some(merge_spec());
+            p
+        }
+    }
+}
+
+/// Book and apply a stream, returning `(journal totals, engine totals)`.
+///
+/// A transaction that fails to book is SKIPPED, not applied — an unbookable
+/// ledger is a different failure and says nothing about this invariant.
+fn run(method: BookingMethod, seeds: &[u32], txns: &[Vec<Leg>]) -> (Totals, Totals) {
+    let mut engine = BookingEngine::with_method(method);
+    let mut journal = Totals::new();
+
+    for (i, cost) in seeds.iter().enumerate() {
+        let mut buy = Posting::new(ACCOUNT, Amount::new(Decimal::from(40), CURRENCY));
+        buy.cost = Some(per_unit(*cost));
+        let txn = Transaction::new(date(u32::try_from(i).unwrap_or(0) + 1), "seed")
+            .with_synthesized_posting(buy);
+        if engine.apply(&txn).is_ok() {
+            add_booked_postings(&mut journal, &txn);
+        }
+    }
+
+    for (i, legs) in txns.iter().enumerate() {
+        let mut txn = Transaction::new(date(u32::try_from(i).unwrap_or(0) + 10), "generated");
+        for leg in legs {
+            txn = txn.with_synthesized_posting(posting_for(leg));
+        }
+        let Ok(booked) = engine.book(&txn) else {
+            continue;
+        };
+        if engine.apply(&booked.transaction).is_ok() {
+            add_booked_postings(&mut journal, &booked.transaction);
+        }
+    }
+
+    (journal, engine_totals(&engine))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Whatever the booked postings add up to is what the account holds.
+    #[test]
+    fn the_engine_equals_the_sum_of_the_booked_postings(
+        method in prop::sample::select(vec![
+            BookingMethod::Strict,
+            BookingMethod::Fifo,
+            BookingMethod::Lifo,
+            BookingMethod::Average,
+        ]),
+        seeds in prop::collection::vec(100u32..104, 1..4),
+        txns in prop::collection::vec(
+            prop::collection::vec(leg_strategy(), 1..4),
+            1..5,
+        ),
+    ) {
+        let (journal, engine) = run(method, &seeds, &txns);
+        for (currency, (j_units, j_basis)) in &journal {
+            let (e_units, e_basis) = engine
+                .get(currency)
+                .copied()
+                .unwrap_or((Decimal::ZERO, Decimal::ZERO));
+            prop_assert_eq!(
+                j_units, &e_units,
+                "unit counts disagree for {} under {:?}\n  seeds: {:?}\n  txns: {:?}",
+                currency, method, seeds, txns,
+            );
+            prop_assert!(
+                within_rounding_residue(*j_basis, e_basis),
+                "cost basis disagrees for {} under {:?} by {}\n  journal {} vs engine {}\n                   seeds: {:?}\n  txns: {:?}",
+                currency, method, (*j_basis - e_basis).abs(), j_basis, e_basis, seeds, txns,
+            );
+        }
+    }
+}
+
+/// The comparison can report DIRTY.
+///
+/// A green property run is worth nothing until the comparison is shown to fail
+/// on input that disagrees — 145 suites passed while #2070's divergence
+/// shipped. This checks the COMPARATOR, deliberately, rather than asserting
+/// that the engine still has the bug: a self-check written that way inverts the
+/// moment the bug is fixed, and then the harness is unguarded exactly when it
+/// starts mattering.
+#[test]
+fn the_comparison_can_report_dirty() {
+    let one = |units: i64, basis: &str| {
+        let mut t = Totals::new();
+        t.insert(
+            "X".to_string(),
+            (
+                Decimal::from(units),
+                Decimal::from_str_exact(basis).expect("literal is a valid decimal"),
+            ),
+        );
+        t
+    };
+
+    // #2070's magnitude: 50 whole units of cost currency.
+    let journal = one(15, "1700");
+    let engine = one(15, "1650");
+    let (j_basis, e_basis) = (journal["X"].1, engine["X"].1);
+    assert!(
+        !within_rounding_residue(j_basis, e_basis),
+        "a 50-unit basis gap must be reported, not absorbed as rounding",
+    );
+
+    // Unit counts are compared exactly, with no tolerance at all.
+    assert_ne!(one(15, "1700")["X"].0, one(14, "1700")["X"].0);
+
+    // ...and the residue a weighted average cannot represent is absorbed.
+    assert!(
+        within_rounding_residue(
+            Decimal::from_str_exact("7838.5063291139240506329113924")
+                .expect("literal is a valid decimal"),
+            Decimal::from_str_exact("7838.5063291139240506329113920")
+                .expect("literal is a valid decimal"),
+        ),
+        "representation residue must not be reported as disagreement",
+    );
+}


### PR DESCRIPTION
Fixes #2070. Two commits: a detector, then the fix — in that order deliberately.

## The bug

`book` decides every posting against the inventory as it stood **before** the transaction, threaded with that transaction's earlier reductions and nothing else. That matches beancount's `book_reductions` exactly, including the reason its comment gives:

```python
# Update the local balance in order to avoid matching against
# the same postings twice when processing multiple postings in
# the same transaction. Note that we only do this for postings
# held at cost because the other postings may need interpolation
# in order to be resolved properly.
for posting in reduction_postings:
    balance.add_position(posting)
```

The augmentation branch never touches `balance`. `apply`, however, mutated in posting order — so a buy earlier in the transaction was already in the account when a later reduction ran.

For a spec naming a concrete lot that changes nothing; the lot is found either way. For the two specs that **re-derive a pool** — `AVERAGE` and `{*}` — it moves the pool:

```beancount
2000-01-01 open Assets:Stock X "AVERAGE"

2024-01-01 * "buy lot 1"
  Assets:Stock  10 X {100.00 USD}

2024-02-01 * "buy then sell in ONE transaction"
  Assets:Stock   10 X {120.00 USD}
  Assets:Stock   -5 X {}
```

`rledger check` reports no errors, and then the two views disagree: the booked postings total **1,700.00 USD** of basis (1000 + 1200 − 500), while the engine holds **1,650.00** (15 × 110). Silently, on `main` today, with no `{*}` required.

## The detector comes first

Nothing checked that `book` and `apply` agree, which is why this shipped. The first commit adds that check — `the engine's holdings equal the sum of the booked postings` — as a proptest over four booking methods and all four reduction shapes.

It earned its place three times over:

1. **It shrinks the bug far below what I hand-built**: hold 40 @ 100, then buy 1 @ 101 and `{*}`-sell 1 in one transaction. Two postings.
2. **It found a second, unrelated class**: a pooled cost like `7939/79` does not terminate, so the engine stores it rounded on the remainder while the journal keeps the un-rounded sum, and the two differ in the **25th significant digit**. That is inherent to per-unit average costing rather than a disagreement about a decision, so `within_rounding_residue` absorbs it — at a bar twenty orders of magnitude below the divergence this file hunts.
3. **It says the fix is complete**, not merely that my example stopped failing: 256 generated cases across `STRICT`/`FIFO`/`LIFO`/`AVERAGE` pass with the fix and fail without it.

The invariant compares units and basis, not lot structure, because ADR-0007 deliberately lets the engine pool while the journal keeps per-lot costs — pooling preserves both totals, so this asserts only what the two representations must agree on.

The self-check tests the **comparator**, with synthetic values. My first version asserted "the known-bad shape still diverges", which inverts the moment the fix lands — leaving the harness unguarded exactly when it starts mattering.

## The fix

Order the cost-bearing reductions ahead of the other postings. Classifying against the pre-transaction inventory rather than threading (as `book` does) decides **order only**: `apply_posting` classifies each posting itself against live state, so a posting sorted into the wrong bucket still does the right thing, and the disagreement can only run one way, since threading removes units and can only make a posting look *less* like a reduction. Reductions keep their relative order, which a second reduction on one account depends on.

## Nothing that used to load stops loading

The case that could regress is a reduction covered only by its own transaction's augmentation. `book` already rejects that, so it is the stricter gate either way — verified identical before and after:

```
$ rledger check oversell.beancount
error[BOOK]: Not enough units in Assets:Stock: requested 15, available 10
```

Also verified unchanged end to end: `{*}` books and applies (#2069), and a merged pool is still referenceable by cost in a later transaction — the property that rules out "make `apply` a pure fold" as an alternative fix, since a fold would leave no positive lot at the pool cost.

## Verification

146 test suites green; clippy (1.97.0), fmt and doc clean. `.proptest-regressions` is committed per repo convention, pinning both discovered counterexamples as permanent seeds.

## Not in scope

This aligns two derivations of the same quantity; it does not remove the second one. The root cause is that `book` computes a decision and discards it, leaving `apply` to recompute it — see the options analysis on #2070, where "carry the decision" (making booking's `plan_*` result a value `apply` consumes) is the architectural end state. The detector is the guard that makes that refactor safe to attempt, and it should be pointed at the Late validator next — a third implementation of the same reduction decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr