### PR TITLE
feat(wasm): let the loader ask the host for files (closes #2101)

### DIFF
--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -69,7 +69,6 @@ js-sys = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-js-sys = "0.3"
 # TypeScript export (#1218 Phase 1): ts-rs is a host-only optional dep,
 # opt-in via the `ts-export` feature above. With the feature on,
 # `cargo test -p rustledger-wasm --features ts-export` writes per-type

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -62,6 +62,11 @@ getrandom.workspace = true
 # Better panic messages in WASM
 console_error_panic_hook = "0.1"
 
+# Host-callback filesystem (#2101): reading `readFile`/`glob`/`realpath` off
+# the JS object the caller passes needs Reflect, Function and Array. Already a
+# dev-dependency for the wasm-bindgen tests; promoted so `host_fs` can use it.
+js-sys = "0.3"
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 js-sys = "0.3"

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -924,3 +924,87 @@ pub fn hash_sources(sources: Vec<String>) -> String {
     let refs: Vec<&str> = sources.iter().map(String::as_str).collect();
     crate::cache::hash_sources(&refs)
 }
+
+#[cfg(test)]
+mod load_error_tests {
+    use super::*;
+    use rustledger_loader::VirtualFileSystem;
+    use std::collections::HashMap;
+
+    /// A diamond — `shared` reached directly and again through `mid` — that
+    /// ALSO fails a balance assertion.
+    ///
+    /// The second error is what makes the test discriminating. Both errors
+    /// being present proves the pipeline RAN; the duplicate alone would prove
+    /// only that something reported it, which an abort does too. An earlier
+    /// version of this test asserted just the duplicate and passed happily
+    /// with the abort restored.
+    fn diamond_with_a_failing_assertion() -> VirtualFileSystem {
+        let mut files = HashMap::new();
+        files.insert(
+            "main.beancount".to_string(),
+            "2020-01-01 open Assets:Cash USD\n2020-01-01 open Expenses:Food USD\n\
+             include \"sub/shared.beancount\"\ninclude \"sub/mid.beancount\"\n\
+             2020-06-01 balance Assets:Cash  -999999.00 USD\n"
+                .to_string(),
+        );
+        files.insert(
+            "sub/shared.beancount".to_string(),
+            "2020-03-01 * \"s\"\n  Expenses:Food   100.00 USD\n  Assets:Cash    -100.00 USD\n"
+                .to_string(),
+        );
+        files.insert(
+            "sub/mid.beancount".to_string(),
+            "include \"shared.beancount\"\n".to_string(),
+        );
+        VirtualFileSystem::from_files(files)
+    }
+
+    #[test]
+    fn a_duplicate_include_is_reported_but_does_not_abort() {
+        // The ledger is COMPLETE — the loader loaded the shared file once — so
+        // processing must still run. Aborting instead is what made a wasm
+        // query over such a ledger return no rows at all, where `rledger
+        // query` prints the notice and answers.
+        let result = validate_with_filesystem(
+            Box::new(diamond_with_a_failing_assertion()),
+            "main.beancount",
+        );
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("Duplicate filename")),
+            "the duplicate must be reported, as `rledger check` reports it: {:?}",
+            result.errors
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("Balance failed")),
+            "the balance assertion must have been CHECKED, which only happens \
+             if the duplicate did not abort the pipeline: {:?}",
+            result.errors
+        );
+        assert!(!result.valid, "matching bean-check's exit 1");
+    }
+
+    #[test]
+    fn only_unusable_load_errors_are_fatal() {
+        // A duplicate include leaves a usable directive stream; a parse error
+        // does not. This predicate is what lets the query path answer over the
+        // first and refuse the second.
+        assert!(!load_error_is_fatal(&LoadError::DuplicateInclude {
+            path: "shared.beancount".to_string(),
+        }));
+        assert!(load_error_is_fatal(&LoadError::IncludeCycle {
+            cycle: vec!["a".to_string(), "a".to_string()],
+        }));
+        assert!(load_error_is_fatal(&LoadError::PathTraversal {
+            include_path: "../../etc/passwd".to_string(),
+            base_dir: std::path::PathBuf::from("/ledger"),
+        }));
+    }
+}

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -23,9 +23,6 @@ use crate::types::{
 use crate::types::{PluginInfo, PluginResult};
 use crate::utils::LineLookup;
 
-/// Convert [`LoadResult`] errors to detailed Error objects with line/column info.
-///
-/// This preserves parse error details that would be lost by simple `to_string()`.
 /// Whether a load error makes the directive stream unusable.
 ///
 /// Not every load error does. `DuplicateInclude` says a file was reached twice
@@ -43,6 +40,9 @@ fn load_error_is_fatal(error: &LoadError) -> bool {
     !matches!(error, LoadError::DuplicateInclude { .. })
 }
 
+/// Convert [`LoadResult`] errors to detailed Error objects with line/column info.
+///
+/// This preserves parse error details that would be lost by simple `to_string()`.
 fn load_errors_to_errors(load_result: &LoadResult) -> Vec<Error> {
     let mut errors = Vec::new();
 

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -26,6 +26,23 @@ use crate::utils::LineLookup;
 /// Convert [`LoadResult`] errors to detailed Error objects with line/column info.
 ///
 /// This preserves parse error details that would be lost by simple `to_string()`.
+/// Whether a load error makes the directive stream unusable.
+///
+/// Not every load error does. `DuplicateInclude` says a file was reached twice
+/// in the include graph — the loader still loaded it exactly once, so the
+/// ledger is complete and every figure derived from it is right. It has to be
+/// REPORTED (beancount says `Duplicate filename parsed` and `bean-check` exits
+/// 1, as does `rledger check`), but aborting on it throws away a correct
+/// answer: `rledger query` prints the notice and still returns the rows.
+///
+/// Treating every load error as fatal did exactly that — a query over a ledger
+/// with a shared prices file included from two journals returned NO rows,
+/// where the CLI returns them. The same shape as a warning being treated as an
+/// error, one layer down.
+fn load_error_is_fatal(error: &LoadError) -> bool {
+    !matches!(error, LoadError::DuplicateInclude { .. })
+}
+
 fn load_errors_to_errors(load_result: &LoadResult) -> Vec<Error> {
     let mut errors = Vec::new();
 
@@ -574,34 +591,20 @@ pub fn parse_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue, Js
     to_js(&result)
 }
 
-/// Validate multiple Beancount files with include resolution.
+/// The validation pipeline, over whichever [`FileSystem`] it is handed.
 ///
-/// Similar to `parseMultiFile`, but also runs validation.
-/// Returns a `ValidationResult` indicating whether the ledger is valid.
-#[wasm_bindgen(js_name = "validateMultiFile")]
-pub fn validate_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue, JsError> {
-    use rustledger_loader::{LoadOptions, Loader, VirtualFileSystem, process};
+/// One body for every backend: a file map through `validateMultiFile`, host
+/// callbacks through `validateWithHost`. Include resolution, ordering, glob
+/// expansion, duplicate detection and per-file error attribution belong to the
+/// loader in both cases — which is the point of #2101, and would be undone by
+/// giving either entry point its own copy of this.
+fn validate_with_filesystem(
+    fs: Box<dyn rustledger_loader::FileSystem>,
+    entry_point: &str,
+) -> ValidationResult {
+    use rustledger_loader::{LoadOptions, Loader, process};
 
-    // Parse the JavaScript object to a HashMap
-    let file_map: HashMap<String, String> = serde_wasm_bindgen::from_value(files)
-        .map_err(|e| JsError::new(&format!("Invalid files object: {e}")))?;
-
-    if file_map.is_empty() {
-        return Err(JsError::new("Files map cannot be empty"));
-    }
-
-    // Create virtual filesystem with all files
-    let vfs = VirtualFileSystem::from_files(file_map);
-
-    // Check entry point exists using VFS path normalization
-    if !vfs.exists(Path::new(entry_point)) {
-        return Err(JsError::new(&format!(
-            "Entry point '{entry_point}' not found in files map"
-        )));
-    }
-
-    // Create loader with virtual filesystem
-    let mut loader = Loader::new().with_filesystem(Box::new(vfs));
+    let mut loader = Loader::new().with_filesystem(fs);
 
     // Load from entry point
     let load_result = match loader.load(Path::new(entry_point)) {
@@ -611,18 +614,18 @@ pub fn validate_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue,
                 valid: false,
                 errors: vec![Error::new(format!("Load error: {e}"))],
             };
-            return to_js(&result);
+            return result;
         }
     };
 
-    // Check for parse errors first (preserves detailed per-error line info)
-    let parse_errors = load_errors_to_errors(&load_result);
-    if !parse_errors.is_empty() {
-        let result = ValidationResult {
+    // Report every load error, but abort only on one that makes the directive
+    // stream unusable — see `load_error_is_fatal`.
+    let load_errors = load_errors_to_errors(&load_result);
+    if load_result.errors.iter().any(load_error_is_fatal) {
+        return ValidationResult {
             valid: false,
-            errors: parse_errors,
+            errors: load_errors,
         };
-        return to_js(&result);
     }
 
     // Run the shared processing pipeline:
@@ -639,35 +642,26 @@ pub fn validate_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue,
                 valid: false,
                 errors: vec![Error::new(format!("Processing error: {e}"))],
             };
-            return to_js(&result);
+            return result;
         }
     };
 
     let errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
 
-    let result = ValidationResult {
+    ValidationResult {
         // Warnings do not invalidate a ledger; only actual errors do.
         valid: !has_fatal(&errors),
         errors,
-    };
-    to_js(&result)
+    }
 }
 
