### PR TITLE
chore(release): catch the three gaps v0.22.0 found

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -29,9 +29,23 @@ jobs:
   # Extract version and validate before running tests
   prepare:
     runs-on: ubuntu-latest
-    # Only run if triggered manually OR if the publish workflow succeeded
+    # Runs whenever Release Publish finished, success or failure — not only
+    # on success.
+    #
+    # Gating on success meant one unrelated packaging credential could
+    # suppress the verification entirely. At v0.22.0 an expired COPR token
+    # failed that job, the whole publish run concluded `failure`, and this
+    # workflow never fired — so nothing checked whether crates.io and npm were
+    # actually serving the release, which is the question this exists to
+    # answer and the one you most want answered when a release went sideways.
+    #
+    # A partial publish now produces red channel tests naming exactly which
+    # channels are short, which is strictly more useful than silence.
+    # `cancelled` and `skipped` are still skipped: there is nothing to verify.
     if: >-
-      github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -41,11 +41,16 @@ jobs:
     #
     # A partial publish now produces red channel tests naming exactly which
     # channels are short, which is strictly more useful than silence.
-    # `cancelled` and `skipped` are still skipped: there is nothing to verify.
+    #
+    # Expressed as "unless there is nothing to verify" rather than by listing
+    # the conclusions that should run. `conclusion` also takes `timed_out`,
+    # `action_required` and `neutral`, and every one of those can leave a
+    # partial publish behind — enumerating `success`/`failure` would have gone
+    # quiet on exactly the messiest outcomes.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success' ||
-      github.event.workflow_run.conclusion == 'failure'
+      (github.event.workflow_run.conclusion != 'cancelled' &&
+       github.event.workflow_run.conclusion != 'skipped')
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,6 +110,15 @@ changes belong in the release notes.
 Before opening the release PR, build the things CI doesn't exercise on every PR. The mcp-server in particular has its own `tsc` step that the regular CI matrix doesn't run, and a TS error there silently blocks `Publish MCP server to npm` (this hid an `amount`/`date` type bug across both v0.13.0 and v0.14.0 — see #926).
 
 ```bash
+# Every crate in release-publish.yml's CRATES array must already EXIST on
+# crates.io. Trusted publishing cannot create one, so a crate added since the
+# last release fails the crates.io job part-way through and takes every
+# dependent crate down with it — which is how v0.22.0 broke, with
+# rustledger-returns and rustledger-budget both correctly listed and neither
+# ever published. Without `--check-registry` this is the offline per-PR check
+# that the array matches the workspace.
+python3 scripts/check-publish-crates.py --check-registry
+
 cargo check --workspace --all-features --all-targets
 
 # mcp-server: needs @rustledger/wasm@<previous version> available on npm to install.
@@ -150,7 +159,7 @@ This creates the `v0.14.0` tag and starts a chain of **three** workflows:
 
 - `release-build.yml` — builds binaries for all 8 platforms, the WASM package, the FFI-WASI binary, the FFI-Component (wasip2) wasm, and the VS Code extension; attaches them to the release.
 - `release-publish.yml` — distributes to crates.io, npm, Docker, Scoop, COPR, AUR (Homebrew autobumps separately).
-- `release-test.yml` — fires on `workflow_run` once Release Publish *completes*, and checks the published channels actually serve the new version. This is the one that catches a publish that "succeeded" without shipping: v0.17.0 passed build and publish while `@rustledger/mcp-server@0.17.0` was never published, because `package.json` was still 0.16.5.
+- `release-test.yml` — fires on `workflow_run` once Release Publish *completes*, success **or** failure, and checks the published channels actually serve the new version. It used to run only on success, so one expired packaging credential could suppress the verification entirely: at v0.22.0 a stale COPR token failed the run and nothing checked crates.io or npm at all. This is the one that catches a publish that "succeeded" without shipping: v0.17.0 passed build and publish while `@rustledger/mcp-server@0.17.0` was never published, because `package.json` was still 0.16.5.
 
 The first two run in parallel (see the race note under Troubleshooting); the
 third waits on the second. The full release takes ~30–45 minutes.
@@ -270,6 +279,24 @@ The publish workflow is idempotent. Already-published artifacts are skipped (the
 gh run view <release-publish-run-id> --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .databaseId'
 gh run rerun --failed --job=<job-id>
 ```
+
+### COPR build wasn't triggered
+
+`Trigger COPR build` fails with `Login invalid/expired`. COPR tokens expire
+(180 days), and the job authenticates from **repository secrets**, not from
+any file in the tree — a local `~/.config/copr` does nothing for CI. Renew at
+<https://copr.fedorainfracloud.org/api>, then set both halves of the pair;
+each prompts with hidden input, so neither value lands in shell history:
+
+```bash
+gh secret set COPR_LOGIN   # the `login` field from the COPR page
+gh secret set COPR_TOKEN   # the `token` field
+gh run rerun --failed <release-publish-run-id>
+```
+
+`username` is hardcoded in the workflow, so only those two move. Until this
+succeeds COPR keeps building the previous version — silently, which is why
+the job fails the run rather than warning.
 
 ### Homebrew formula didn't update
 

--- a/scripts/check-publish-crates.py
+++ b/scripts/check-publish-crates.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Guardrail: keep the crates.io publish list in sync with the workspace.
 
+With `--check-registry`, also verifies every listed crate already EXISTS on
+crates.io. Off by default so the per-PR run stays offline; RELEASING.md calls
+it with the flag at release pre-flight.
+
 `release-publish.yml` publishes a hand-maintained `CRATES=( ... )` array to
 crates.io. If a new publishable crate is added to the workspace but not to that
 array, the release silently skips it — and any crate that depends on it then
@@ -17,8 +21,14 @@ import json
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 
 WORKFLOW = ".github/workflows/release-publish.yml"
+
+# crates.io rejects requests without one, with 403 — which reads as "exists"
+# to a naive status check. Send a real one and treat only 404 as absent.
+USER_AGENT = "rustledger release pre-flight (https://github.com/rustledger/rustledger)"
 
 
 def publishable_crates() -> set[str]:
@@ -39,7 +49,39 @@ def listed_crates() -> set[str]:
     return set(m.group(1).split())
 
 
+def unpublished(crates: set[str]) -> list[str]:
+    """Which of `crates` crates.io has never seen.
+
+    Trusted-publishing OIDC tokens cannot CREATE a crate, only push new
+    versions of one that exists, so a crate that has never been published by
+    hand fails the release with `403 Trusted Publishing tokens do not support
+    creating new crates` — and every crate depending on it then fails with
+    `no matching package`. That is v0.22.0, where `rustledger-returns` and
+    `rustledger-budget` were both correctly listed in the array and neither
+    had ever been published, so this script passed and the release broke
+    half-way through distributing.
+    """
+    absent = []
+    for crate in sorted(crates):
+        req = urllib.request.Request(
+            f"https://crates.io/api/v1/crates/{crate}",
+            headers={"User-Agent": USER_AGENT},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                absent.append(crate)
+                continue
+            sys.exit(f"::error::crates.io returned {e.code} for {crate}; cannot verify")
+        except urllib.error.URLError as e:
+            sys.exit(f"::error::could not reach crates.io ({e.reason}); cannot verify")
+    return absent
+
+
 def main() -> int:
+    check_registry = "--check-registry" in sys.argv[1:]
     publishable = publishable_crates()
     listed = listed_crates()
 
@@ -69,6 +111,29 @@ def main() -> int:
 
     if status == 0:
         print(f"✓ crates.io publish list matches all {len(publishable)} publishable crates")
+
+    if check_registry and status == 0:
+        absent = unpublished(listed)
+        if absent:
+            print("::error::Crate(s) in the CRATES array have never been published to crates.io:")
+            for c in absent:
+                print(f"  - {c}")
+            print()
+            print("Trusted publishing cannot create a crate. Publish each ONCE by hand:")
+            print("  cargo login <token from https://crates.io/settings/tokens>")
+            for c in absent:
+                print(f"  cargo publish -p {c}")
+            print("then configure trusted publishing at")
+            for c in absent:
+                print(f"  https://crates.io/crates/{c}/settings")
+            print()
+            print("Doing this BEFORE the release is the whole point: left until the")
+            print("release runs, the crates.io job fails part-way through and every")
+            print("dependent crate cascades behind it.")
+            status = 1
+        else:
+            print(f"✓ all {len(listed)} listed crates exist on crates.io")
+
     return status
 
 

--- a/scripts/check-publish-crates.py
+++ b/scripts/check-publish-crates.py
@@ -21,6 +21,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -29,6 +30,12 @@ WORKFLOW = ".github/workflows/release-publish.yml"
 # crates.io rejects requests without one, with 403 — which reads as "exists"
 # to a naive status check. Send a real one and treat only 404 as absent.
 USER_AGENT = "rustledger release pre-flight (https://github.com/rustledger/rustledger)"
+
+# Retried rather than treated as an answer: rate limiting and gateway errors
+# say nothing about whether the crate exists.
+RETRYABLE = frozenset({408, 425, 429, 500, 502, 503, 504})
+ATTEMPTS = 4
+BACKOFF_SECONDS = 1.5
 
 
 def publishable_crates() -> set[str]:
@@ -67,16 +74,35 @@ def unpublished(crates: set[str]) -> list[str]:
             f"https://crates.io/api/v1/crates/{crate}",
             headers={"User-Agent": USER_AGENT},
         )
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                resp.read()
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                absent.append(crate)
-                continue
-            sys.exit(f"::error::crates.io returned {e.code} for {crate}; cannot verify")
-        except urllib.error.URLError as e:
-            sys.exit(f"::error::could not reach crates.io ({e.reason}); cannot verify")
+        # 404 is the answer we are here for and never retried. Everything else
+        # that is not a definitive answer — rate limiting, a bad gateway, a
+        # dropped connection — is retried, because failing pre-flight on a
+        # transient blip would train people to ignore this check, which is
+        # worse than not having it.
+        last = None
+        for attempt in range(ATTEMPTS):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    resp.read()
+                last = None
+                break
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    absent.append(crate)
+                    last = None
+                    break
+                if e.code not in RETRYABLE:
+                    sys.exit(f"::error::crates.io returned {e.code} for {crate}; cannot verify")
+                last = f"HTTP {e.code}"
+            except urllib.error.URLError as e:
+                last = str(e.reason)
+            if attempt + 1 < ATTEMPTS:
+                time.sleep(BACKOFF_SECONDS * (2**attempt))
+        if last is not None:
+            sys.exit(
+                f"::error::crates.io unreachable for {crate} after {ATTEMPTS} attempts "
+                f"({last}); cannot verify"
+            )
     return absent
 
 


### PR DESCRIPTION
Each of these turned a five-second pre-flight question into a failure
part-way through distributing v0.22.0.

## 1. A never-published crate now fails pre-flight, not the release

`scripts/check-publish-crates.py` already kept the `CRATES` array in sync with
the workspace, and it **passed** for v0.22.0 — `rustledger-returns` and
`rustledger-budget` were both correctly listed. Neither had ever been
published, and trusted publishing cannot create a crate, so the crates.io job
died on the first of them (`403 Trusted Publishing tokens do not support
creating new crates`) and seven dependents cascaded behind it with `no
matching package`. Half the release had already gone out.

`--check-registry` asks crates.io whether each listed crate exists.
RELEASING.md's pre-flight now runs it. Off by default, so the per-PR run stays
offline and network-independent.

Two things worth noting about the check itself:

- It sends a **User-Agent**. crates.io answers `403` without one, which a
  naive status check reads as "exists" — for every crate. I made exactly that
  mistake while diagnosing the failure, and briefly concluded both crates were
  already published.
- **Verified it can report dirty**: a bogus crate name comes back absent, two
  real ones do not. A guard that has only ever said "clean" isn't a guard.

## 2. Channel verification no longer requires the publish run to have succeeded

`release-test.yml` gated on `conclusion == 'success'`. At v0.22.0 an expired
COPR token failed one packaging job, the run concluded `failure`, and the
workflow **never fired** — so nothing checked whether crates.io and npm were
actually serving the release. That is the question it exists to answer, and
the one you most want answered when a release has gone sideways.

It now runs on `failure` too. A partial publish produces red channel tests
naming exactly which channels are short, which beats silence. `cancelled` and
`skipped` still skip — there is nothing to verify.

## 3. COPR credentials have a troubleshooting entry

The job builds `~/.config/copr` from the `COPR_LOGIN` / `COPR_TOKEN`
**repository secrets**, so renewing the token locally does nothing for CI — a
fact that took reading the workflow to establish while the release was
half-done. The entry names both secrets and uses `gh secret set` with no
argument, which prompts with hidden input rather than putting the value in
shell history.

## Verification

- `check-publish-crates.py` passes offline and with `--check-registry`
  (17/17 crates present), and `unpublished()` correctly flags a bogus name.
- `actionlint` on `release-test.yml`: 38 shellcheck findings, identical to
  main — none introduced. (They are pre-existing unquoted-variable warnings
  elsewhere in the file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr