### PR TITLE
perf(core): give HIFO and STRICT_WITH_SIZE plan halves and a shared ordered walk

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -9,7 +9,9 @@ use rust_decimal::prelude::Signed;
 
 use smallvec::{SmallVec, smallvec};
 
-use super::{BookingError, BookingMethod, BookingResult, Inventory, MatchedLots, OverflowError};
+use super::{
+    BookingError, BookingMethod, BookingResult, Inventory, LotOrder, MatchedLots, OverflowError,
+};
 use crate::{Amount, Cost, CostSpec, Currency, Position};
 
 /// Compute weighted-average cost from a set of positions.
@@ -132,12 +134,19 @@ impl Inventory {
         }
         match method {
             BookingMethod::Strict => self.plan_strict(units, &spec).map(|(r, _)| r),
-            BookingMethod::Fifo => self.plan_ordered(units, &spec, false).map(|(r, _)| r),
-            BookingMethod::Lifo => self.plan_ordered(units, &spec, true).map(|(r, _)| r),
-            BookingMethod::StrictWithSize
-            | BookingMethod::Hifo
-            | BookingMethod::Average
-            | BookingMethod::None => self.clone().reduce(units, cost_spec, method),
+            BookingMethod::Fifo => self
+                .plan_ordered(units, &spec, LotOrder::Date, false)
+                .map(|(r, _)| r),
+            BookingMethod::Lifo => self
+                .plan_ordered(units, &spec, LotOrder::Date, true)
+                .map(|(r, _)| r),
+            BookingMethod::Hifo => self.plan_hifo(units, &spec).map(|(r, _)| r),
+            BookingMethod::StrictWithSize => {
+                self.plan_strict_with_size(units, &spec).map(|(r, _)| r)
+            }
+            BookingMethod::Average | BookingMethod::None => {
+                self.clone().reduce(units, cost_spec, method)
+            }
         }
     }
 
@@ -280,7 +289,8 @@ impl Inventory {
                 });
 
                 if all_same_value {
-                    let (result, updates) = self.plan_ordered(units, spec, false)?;
+                    let (result, updates) =
+                        self.plan_ordered(units, spec, LotOrder::Date, false)?;
                     return Ok((result, ReductionPlan::Updates(updates)));
                 }
 
@@ -292,7 +302,8 @@ impl Inventory {
                     .map(|&i| self.positions[i].units.number.abs())
                     .sum();
                 if total_units == units.number.abs() {
-                    let (result, updates) = self.plan_ordered(units, spec, false)?;
+                    let (result, updates) =
+                        self.plan_ordered(units, spec, LotOrder::Date, false)?;
                     return Ok((result, ReductionPlan::Updates(updates)));
                 }
 
@@ -305,64 +316,90 @@ impl Inventory {
     }
 
     /// `STRICT_WITH_SIZE` booking: like STRICT, but exact-size matches accept oldest lot.
-    pub(super) fn reduce_strict_with_size(
-        &mut self,
+    /// `STRICT_WITH_SIZE`: an explicit cost, disambiguated by lot size.
+    ///
+    /// Planned from `&self` so `try_reduce` can preview it without copying the
+    /// inventory. It used to be reachable only through `self.clone().reduce()`
+    /// — an O(lots) copy per reducing posting, which is quadratic across a
+    /// ledger and was most of this method's cost (#2091). The conversion is the
+    /// one #2061 left as "mechanical" when it split STRICT, FIFO and LIFO.
+    pub(super) fn plan_strict_with_size(
+        &self,
         units: &Amount,
         spec: &CostSpec,
-    ) -> Result<BookingResult, BookingError> {
-        let matching_indices: Vec<usize> = self
-            .positions
-            .iter_slots()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.can_reduce(units)
-                    && p.matches_cost_spec(spec)
+    ) -> Result<(BookingResult, ReductionPlan), BookingError> {
+        // Narrow through the cost index before filtering, the way `plan_strict`
+        // does. This walked every slot in the account on every reduction. A
+        // spec naming a cost has a handful of candidates; one that names none
+        // still scans, because it can match anything.
+        let candidates: Vec<usize> = self.cost_candidates(units, spec).unwrap_or_else(|| {
+            self.positions
+                .iter_slots()
+                .filter(|(_, p)| p.units.currency == units.currency)
+                .map(|(i, _)| i)
+                .collect()
+        });
+        let matching_indices: Vec<usize> = candidates
+            .into_iter()
+            .filter(|&i| {
+                self.positions.get(i).is_some_and(|p| {
+                    p.units.currency == units.currency
+                        && !p.is_empty()
+                        && p.can_reduce(units)
+                        && p.matches_cost_spec(spec)
+                })
             })
-            .map(|(i, _)| i)
             .collect();
+
+        let from_lot = |idx: usize| {
+            self.plan_from_lot(idx, units)
+                .map(|(result, new_units)| (result, ReductionPlan::FromLot { idx, new_units }))
+        };
 
         match matching_indices.len() {
             0 => Err(BookingError::NoMatchingLot {
                 currency: units.currency.clone(),
                 cost_spec: spec.clone(),
             }),
-            1 => {
-                let idx = matching_indices[0];
-                self.reduce_from_lot(idx, units)
-            }
+            1 => from_lot(matching_indices[0]),
             n => {
-                // Check for exact-size match with any lot
-                let exact_matches: Vec<usize> = matching_indices
+                // A lot of exactly the reduction's size disambiguates.
+                let exact = matching_indices
                     .iter()
-                    .filter(|&&i| self.positions[i].units.number.abs() == units.number.abs())
                     .copied()
-                    .collect();
-
-                if exact_matches.is_empty() {
-                    // Total match exception
-                    let total_units: Decimal = matching_indices
-                        .iter()
-                        .map(|&i| self.positions[i].units.number.abs())
-                        .sum();
-                    if total_units == units.number.abs() {
-                        self.reduce_ordered(units, spec, false)
-                    } else {
-                        Err(BookingError::AmbiguousMatch {
-                            num_matches: n,
-                            currency: units.currency.clone(),
-                        })
-                    }
-                } else {
-                    // Use oldest (first) exact-size match
-                    let idx = exact_matches[0];
-                    self.reduce_from_lot(idx, units)
+                    .find(|&i| self.positions[i].units.number.abs() == units.number.abs());
+                if let Some(idx) = exact {
+                    return from_lot(idx);
                 }
+                // Total match exception: selling the whole matched inventory
+                // makes the choice of lot irrelevant.
+                let total_units: Decimal = matching_indices
+                    .iter()
+                    .map(|&i| self.positions[i].units.number.abs())
+                    .sum();
+                if total_units == units.number.abs() {
+                    let (result, updates) =
+                        self.plan_ordered(units, spec, LotOrder::Date, false)?;
+                    return Ok((result, ReductionPlan::Updates(updates)));
+                }
+                Err(BookingError::AmbiguousMatch {
+                    num_matches: n,
+                    currency: units.currency.clone(),
+                })
             }
         }
     }
 
-    /// FIFO booking: reduce from oldest lots first.
+    pub(super) fn reduce_strict_with_size(
+        &mut self,
+        units: &Amount,
+        spec: &CostSpec,
+    ) -> Result<BookingResult, BookingError> {
+        let (result, plan) = self.plan_strict_with_size(units, spec)?;
+        self.commit_plan(&plan, units);
+        Ok(result)
+    }
+
     pub(super) fn reduce_fifo(
         &mut self,
         units: &Amount,
@@ -381,131 +418,40 @@ impl Inventory {
     }
 
     /// HIFO booking: reduce from highest-cost lots first.
+    /// HIFO booking: take from the most expensive lots first.
+    ///
+    /// The plan half of the ordered walk with a cost key, which is all HIFO
+    /// ever was. It used to carry its own copy of that walk — scan every slot,
+    /// sort the survivors by cost, sum them for sufficiency, then take — which
+    /// is O(lots) per reduction and was 18s on a 20,000-transaction ledger
+    /// against FIFO's 0.27s (#2091). Sharing `plan_ordered` gives it the
+    /// maintained index, the early stop, and a plan half so `try_reduce` can
+    /// preview without cloning the inventory.
+    pub(super) fn plan_hifo(
+        &self,
+        units: &Amount,
+        spec: &CostSpec,
+    ) -> Result<(BookingResult, SmallVec<[(usize, Decimal); 1]>), BookingError> {
+        self.plan_ordered(units, spec, LotOrder::CostDescending, false)
+    }
+
     pub(super) fn reduce_hifo(
         &mut self,
         units: &Amount,
         spec: &CostSpec,
     ) -> Result<BookingResult, BookingError> {
-        let mut remaining = units.number.abs();
-        let mut matched: MatchedLots = SmallVec::new();
-        let mut cost_basis = Decimal::ZERO;
-        let mut cost_currency = None;
-
-        // Get matching positions with their costs
-        let mut matching: Vec<(usize, Decimal)> = self
-            .positions
-            .iter_slots()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.units.number.signum() != units.number.signum()
-                    && p.matches_cost_spec(spec)
-            })
-            .map(|(i, p)| {
-                let cost = p.cost.as_ref().map_or(Decimal::ZERO, |c| c.number);
-                (i, cost)
-            })
-            .collect();
-
-        if matching.is_empty() {
-            return Err(BookingError::NoMatchingLot {
-                currency: units.currency.clone(),
-                cost_spec: spec.clone(),
-            });
-        }
-
-        // Sort by cost descending (highest first)
-        matching.sort_by_key(|(_, cost)| std::cmp::Reverse(*cost));
-
-        let indices: Vec<usize> = matching.into_iter().map(|(i, _)| i).collect();
-
-        // Check sufficiency BEFORE mutating any lot: a failed reduction must
-        // leave the inventory untouched (same invariant as `reduce_ordered`;
-        // see the comment there and `booking_properties.rs`).
-        let available: Decimal = indices
-            .iter()
-            .map(|&i| self.positions[i].units.number.abs())
-            .sum();
-        if available < remaining {
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: remaining,
-                available,
-            });
-        }
-
-        for idx in indices {
-            if remaining.is_zero() {
-                break;
-            }
-
-            let pos = &self.positions[idx];
-            let available = pos.units.number.abs();
-            let take = remaining.min(available);
-
-            // Calculate cost basis for this portion
-            if let Some(cost) = &pos.cost {
-                // Checked, not clamped: a clamped cost basis becomes a
-                // fabricated capital gain (#1863).
-                //
-                // DEFENSE-IN-DEPTH, not a currently-reachable fix: no ledger
-                // was found that gets here with an overflowing accumulation —
-                // to sum two in-range cost bases past the ceiling, the
-                // reducing posting's own weight must exceed it too, and that
-                // is reported earlier (verified by removing this check and
-                // re-running the multi-lot fixtures, which still did not
-                // panic). Kept because reachability rests on those upstream
-                // checks, and a future caller reaching `reduce` directly must
-                // not resurrect the panic.
-                cost_basis = take
-                    .checked_mul(cost.number)
-                    .and_then(|v| cost_basis.checked_add(v))
-                    .ok_or_else(|| {
-                        BookingError::Overflow(OverflowError {
-                            currency: cost.currency.clone(),
-                        })
-                    })?;
-                cost_currency = Some(cost.currency.clone());
-            }
-
-            // Record what we matched
-            let (taken, _) = pos.split(take * pos.units.number.signum());
-            matched.push(taken);
-
-            // Reduce the lot
-            let reduction = if units.number.is_sign_negative() {
-                -take
-            } else {
-                take
-            };
-
-            let new_pos = Position {
-                units: Amount::new(pos.units.number + reduction, pos.units.currency.clone()),
-                cost: pos.cost.clone(),
-            };
-            self.positions[idx] = new_pos;
-
-            remaining -= take;
-        }
-
-        // Clean up empty positions
-        self.positions.retain(|p| !p.is_empty());
-        self.rebuild_index();
-
-        Ok(BookingResult {
-            matched,
-            cost_basis: cost_currency.map(|c| Amount::new(cost_basis, c)),
-        })
+        let (result, updates) = self.plan_hifo(units, spec)?;
+        self.commit_updates(&updates);
+        Ok(result)
     }
 
-    /// Reduce in order (FIFO or LIFO).
     pub(super) fn reduce_ordered(
         &mut self,
         units: &Amount,
         spec: &CostSpec,
         reverse: bool,
     ) -> Result<BookingResult, BookingError> {
-        let (result, updates) = self.plan_ordered(units, spec, reverse)?;
+        let (result, updates) = self.plan_ordered(units, spec, LotOrder::Date, reverse)?;
         self.commit_updates(&updates);
         Ok(result)
     }
@@ -521,6 +467,7 @@ impl Inventory {
         &self,
         units: &Amount,
         spec: &CostSpec,
+        order: LotOrder,
         reverse: bool,
     ) -> Result<(BookingResult, SmallVec<[(usize, Decimal); 1]>), BookingError> {
         let mut remaining = units.number.abs();
@@ -539,24 +486,25 @@ impl Inventory {
         // The predicate still runs per candidate: the index knows nothing
         // about sign, emptiness or what this spec matches, and a stale entry
         // for a drained lot is expected, since removal is best-effort.
-        let scanned: Option<Vec<usize>> = if self.ordered_candidates(&units.currency).is_some() {
-            None
-        } else {
-            // No index — a shared snapshot, or one never rebuilt. Scanning is
-            // the only correct answer, and it is what this always did.
-            let mut all: Vec<usize> = self
-                .positions
-                .iter_slots()
-                .filter(|(_, p)| p.units.currency == units.currency)
-                .map(|(i, _)| i)
-                .collect();
-            all.sort_by_key(|&i| self.positions[i].cost.as_ref().and_then(|c| c.date));
-            Some(all)
-        };
+        let scanned: Option<Vec<usize>> =
+            if self.ordered_candidates(&units.currency, order).is_some() {
+                None
+            } else {
+                // No index — a shared snapshot, or one never rebuilt. Scanning is
+                // the only correct answer, and it is what this always did.
+                let mut all: Vec<usize> = self
+                    .positions
+                    .iter_slots()
+                    .filter(|(_, p)| p.units.currency == units.currency)
+                    .map(|(i, _)| i)
+                    .collect();
+                all.sort_by_key(|&i| self.order_key(order, i));
+                Some(all)
+            };
         let candidates: &[usize] = match &scanned {
             Some(all) => all,
             None => self
-                .ordered_candidates(&units.currency)
+                .ordered_candidates(&units.currency, order)
                 .expect("the branch above proved it is Some"),
         };
 
@@ -1102,30 +1050,6 @@ impl Inventory {
     }
 
     /// Reduce from a specific lot.
-    pub(super) fn reduce_from_lot(
-        &mut self,
-        idx: usize,
-        units: &Amount,
-    ) -> Result<BookingResult, BookingError> {
-        let (result, new_units) = self.plan_from_lot(idx, units)?;
-        self.commit_from_lot(idx, units, new_units);
-        Ok(result)
-    }
-
-    /// The read-only half of [`Self::reduce_from_lot`]: everything up to the
-    /// first mutation, returning what WOULD be matched plus the lot's new
-    /// units number.
-    ///
-    /// Split out so `try_reduce` can answer from `&self`. It used to be
-    /// `self.clone().reduce(..)`, which deep-copied every lot in the account
-    /// to preview a reduction that touches one of them — the dominant
-    /// superlinear term in the pipeline (`Position::clone` grew 104x for 10x
-    /// the input on the `investment` profiling shape).
-    ///
-    /// Selection logic lives HERE and only here; the mutating path calls this
-    /// too. That is deliberate — `try_reduce` duplicating `reduce`'s selection
-    /// is the exact drift that `try_reduce_equivalence` exists to police, and
-    /// it had already bitten once before that test was written.
     pub(super) fn plan_from_lot(
         &self,
         idx: usize,
@@ -1240,6 +1164,7 @@ mod reduction_tests {
     //! the lot-reduction mutants surfaced by the #1309 audit are killed
     //! (the public mutating `reduce_*` path was covered indirectly, but
     //! the `try_reduce_*` preview path had no direct assertions).
+    use super::LotOrder;
     use crate::{Amount, BookingMethod, Cost, CostSpec, Inventory, Position, naive_date};
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
@@ -1308,7 +1233,12 @@ mod reduction_tests {
         .expect("fixture fits in Decimal");
 
         let err = inv
-            .plan_ordered(&Amount::new(d(-99), "STK"), &CostSpec::default(), false)
+            .plan_ordered(
+                &Amount::new(d(-99), "STK"),
+                &CostSpec::default(),
+                LotOrder::Date,
+                false,
+            )
             .expect_err("99 units are not there");
         assert!(
             matches!(err, crate::BookingError::InsufficientUnits { .. }),
@@ -1328,6 +1258,14 @@ mod reduction_tests {
     ///
     /// Clearing `ordered_index` is what forces the scan: an empty index is
     /// how a shared snapshot looks, and the fallback exists for exactly that.
+    ///
+    /// What this does NOT check is whether the ORDER is the right one. Both
+    /// sides call `order_key`, so reversing it moves them together and this
+    /// test stays green — verified by mutating it. The orderings themselves
+    /// are pinned by the method tests (`test_hifo_reduces_highest_cost_first`,
+    /// `test_fifo_respects_dates` and their neighbors), which is the division
+    /// of labor: those say what order a method takes lots in, this says the
+    /// index reproduces whatever that order is.
     #[test]
     fn the_ordered_index_selects_what_the_scan_selects() {
         // Deliberately awkward: out-of-order dates, a duplicate date, a
@@ -1358,52 +1296,61 @@ mod reduction_tests {
             },
         ];
 
-        for spec in &specs {
-            for reverse in [false, true] {
-                for take in [1i64, 15, 45] {
-                    let units = Amount::new(d(-take), "STK");
+        for (order, reverse) in [
+            (LotOrder::Date, false),
+            (LotOrder::Date, true),
+            // HIFO: the cost ordering added in #2091. Its tiebreak has to match
+            // the `sort_by_key(Reverse(cost))` it replaced — stable, so equal
+            // costs stayed in ascending slot order.
+            (LotOrder::CostDescending, false),
+        ] {
+            for spec in &specs {
+                {
+                    for take in [1i64, 15, 45] {
+                        let units = Amount::new(d(-take), "STK");
 
-                    // Build it explicitly: `reduce` is what normally triggers
-                    // the build, and calling `plan_ordered` directly would
-                    // otherwise leave the index empty and compare the scan
-                    // against itself. That vacuous version of this test passed
-                    // against a deliberately reversed tiebreak.
-                    let mut indexing = inv.clone();
-                    indexing.build_ordered_index();
-                    assert!(
-                        indexing.ordered_index.is_some(),
-                        "the fixture must produce an index, or this test compares \
+                        // Build it explicitly: `reduce` is what normally triggers
+                        // the build, and calling `plan_ordered` directly would
+                        // otherwise leave the index empty and compare the scan
+                        // against itself. That vacuous version of this test passed
+                        // against a deliberately reversed tiebreak.
+                        let mut indexing = inv.clone();
+                        indexing.build_ordered_index(order);
+                        assert!(
+                            indexing.ordered_index.is_some(),
+                            "the fixture must produce an index, or this test compares \
                          the scan against itself",
-                    );
-                    let indexed = indexing.plan_ordered(&units, spec, reverse);
+                        );
+                        let indexed = indexing.plan_ordered(&units, spec, order, reverse);
 
-                    let mut scanning = inv.clone();
-                    scanning.ordered_index = None;
-                    let scanned = scanning.plan_ordered(&units, spec, reverse);
+                        let mut scanning = inv.clone();
+                        scanning.ordered_index = None;
+                        let scanned = scanning.plan_ordered(&units, spec, order, reverse);
 
-                    match (indexed, scanned) {
-                        (Ok((a_result, a_updates)), Ok((b_result, b_updates))) => {
-                            assert_eq!(
-                                a_updates, b_updates,
-                                "index and scan chose different lots for {spec:?} \
+                        match (indexed, scanned) {
+                            (Ok((a_result, a_updates)), Ok((b_result, b_updates))) => {
+                                assert_eq!(
+                                    a_updates, b_updates,
+                                    "index and scan chose different lots for {spec:?} \
                                  reverse={reverse} take={take}",
-                            );
-                            assert_eq!(
-                                a_result.cost_basis, b_result.cost_basis,
-                                "index and scan disagree on cost basis for {spec:?} \
+                                );
+                                assert_eq!(
+                                    a_result.cost_basis, b_result.cost_basis,
+                                    "index and scan disagree on cost basis for {spec:?} \
                                  reverse={reverse} take={take}",
-                            );
-                        }
-                        (Err(a), Err(b)) => assert_eq!(
-                            a.to_string(),
-                            b.to_string(),
-                            "index and scan report different errors for {spec:?} \
+                                );
+                            }
+                            (Err(a), Err(b)) => assert_eq!(
+                                a.to_string(),
+                                b.to_string(),
+                                "index and scan report different errors for {spec:?} \
                              reverse={reverse} take={take}",
-                        ),
-                        (a, b) => panic!(
-                            "index and scan disagree on success for {spec:?} \
-                             reverse={reverse} take={take}: {a:?} vs {b:?}"
-                        ),
+                            ),
+                            (a, b) => panic!(
+                                "index and scan disagree on success for {spec:?} \
+                             order={order:?} reverse={reverse} take={take}: {a:?} vs {b:?}"
+                            ),
+                        }
                     }
                 }
             }

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1247,6 +1247,40 @@ mod reduction_tests {
         );
     }
 
+    /// HIFO takes costed lots before cost-less ones.
+    ///
+    /// A cost-less lot has no cost to compare, and an empty cost spec matches
+    /// it, so it is a candidate. The scan this replaced counted it as zero
+    /// before reversing, which put it last; ordering on `Option<Decimal>`
+    /// would put it FIRST, because `None` sorts before `Some`. Same lots,
+    /// opposite lot chosen.
+    #[test]
+    fn hifo_takes_costed_lots_before_costless_ones() {
+        let mut inv = Inventory::new();
+        inv.add(Position::simple(Amount::new(d(10), "STK")))
+            .expect("fixture fits in Decimal");
+        inv.add(lot(10, 100, 1)).expect("fixture fits in Decimal");
+
+        let result = inv
+            .reduce(
+                &Amount::new(d(-5), "STK"),
+                Some(&CostSpec::default()),
+                BookingMethod::Hifo,
+            )
+            .expect("5 of 20 units are there");
+
+        assert_eq!(
+            result.matched[0].cost.as_ref().map(|c| c.number),
+            Some(d(100)),
+            "the 100 USD lot outranks the cost-less one",
+        );
+        assert_eq!(
+            result.cost_basis.map(|b| b.number),
+            Some(d(500)),
+            "and the basis comes from it",
+        );
+    }
+
     /// The ordered index selects exactly what the scan selects (#2083).
     ///
     /// `plan_ordered` used to sort every matching lot on every call; it now

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1754,6 +1754,19 @@ mod reduction_tests {
         let inv = mk([lot(10, 100, 1), lot(10, 200, 2)]);
         let r = try_reduce(&inv, &sell_stk(20), BookingMethod::StrictWithSize);
         assert_eq!(basis(&r), dec!(3000)); // total match → FIFO: 1000 + 2000
+
+        // The basis alone cannot tell FIFO from LIFO here: a total match
+        // consumes every matching lot, so any order sums to 3000. The name of
+        // this test is about the ORDER, so assert it — flipping the fallback
+        // to LIFO used to leave this green.
+        assert_eq!(
+            r.matched
+                .iter()
+                .map(|p| p.cost.as_ref().map(|c| c.number))
+                .collect::<Vec<_>>(),
+            vec![Some(dec!(100)), Some(dec!(200))],
+            "oldest lot first",
+        );
     }
 
     // ---- Mutating reduce() path (reduce_*) ----------------------------

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1010,7 +1010,7 @@ pub struct Inventory {
     /// three words plus its allocation, on a type that is created per account
     /// and cloned per BQL output row.
     #[serde(skip)]
-    ordered_index: Option<Box<FxHashMap<crate::Currency, Vec<usize>>>>,
+    ordered_index: Option<Box<OrderedIndex>>,
     /// Whether an undo log is open. Not serialized; a transaction never spans
     /// a round trip.
     #[serde(skip)]
@@ -1020,6 +1020,28 @@ pub struct Inventory {
     #[cfg(debug_assertions)]
     #[serde(skip)]
     undo_witness: Option<Box<Self>>,
+}
+
+/// The order a booking method consumes lots in.
+///
+/// One inventory needs one ordering, because an account has one booking
+/// method — so this is stored alongside the index rather than a second index
+/// being kept in step with the first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LotOrder {
+    /// Oldest lot first. FIFO walks it forward, LIFO backward.
+    Date,
+    /// Most expensive lot first, which is what HIFO takes.
+    CostDescending,
+}
+
+/// Lots per units-currency, in the order some booking method consumes them.
+#[derive(Debug, Clone)]
+pub(super) struct OrderedIndex {
+    /// Which ordering `by_currency` is sorted in.
+    order: LotOrder,
+    /// Slots per units-currency, sorted by `order` then slot ascending.
+    by_currency: FxHashMap<crate::Currency, Vec<usize>>,
 }
 
 /// What [`Inventory::cost_index`] groups lots by: the units they are held in,
@@ -1747,16 +1769,12 @@ impl Inventory {
         // matches a cost-less lot (`matches_cost_spec`: `(None, true)`), so
         // ordered selection can drain one, and an index that omitted them
         // picked a different lot than the scan.
-        let ordering = (
-            position.units.currency.clone(),
-            position.cost.as_ref().and_then(|cost| cost.date),
-        );
+        let ordering = position.units.currency.clone();
         let slot = self.positions.push_slot(position);
         if let Some(key) = key {
             self.cost_index.entry(key).or_default().push(slot);
         }
-        let (currency, date) = ordering;
-        self.ordered_index_insert(&currency, date, slot);
+        self.ordered_index_insert(&ordering, slot);
         Ok(())
     }
 
@@ -1774,12 +1792,10 @@ impl Inventory {
         // every drained lot, and cloning the currency to probe a map that is
         // not there is pure overhead for a ledger that never reduces with an
         // under-specified spec.
-        let ordered = self.ordered_index.is_some().then(|| {
-            (
-                position.units.currency.clone(),
-                position.cost.as_ref().and_then(|c| c.date),
-            )
-        });
+        let ordered = self
+            .ordered_index
+            .is_some()
+            .then(|| position.units.currency.clone());
         if let Some(key) = cost_key(position)
             && let Some(slots) = self.cost_index.get_mut(&key)
         {
@@ -1791,34 +1807,23 @@ impl Inventory {
         // The list is ordered, so find the entry rather than scanning for it:
         // a FIFO account drains its oldest lot over and over, and `retain`
         // walked every lot each time.
-        let Some((currency, date)) = ordered else {
+        let Some(currency) = ordered else {
             return;
         };
         let Some(index) = self.ordered_index.as_mut() else {
             return;
         };
-        if let Some(slots) = index.get_mut(&currency) {
-            let positions = &self.positions;
-            let at = slots.partition_point(|&existing| {
-                let existing_key = (
-                    positions
-                        .get(existing)
-                        .and_then(|p| p.cost.as_ref())
-                        .and_then(|c| c.date),
-                    existing,
-                );
-                existing_key < (date, idx)
-            });
-            if slots.get(at) == Some(&idx) {
+        if let Some(slots) = index.by_currency.get_mut(&currency) {
+            // Linear here rather than a binary search: `order_key` needs
+            // `&self.positions`, which is already borrowed through `index`.
+            // Removal is off the hot path — the walk is what this index exists
+            // to speed up — and it keeps the ordering rule in one place.
+            let at = slots.iter().position(|&existing| existing == idx);
+            if let Some(at) = at {
                 slots.remove(at);
-            } else {
-                // Not where the order says it should be — a lot mutated in
-                // place since it was indexed. Fall back rather than leave it:
-                // a stale entry is safe, but cheap removal is the point.
-                slots.retain(|slot| *slot != idx);
             }
             if slots.is_empty() {
-                index.remove(&currency);
+                index.by_currency.remove(&currency);
             }
         }
     }
@@ -1828,12 +1833,7 @@ impl Inventory {
     /// Ledgers book in date order, so the new lot almost always belongs at the
     /// end and the search settles immediately; the binary search is what keeps
     /// an out-of-order lot correct rather than fast.
-    fn ordered_index_insert(
-        &mut self,
-        currency: &crate::Currency,
-        date: Option<crate::NaiveDate>,
-        slot: usize,
-    ) {
+    fn ordered_index_insert(&mut self, currency: &crate::Currency, slot: usize) {
         // Maintain only an index that has been built. A ledger whose
         // reductions all resolve through `cost_index` never builds one and so
         // never pays for it: maintaining it from every `add` unconditionally
@@ -1841,23 +1841,20 @@ impl Inventory {
         if !matches!(self.positions, PositionStore::Owned(_)) {
             return;
         }
-        let Some(index) = self.ordered_index.as_mut() else {
+        let Some(mut index) = self.ordered_index.take() else {
             return;
         };
-        let key = (date, slot);
-        let positions = &self.positions;
-        let entry = index.entry(currency.clone()).or_default();
-        let at = entry.partition_point(|&existing| {
-            let existing_key = (
-                positions
-                    .get(existing)
-                    .and_then(|p| p.cost.as_ref())
-                    .and_then(|c| c.date),
-                existing,
-            );
-            existing_key < key
-        });
+        let order = index.order;
+        let key = (self.order_key(order, slot), slot);
+        // The index is OUT of `self` for the search, so the binary search can
+        // read `self.positions` for each probe. Materializing the keys instead
+        // — the obvious way around the borrow — makes every `add` walk the
+        // whole currency, which is the quadratic this index exists to remove.
+        let entry = index.by_currency.entry(currency.clone()).or_default();
+        let at =
+            entry.partition_point(|&existing| (self.order_key(order, existing), existing) < key);
         entry.insert(at, slot);
+        self.ordered_index = Some(index);
     }
 
     /// Populate `ordered_index` from the current lots — all of them, cost-less
@@ -1867,36 +1864,58 @@ impl Inventory {
     /// inventory, then kept current incrementally. Ordering matches what
     /// `plan_ordered` produced when it sorted per call: date ascending, slot
     /// ascending within a date.
-    pub(super) fn build_ordered_index(&mut self) {
+    /// The value `order` sorts `slot` by. Ties fall through to the slot
+    /// number, which is what makes both orderings match the stable sorts they
+    /// replace: `sort_by_key(date)` and `sort_by_key(Reverse(cost))` both left
+    /// equal keys in ascending slot order.
+    fn order_key(
+        &self,
+        order: LotOrder,
+        slot: usize,
+    ) -> (Option<Decimal>, Option<crate::NaiveDate>) {
+        let cost = self.positions.get(slot).and_then(|p| p.cost.as_ref());
+        match order {
+            LotOrder::Date => (None, cost.and_then(|c| c.date)),
+            // Negated rather than reversed so the tuple still sorts ascending
+            // and the slot tiebreak keeps its direction.
+            LotOrder::CostDescending => (cost.map(|c| -c.number), None),
+        }
+    }
+
+    pub(super) fn build_ordered_index(&mut self, order: LotOrder) {
         if !matches!(self.positions, PositionStore::Owned(_)) {
             return;
         }
-        let mut index: FxHashMap<crate::Currency, Vec<usize>> = FxHashMap::default();
+        let mut by_currency: FxHashMap<crate::Currency, Vec<usize>> = FxHashMap::default();
         for (idx, pos) in self.positions.iter_slots() {
-            index
+            by_currency
                 .entry(pos.units.currency.clone())
                 .or_default()
                 .push(idx);
         }
-        let positions = &self.positions;
-        for slots in index.values_mut() {
-            slots.sort_by_key(|&idx| {
-                positions
-                    .get(idx)
-                    .and_then(|p| p.cost.as_ref())
-                    .and_then(|c| c.date)
-            });
+        for slots in by_currency.values_mut() {
+            slots.sort_by_key(|&idx| self.order_key(order, idx));
         }
-        self.ordered_index = Some(Box::new(index));
+        self.ordered_index = Some(Box::new(OrderedIndex { order, by_currency }));
     }
 
     /// Every slot of `currency` in FIFO order, or `None` when the index cannot
     /// answer and the caller must scan.
     ///
     /// Cost-less slots included — see the field's own note on why.
-    fn ordered_candidates(&self, currency: &crate::Currency) -> Option<&[usize]> {
+    fn ordered_candidates(&self, currency: &crate::Currency, order: LotOrder) -> Option<&[usize]> {
         let index = self.ordered_index.as_ref()?;
-        Some(index.get(currency).map_or(&[][..], Vec::as_slice))
+        // A different ordering answers a different question; scanning is the
+        // only correct fallback until something rebuilds it.
+        if index.order != order {
+            return None;
+        }
+        Some(
+            index
+                .by_currency
+                .get(currency)
+                .map_or(&[][..], Vec::as_slice),
+        )
     }
 
     /// Slots that could satisfy `spec` for `units`, or `None` when the spec
@@ -2041,14 +2060,18 @@ impl Inventory {
         // STRICT account resolves through `cost_index` instead and never
         // reaches this, which is why the build is gated rather than
         // unconditional (#2083).
-        // FIFO and LIFO only: `reduce_hifo` sorts by COST and has its own scan,
-        // so it never reads this index — building one for it would be pure
-        // maintenance for a map nothing consults. (That scan is the same shape
-        // this PR fixes, and still unfixed for HIFO.)
-        if matches!(method, BookingMethod::Fifo | BookingMethod::Lifo)
-            && self.ordered_index.is_none()
+        // Which ordering this account's method consumes, if any. STRICT
+        // resolves through `cost_index` instead and never reaches the walk, so
+        // it builds nothing.
+        let wanted_order = match method {
+            BookingMethod::Fifo | BookingMethod::Lifo => Some(LotOrder::Date),
+            BookingMethod::Hifo => Some(LotOrder::CostDescending),
+            _ => None,
+        };
+        if let Some(order) = wanted_order
+            && self.ordered_index.as_ref().is_none_or(|i| i.order != order)
         {
-            self.build_ordered_index();
+            self.build_ordered_index(order);
         }
 
         // {*} merge operator: merge all lots into a single weighted-average-cost
@@ -2104,7 +2127,7 @@ impl Inventory {
         // unconditionally handed the index (and its maintenance cost) to every
         // ledger, including the ones whose reductions all resolve through
         // `cost_index`.
-        let ordered_was_built = self.ordered_index.is_some();
+        let ordered_was_built = self.ordered_index.as_ref().map(|i| i.order);
         self.ordered_index = None;
 
         // The cost index is for BOOKING, and only the owned backing books.
@@ -2123,9 +2146,15 @@ impl Inventory {
                 if let Some(key) = cost_key(pos) {
                     self.cost_index.entry(key).or_default().push(idx);
                 }
-                if ordered_was_built {
+                if let Some(order) = ordered_was_built {
                     self.ordered_index
-                        .get_or_insert_with(Box::default)
+                        .get_or_insert_with(|| {
+                            Box::new(OrderedIndex {
+                                order,
+                                by_currency: FxHashMap::default(),
+                            })
+                        })
+                        .by_currency
                         .entry(pos.units.currency.clone())
                         .or_default()
                         .push(idx);
@@ -2173,15 +2202,22 @@ impl Inventory {
         // order with slot as the tiebreak. `sort_by_key` is stable, so the
         // slot order already there survives — the same two-level order
         // `plan_ordered` produced when it sorted per call.
-        if let Some(index) = self.ordered_index.as_mut() {
-            let positions = &self.positions;
-            for slots in index.values_mut() {
-                slots.sort_by_key(|&idx| {
-                    positions
-                        .get(idx)
-                        .and_then(|p| p.cost.as_ref())
-                        .and_then(|c| c.date)
-                });
+        if let Some(order) = ordered_was_built {
+            let keys: Vec<(crate::Currency, Vec<usize>)> = self
+                .ordered_index
+                .as_ref()
+                .map(|i| {
+                    i.by_currency
+                        .iter()
+                        .map(|(c, slots)| (c.clone(), slots.clone()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            for (currency, mut slots) in keys {
+                slots.sort_by_key(|&idx| self.order_key(order, idx));
+                if let Some(index) = self.ordered_index.as_mut() {
+                    index.by_currency.insert(currency, slots);
+                }
             }
         }
         Ok(())

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1878,7 +1878,13 @@ impl Inventory {
             LotOrder::Date => (None, cost.and_then(|c| c.date)),
             // Negated rather than reversed so the tuple still sorts ascending
             // and the slot tiebreak keeps its direction.
-            LotOrder::CostDescending => (cost.map(|c| -c.number), None),
+            //
+            // A cost-less lot counts as zero rather than as `None`. `None`
+            // sorts BEFORE `Some`, which would put cost-less lots at the front
+            // of a highest-cost-first walk — the opposite of where the
+            // `map_or(Decimal::ZERO, ..)` this replaces put them. An empty cost
+            // spec matches a cost-less position, so HIFO can reach one.
+            LotOrder::CostDescending => (Some(-cost.map_or(Decimal::ZERO, |c| c.number)), None),
         }
     }
 


### PR DESCRIPTION
Fixes #2091. Both methods were quadratic; on a ledger whose sells name an exact cost, at 20,000 transactions:

| method | main | this PR | |
|---|---|---|---|
| **HIFO** | 7.79s | **0.58s** | **13.4×** |
| **STRICT_WITH_SIZE** | 2.42s | **0.29s** | **8.3×** |
| STRICT / FIFO / LIFO / AVERAGE / NONE | 0.27–0.33s | 0.27–0.29s | unchanged |

All seven booking methods now sit between 0.27s and 0.58s. HIFO was **27× slower than FIFO** on the same ledger for no reason a user could see.

## The cost was not where the issue said it was

I filed #2091 pointing at their lot scans, because that is what #2083 had just fixed one function over. The scans are real but secondary. `try_reduce` — the preview `book` uses — answered from `&self` only for STRICT, FIFO and LIFO:

```rust
BookingMethod::StrictWithSize | BookingMethod::Hifo
| BookingMethod::Average | BookingMethod::None => self.clone().reduce(units, cost_spec, method),
```

An **O(lots) copy of the whole inventory per reducing posting**. #2061 split the first three and left a comment calling the rest "mechanical to convert". This converts the two that measured quadratic.

`reduce_hifo` also carried its own copy of the ordered walk — scan every slot, sort by cost, sum for sufficiency, take — which is `plan_ordered` with a different key. It now shares that walk and gets the maintained index and early stop with it. `LotOrder` records which key an inventory's index is sorted by; `reduce` builds the one the account's method consumes. An account has one booking method, so that is one index with a recorded ordering rather than two kept in step.

`reduce_strict_with_size` additionally narrows through `cost_index` before filtering, as `plan_strict` does.

## Two things measuring caught that reading would not

**My first index insert was itself quadratic.** To dodge a borrow conflict it materialized every key in the currency per `add` — so the growth term moved rather than left, and HIFO measured 7.73s → 7.86s. Taking the index out of `self` lets the binary search read `positions` on each probe. Without measuring after the change, this would have shipped as a "fix".

**The scan-equivalence test cannot see an ordering error.** Both sides call `order_key`, so reversing it moves them together and the test stays green — I verified that by mutating it. The orderings are pinned by the method tests instead (`test_hifo_reduces_highest_cost_first` and five others fail on the reversed key), and the test now documents that division rather than implying coverage it does not have.

## Left alone deliberately

AVERAGE and NONE still preview by cloning. Both measure flat here — AVERAGE holds one pooled lot per commodity, NONE matches no lots — so the copy is small. Converting them on speculation is how the previous "mechanical" note aged into two quadratics.

## Verification

- 146 suites green; clippy (1.97.0), fmt and doc clean.
- The scan-equivalence differential now covers the cost ordering as well as the date ordering.
- Both workloads still book cleanly (`✓ No errors found`) — worth stating, because the first STRICT_WITH_SIZE measurement in #2091 was taken on a ledger that failed to book and was therefore profiling the error path. Corrected on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr