### PR TITLE
perf(core): stop rebuilding and rescanning on every ordered reduction

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -528,72 +528,83 @@ impl Inventory {
         let mut cost_basis = Decimal::ZERO;
         let mut cost_currency = None;
 
-        // Get indices of matching positions
-        let mut indices: Vec<usize> = self
-            .positions
-            .iter_slots()
-            .filter(|(_, p)| {
+        // Candidates in FIFO order.
+        //
+        // `ordered_index` already holds this currency's cost-bearing lots in
+        // (date, slot) order, so the common path neither scans every slot nor
+        // sorts per call. It did both, once per reduction, and `{}` is how
+        // FIFO sells are written — so that was the normal case (#2083).
+        //
+        // The predicate still runs per candidate: the index knows nothing
+        // about sign, emptiness or what this spec matches, and a stale entry
+        // for a drained lot is expected, since removal is best-effort.
+        let scanned: Option<Vec<usize>> = if self.ordered_candidates(&units.currency).is_some() {
+            None
+        } else {
+            // No index — a shared snapshot, or one never rebuilt. Scanning is
+            // the only correct answer, and it is what this always did.
+            let mut all: Vec<usize> = self
+                .positions
+                .iter_slots()
+                .filter(|(_, p)| p.units.currency == units.currency)
+                .map(|(i, _)| i)
+                .collect();
+            all.sort_by_key(|&i| self.positions[i].cost.as_ref().and_then(|c| c.date));
+            Some(all)
+        };
+        let candidates: &[usize] = match &scanned {
+            Some(all) => all,
+            None => self
+                .ordered_candidates(&units.currency)
+                .expect("the branch above proved it is Some"),
+        };
+
+        let keeps = |i: usize| {
+            self.positions.get(i).is_some_and(|p| {
                 p.units.currency == units.currency
                     && !p.is_empty()
                     && p.units.number.signum() != units.number.signum()
                     && p.matches_cost_spec(spec)
             })
-            .map(|(i, _)| i)
-            .collect();
+        };
 
-        // Sort by date for correct FIFO/LIFO ordering (oldest first)
-        // This ensures we select by acquisition date, not insertion order
-        indices.sort_by_key(|&i| self.positions[i].cost.as_ref().and_then(|c| c.date));
-
-        if reverse {
-            indices.reverse();
-        }
-
-        if indices.is_empty() {
-            return Err(BookingError::NoMatchingLot {
-                currency: units.currency.clone(),
-                cost_spec: spec.clone(),
-            });
-        }
-
-        // Get cost currency from first lot (all lots of same commodity have same cost currency)
-        if let Some(&first_idx) = indices.first()
-            && let Some(cost) = &self.positions[first_idx].cost
-        {
-            cost_currency = Some(cost.currency.clone());
-        }
-
-        // Check sufficiency BEFORE mutating any lot: a failed reduction must
-        // leave the inventory untouched. The validator reduces against the
-        // live `LedgerState` inventories, so a partial drain on the error
-        // path would corrupt every later balance assertion on the account
-        // (found by the failed-reduce-must-not-mutate property in
-        // `rustledger-booking/tests/booking_properties.rs`).
-        let available: Decimal = indices
-            .iter()
-            .map(|&i| self.positions[i].units.number.abs())
-            .sum();
-        if available < remaining {
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: remaining,
-                available,
-            });
-        }
-
+        // Sufficiency used to be checked up front, by summing every matching
+        // lot before taking any. That was needed when this function mutated;
+        // since the plan/commit split (#2061) it only computes and the caller
+        // commits, so exhausting the walk reports the same shortfall with the
+        // same total, having visited the same lots. The invariant it protected
+        // — a failed reduction leaves the inventory untouched — is structural
+        // now, and `booking_properties.rs` still pins it.
         let mut updates: SmallVec<[(usize, Decimal); 1]> = SmallVec::new();
-        for idx in indices {
-            if remaining.is_zero() {
-                break;
-            }
+        let mut seen_any = false;
+        let mut available_total = Decimal::ZERO;
 
+        let mut forward;
+        let mut backward;
+        let walk: &mut dyn Iterator<Item = usize> = if reverse {
+            backward = candidates.iter().rev().copied();
+            &mut backward
+        } else {
+            forward = candidates.iter().copied();
+            &mut forward
+        };
+
+        for idx in walk {
+            if !keeps(idx) {
+                continue;
+            }
+            seen_any = true;
             let pos = &self.positions[idx];
+            available_total += pos.units.number.abs();
             let available = pos.units.number.abs();
             let take = remaining.min(available);
 
             // Calculate cost basis for this portion (checked — see the
             // matching site in the FIFO/LIFO ladder above).
             if let Some(cost) = &pos.cost {
+                if cost_currency.is_none() {
+                    cost_currency = Some(cost.currency.clone());
+                }
                 cost_basis = take
                     .checked_mul(cost.number)
                     .and_then(|v| cost_basis.checked_add(v))
@@ -618,6 +629,35 @@ impl Inventory {
             updates.push((idx, pos.units.number + reduction));
 
             remaining -= take;
+
+            // Covered: stop here rather than walking the rest of the account.
+            // `available_total` is left partial on purpose — it feeds the
+            // shortfall message only, which is unreachable once the reduction
+            // is satisfied. Walking on to complete a number nobody reads is
+            // what made this O(lots): the spec is concrete by the time `apply`
+            // re-derives, so most later lots fail the predicate and the loop
+            // ran the cost comparison against every one of them.
+            if remaining.is_zero() {
+                break;
+            }
+        }
+
+        // No lot of this currency matched the spec at all.
+        if !seen_any {
+            return Err(BookingError::NoMatchingLot {
+                currency: units.currency.clone(),
+                cost_spec: spec.clone(),
+            });
+        }
+        // Lots matched but did not cover the reduction. Reported with the same
+        // total the up-front sum produced, because reaching here means the
+        // walk visited every matching lot.
+        if !remaining.is_zero() {
+            return Err(BookingError::InsufficientUnits {
+                currency: units.currency.clone(),
+                requested: units.number.abs(),
+                available: available_total,
+            });
         }
 
         Ok((
@@ -634,12 +674,55 @@ impl Inventory {
     /// `retain` + `rebuild_index` exactly as the fused `reduce_ordered` did —
     /// the multi-lot path always paid an O(lots) cache rebuild, and changing
     /// that is a separate question from removing the preview's clone.
+    /// Apply a multi-lot plan, repairing the caches rather than rebuilding
+    /// them.
+    ///
+    /// This used to `retain` away the drained lots and then `rebuild_index()`,
+    /// which is two walks of every slot plus a rehash of every key — per
+    /// reduction. In a FIFO ledger, where reductions are frequent and lots
+    /// accumulate, that is the whole cost: 20k transactions took 8.9s, of
+    /// which 7.1s was the rebuild (#2083).
+    ///
+    /// `updates` already names every slot that changed, so the repair is
+    /// proportional to the lots the reduction touched rather than to the lots
+    /// the account holds. Same treatment `commit_from_lot` got in #2063, for
+    /// the same reason; this is the multi-lot half of that change.
     fn commit_updates(&mut self, updates: &[(usize, Decimal)]) {
+        let mut delta = Decimal::ZERO;
+        let mut currency = None;
+
         for &(idx, new_units) in updates {
+            let previous = self.positions[idx].units.number;
+            delta += new_units - previous;
+            if currency.is_none() {
+                currency = Some(self.positions[idx].units.currency.clone());
+            }
+
+            // Drop the old classification before overwriting: a reduction can
+            // take a lot through zero and flip its sign bucket.
+            self.sign_index_bump(idx, -1);
             self.positions[idx].units.number = new_units;
+            self.sign_index_bump(idx, 1);
+
+            if self.positions[idx].is_empty() {
+                self.sign_index_bump(idx, -1);
+                self.cost_index_remove(idx);
+                self.positions.remove(idx);
+                // Removal leaves a tombstone, so no surviving lot is
+                // renumbered and only the entry naming this lot has to go. An
+                // empty cost spec matches a cost-less position, so ordered
+                // selection can drain one and this map can name it.
+                self.simple_index.retain(|_, stored| *stored != idx);
+            }
         }
-        self.positions.retain(|p| !p.is_empty());
-        self.rebuild_index();
+
+        // One adjustment for the whole plan: every update is a lot of the same
+        // currency, since ordered selection filtered on it.
+        if let Some(currency) = currency
+            && let Some(stats) = self.units_cache.get_mut(&currency)
+        {
+            stats.total = crate::decimal::add_python_scale(stats.total, delta);
+        }
     }
 
     /// AVERAGE booking: merge all lots of the currency.
@@ -1141,6 +1224,99 @@ mod reduction_tests {
             Amount::new(d(units), "STK"),
             Cost::new(d(cost), "USD").with_date(naive_date(2024, 1, day).unwrap()),
         )
+    }
+
+    /// The ordered index selects exactly what the scan selects (#2083).
+    ///
+    /// `plan_ordered` used to sort every matching lot on every call; it now
+    /// walks a maintained (date, slot) index and stops once the reduction is
+    /// covered. That is only sound if the index reproduces the scan's order
+    /// exactly — including the stable-sort tiebreak, `None` dates sorting
+    /// first, and lots added out of date order — so this runs both paths over
+    /// the same inventory and compares.
+    ///
+    /// Clearing `ordered_index` is what forces the scan: an empty index is
+    /// how a shared snapshot looks, and the fallback exists for exactly that.
+    #[test]
+    fn the_ordered_index_selects_what_the_scan_selects() {
+        // Deliberately awkward: out-of-order dates, a duplicate date, a
+        // date-less lot, a second currency, and a cost-less lot.
+        let mut inv = Inventory::new();
+        for lot in [
+            lot(10, 100, 5),
+            lot(10, 101, 2),
+            lot(10, 102, 9),
+            lot(10, 103, 2),
+            Position::with_cost(Amount::new(d(10), "STK"), Cost::new(d(104), "USD")),
+            Position::with_cost(Amount::new(d(10), "OTH"), Cost::new(d(105), "USD")),
+            Position::simple(Amount::new(d(10), "STK")),
+        ] {
+            inv.add(lot).expect("fixture fits in Decimal");
+        }
+
+        let specs = [
+            CostSpec::default(),
+            CostSpec {
+                number: Some(crate::CostNumber::PerUnit { value: d(101) }),
+                currency: Some("USD".into()),
+                ..CostSpec::default()
+            },
+            CostSpec {
+                date: Some(naive_date(2024, 1, 2).unwrap()),
+                ..CostSpec::default()
+            },
+        ];
+
+        for spec in &specs {
+            for reverse in [false, true] {
+                for take in [1i64, 15, 45] {
+                    let units = Amount::new(d(-take), "STK");
+
+                    // Build it explicitly: `reduce` is what normally triggers
+                    // the build, and calling `plan_ordered` directly would
+                    // otherwise leave the index empty and compare the scan
+                    // against itself. That vacuous version of this test passed
+                    // against a deliberately reversed tiebreak.
+                    let mut indexing = inv.clone();
+                    indexing.build_ordered_index();
+                    assert!(
+                        !indexing.ordered_index.is_empty(),
+                        "the fixture must produce an index, or this test compares \
+                         the scan against itself",
+                    );
+                    let indexed = indexing.plan_ordered(&units, spec, reverse);
+
+                    let mut scanning = inv.clone();
+                    scanning.ordered_index.clear();
+                    let scanned = scanning.plan_ordered(&units, spec, reverse);
+
+                    match (indexed, scanned) {
+                        (Ok((a_result, a_updates)), Ok((b_result, b_updates))) => {
+                            assert_eq!(
+                                a_updates, b_updates,
+                                "index and scan chose different lots for {spec:?} \
+                                 reverse={reverse} take={take}",
+                            );
+                            assert_eq!(
+                                a_result.cost_basis, b_result.cost_basis,
+                                "index and scan disagree on cost basis for {spec:?} \
+                                 reverse={reverse} take={take}",
+                            );
+                        }
+                        (Err(a), Err(b)) => assert_eq!(
+                            a.to_string(),
+                            b.to_string(),
+                            "index and scan report different errors for {spec:?} \
+                             reverse={reverse} take={take}",
+                        ),
+                        (a, b) => panic!(
+                            "index and scan disagree on success for {spec:?} \
+                             reverse={reverse} take={take}: {a:?} vs {b:?}"
+                        ),
+                    }
+                }
+            }
+        }
     }
 
     fn mk(lots: impl IntoIterator<Item = Position>) -> Inventory {

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -579,6 +579,7 @@ impl Inventory {
         let mut updates: SmallVec<[(usize, Decimal); 1]> = SmallVec::new();
         let mut seen_any = false;
         let mut available_total = Decimal::ZERO;
+        let mut overflow: Option<OverflowError> = None;
 
         let mut forward;
         let mut backward;
@@ -606,14 +607,22 @@ impl Inventory {
                 if cost_currency.is_none() {
                     cost_currency = Some(cost.currency.clone());
                 }
-                cost_basis = take
+                // Recorded, not returned. Sufficiency used to be settled before
+                // any basis arithmetic ran, so a reduction that was BOTH short
+                // of units and unrepresentable reported the shortfall — the
+                // actionable half. Returning here would report the overflow
+                // instead, which is a behavior change nothing asked for.
+                match take
                     .checked_mul(cost.number)
                     .and_then(|v| cost_basis.checked_add(v))
-                    .ok_or_else(|| {
-                        BookingError::Overflow(OverflowError {
+                {
+                    Some(v) => cost_basis = v,
+                    None => {
+                        overflow.get_or_insert_with(|| OverflowError {
                             currency: cost.currency.clone(),
-                        })
-                    })?;
+                        });
+                    }
+                }
             }
 
             // Record what we matched
@@ -659,6 +668,11 @@ impl Inventory {
                 requested: units.number.abs(),
                 available: available_total,
             });
+        }
+        // Only now: the reduction is satisfiable, so the arithmetic is what
+        // failed.
+        if let Some(error) = overflow {
+            return Err(BookingError::Overflow(error));
         }
 
         Ok((
@@ -1225,6 +1239,29 @@ mod reduction_tests {
             Amount::new(d(units), "STK"),
             Cost::new(d(cost), "USD").with_date(naive_date(2024, 1, day).unwrap()),
         )
+    }
+
+    /// Insufficiency outranks overflow, as it did before the walk was made lazy.
+    #[test]
+    fn insufficient_units_are_reported_even_when_the_basis_would_overflow() {
+        // A lot whose cost basis cannot be represented, and a reduction asking
+        // for more units than exist.
+        let huge = Decimal::MAX / d(2);
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(d(10), "STK"),
+            Cost::new(huge, "USD").with_date(naive_date(2024, 1, 1).unwrap()),
+        ))
+        .expect("fixture fits in Decimal");
+
+        let err = inv
+            .plan_ordered(&Amount::new(d(-99), "STK"), &CostSpec::default(), false)
+            .expect_err("99 units are not there");
+        assert!(
+            matches!(err, crate::BookingError::InsufficientUnits { .. }),
+            "the shortfall is the actionable error, not the arithmetic it would \
+             have done on the way: {err:?}",
+        );
     }
 
     /// The ordered index selects exactly what the scan selects (#2083).

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -530,7 +530,8 @@ impl Inventory {
 
         // Candidates in FIFO order.
         //
-        // `ordered_index` already holds this currency's cost-bearing lots in
+        // `ordered_index` already holds this currency's lots — every one of
+        // them, cost-less included, since an empty spec matches those too — in
         // (date, slot) order, so the common path neither scans every slot nor
         // sorts per call. It did both, once per reduction, and `{}` is how
         // FIFO sells are written — so that was the normal case (#2083).

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1280,14 +1280,14 @@ mod reduction_tests {
                     let mut indexing = inv.clone();
                     indexing.build_ordered_index();
                     assert!(
-                        !indexing.ordered_index.is_empty(),
+                        indexing.ordered_index.is_some(),
                         "the fixture must produce an index, or this test compares \
                          the scan against itself",
                     );
                     let indexed = indexing.plan_ordered(&units, spec, reverse);
 
                     let mut scanning = inv.clone();
-                    scanning.ordered_index.clear();
+                    scanning.ordered_index = None;
                     let scanned = scanning.plan_ordered(&units, spec, reverse);
 
                     match (indexed, scanned) {

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -703,6 +703,22 @@ impl Inventory {
     /// the account holds. Same treatment `commit_from_lot` got in #2063, for
     /// the same reason; this is the multi-lot half of that change.
     fn commit_updates(&mut self, updates: &[(usize, Decimal)]) {
+        // Every update names a lot of the same currency, because every producer
+        // of `ReductionPlan::Updates` filters on `units.currency` before
+        // planning. This repair DEPENDS on that — it adjusts one currency's
+        // running total — where the old `rebuild_index()` recomputed them all
+        // and so could not notice the invariant being violated.
+        //
+        // Checked here rather than after the loop: by then the drained lots are
+        // tombstones, and indexing one panics.
+        debug_assert!(
+            updates.windows(2).all(|pair| {
+                self.positions[pair[0].0].units.currency == self.positions[pair[1].0].units.currency
+            }),
+            "commit_updates was given lots of more than one currency; the units \
+             cache is adjusted per currency and would silently drift",
+        );
+
         let mut delta = Decimal::ZERO;
         let mut currency = None;
 
@@ -731,8 +747,7 @@ impl Inventory {
             }
         }
 
-        // One adjustment for the whole plan: every update is a lot of the same
-        // currency, since ordered selection filtered on it.
+        // One adjustment for the whole plan: see the assertion at the top.
         if let Some(currency) = currency
             && let Some(stats) = self.units_cache.get_mut(&currency)
         {
@@ -1239,6 +1254,44 @@ mod reduction_tests {
             Amount::new(d(units), "STK"),
             Cost::new(d(cost), "USD").with_date(naive_date(2024, 1, day).unwrap()),
         )
+    }
+
+    /// A multi-lot reduction removes what it drained, and nothing else.
+    ///
+    /// `commit_updates` used to `retain(|p| !p.is_empty())` over the whole
+    /// inventory, so any reduction that crossed two lots also swept away every
+    /// unrelated zero-unit position as a side effect. Zero-unit lots are not
+    /// scrap: `Inventory::len` counts them and `currency_accounts` branches on
+    /// `len() == 1`, so sweeping them changed what other surfaces reported
+    /// depending on whether a reduction happened to be multi-lot.
+    #[test]
+    fn a_multi_lot_reduction_leaves_unrelated_empty_lots_alone() {
+        let mut inv = mk([lot(10, 100, 1), lot(10, 200, 2)]);
+        // An unrelated zero-unit position in another commodity. Netted to
+        // zero rather than added as zero: `add` drops a zero-unit position
+        // outright, so the only way one exists is a cost-less lot merging
+        // through zero — which is exactly the case `Inventory::len`'s contract
+        // is about.
+        inv.add(Position::simple(Amount::new(d(5), "ZERO")))
+            .expect("fixture fits in Decimal");
+        inv.add(Position::simple(Amount::new(d(-5), "ZERO")))
+            .expect("fixture fits in Decimal");
+        let before = inv.len();
+
+        // Cross both STK lots, draining the first.
+        inv.reduce(
+            &Amount::new(d(-15), "STK"),
+            Some(&CostSpec::default()),
+            BookingMethod::Fifo,
+        )
+        .expect("15 of 20 units are there");
+
+        assert_eq!(
+            inv.len(),
+            before - 1,
+            "exactly the drained lot should be gone: the untouched zero-unit \
+             position is not this reduction's business",
+        );
     }
 
     /// Insufficiency outranks overflow, as it did before the walk was made lazy.

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -998,8 +998,12 @@ pub struct Inventory {
     /// entry hides a lot the reduction should have seen. Insertion is at the
     /// single `add` site; removal rides on `cost_index_remove`.
     /// Not serialized - rebuilt on demand, like the caches above.
+    /// `None` until ordered selection asks for it: boxed so an inventory that
+    /// never needs one carries a pointer rather than a map. The map itself is
+    /// three words plus its allocation, on a type that is created per account
+    /// and cloned per BQL output row.
     #[serde(skip)]
-    ordered_index: FxHashMap<crate::Currency, Vec<usize>>,
+    ordered_index: Option<Box<FxHashMap<crate::Currency, Vec<usize>>>>,
     /// Whether an undo log is open. Not serialized; a transaction never spans
     /// a round trip.
     #[serde(skip)]
@@ -1146,7 +1150,7 @@ impl TryFrom<InventoryWire> for Inventory {
             simple_index: FxHashMap::default(),
             units_cache: FxHashMap::default(),
             cost_index: FxHashMap::default(),
-            ordered_index: FxHashMap::default(),
+            ordered_index: None,
             undo_open: false,
             #[cfg(debug_assertions)]
             undo_witness: None,
@@ -1759,7 +1763,16 @@ impl Inventory {
         let Some(position) = self.positions.get(idx) else {
             return;
         };
-        let currency = position.units.currency.clone();
+        // Only pay for the ordered index when one has been built: this runs on
+        // every drained lot, and cloning the currency to probe a map that is
+        // not there is pure overhead for a ledger that never reduces with an
+        // under-specified spec.
+        let ordered = self.ordered_index.is_some().then(|| {
+            (
+                position.units.currency.clone(),
+                position.cost.as_ref().and_then(|c| c.date),
+            )
+        });
         if let Some(key) = cost_key(position)
             && let Some(slots) = self.cost_index.get_mut(&key)
         {
@@ -1771,8 +1784,13 @@ impl Inventory {
         // The list is ordered, so find the entry rather than scanning for it:
         // a FIFO account drains its oldest lot over and over, and `retain`
         // walked every lot each time.
-        let date = position.cost.as_ref().and_then(|c| c.date);
-        if let Some(slots) = self.ordered_index.get_mut(&currency) {
+        let Some((currency, date)) = ordered else {
+            return;
+        };
+        let Some(index) = self.ordered_index.as_mut() else {
+            return;
+        };
+        if let Some(slots) = index.get_mut(&currency) {
             let positions = &self.positions;
             let at = slots.partition_point(|&existing| {
                 let existing_key = (
@@ -1793,7 +1811,7 @@ impl Inventory {
                 slots.retain(|slot| *slot != idx);
             }
             if slots.is_empty() {
-                self.ordered_index.remove(&currency);
+                index.remove(&currency);
             }
         }
     }
@@ -1813,12 +1831,15 @@ impl Inventory {
         // reductions all resolve through `cost_index` never builds one and so
         // never pays for it: maintaining it from every `add` unconditionally
         // cost 6% on the `investment` shape, which never reads it.
-        if self.ordered_index.is_empty() || !matches!(self.positions, PositionStore::Owned(_)) {
+        if !matches!(self.positions, PositionStore::Owned(_)) {
             return;
         }
+        let Some(index) = self.ordered_index.as_mut() else {
+            return;
+        };
         let key = (date, slot);
         let positions = &self.positions;
-        let entry = self.ordered_index.entry(currency.clone()).or_default();
+        let entry = index.entry(currency.clone()).or_default();
         let at = entry.partition_point(|&existing| {
             let existing_key = (
                 positions
@@ -1842,15 +1863,15 @@ impl Inventory {
         if !matches!(self.positions, PositionStore::Owned(_)) {
             return;
         }
-        self.ordered_index.clear();
+        let mut index: FxHashMap<crate::Currency, Vec<usize>> = FxHashMap::default();
         for (idx, pos) in self.positions.iter_slots() {
-            self.ordered_index
+            index
                 .entry(pos.units.currency.clone())
                 .or_default()
                 .push(idx);
         }
         let positions = &self.positions;
-        for slots in self.ordered_index.values_mut() {
+        for slots in index.values_mut() {
             slots.sort_by_key(|&idx| {
                 positions
                     .get(idx)
@@ -1858,19 +1879,14 @@ impl Inventory {
                     .and_then(|c| c.date)
             });
         }
+        self.ordered_index = Some(Box::new(index));
     }
 
     /// Cost-bearing slots of `currency` in FIFO order, or `None` when the
     /// index cannot answer and the caller must scan.
     fn ordered_candidates(&self, currency: &crate::Currency) -> Option<&[usize]> {
-        if self.ordered_index.is_empty() {
-            return None;
-        }
-        Some(
-            self.ordered_index
-                .get(currency)
-                .map_or(&[][..], Vec::as_slice),
-        )
+        let index = self.ordered_index.as_ref()?;
+        Some(index.get(currency).map_or(&[][..], Vec::as_slice))
     }
 
     /// Slots that could satisfy `spec` for `units`, or `None` when the spec
@@ -2018,7 +2034,7 @@ impl Inventory {
         if matches!(
             method,
             BookingMethod::Fifo | BookingMethod::Lifo | BookingMethod::Hifo
-        ) && self.ordered_index.is_empty()
+        ) && self.ordered_index.is_none()
         {
             self.build_ordered_index();
         }
@@ -2070,7 +2086,14 @@ impl Inventory {
         self.simple_index.clear();
         self.units_cache.clear();
         self.cost_index.clear();
-        self.ordered_index.clear();
+        // Preserve whether the ordered index has been BUILT, rather than
+        // building it here. A rebuild happens on compaction and on rollback,
+        // neither of which means ordered selection is in use — repopulating
+        // unconditionally handed the index (and its maintenance cost) to every
+        // ledger, including the ones whose reductions all resolve through
+        // `cost_index`.
+        let ordered_was_built = self.ordered_index.is_some();
+        self.ordered_index = None;
 
         // The cost index is for BOOKING, and only the owned backing books.
         //
@@ -2088,10 +2111,13 @@ impl Inventory {
                 if let Some(key) = cost_key(pos) {
                     self.cost_index.entry(key).or_default().push(idx);
                 }
-                self.ordered_index
-                    .entry(pos.units.currency.clone())
-                    .or_default()
-                    .push(idx);
+                if ordered_was_built {
+                    self.ordered_index
+                        .get_or_insert_with(Box::default)
+                        .entry(pos.units.currency.clone())
+                        .or_default()
+                        .push(idx);
+                }
             }
             // Update units cache for all positions. Checked, not `+=`:
             // `Decimal`'s `+` panics on overflow, and this runs over payloads.
@@ -2135,14 +2161,16 @@ impl Inventory {
         // order with slot as the tiebreak. `sort_by_key` is stable, so the
         // slot order already there survives — the same two-level order
         // `plan_ordered` produced when it sorted per call.
-        let positions = &self.positions;
-        for slots in self.ordered_index.values_mut() {
-            slots.sort_by_key(|&idx| {
-                positions
-                    .get(idx)
-                    .and_then(|p| p.cost.as_ref())
-                    .and_then(|c| c.date)
-            });
+        if let Some(index) = self.ordered_index.as_mut() {
+            let positions = &self.positions;
+            for slots in index.values_mut() {
+                slots.sort_by_key(|&idx| {
+                    positions
+                        .get(idx)
+                        .and_then(|p| p.cost.as_ref())
+                        .and_then(|c| c.date)
+                });
+            }
         }
         Ok(())
     }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -985,8 +985,15 @@ pub struct Inventory {
     /// Not serialized - rebuilt on demand, like the caches above.
     #[serde(skip)]
     cost_index: FxHashMap<CostKey, smallvec::SmallVec<[usize; 2]>>,
-    /// Cost-bearing lots per units-currency, in the order FIFO consumes them:
-    /// lot date ascending, ties broken by slot ascending.
+    /// EVERY lot per units-currency, in the order FIFO consumes them: lot date
+    /// ascending, ties broken by slot ascending.
+    ///
+    /// Cost-LESS lots are in here too, and deliberately. An empty cost spec
+    /// matches one (`matches_cost_spec`: `(None, true) => true`), so ordered
+    /// selection can drain one — an index holding only cost-bearing lots chose
+    /// a different lot than the scan it replaced, which is what the
+    /// scan-equivalence test caught. `cost_index` is the map keyed on cost;
+    /// this one is keyed on nothing but the commodity.
     ///
     /// `cost_index` cannot serve an under-specified spec — a bare `{}` names
     /// no cost to key on — so ordered selection scanned every slot instead,
@@ -1853,7 +1860,8 @@ impl Inventory {
         entry.insert(at, slot);
     }
 
-    /// Populate `ordered_index` from the current lots.
+    /// Populate `ordered_index` from the current lots — all of them, cost-less
+    /// included, because an empty cost spec selects those too.
     ///
     /// Called the first time an ordered booking method reduces against this
     /// inventory, then kept current incrementally. Ordering matches what
@@ -1882,8 +1890,10 @@ impl Inventory {
         self.ordered_index = Some(Box::new(index));
     }
 
-    /// Cost-bearing slots of `currency` in FIFO order, or `None` when the
-    /// index cannot answer and the caller must scan.
+    /// Every slot of `currency` in FIFO order, or `None` when the index cannot
+    /// answer and the caller must scan.
+    ///
+    /// Cost-less slots included — see the field's own note on why.
     fn ordered_candidates(&self, currency: &crate::Currency) -> Option<&[usize]> {
         let index = self.ordered_index.as_ref()?;
         Some(index.get(currency).map_or(&[][..], Vec::as_slice))

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -985,6 +985,21 @@ pub struct Inventory {
     /// Not serialized - rebuilt on demand, like the caches above.
     #[serde(skip)]
     cost_index: FxHashMap<CostKey, smallvec::SmallVec<[usize; 2]>>,
+    /// Cost-bearing lots per units-currency, in the order FIFO consumes them:
+    /// lot date ascending, ties broken by slot ascending.
+    ///
+    /// `cost_index` cannot serve an under-specified spec — a bare `{}` names
+    /// no cost to key on — so ordered selection scanned every slot instead,
+    /// once per reduction. Walking this list stops as soon as the reduction is
+    /// covered, so the common single-lot sale touches one entry (#2083).
+    ///
+    /// Same safety asymmetry as `cost_index`: a STALE entry is harmless
+    /// because the walk re-checks liveness, sign and the spec, while a MISSING
+    /// entry hides a lot the reduction should have seen. Insertion is at the
+    /// single `add` site; removal rides on `cost_index_remove`.
+    /// Not serialized - rebuilt on demand, like the caches above.
+    #[serde(skip)]
+    ordered_index: FxHashMap<crate::Currency, Vec<usize>>,
     /// Whether an undo log is open. Not serialized; a transaction never spans
     /// a round trip.
     #[serde(skip)]
@@ -1131,6 +1146,7 @@ impl TryFrom<InventoryWire> for Inventory {
             simple_index: FxHashMap::default(),
             units_cache: FxHashMap::default(),
             cost_index: FxHashMap::default(),
+            ordered_index: FxHashMap::default(),
             undo_open: false,
             #[cfg(debug_assertions)]
             undo_witness: None,
@@ -1716,10 +1732,20 @@ impl Inventory {
         // This is O(1) and keeps all lots separate, matching Python beancount behavior.
         // Lot aggregation for display purposes is handled separately in query output.
         let key = cost_key(&position);
+        // Every position, not only cost-bearing ones: an empty cost spec
+        // matches a cost-less lot (`matches_cost_spec`: `(None, true)`), so
+        // ordered selection can drain one, and an index that omitted them
+        // picked a different lot than the scan.
+        let ordering = (
+            position.units.currency.clone(),
+            position.cost.as_ref().and_then(|cost| cost.date),
+        );
         let slot = self.positions.push_slot(position);
         if let Some(key) = key {
             self.cost_index.entry(key).or_default().push(slot);
         }
+        let (currency, date) = ordering;
+        self.ordered_index_insert(&currency, date, slot);
         Ok(())
     }
 
@@ -1730,15 +1756,121 @@ impl Inventory {
     /// Drop `idx` from [`Self::cost_index`]. Called wherever a lot is
     /// tombstoned, since the slot stays valid but the lot is gone.
     pub(super) fn cost_index_remove(&mut self, idx: usize) {
-        let Some(key) = self.positions.get(idx).and_then(cost_key) else {
+        let Some(position) = self.positions.get(idx) else {
             return;
         };
-        if let Some(slots) = self.cost_index.get_mut(&key) {
+        let currency = position.units.currency.clone();
+        if let Some(key) = cost_key(position)
+            && let Some(slots) = self.cost_index.get_mut(&key)
+        {
             slots.retain(|slot| *slot != idx);
             if slots.is_empty() {
                 self.cost_index.remove(&key);
             }
         }
+        // The list is ordered, so find the entry rather than scanning for it:
+        // a FIFO account drains its oldest lot over and over, and `retain`
+        // walked every lot each time.
+        let date = position.cost.as_ref().and_then(|c| c.date);
+        if let Some(slots) = self.ordered_index.get_mut(&currency) {
+            let positions = &self.positions;
+            let at = slots.partition_point(|&existing| {
+                let existing_key = (
+                    positions
+                        .get(existing)
+                        .and_then(|p| p.cost.as_ref())
+                        .and_then(|c| c.date),
+                    existing,
+                );
+                existing_key < (date, idx)
+            });
+            if slots.get(at) == Some(&idx) {
+                slots.remove(at);
+            } else {
+                // Not where the order says it should be — a lot mutated in
+                // place since it was indexed. Fall back rather than leave it:
+                // a stale entry is safe, but cheap removal is the point.
+                slots.retain(|slot| *slot != idx);
+            }
+            if slots.is_empty() {
+                self.ordered_index.remove(&currency);
+            }
+        }
+    }
+
+    /// Place `slot` under `currency`, keeping the list in (date, slot) order.
+    ///
+    /// Ledgers book in date order, so the new lot almost always belongs at the
+    /// end and the search settles immediately; the binary search is what keeps
+    /// an out-of-order lot correct rather than fast.
+    fn ordered_index_insert(
+        &mut self,
+        currency: &crate::Currency,
+        date: Option<crate::NaiveDate>,
+        slot: usize,
+    ) {
+        // Maintain only an index that has been built. A ledger whose
+        // reductions all resolve through `cost_index` never builds one and so
+        // never pays for it: maintaining it from every `add` unconditionally
+        // cost 6% on the `investment` shape, which never reads it.
+        if self.ordered_index.is_empty() || !matches!(self.positions, PositionStore::Owned(_)) {
+            return;
+        }
+        let key = (date, slot);
+        let positions = &self.positions;
+        let entry = self.ordered_index.entry(currency.clone()).or_default();
+        let at = entry.partition_point(|&existing| {
+            let existing_key = (
+                positions
+                    .get(existing)
+                    .and_then(|p| p.cost.as_ref())
+                    .and_then(|c| c.date),
+                existing,
+            );
+            existing_key < key
+        });
+        entry.insert(at, slot);
+    }
+
+    /// Populate `ordered_index` from the current lots.
+    ///
+    /// Called the first time an ordered booking method reduces against this
+    /// inventory, then kept current incrementally. Ordering matches what
+    /// `plan_ordered` produced when it sorted per call: date ascending, slot
+    /// ascending within a date.
+    pub(super) fn build_ordered_index(&mut self) {
+        if !matches!(self.positions, PositionStore::Owned(_)) {
+            return;
+        }
+        self.ordered_index.clear();
+        for (idx, pos) in self.positions.iter_slots() {
+            self.ordered_index
+                .entry(pos.units.currency.clone())
+                .or_default()
+                .push(idx);
+        }
+        let positions = &self.positions;
+        for slots in self.ordered_index.values_mut() {
+            slots.sort_by_key(|&idx| {
+                positions
+                    .get(idx)
+                    .and_then(|p| p.cost.as_ref())
+                    .and_then(|c| c.date)
+            });
+        }
+    }
+
+    /// Cost-bearing slots of `currency` in FIFO order, or `None` when the
+    /// index cannot answer and the caller must scan.
+    fn ordered_candidates(&self, currency: &crate::Currency) -> Option<&[usize]> {
+        if self.ordered_index.is_empty() {
+            return None;
+        }
+        Some(
+            self.ordered_index
+                .get(currency)
+                .map_or(&[][..], Vec::as_slice),
+        )
     }
 
     /// Slots that could satisfy `spec` for `units`, or `None` when the spec
@@ -1877,6 +2009,20 @@ impl Inventory {
             self.compact_if_sparse();
         }
 
+        // Ordered selection walks lots in date order, so give it the index
+        // that holds them that way — built here, on the first reduction that
+        // will actually read it, and maintained incrementally afterwards. A
+        // STRICT account resolves through `cost_index` instead and never
+        // reaches this, which is why the build is gated rather than
+        // unconditional (#2083).
+        if matches!(
+            method,
+            BookingMethod::Fifo | BookingMethod::Lifo | BookingMethod::Hifo
+        ) && self.ordered_index.is_empty()
+        {
+            self.build_ordered_index();
+        }
+
         // {*} merge operator: merge all lots into a single weighted-average-cost
         // lot before reducing, regardless of the account's booking method.
         if spec.merge {
@@ -1924,6 +2070,7 @@ impl Inventory {
         self.simple_index.clear();
         self.units_cache.clear();
         self.cost_index.clear();
+        self.ordered_index.clear();
 
         // The cost index is for BOOKING, and only the owned backing books.
         //
@@ -1937,8 +2084,14 @@ impl Inventory {
         let index_costs = matches!(self.positions, PositionStore::Owned(_));
 
         for (idx, pos) in self.positions.iter_slots() {
-            if index_costs && let Some(key) = cost_key(pos) {
-                self.cost_index.entry(key).or_default().push(idx);
+            if index_costs {
+                if let Some(key) = cost_key(pos) {
+                    self.cost_index.entry(key).or_default().push(idx);
+                }
+                self.ordered_index
+                    .entry(pos.units.currency.clone())
+                    .or_default()
+                    .push(idx);
             }
             // Update units cache for all positions. Checked, not `+=`:
             // `Decimal`'s `+` panics on overflow, and this runs over payloads.
@@ -1976,6 +2129,20 @@ impl Inventory {
                 // `add` merges into is affected.
                 self.simple_index.insert(pos.units.currency.clone(), idx);
             }
+        }
+
+        // The walk above pushed in slot order; ordered selection wants date
+        // order with slot as the tiebreak. `sort_by_key` is stable, so the
+        // slot order already there survives — the same two-level order
+        // `plan_ordered` produced when it sorted per call.
+        let positions = &self.positions;
+        for slots in self.ordered_index.values_mut() {
+            slots.sort_by_key(|&idx| {
+                positions
+                    .get(idx)
+                    .and_then(|p| p.cost.as_ref())
+                    .and_then(|c| c.date)
+            });
         }
         Ok(())
     }

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -2041,10 +2041,12 @@ impl Inventory {
         // STRICT account resolves through `cost_index` instead and never
         // reaches this, which is why the build is gated rather than
         // unconditional (#2083).
-        if matches!(
-            method,
-            BookingMethod::Fifo | BookingMethod::Lifo | BookingMethod::Hifo
-        ) && self.ordered_index.is_none()
+        // FIFO and LIFO only: `reduce_hifo` sorts by COST and has its own scan,
+        // so it never reads this index — building one for it would be pure
+        // maintenance for a map nothing consults. (That scan is the same shape
+        // this PR fixes, and still unfixed for HIFO.)
+        if matches!(method, BookingMethod::Fifo | BookingMethod::Lifo)
+            && self.ordered_index.is_none()
         {
             self.build_ordered_index();
         }

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -129,7 +129,14 @@ impl Position {
         match (&self.cost, spec.is_empty()) {
             (None, true) => true,
             (None, false) => false,
-            (Some(cost), _) => spec.matches(cost),
+            // A spec that constrains nothing matches every lot, so skip the
+            // field-by-field walk. `matches` returns `true` for an all-`None`
+            // spec by construction, which makes this a short-circuit rather
+            // than a second rule. Ordered selection calls this once per lot
+            // per reduction, and the bare `{}` FIFO sell is the spec that
+            // reaches it most (#2083).
+            (Some(_), true) => true,
+            (Some(cost), false) => spec.matches(cost),
         }
     }
 

--- a/scripts/gen-profile-workload.py
+++ b/scripts/gen-profile-workload.py
@@ -51,6 +51,10 @@ SHAPES: dict[str, str] = {
     "link and taglink error passes that `simple` skips entirely.",
     "multicurrency": "Several currencies with price directives and @ "
     "conversions. Exercises price lookup and multi-currency balancing.",
+    "fifo": "Bare `{}` reductions against a FIFO account — how FIFO sells are "
+    "normally written. The other four shapes reach the ordered-selection path "
+    "twice in 2k transactions between them, so it was effectively unprofiled "
+    "until it turned out to be quadratic (#2083).",
 }
 
 
@@ -124,6 +128,48 @@ def gen_investment(n: int) -> None:
             print(f"  Assets:Broker:Cash  -{units * float(cost):.2f} USD")
 
 
+def gen_fifo(n: int) -> None:
+    """Bare `{}` reductions against a FIFO account.
+
+    `investment` writes every sell with an explicit cost, which resolves
+    through the cost index and never exercises ordered selection. Real FIFO
+    ledgers write `{}` and let the booking method choose the lot, which walks
+    lots in date order instead — a different code path with different scaling,
+    and the one that turned out to be quadratic in #2083.
+
+    One account and one commodity on purpose: the cost is proportional to lots
+    held in the account being reduced, so spreading lots over several accounts
+    would divide the very quantity this shape exists to grow.
+    """
+    rng = random.Random(45)
+    _header(
+        "Profiling Workload — fifo",
+        ['Assets:Broker:HOOL HOOL "FIFO"', "Assets:Broker:Cash USD", "Income:Gains USD"],
+        ["HOOL"],
+    )
+    d = datetime.date(2020, 1, 2)
+    held = 0
+    for _ in range(n):
+        d += datetime.timedelta(days=1)
+        # Roughly one sell in three, and only when there is something to sell,
+        # so the workload never profiles the error path.
+        if held > 0 and rng.random() < 0.33:
+            units = rng.randint(1, min(held, 10))
+            held -= units
+            price = f"{rng.uniform(5, 400):.2f}"
+            print(f'{d.isoformat()} * "Sell HOOL"')
+            print(f"  Assets:Broker:HOOL  -{units} HOOL {{}} @ {price} USD")
+            print(f"  Assets:Broker:Cash  {units * float(price):.2f} USD")
+            print("  Income:Gains")
+        else:
+            units = rng.randint(1, 50)
+            held += units
+            cost = f"{rng.uniform(5, 400):.2f}"
+            print(f'{d.isoformat()} * "Buy HOOL"')
+            print(f"  Assets:Broker:HOOL   {units} HOOL {{{cost} USD}}")
+            print(f"  Assets:Broker:Cash  -{units * float(cost):.2f} USD")
+
+
 def gen_tagged(n: int) -> None:
     """Tags, links and metadata on both transactions and postings.
 
@@ -179,6 +225,7 @@ GENERATORS = {
     "investment": gen_investment,
     "tagged": gen_tagged,
     "multicurrency": gen_multicurrency,
+    "fifo": gen_fifo,
 }
 
 


### PR DESCRIPTION
Fixes #2083. A FIFO ledger was quadratic: **20,000 transactions took 9.1s**, growing 93× for 10× the input. The same size on the `investment` shape takes 0.04s.

| N | main | this PR | |
|---|---|---|---|
| 2,000 | 0.10s | 0.02s | 5.0× |
| 6,000 | 0.78s | 0.08s | 9.8× |
| 20,000 | **9.11s** | **0.29s** | **31.4×** |

Growth for 10× input: **93× → ~11×.** Linear. All timings are cold runs with `.beancount.cache` deleted between them — a warm run is a different measurement, and mixing the two is how my first set of numbers came out wrong.

## Two costs, both per reduction, both proportional to lots held

**`commit_updates` rebuilt every index.** It tombstoned drained lots with a `retain` over every slot, then called `rebuild_index()`, which walks every slot again and rehashes every key — per reduction. `updates` already names the slots that changed, so the repair is now proportional to the lots the reduction touched. This is the treatment `commit_from_lot` got in #2063, applied to the multi-lot half; on its own it was 5.2×.

**`plan_ordered` scanned everything to take from the front.** Every slot walked, the cost-spec predicate applied to each, the survivors sorted, then summed for a sufficiency check. `ordered_index` now keeps each currency's lots in `(date, slot)` order, so the walk starts where the answer is and stops once the reduction is covered.

The up-front sufficiency sum went with it. That existed to guarantee a failed reduction does not mutate — which the plan/commit split (#2061) made structural, since `plan_ordered` now only computes and the caller commits. Exhausting the walk reports the same shortfall, having visited the same lots.

## The trade

| shape | change |
|---|---|
| investment | +2.35% |
| tagged | +1.33% |
| simple | +1.16% |
| multicurrency | +0.93% |

That is the honest cost of the index, and it is a constant against a growth term removed. It is built on the first reduction under an ordered booking method and maintained from `add` only once built, so a ledger whose reductions all resolve through `cost_index` never pays for it. Binary-search removal rather than `retain` took the `investment` figure from +6.06% to +2.35%; the remainder is structural (an extra field on a type that is cloned per BQL output row).

## What the differential test caught

`the_ordered_index_selects_what_the_scan_selects` runs both paths over an inventory with out-of-order dates, a duplicate date, a date-less lot, a second currency and a cost-less lot, across three specs and both directions. The existing 480 core tests noticed neither of these:

1. **The index must hold cost-less positions.** An empty cost spec matches one (`matches_cost_spec`: `(None, true) => true`), so ordered selection can drain one — omitting them selected a different lot than the scan. `commit_from_lot` documents the same subtlety for `simple_index`.
2. **My first version of that test was vacuous.** It called `plan_ordered` directly, which never builds the index, so it compared the scan against itself — and passed against a deliberately reversed tiebreak. It now builds the index explicitly and asserts it is non-empty. Both facts are in the test's doc comment, because the failure mode is silent.

## Workload coverage

Adds a `fifo` shape to `gen-profile-workload.py`. The existing four shapes reach ordered selection **twice in 2,000 transactions between them** — `investment` writes every sell with an explicit cost, which resolves through `cost_index` — which is why a quadratic survived the six superlinear terms fixed in #2059–#2067. The most common real-world reduction spec was simply not represented.

## Verification

146 test suites green; clippy (1.97.0), fmt and doc clean. The differential test is mutation-checked: reversing the index tiebreak fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr