### PR TITLE
test(booking): stop the rollback property failing at random

### DIFF
--- a/crates/rustledger-booking/tests/apply_rollback_properties.rs
+++ b/crates/rustledger-booking/tests/apply_rollback_properties.rs
@@ -20,6 +20,9 @@ use rustledger_core::{
 };
 
 const CURRENCY: &str = "X";
+/// A commodity the generated legs never mention, so the doomed posting can
+/// always find lots to fail against.
+const ANCHOR: &str = "ANCHOR";
 const COST_CURRENCY: &str = "USD";
 
 fn date(d: u32) -> NaiveDate {
@@ -102,6 +105,23 @@ proptest! {
             engine.apply(&txn).expect("seeding fits");
         }
 
+        // A lot in a commodity no generated leg touches. The doomed posting
+        // below reduces THIS, so it is a reduction no matter what the prefix
+        // did to `STK` — see the comment there.
+        let mut anchor = Posting::new("Assets:Stock", Amount::new(Decimal::from(50), ANCHOR));
+        anchor.cost = Some(CostSpec {
+            number: Some(CostNumber::PerUnit {
+                value: Decimal::from(7),
+            }),
+            currency: Some(COST_CURRENCY.into()),
+            date: Some(date(1)),
+            label: None,
+            merge: false,
+        });
+        engine
+            .apply(&Transaction::new(date(1), "anchor").with_synthesized_posting(anchor))
+            .expect("the anchor lot fits");
+
         let before = holdings(&engine);
 
         // The transaction: some legs, then one that cannot succeed.
@@ -142,9 +162,20 @@ proptest! {
             };
             txn = txn.with_synthesized_posting(posting);
         }
+        // Doomed against the ANCHOR commodity, not the generated one.
+        //
+        // It used to oversell `STK`, on the assumption that overselling always
+        // fails. It does not: a prefix of `{*}` merges can empty the account,
+        // and an empty cost spec against an empty account is an AUGMENTATION,
+        // not a failed reduction — beancount's `book_reductions` makes the same
+        // call (`if balance.is_reduced_by(units)`, else augment). So the
+        // transaction succeeded, and this property test failed at random
+        // depending on which prefix proptest generated. Reducing a commodity
+        // the prefix cannot drain restores "this leg always fails" as a fact
+        // rather than a hope.
         let mut doomed = Posting::new(
             "Assets:Stock",
-            Amount::new(Decimal::from(-100_000), CURRENCY),
+            Amount::new(Decimal::from(-100_000), ANCHOR),
         );
         doomed.cost = Some(CostSpec {
             number: None,

--- a/crates/rustledger-booking/tests/apply_rollback_properties.rs
+++ b/crates/rustledger-booking/tests/apply_rollback_properties.rs
@@ -107,17 +107,9 @@ proptest! {
 
         // A lot in a commodity no generated leg touches. The doomed posting
         // below reduces THIS, so it is a reduction no matter what the prefix
-        // did to `STK` — see the comment there.
+        // did to the generated commodity — see the comment there.
         let mut anchor = Posting::new("Assets:Stock", Amount::new(Decimal::from(50), ANCHOR));
-        anchor.cost = Some(CostSpec {
-            number: Some(CostNumber::PerUnit {
-                value: Decimal::from(7),
-            }),
-            currency: Some(COST_CURRENCY.into()),
-            date: Some(date(1)),
-            label: None,
-            merge: false,
-        });
+        anchor.cost = Some(per_unit(7, 1));
         engine
             .apply(&Transaction::new(date(1), "anchor").with_synthesized_posting(anchor))
             .expect("the anchor lot fits");
@@ -164,9 +156,11 @@ proptest! {
         }
         // Doomed against the ANCHOR commodity, not the generated one.
         //
-        // It used to oversell `STK`, on the assumption that overselling always
-        // fails. It does not: a prefix of `{*}` merges can empty the account,
-        // and an empty cost spec against an empty account is an AUGMENTATION,
+        // It used to oversell the generated commodity, on the assumption that
+        // overselling always
+        // fails. It does not: a prefix of
+        // `{*}` merges can empty the account, and an empty cost spec against an
+        // empty account is an AUGMENTATION,
         // not a failed reduction — beancount's `book_reductions` makes the same
         // call (`if balance.is_reduced_by(units)`, else augment). So the
         // transaction succeeded, and this property test failed at random

--- a/crates/rustledger-booking/tests/apply_rollback_properties.rs
+++ b/crates/rustledger-booking/tests/apply_rollback_properties.rs
@@ -62,13 +62,19 @@ fn leg_strategy(costs: Vec<u32>) -> impl Strategy<Value = Leg> {
 }
 
 /// The lots an account holds, as a comparable snapshot.
-fn holdings(engine: &BookingEngine) -> Vec<(Decimal, Option<Decimal>, Option<NaiveDate>)> {
+fn holdings(engine: &BookingEngine) -> Vec<(String, Decimal, Option<Decimal>, Option<NaiveDate>)> {
     engine
         .inventories()
         .filter(|(account, _)| account.as_str() == "Assets:Stock")
         .flat_map(|(_, inv)| inv.positions())
         .map(|p| {
             (
+                // The commodity is part of the snapshot because the account
+                // now holds two: the generated legs work on one, the doomed
+                // leg reduces the other. Without it, a rollback that restored
+                // the right numbers against the wrong commodity would compare
+                // equal.
+                p.units.currency.to_string(),
                 p.units.number,
                 p.cost.as_ref().map(|c| c.number),
                 p.cost.as_ref().and_then(|c| c.date),


### PR DESCRIPTION
A latent CI flake in `apply_rollback_properties`, found while measuring something unrelated.

## What happens

The property builds a randomized prefix of legs, appends a doomed final leg that oversells `STK` by 100,000, and asserts the transaction is rejected and the account untouched.

The doomed leg does not always fail. A prefix of `{*}` merges can **empty the account**, and an empty cost spec against an empty account is an **augmentation**, not a failed reduction — so the transaction succeeds and the property reports:

```
Test failed: the doomed leg must reject the transaction
minimal failing input: seed_costs = [100],
  legs = [Merge { units: 10 }, Merge { units: 4 }, Merge { units: 19 }, Merge { units: 17 }]
```

Whether CI sees it depends on which prefix proptest generates that run.

## The product is right; the test was wrong

Beancount's `book_reductions` makes the same call — a posting held at cost is a reduction only `if balance.is_reduced_by(units)`, otherwise it is booked as an augmentation. rustledger matches. So an all-`Merge` prefix draining the account and the doomed leg then augmenting is correct behavior, and the assertion was asserting something that was never true.

## Fix

The doomed posting now reduces a commodity the generated legs never mention, seeded once up front. "This leg always fails" becomes a fact about the fixture rather than a hope about the prefix, and the prefix still exercises every mutation shape the undo log has to cover (push a slot, write a lot in place, drain one, and `{*}` dropping every matched lot at once).

## Verification

- The seed that fails on `main` passes here.
- Eight randomized runs pass.
- The property still has teeth: neutering `has_reduction` so the undo log is never armed fails it.
- 146 suites green, clippy/fmt clean.

## Age

It reproduces on every commit I tried, including before #2085 and #2081, so it has been latent since the file was added in #2067. Not a regression from recent work — it simply needed proptest to roll four merges in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr