### PR TITLE
perf(query): stop copying the account inventory twice per row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,6 +3390,7 @@ dependencies = [
  "pprof",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustc-hash 2.1.3",
  "rustledger-booking",
  "rustledger-budget",
  "rustledger-core",

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -378,7 +378,7 @@ impl<'a> Executor<'a> {
                                     .merge_average()
                                     .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
-                            Ok(Value::Inventory(Box::new(total_inventory)))
+                            Ok(Value::Inventory(std::sync::Arc::new(total_inventory)))
                         } else if has_numbers {
                             // Pure number sum - return as Number
                             Ok(Value::Number(total_number))
@@ -885,7 +885,7 @@ impl<'a> Executor<'a> {
                                     )))
                                     .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
-                            Ok(Value::Inventory(Box::new(total_inventory)))
+                            Ok(Value::Inventory(std::sync::Arc::new(total_inventory)))
                         } else if has_numbers {
                             Ok(Value::Number(total_number))
                         } else {

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -378,7 +378,7 @@ impl Executor<'_> {
                 // Cumulative running balance across WHERE-filtered postings —
                 // matches bean-query semantics. See `PostingContext::balance`.
                 if let Some(ref balance) = ctx.balance {
-                    Ok(Value::Inventory(Box::new(balance.clone())))
+                    Ok(Value::Inventory(std::sync::Arc::new(balance.clone())))
                 } else {
                     Ok(Value::Null)
                 }
@@ -387,7 +387,11 @@ impl Executor<'_> {
                 // Per-account running balance for this posting's account.
                 // Always reflects the true ledger balance, independent of WHERE.
                 if let Some(ref balance) = ctx.account_balance {
-                    Ok(Value::Inventory(Box::new(balance.clone())))
+                    // `Arc::clone`, not a copy of the inventory. Reading this
+                    // column used to deep-clone every lot a second time, on top
+                    // of the copy the context already held — once per row that
+                    // reads it (#2086).
+                    Ok(Value::Inventory(std::sync::Arc::clone(balance)))
                 } else {
                     Ok(Value::Null)
                 }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -529,7 +529,7 @@ impl Executor<'_> {
                 }
                 let mut r = row.clone();
                 if let Some(i) = balance_idx {
-                    r[i] = Value::Inventory(Box::new(running_balance.clone()));
+                    r[i] = Value::Inventory(std::sync::Arc::new(running_balance.clone()));
                 }
                 overridden_row = r;
                 &overridden_row
@@ -1055,7 +1055,7 @@ impl Executor<'_> {
                             narration,
                             Value::String(posting.account.to_string()),
                             position_value,
-                            Value::Inventory(Box::new(balance_for_row)),
+                            Value::Inventory(std::sync::Arc::new(balance_for_row)),
                         ];
                         result.add_row(row);
                     }
@@ -1104,19 +1104,19 @@ impl Executor<'_> {
                         let cost_inventory = balance
                             .at_cost()
                             .map_err(|e| QueryError::Evaluation(e.to_string()))?;
-                        Value::Inventory(Box::new(cost_inventory))
+                        Value::Inventory(std::sync::Arc::new(cost_inventory))
                     }
                     "UNITS" => {
                         // Just the units (remove cost info)
                         let units_inventory = balance
                             .at_units()
                             .map_err(|e| QueryError::Evaluation(e.to_string()))?;
-                        Value::Inventory(Box::new(units_inventory))
+                        Value::Inventory(std::sync::Arc::new(units_inventory))
                     }
-                    _ => Value::Inventory(Box::new(balance.clone())),
+                    _ => Value::Inventory(std::sync::Arc::new(balance.clone())),
                 }
             } else {
-                Value::Inventory(Box::new(balance.clone()))
+                Value::Inventory(std::sync::Arc::new(balance.clone()))
             };
 
             let row = vec![Value::String(account.to_string()), balance_value];

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -445,7 +445,7 @@ impl<'a> Executor<'a> {
         // — `BALANCES` applies its own `WHERE` to the result afterward, and
         // `account_balances` is WHERE-independent by construction anyway.
         Ok(self
-            .scan_postings(from, None, false, true, false, false)?
+            .scan_postings(from, None, false, true, false, false, false)?
             .account_balances)
     }
 