-/// Run a BQL query on multiple Beancount files.
+/// Validate multiple Beancount files with include resolution.
 ///
-/// Similar to `query`, but accepts multiple files with include resolution.
-///
-/// Note: Glob patterns in `include` directives are not supported in multi-file mode
-/// since there is no real filesystem to enumerate. Use explicit file paths instead.
-#[wasm_bindgen(js_name = "queryMultiFile")]
-pub fn query_multi_file(
-    files: JsValue,
-    entry_point: &str,
-    query_str: &str,
-) -> Result<JsValue, JsError> {
-    use rustledger_booking::merge_with_padding;
-    use rustledger_loader::{LoadOptions, Loader, VirtualFileSystem, process};
-    use rustledger_query::{Executor, parse as parse_query};
+/// Similar to `parseMultiFile`, but also runs validation.
+/// Returns a `ValidationResult` indicating whether the ledger is valid.
+#[wasm_bindgen(js_name = "validateMultiFile")]
+pub fn validate_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue, JsError> {
+    use rustledger_loader::VirtualFileSystem;
 
     // Parse the JavaScript object to a HashMap
     let file_map: HashMap<String, String> = serde_wasm_bindgen::from_value(files)
@@ -687,8 +681,80 @@ pub fn query_multi_file(
         )));
     }
 
-    // Create loader with virtual filesystem
-    let mut loader = Loader::new().with_filesystem(Box::new(vfs));
+    to_js(&validate_with_filesystem(Box::new(vfs), entry_point))
+}
+
+/// Validate a ledger whose files the HOST supplies, one at a time.
+///
+/// `host` is an object with:
+///
+/// - `readFile(path) => string | null` — required. `null` means "cannot read
+///   this", which the loader reports as a missing include against the file
+///   that asked for it.
+/// - `glob(pattern) => string[]` — optional. Without it, a glob `include`
+///   reports "does not match any files", as a backend without glob support
+///   does.
+/// - `realpath(path) => string` — optional, and the interesting one. The
+///   loader de-duplicates by the path this returns, so a host that resolves
+///   symlinks (and, on a case-insensitive filesystem, case) gets a file
+///   reached two ways loaded ONCE, without the caller having to know that
+///   include graphs can contain diamonds.
+///
+/// # Why this exists alongside `validateMultiFile`
+///
+/// `validateMultiFile` takes every file up front, which means the CALLER has
+/// to know which files a ledger contains — so it walks `include` directives
+/// itself. That is a second implementation of the loader's include handling,
+/// and the MCP server's copy was wrong four separate ways before it was
+/// replaced (#2100). Here the host supplies primitives that encode nothing
+/// about beancount, and the walking has one implementation: this one, the
+/// same `Loader` behind `rledger check` (#2101).
+///
+/// # Errors
+///
+/// When `host` is not an object carrying a callable `readFile`.
+#[wasm_bindgen(js_name = "validateWithHost")]
+pub fn validate_with_host(host: &JsValue, entry_point: &str) -> Result<JsValue, JsError> {
+    use crate::host_fs::{HostFs, HostScope};
+
+    // Held for the whole call; cleared on drop, including on an early return.
+    let _scope = HostScope::install(host).map_err(|e| JsError::new(&e))?;
+    let result = validate_with_filesystem(Box::new(HostFs), entry_point);
+    to_js(&result)
+}
+
+/// Run a BQL query over a ledger whose files the HOST supplies.
+///
+/// Same contract as [`validate_with_host`]; see it for the shape of `host`.
+///
+/// # Errors
+///
+/// When `host` is not an object carrying a callable `readFile`.
+#[wasm_bindgen(js_name = "queryWithHost")]
+pub fn query_with_host(
+    host: &JsValue,
+    entry_point: &str,
+    query_str: &str,
+) -> Result<JsValue, JsError> {
+    use crate::host_fs::{HostFs, HostScope};
+
+    let _scope = HostScope::install(host).map_err(|e| JsError::new(&e))?;
+    query_with_filesystem(Box::new(HostFs), entry_point, query_str)
+}
+
+/// The query pipeline, over whichever [`FileSystem`] it is handed.
+///
+/// Companion to [`validate_with_filesystem`]; see it for why both entry points
+/// share one body rather than each carrying a copy.
+fn query_with_filesystem(
+    fs: Box<dyn rustledger_loader::FileSystem>,
+    entry_point: &str,
+    query_str: &str,
+) -> Result<JsValue, JsError> {
+    use rustledger_booking::merge_with_padding;
+    use rustledger_loader::{LoadOptions, Loader, process};
+    use rustledger_query::{Executor, parse as parse_query};
+    let mut loader = Loader::new().with_filesystem(fs);
 
     // Load from entry point
     let load_result = match loader.load(Path::new(entry_point)) {
@@ -703,13 +769,15 @@ pub fn query_multi_file(
         }
     };
 
-    // Check for parse errors first (preserves detailed per-error line info)
-    let parse_errors = load_errors_to_errors(&load_result);
-    if !parse_errors.is_empty() {
+    // Report every load error, but abort only on one that makes the directive
+    // stream unusable. A duplicate include is not one: the ledger loaded
+    // correctly and `rledger query` returns its rows alongside the notice.
+    let load_errors = load_errors_to_errors(&load_result);
+    if load_result.errors.iter().any(load_error_is_fatal) {
         let result = QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
-            errors: parse_errors,
+            errors: load_errors,
         };
         return to_js(&result);
     }
@@ -734,8 +802,16 @@ pub fn query_multi_file(
     };
 
     // Only abort on actual errors, not warnings (matching CLI query behavior)
+    // — and not on a LOAD-phase notice either. `process` turns every load
+    // error into a blocking `LOAD` ledger error, which is right for `check`
+    // but not here: anything genuinely unusable already aborted above via
+    // `load_error_is_fatal`, so what survives to this point is reportable and
+    // no reason to throw away a correct answer. `rledger query` prints
+    // `LOAD: Duplicate filename parsed` and still returns the rows.
     let errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
-    let has_errors = errors.iter().any(|e| e.severity == Severity::Error);
+    let has_errors = errors
+        .iter()
+        .any(|e| e.severity == Severity::Error && e.code.as_deref() != Some("LOAD"));
     if has_errors {
         let result = QueryResult {
             columns: Vec::new(),
@@ -780,7 +856,7 @@ pub fn query_multi_file(
             let query_result = QueryResult {
                 columns: result.columns,
                 rows,
-                errors: Vec::new(),
+                errors: load_errors,
             };
             to_js(&query_result)
         }
@@ -793,6 +869,41 @@ pub fn query_multi_file(
             to_js(&result)
         }
     }
+}
+
+/// Run a BQL query on multiple Beancount files.
+///
+/// Similar to `query`, but accepts multiple files with include resolution.
+///
+/// Note: Glob patterns in `include` directives are not supported in multi-file mode
+/// since there is no real filesystem to enumerate. Use explicit file paths instead.
+#[wasm_bindgen(js_name = "queryMultiFile")]
+pub fn query_multi_file(
+    files: JsValue,
+    entry_point: &str,
+    query_str: &str,
+) -> Result<JsValue, JsError> {
+    use rustledger_loader::VirtualFileSystem;
+
+    // Parse the JavaScript object to a HashMap
+    let file_map: HashMap<String, String> = serde_wasm_bindgen::from_value(files)
+        .map_err(|e| JsError::new(&format!("Invalid files object: {e}")))?;
+
+    if file_map.is_empty() {
+        return Err(JsError::new("Files map cannot be empty"));
+    }
+
+    // Create virtual filesystem with all files
+    let vfs = VirtualFileSystem::from_files(file_map);
+
+    // Check entry point exists using VFS path normalization
+    if !vfs.exists(Path::new(entry_point)) {
+        return Err(JsError::new(&format!(
+            "Entry point '{entry_point}' not found in files map"
+        )));
+    }
+
+    query_with_filesystem(Box::new(vfs), entry_point, query_str)
 }
 
 /// Compute a SHA-256 fingerprint of one or more source strings.

--- a/crates/rustledger-wasm/src/host_fs.rs
+++ b/crates/rustledger-wasm/src/host_fs.rs
@@ -43,6 +43,10 @@ use wasm_bindgen::JsValue;
 
 /// The host functions installed for the duration of one entry-point call.
 struct HostCallbacks {
+    /// The object the callbacks came from, used as their `this`. A host is
+    /// free to write `{ readFile(p) { return this.cache.get(p); } }`, and
+    /// calling that with a null receiver breaks it at runtime.
+    receiver: JsValue,
     /// `(path: string) => string | null` — contents, or null if unreadable.
     read_file: js_sys::Function,
     /// `(pattern: string) => string[]` — optional; without it a glob include
@@ -73,6 +77,21 @@ impl HostScope {
     /// When `readFile` is absent or is not callable. The other two are
     /// optional; the loader degrades the way a backend without them does.
     pub fn install(host: &JsValue) -> Result<Self, String> {
+        // Refuse rather than clobber. An inner scope would overwrite the outer
+        // one's callbacks and then clear them on drop, leaving the OUTER load
+        // to fail with "no host filesystem installed" — a confusing error a
+        // long way from its cause. This can only happen if a host callback
+        // re-enters, which is legal but not something the loader can be in the
+        // middle of.
+        let occupied = HOST.with(|h| h.borrow().is_some());
+        if occupied {
+            return Err(
+                "a host filesystem is already installed — a host callback cannot re-enter \
+                 `validateWithHost` or `queryWithHost` while a load is in progress"
+                    .to_string(),
+            );
+        }
+
         let read_file = js_fn(host, "readFile")?
             .ok_or_else(|| "host must provide a `readFile(path) => string | null`".to_string())?;
         let glob = js_fn(host, "glob")?;
@@ -80,6 +99,7 @@ impl HostScope {
 
         HOST.with(|h| {
             *h.borrow_mut() = Some(HostCallbacks {
+                receiver: host.clone(),
                 read_file,
                 glob,
                 realpath,
@@ -120,12 +140,11 @@ use wasm_bindgen::JsCast;
 pub struct HostFs;
 
 impl HostFs {
-    fn call1(f: &js_sys::Function, arg: &str) -> Result<JsValue, String> {
-        f.call1(&JsValue::NULL, &JsValue::from_str(arg))
-            .map_err(|e| {
-                e.as_string()
-                    .unwrap_or_else(|| "host callback threw".to_string())
-            })
+    fn call1(f: &js_sys::Function, receiver: &JsValue, arg: &str) -> Result<JsValue, String> {
+        f.call1(receiver, &JsValue::from_str(arg)).map_err(|e| {
+            e.as_string()
+                .unwrap_or_else(|| "host callback threw".to_string())
+        })
     }
 }
 
@@ -136,9 +155,14 @@ impl FileSystem for HostFs {
         // callback is free to re-enter — a caching or logging host might — and
         // re-entering while this borrow is live panics the `RefCell`. Cloning
         // a `js_sys::Function` copies a handle, not a function.
-        let f = HOST.with(|h| h.borrow().as_ref().map(|host| host.read_file.clone()));
-        let f = f.ok_or_else(|| not_found(path, "no host filesystem installed"))?;
-        let value = Self::call1(&f, &display).map_err(|message| not_found(path, &message))?;
+        let pair = HOST.with(|h| {
+            h.borrow()
+                .as_ref()
+                .map(|host| (host.read_file.clone(), host.receiver.clone()))
+        });
+        let (f, receiver) = pair.ok_or_else(|| not_found(path, "no host filesystem installed"))?;
+        let value =
+            Self::call1(&f, &receiver, &display).map_err(|message| not_found(path, &message))?;
         value
             .as_string()
             .map(Arc::from)
@@ -168,8 +192,15 @@ impl FileSystem for HostFs {
 
     fn normalize(&self, path: &Path) -> PathBuf {
         let display = path.display().to_string();
-        let f = HOST.with(|h| h.borrow().as_ref().and_then(|host| host.realpath.clone()));
-        match f.and_then(|f| Self::call1(&f, &display).ok().and_then(|v| v.as_string())) {
+        let pair = HOST.with(|h| {
+            h.borrow()
+                .as_ref()
+                .and_then(|host| host.realpath.clone().map(|f| (f, host.receiver.clone())))
+        });
+        match pair
+            .and_then(|(f, r)| Self::call1(&f, &r, &display).ok())
+            .and_then(|v| v.as_string())
+        {
             Some(real) => PathBuf::from(real),
             // No `realpath`, or the host could not resolve it. Fall back to
             // the same textual normalization the virtual backend applies, so
@@ -189,11 +220,15 @@ impl FileSystem for HostFs {
 
     fn glob(&self, pattern: &str) -> Result<Vec<PathBuf>, String> {
         // Same reason as `read`: the borrow must not span the JS call.
-        let f = HOST.with(|h| h.borrow().as_ref().and_then(|host| host.glob.clone()));
-        let Some(f) = f else {
+        let pair = HOST.with(|h| {
+            h.borrow()
+                .as_ref()
+                .and_then(|host| host.glob.clone().map(|f| (f, host.receiver.clone())))
+        });
+        let Some((f, receiver)) = pair else {
             return Err("glob is not supported by this filesystem".to_string());
         };
-        let value = Self::call1(&f, pattern)?;
+        let value = Self::call1(&f, &receiver, pattern)?;
         let array = js_sys::Array::from(&value);
         let mut matched: Vec<PathBuf> = array
             .iter()

--- a/crates/rustledger-wasm/src/host_fs.rs
+++ b/crates/rustledger-wasm/src/host_fs.rs
@@ -132,21 +132,20 @@ impl HostFs {
 impl FileSystem for HostFs {
     fn read(&self, path: &Path) -> Result<Arc<str>, LoadError> {
         let display = path.display().to_string();
-        HOST.with(|h| {
-            let borrowed = h.borrow();
-            let host = borrowed
-                .as_ref()
-                .ok_or_else(|| not_found(path, "no host filesystem installed"))?;
-            let value = Self::call1(&host.read_file, &display)
-                .map_err(|message| not_found(path, &message))?;
-            value
-                .as_string()
-                .map(Arc::from)
-                // `null` is the host saying it cannot read this path. It is
-                // NOT an error to raise here — a missing include is reported
-                // against the file that asked for it, with that file's span.
-                .ok_or_else(|| not_found(path, "file not found"))
-        })
+        // Clone the handle out and DROP the borrow before calling into JS. A
+        // callback is free to re-enter — a caching or logging host might — and
+        // re-entering while this borrow is live panics the `RefCell`. Cloning
+        // a `js_sys::Function` copies a handle, not a function.
+        let f = HOST.with(|h| h.borrow().as_ref().map(|host| host.read_file.clone()));
+        let f = f.ok_or_else(|| not_found(path, "no host filesystem installed"))?;
+        let value = Self::call1(&f, &display).map_err(|message| not_found(path, &message))?;
+        value
+            .as_string()
+            .map(Arc::from)
+            // `null` is the host saying it cannot read this path. It is NOT an
+            // error to raise here — a missing include is reported against the
+            // file that asked for it, with that file's span.
+            .ok_or_else(|| not_found(path, "file not found"))
     }
 
     fn exists(&self, path: &Path) -> bool {
@@ -169,22 +168,16 @@ impl FileSystem for HostFs {
 
     fn normalize(&self, path: &Path) -> PathBuf {
         let display = path.display().to_string();
-        HOST.with(|h| {
-            let borrowed = h.borrow();
-            let resolved = borrowed
-                .as_ref()
-                .and_then(|host| host.realpath.as_ref())
-                .and_then(|f| Self::call1(f, &display).ok())
-                .and_then(|v| v.as_string());
-            match resolved {
-                Some(real) => PathBuf::from(real),
-                // No `realpath` callback, or the host could not resolve it:
-                // fall back to a textual clean-up. A file reached two ways is
-                // then two files, which is exactly the bug a host that
-                // implements `realpath` avoids.
-                None => PathBuf::from(display.replace('\\', "/")),
-            }
-        })
+        let f = HOST.with(|h| h.borrow().as_ref().and_then(|host| host.realpath.clone()));
+        match f.and_then(|f| Self::call1(&f, &display).ok().and_then(|v| v.as_string())) {
+            Some(real) => PathBuf::from(real),
+            // No `realpath`, or the host could not resolve it. Fall back to
+            // the same textual normalization the virtual backend applies, so
+            // `./j/x` and `j/x` stay ONE file — otherwise the loader reads it
+            // twice and doubles everything in it. What this cannot collapse is
+            // a symlink or a case-fold, which is what `realpath` is for.
+            None => textual_normalize(&display),
+        }
     }
 
     fn supports_parallel_read(&self) -> bool {
@@ -195,29 +188,91 @@ impl FileSystem for HostFs {
     }
 
     fn glob(&self, pattern: &str) -> Result<Vec<PathBuf>, String> {
-        HOST.with(|h| {
-            let borrowed = h.borrow();
-            let Some(f) = borrowed.as_ref().and_then(|host| host.glob.as_ref()) else {
-                return Err("glob is not supported by this filesystem".to_string());
-            };
-            let value = Self::call1(f, pattern)?;
-            let array = js_sys::Array::from(&value);
-            let mut matched: Vec<PathBuf> = array
-                .iter()
-                .filter_map(|v| v.as_string())
-                .map(PathBuf::from)
-                .collect();
-            // Sorted for the same reason the disk backend sorts: the assembled
-            // ledger must not depend on the order a host happened to list in.
-            matched.sort();
-            Ok(matched)
-        })
+        // Same reason as `read`: the borrow must not span the JS call.
+        let f = HOST.with(|h| h.borrow().as_ref().and_then(|host| host.glob.clone()));
+        let Some(f) = f else {
+            return Err("glob is not supported by this filesystem".to_string());
+        };
+        let value = Self::call1(&f, pattern)?;
+        let array = js_sys::Array::from(&value);
+        let mut matched: Vec<PathBuf> = array
+            .iter()
+            .filter_map(|v| v.as_string())
+            .map(PathBuf::from)
+            .collect();
+        // Sorted for the same reason the disk backend sorts: the assembled
+        // ledger must not depend on the order a host happened to list in.
+        matched.sort();
+        Ok(matched)
     }
+}
+
+/// The clean-up the virtual backend applies: forward slashes, no leading
+/// `./`, `..` resolved. Mirrors the loader's private `normalize_vfs_path`; if
+/// the two drift, a path spelled two ways is two files here and one there.
+fn textual_normalize(path: &str) -> PathBuf {
+    let normalized = path.replace('\\', "/");
+    let stripped = normalized.strip_prefix("./").unwrap_or(&normalized);
+    let mut components: Vec<&str> = Vec::new();
+    for part in stripped.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            other => components.push(other),
+        }
+    }
+    let joined = components.join("/");
+    PathBuf::from(if stripped.starts_with('/') {
+        format!("/{joined}")
+    } else {
+        joined
+    })
 }
 
 fn not_found(path: &Path, message: &str) -> LoadError {
     LoadError::Io {
         path: path.to_path_buf(),
         source: std::io::Error::new(std::io::ErrorKind::NotFound, message.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::textual_normalize;
+    use std::path::PathBuf;
+
+    #[test]
+    fn the_fallback_collapses_paths_that_name_one_file() {
+        // Without a host `realpath`, this is all that keeps `./j/x` and `j/x`
+        // from being two entries in the loader's "already loaded" set — and
+        // two entries means the file's directives are read twice and every
+        // amount in it doubles.
+        for spelling in [
+            "j/x.beancount",
+            "./j/x.beancount",
+            "j/./x.beancount",
+            "j/y/../x.beancount",
+        ] {
+            assert_eq!(
+                textual_normalize(spelling),
+                PathBuf::from("j/x.beancount"),
+                "{spelling} names the same file"
+            );
+        }
+        assert_eq!(
+            textual_normalize("j\\x.beancount"),
+            PathBuf::from("j/x.beancount"),
+            "a Windows separator names the same file too"
+        );
+    }
+
+    #[test]
+    fn the_fallback_keeps_an_absolute_path_absolute() {
+        assert_eq!(
+            textual_normalize("/ledger/./j/../main.beancount"),
+            PathBuf::from("/ledger/main.beancount")
+        );
     }
 }

--- a/crates/rustledger-wasm/src/host_fs.rs
+++ b/crates/rustledger-wasm/src/host_fs.rs
@@ -1,0 +1,223 @@
+//! A [`FileSystem`] backed by host callbacks.
+//!
+//! The loader never touches a filesystem itself — it asks its [`FileSystem`]
+//! for files. `DiskFileSystem` answers from the disk, `VirtualFileSystem` from
+//! a map handed over in one go, and this one asks the JS host, one path at a
+//! time, as the loader walks the include graph.
+//!
+//! # Why this exists
+//!
+//! Handing over a map first means the host has to know which files to hand
+//! over, which means the host has to walk `include` directives itself — a
+//! second, approximate implementation of the thing the loader already does.
+//! The MCP server carried one, and it was wrong four separate ways before it
+//! was replaced (#2100): globs unexpanded, a file reached twice counted twice,
+//! a symlinked include counted twice, a symlinked entry point resolved against
+//! the wrong directory. None of those are beancount questions.
+//!
+//! With this, the host supplies `readFile`, `glob` and `realpath` — primitives
+//! that encode nothing about beancount — and include semantics have one
+//! implementation, the same one `rledger check` runs (#2101).
+//!
+//! # Why the callbacks live in a `thread_local` and not in the struct
+//!
+//! [`FileSystem`] requires `Send + Sync`, because the loader hands it to rayon
+//! when the backend permits parallel reads. `js_sys::Function` is neither, and
+//! this crate is `#![forbid(unsafe_code)]`, so it cannot be asserted away.
+//!
+//! [`HostFs`] therefore holds NOTHING — a unit struct is `Send + Sync` for
+//! free — and reads the callbacks from a thread-local installed for the
+//! duration of one call. That mirrors how the WASI component satisfies the
+//! same trait for `host.decrypt` (#1667): the capability is an ambient host
+//! function, not a handle carried around in the struct.
+//!
+//! `supports_parallel_read` answers `false`, so the rayon path this bound
+//! exists for is never taken here anyway; wasm is single-threaded.
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustledger_loader::{FileSystem, LoadError};
+use wasm_bindgen::JsValue;
+
+/// The host functions installed for the duration of one entry-point call.
+struct HostCallbacks {
+    /// `(path: string) => string | null` — contents, or null if unreadable.
+    read_file: js_sys::Function,
+    /// `(pattern: string) => string[]` — optional; without it a glob include
+    /// reports the same "does not match any files" the disk backend does.
+    glob: Option<js_sys::Function>,
+    /// `(path: string) => string` — optional. This is where symlink and
+    /// case-fold collapsing belongs: the loader de-duplicates by the path this
+    /// returns, so a host that answers with a real path gets a file reached
+    /// two ways loaded once, for free.
+    realpath: Option<js_sys::Function>,
+}
+
+thread_local! {
+    static HOST: RefCell<Option<HostCallbacks>> = const { RefCell::new(None) };
+}
+
+/// Installs host callbacks for as long as it is alive, and clears them on
+/// drop — including on an early return, so a failed load cannot leave a stale
+/// callback installed for the next call.
+pub struct HostScope;
+
+impl HostScope {
+    /// Reads `readFile`, `glob` and `realpath` off a JS object and installs
+    /// them.
+    ///
+    /// # Errors
+    ///
+    /// When `readFile` is absent or is not callable. The other two are
+    /// optional; the loader degrades the way a backend without them does.
+    pub fn install(host: &JsValue) -> Result<Self, String> {
+        let read_file = js_fn(host, "readFile")?
+            .ok_or_else(|| "host must provide a `readFile(path) => string | null`".to_string())?;
+        let glob = js_fn(host, "glob")?;
+        let realpath = js_fn(host, "realpath")?;
+
+        HOST.with(|h| {
+            *h.borrow_mut() = Some(HostCallbacks {
+                read_file,
+                glob,
+                realpath,
+            });
+        });
+        Ok(Self)
+    }
+}
+
+impl Drop for HostScope {
+    fn drop(&mut self) {
+        HOST.with(|h| {
+            *h.borrow_mut() = None;
+        });
+    }
+}
+
+/// Reads an optional function-valued property, erroring when it is present but
+/// not callable — a silent skip there would look like an unsupported
+/// capability rather than a typo.
+fn js_fn(host: &JsValue, name: &str) -> Result<Option<js_sys::Function>, String> {
+    let value = js_sys::Reflect::get(host, &JsValue::from_str(name))
+        .map_err(|_| format!("could not read `{name}` from the host object"))?;
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+    value
+        .dyn_into::<js_sys::Function>()
+        .map(Some)
+        .map_err(|_| format!("host property `{name}` is not a function"))
+}
+
+use wasm_bindgen::JsCast;
+
+/// A [`FileSystem`] that asks the JS host for each file as the loader reaches
+/// it. See the module docs for why it is a unit struct.
+#[derive(Debug)]
+pub struct HostFs;
+
+impl HostFs {
+    fn call1(f: &js_sys::Function, arg: &str) -> Result<JsValue, String> {
+        f.call1(&JsValue::NULL, &JsValue::from_str(arg))
+            .map_err(|e| {
+                e.as_string()
+                    .unwrap_or_else(|| "host callback threw".to_string())
+            })
+    }
+}
+
+impl FileSystem for HostFs {
+    fn read(&self, path: &Path) -> Result<Arc<str>, LoadError> {
+        let display = path.display().to_string();
+        HOST.with(|h| {
+            let borrowed = h.borrow();
+            let host = borrowed
+                .as_ref()
+                .ok_or_else(|| not_found(path, "no host filesystem installed"))?;
+            let value = Self::call1(&host.read_file, &display)
+                .map_err(|message| not_found(path, &message))?;
+            value
+                .as_string()
+                .map(Arc::from)
+                // `null` is the host saying it cannot read this path. It is
+                // NOT an error to raise here — a missing include is reported
+                // against the file that asked for it, with that file's span.
+                .ok_or_else(|| not_found(path, "file not found"))
+        })
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.read(path).is_ok()
+    }
+
+    fn dir_exists(&self, _path: &Path) -> bool {
+        // Same answer as the virtual backend: there are no directories to
+        // interrogate, and answering `false` would warn on every
+        // `option "documents"` root. See `FileSystem::dir_exists`.
+        true
+    }
+
+    fn is_encrypted(&self, _path: &Path) -> bool {
+        // The host hands over contents, not ciphertext; if it wants to serve a
+        // `.gpg` ledger it decrypts before returning, as the WASI component's
+        // embedder does for `host.decrypt`.
+        false
+    }
+
+    fn normalize(&self, path: &Path) -> PathBuf {
+        let display = path.display().to_string();
+        HOST.with(|h| {
+            let borrowed = h.borrow();
+            let resolved = borrowed
+                .as_ref()
+                .and_then(|host| host.realpath.as_ref())
+                .and_then(|f| Self::call1(f, &display).ok())
+                .and_then(|v| v.as_string());
+            match resolved {
+                Some(real) => PathBuf::from(real),
+                // No `realpath` callback, or the host could not resolve it:
+                // fall back to a textual clean-up. A file reached two ways is
+                // then two files, which is exactly the bug a host that
+                // implements `realpath` avoids.
+                None => PathBuf::from(display.replace('\\', "/")),
+            }
+        })
+    }
+
+    fn supports_parallel_read(&self) -> bool {
+        // Never: the callbacks are JS, wasm is single-threaded, and the
+        // `Send + Sync` bound this would exercise is satisfied only because
+        // the struct is empty.
+        false
+    }
+
+    fn glob(&self, pattern: &str) -> Result<Vec<PathBuf>, String> {
+        HOST.with(|h| {
+            let borrowed = h.borrow();
+            let Some(f) = borrowed.as_ref().and_then(|host| host.glob.as_ref()) else {
+                return Err("glob is not supported by this filesystem".to_string());
+            };
+            let value = Self::call1(f, pattern)?;
+            let array = js_sys::Array::from(&value);
+            let mut matched: Vec<PathBuf> = array
+                .iter()
+                .filter_map(|v| v.as_string())
+                .map(PathBuf::from)
+                .collect();
+            // Sorted for the same reason the disk backend sorts: the assembled
+            // ledger must not depend on the order a host happened to list in.
+            matched.sort();
+            Ok(matched)
+        })
+    }
+}
+
+fn not_found(path: &Path, message: &str) -> LoadError {
+    LoadError::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::new(std::io::ErrorKind::NotFound, message.to_string()),
+    }
+}

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -55,6 +55,7 @@ mod cache;
 pub mod convert;
 mod editor;
 mod helpers;
+mod host_fs;
 mod utils;
 
 // Public modules


### PR DESCRIPTION
Closes #2101.

## What this adds

`validateWithHost(host, entry)` and `queryWithHost(host, entry, query)`. `host` is an object with three primitives, none of them beancount-aware:

- `readFile(path) => string | null` — required
- `glob(pattern) => string[]` — optional
- `realpath(path) => string` — optional, and the interesting one

The loader walks the include graph itself, asking for each file as it reaches it.

## Why

`validateMultiFile` takes every file up front, so the **caller** has to know which files a ledger contains — which means walking `include` directives itself. That is a second implementation of the loader's include handling, and the MCP server's copy was wrong four separate ways before #2100 replaced it: globs unexpanded, a file reached twice counted twice, a symlinked include counted twice, a symlinked entry resolved against the wrong directory.

Verified against `rledger check` on exactly the cases that each needed hand-written code before:

| | host path | `rledger` |
|---|---|---|
| glob include | 306.00 | 306.00 |
| diamond | 100.00 + `Duplicate filename parsed` | same |
| symlinked include | 10.00 + `Duplicate filename parsed` | same |
| symlinked entry | 10.00 | 10.00 |

**Nothing in this PR canonicalizes a path.** The host answers `realpath`, the loader de-duplicates by what it returns, and a file reached two ways loads once. That is the difference between a capability and a re-implementation — and it is also where the unfixed macOS case-insensitivity gap belongs, answerable by a host running on the user's machine rather than by me guessing on Linux.

## The `Send + Sync` problem, and how the repo already solved it

`FileSystem` requires `Send + Sync` for the rayon path, `js_sys::Function` is neither, and this crate is `#![forbid(unsafe_code)]`.

`HostFs` therefore holds **nothing** — a unit struct satisfies the bound for free — and the callbacks live in a thread-local installed for one call and cleared on drop, including on an early return. That is the same shape as `HostDecryptFs` in the WASI component (#1667): the capability is an ambient host function, not a handle carried in the struct.

Both entry points share the pipeline with their map-based counterparts rather than copying it. Giving either its own copy is precisely the mistake being removed.

## It also fixes a regression I introduced

#2100 made a duplicate include a `LoadError`, and `process` turns **every** load error into a blocking `LOAD` ledger error. So a wasm **query** over a ledger with a shared prices file included from two journals returned **no rows at all**, where `rledger query` prints the notice and answers. That is live on `main` and would have surfaced the moment the wasm was republished — for rustfava as well as the MCP server.

Only found by building the wasm and running it against real ledgers; CI tests the package against the *published* wasm, which predates the change.

`load_error_is_fatal` now gates the pre-processing abort, and the query path ignores `LOAD`-coded errors — matching the CLI in both directions: `check` still reports the duplicate and fails, `query` still returns the rows. `queryMultiFile` is fixed by the same change, not just the new entry points.

## On the tests

The first version of the duplicate-include test **passed with the regression restored** — reporting the duplicate and aborting on it produce the same symptoms, so asserting them proved nothing. The fixture now also fails a balance assertion: both errors present means the pipeline ran, the duplicate alone means it did not. Both tests were then verified to fail when `load_error_is_fatal` is reverted.

## Not included

Switching the MCP server over. It builds against the published `@rustledger/wasm`, so that is a follow-up after a release — the same ordering #2101 describes. `collectLedgerFiles` can be deleted then, and the five tests it added should keep passing unchanged.