@@ -482,6 +482,11 @@ impl<'a> Executor<'a> {
         // running total after the eager update above.
         let where_reads_balance =
             where_clause.is_some_and(|w| expr_references_column(w, "balance"));
+        // Same distinction for `account_balance`: referenced ANYWHERE decides
+        // whether the column is materialized at all, referenced by the WHERE
+        // decides whether it has to exist before the filter runs.
+        let where_reads_account_balance =
+            where_clause.is_some_and(|w| expr_references_column(w, "account_balance"));
 
         Ok(self
             .scan_postings(
@@ -490,6 +495,7 @@ impl<'a> Executor<'a> {
                 needs_balance,
                 needs_account_balance,
                 where_reads_balance,
+                where_reads_account_balance,
                 true,
             )?
             .postings)
@@ -521,6 +527,7 @@ impl<'a> Executor<'a> {
         needs_balance: bool,
         needs_account_balance: bool,
         where_reads_balance: bool,
+        where_reads_account_balance: bool,
         collect_contexts: bool,
     ) -> Result<PostingScan<'a>, QueryError> {
         let mut postings = Vec::new();
@@ -675,8 +682,23 @@ impl<'a> Executor<'a> {
                         } else {
                             None
                         },
-                        account_balance: if needs_account_balance {
-                            engine.inventory(&posting.account).cloned()
+                        // Cloning the account's inventory is O(lots), and it
+                        // was happening for EVERY posting the FROM clause kept,
+                        // including the ones WHERE was about to reject. That is
+                        // O(rows x lots) — 0.11s / 0.39s / 3.31s for 1k / 2k /
+                        // 6k transactions, quadratic (#2086).
+                        //
+                        // Same treatment `balance` got in #1085: the pre-WHERE
+                        // copy is only observable when the WHERE clause itself
+                        // reads the column. Otherwise it is filled in below,
+                        // for surviving rows only. Nothing mutates the engine
+                        // between here and there, so the deferred value is the
+                        // same one.
+                        account_balance: if needs_account_balance && where_reads_account_balance {
+                            engine
+                                .inventory(&posting.account)
+                                .cloned()
+                                .map(std::sync::Arc::new)
                         } else {
                             None
                         },
@@ -701,6 +723,14 @@ impl<'a> Executor<'a> {
                                 .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
                         ctx.balance = Some(cumulative_balance.clone());
+                    }
+                    // The deferred half of the gate above: this row survived, so
+                    // it is one of the few that will actually be read.
+                    if needs_account_balance && !where_reads_account_balance {
+                        ctx.account_balance = engine
+                            .inventory(&posting.account)
+                            .cloned()
+                            .map(std::sync::Arc::new);
                     }
                     postings.push(ctx);
                 }
@@ -954,7 +984,7 @@ impl<'a> Executor<'a> {
                                 .add(Position::simple(pos.units.clone()))
                                 .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
-                        Ok(Value::Inventory(Box::new(units_inv)))
+                        Ok(Value::Inventory(std::sync::Arc::new(units_inv)))
                     }
                     Value::Null => Ok(Value::Null),
                     _ => Err(QueryError::Type(
@@ -1304,7 +1334,7 @@ impl<'a> Executor<'a> {
                                 .add(pos)
                                 .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                         }
-                        Ok(Value::Inventory(Box::new(new_inv)))
+                        Ok(Value::Inventory(std::sync::Arc::new(new_inv)))
                     }
                     Value::Null => Ok(Value::Null),
                     _ => Err(QueryError::Type(
@@ -1453,7 +1483,7 @@ impl<'a> Executor<'a> {
                         {
                             Ok(Value::Amount(positions[0].units.clone()))
                         } else {
-                            Ok(Value::Inventory(Box::new(result)))
+                            Ok(Value::Inventory(std::sync::Arc::new(result)))
                         }
                     }
                     Value::Number(n) => Ok(Value::Amount(Amount::new(*n, &target_currency))),
@@ -1695,7 +1725,7 @@ impl<'a> Executor<'a> {
                                     .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                             }
                         }
-                        Ok(Value::Inventory(Box::new(result)))
+                        Ok(Value::Inventory(std::sync::Arc::new(result)))
                     }
                     Value::Null => Ok(Value::Null),
                     _ => Err(QueryError::Type(
@@ -2064,7 +2094,7 @@ impl<'a> Executor<'a> {
                         out.add(rustledger_core::Position::simple(units))
                             .map_err(|e| QueryError::Evaluation(e.to_string()))?;
                     }
-                    return Ok(Value::Inventory(Box::new(out)));
+                    return Ok(Value::Inventory(std::sync::Arc::new(out)));
                 }
                 // Two-arg form: collapse to a single Amount in the explicit
                 // target currency. NOTE (pre-existing beanquery divergence,

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -598,7 +598,7 @@ impl Executor<'_> {
         // there are no predicates to evaluate, so the scan is infallible here —
         // assert that invariant rather than silently emitting an empty table.
         let contexts = self
-            .scan_postings(None, None, true, true, false, true)
+            .scan_postings(None, None, true, true, false, false, true)
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
             .postings;
 
@@ -712,12 +712,10 @@ impl Executor<'_> {
             // (`needs_balance`/`needs_account_balance` both `true` above), so they
             // are identical to the old inline accumulators — proven by the
             // #postings parity test.
-            let balance_val = ctx
-                .balance
-                .map_or(Value::Null, |inv| Value::Inventory(Box::new(inv)));
-            let account_balance_val = ctx
-                .account_balance
-                .map_or(Value::Null, |inv| Value::Inventory(Box::new(inv)));
+            let balance_val = ctx.balance.map_or(Value::Null, |inv| {
+                Value::Inventory(std::sync::Arc::new(inv))
+            });
+            let account_balance_val = ctx.account_balance.map_or(Value::Null, Value::Inventory);
 
             // Other accounts: all accounts in the transaction except this posting's.
             let other_accounts: Vec<String> = all_accounts

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -218,7 +218,7 @@ fn test_hash_value_all_variants() {
             Amount::new(dec!(10), "AAPL"),
             Cost::new(dec!(150), "USD"),
         ))),
-        Value::Inventory(Box::new(Inventory::new())),
+        Value::Inventory(std::sync::Arc::new(Inventory::new())),
         Value::StringSet(vec!["tag1".to_string(), "tag2".to_string()]),
         Value::Null,
     ];
@@ -285,8 +285,8 @@ fn test_inventory_hash_includes_cost() {
     ))
     .expect("fixture fits in Decimal");
 
-    let hash1 = hash_single_value(&Value::Inventory(Box::new(inv1)));
-    let hash2 = hash_single_value(&Value::Inventory(Box::new(inv2)));
+    let hash1 = hash_single_value(&Value::Inventory(std::sync::Arc::new(inv1)));
+    let hash2 = hash_single_value(&Value::Inventory(std::sync::Arc::new(inv2)));
 
     assert_ne!(hash1, hash2);
 }

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -110,7 +110,7 @@ pub enum Value {
     /// Position (amount + optional cost). Boxed to reduce enum size.
     Position(Box<Position>),
     /// Inventory (aggregated positions). Boxed to reduce enum size.
-    Inventory(Box<Inventory>),
+    Inventory(std::sync::Arc<Inventory>),
     /// Set of strings (tags, links).
     StringSet(Vec<String>),
     /// Generic set of values for IN operator (supports mixed types).
@@ -392,7 +392,7 @@ pub struct PostingContext<'a> {
     /// `account_balance` column. Updated for every posting, independent of the
     /// WHERE filter, so it always reflects the true ledger balance for the
     /// account at this point in time.
-    pub account_balance: Option<Inventory>,
+    pub account_balance: Option<std::sync::Arc<Inventory>>,
     /// The directive index (for source location lookup).
     pub directive_index: Option<usize>,
 }

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -63,6 +63,7 @@ path = "src/bin/ag-rledger.rs"
 required-features = ["ag-rledger"]
 
 [dependencies]
+rustc-hash.workspace = true
 # Agent-native CLI deps (#1291), enabled only by the `ag-rledger` feature so
 # the sync `rledger` CLI/lib don't carry the async runtime by default.
 agcli = { workspace = true, optional = true }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -368,8 +368,8 @@ const fn position_renders_as_zero(pos: &rustledger_core::Position) -> bool {
 fn rendered_inventory_positions(
     inv: &rustledger_core::Inventory,
 ) -> Vec<rustledger_core::Position> {
+    use rustc_hash::FxHashMap;
     use rustledger_core::{Cost, Currency, Position};
-    use std::collections::HashMap;
 
     // Key on the typed values rather than a formatted string. `Currency` and
     // `Cost` are both `Eq + Hash`, and `rust_decimal`'s `Hash` agrees with its
@@ -377,7 +377,14 @@ fn rendered_inventory_positions(
     // `{1.00 USD}` and `{1 USD}` still net together, which is what the old
     // key's `number.normalize()` was there to ensure. Avoids two allocations
     // per lot on a path walked once per row.
-    let mut aggregated: HashMap<(Currency, Option<Cost>), Position> = HashMap::new();
+    // `FxHashMap`, sized up front. This runs once per OUTPUT ROW and inserts
+    // once per lot, so on a long-held account it was the query's single largest
+    // cost: SipHash plus the rehash of a map grown from empty accounted for
+    // roughly a fifth of the run (#2086). The hasher is free to change here
+    // because the sort below is total — the comment on its label arm records
+    // why — so iteration order cannot reach the output.
+    let mut aggregated: FxHashMap<(Currency, Option<Cost>), Position> =
+        FxHashMap::with_capacity_and_hasher(inv.len(), rustc_hash::FxBuildHasher);
     for pos in inv.positions().filter(|p| !p.is_empty()) {
         let key = (pos.units.currency.clone(), pos.cost.clone());
 
@@ -652,7 +659,7 @@ mod tests {
         let ledger_ctx = DisplayContext::new();
         let mut col_ctx = DisplayContext::new();
         for lots in &rows {
-            let value = Value::Inventory(Box::new(inv_of(lots)));
+            let value = Value::Inventory(std::sync::Arc::new(inv_of(lots)));
             update_column_context(&mut col_ctx, &value, &ledger_ctx);
         }
 
@@ -671,7 +678,7 @@ mod tests {
         let rendered = rendered_inventory_positions(&inv);
         assert_eq!(rendered.len(), 1, "lots at one cost net together");
         assert_eq!(rendered[0].units.number, dec!(545.4545455));
-        let out = format_value(&Value::Inventory(Box::new(inv)), false, &col_ctx);
+        let out = format_value(&Value::Inventory(std::sync::Arc::new(inv)), false, &col_ctx);
         assert!(out.starts_with("545.4545455 COOL_FUND_USD"), "got: {out}");
     }
 
@@ -868,7 +875,7 @@ mod tests {
             Cost::new(dec!(131.73), "USD"),
         ))
         .expect("fixture fits in Decimal");
-        let value = Value::Inventory(Box::new(inv));
+        let value = Value::Inventory(std::sync::Arc::new(inv));
         let ctx = DisplayContext::new();
         let rendered = format_value(&value, false, &ctx);
 
@@ -945,7 +952,7 @@ mod tests {
         inv.add(Position::simple(Amount::new(dec!(-0.0003183), "USD")))
             .expect("fixture fits in Decimal");
 
-        let rendered = format_value(&Value::Inventory(Box::new(inv)), false, &ctx);
+        let rendered = format_value(&Value::Inventory(std::sync::Arc::new(inv)), false, &ctx);
         assert_eq!(
             rendered, "-0.00 USD",
             "a sub-cent USD residual is a position the inventory HOLDS, so \
@@ -988,7 +995,7 @@ mod tests {
         inv.add(Position::simple(Amount::new(dec!(-0.01), "USD")))
             .expect("fixture fits in Decimal");
 
-        let rendered = format_value(&Value::Inventory(Box::new(inv)), false, &ctx);
+        let rendered = format_value(&Value::Inventory(std::sync::Arc::new(inv)), false, &ctx);
         assert!(
             rendered.contains("-0.01"),
             "-0.01 USD is exactly at USD precision; must still render. Got {rendered:?}"
@@ -1016,7 +1023,7 @@ mod tests {
         let mut inv = Inventory::new();
         inv.add(Position::simple(Amount::new(over_scale, "USD")))
             .expect("fixture fits in Decimal");
-        let inv_val = Value::Inventory(Box::new(inv));
+        let inv_val = Value::Inventory(std::sync::Arc::new(inv));
 
         assert_eq!(format_value(&amount_val, true, &ctx), "-1202.01");
         assert_eq!(format_value(&pos_val, true, &ctx), "-1202.01");
@@ -1048,7 +1055,7 @@ mod tests {
         let mut result = QueryResult::new(vec!["account".into(), "sum".into()]);
         result.add_row(vec![
             Value::String("Income:Capital-Gains".into()),
-            Value::Inventory(Box::new(inv)),
+            Value::Inventory(std::sync::Arc::new(inv)),
         ]);
 
         let mut buf: Vec<u8> = Vec::new();
@@ -1087,7 +1094,7 @@ mod tests {
             .expect("fixture fits in Decimal");
 
         let mut result = QueryResult::new(vec!["sum".into()]);
-        result.add_row(vec![Value::Inventory(Box::new(inv))]);
+        result.add_row(vec![Value::Inventory(std::sync::Arc::new(inv))]);
 
         let mut buf: Vec<u8> = Vec::new();
         write_beancount(&result, &mut buf, &ctx).expect("beancount ok");


### PR DESCRIPTION
Partly addresses #2086 — and corrects that issue's framing, which overstated the defect.

| query, 6,000 transactions, cold cache | main | this PR |
|---|---|---|
| `select account, account_balance where account ~ 'HOOL'` | 33.93s | **26.11s** |
| `select count(account) where … and account_balance != 0` | 3.19s | **2.42s** |

## Three changes

**`Value::Inventory` and `PostingContext::account_balance` hold an `Arc`, not a `Box`.** Reading the column deep-copied every lot a *second* time, on top of the copy the context already held — so a query that merely tests `account_balance != 0` paid two O(lots) copies per row to answer a boolean. `Arc::clone` also makes `Value` cheap to clone generally, which the aggregation paths get for free.

**`rendered_inventory_positions` used a std `HashMap`.** SipHash, grown from empty, built once per output row with one insert per lot: **17.8%** of the run in `sip::Hasher::write` plus **11.7%** in `reserve_rehash`. Now `FxHashMap`, sized up front. The hasher is safe to change because the sort below it is total — the comment on its label arm records why that matters.

**The pre-WHERE copy is deferred past the filter** unless the WHERE clause reads the column, which is the treatment `balance` got in #1085. Selective queries stop paying for rows they reject.

## What this does not fix, and a correction to #2086

**Still quadratic.** One O(lots) copy per row remains, because the engine's inventory keeps moving and each row needs the state at its own posting. Removing it needs snapshots that are cheap by construction — the structurally-shared backing #1086 added for the cumulative balance — while the engine's inventories are `Owned` precisely so booking is fast. That is a larger change and belongs on its own.

**And #2086's headline overstates the defect.** I filed it as "34s for a query". Measuring properly:

| | 6,000 txns |
|---|---|
| `select account, account_balance …` | 34s, **producing 409.6 MB** of output (longest line 83,775 chars) |
| same query, column removed | 0.14s |
| reads the column, returns ONE row | 3.19s |

A running lot-level inventory per row genuinely *is* O(rows × lots) of text, so most of that 34s is output the query asked for. The real defect is the third line — 3.19s to answer a query returning a single row — which is what these changes target.

## Verification

146 suites green; clippy (1.97.0), fmt and doc clean.

Note it needs #2087 (an unrelated latent flake in `apply_rollback_properties`) to go green in CI — proptest surfaced that while I was measuring this, and it reproduces on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr