### PR TITLE
fix(nix): update the VS Code extension npmDepsHash, and build it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       vscode: ${{ steps.filter.outputs.vscode }}
+      vscode_nix: ${{ steps.filter.outputs.vscode_nix }}
       should_build: ${{ steps.decide.outputs.should_build }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,9 +56,15 @@ jobs:
             # every Rust PR pay for a Node install.
             vscode:
               - 'packages/vscode/**'
-              # `flake.nix` pins the extension's `npmDepsHash`, so a flake edit
-              # has to re-run the Nix build below even when the extension
-              # itself is untouched.
+            # Separate from `vscode` on purpose. `flake.nix` pins the
+            # extension's `npmDepsHash`, so a flake edit has to re-run the NIX
+            # build even when the extension is untouched — but folding the
+            # flake paths into `vscode` would also drag the npm job along,
+            # making a flake-only PR pay for a Node install and risk failing on
+            # vsce packaging that it never touched. Same reasoning as the note
+            # above about Rust PRs.
+            vscode_nix:
+              - 'packages/vscode/**'
               - 'flake.nix'
               - 'flake.lock'
       - name: Decide if build needed
@@ -262,39 +269,28 @@ jobs:
       - name: Test rustledger-lsp on Windows
         run: cargo test -p rustledger-lsp
 
-  # Build + test the MCP server. Nothing did, until now.
+  # Build the extension the way Nix consumers get it.
   #
-  # `packages/mcp-server` is published to npm as `@rustledger/mcp-server` and
-  # was covered by no PR job at all — only the release workflows touched it. An
-  # SDK MAJOR migration (#1879, monolithic `@modelcontextprotocol/sdk` v1 to the
-  # scoped v2 packages) went through with zero automated verification; it was
-  # checked by hand, which does not scale and does not repeat.
+  # `flake.nix` pins `npmDepsHash`, and NOTHING built that derivation — no
+  # workflow ran `nix build` or `nix flake check` at all. The hash went stale
+  # the moment `packages/vscode/package-lock.json` moved and stayed that way
+  # through two PRs and a release: set on 2026-08-09 (#2004), lockfile changed
+  # 2026-08-13 (#2038, a js-yaml advisory) and 2026-08-17 (#2079), and v0.22.0
+  # shipped a flake that could not evaluate. An external report found it
+  # (#2109).
   #
-  # No `should_build` gate: that filter is for Rust sources, and this package
-  # is TypeScript. Path-filtering on `packages/mcp-server/**` was tempting but
-  # would miss the case that actually bites — the server calls into
-  # `@rustledger/wasm`, so a Rust change can break it without touching a single
-  # file here.
+  # Separate from the npm job above because it catches a different failure: an
+  # npm build cannot see a stale `npmDepsHash`, which only matters to Nix.
   vscode-nix:
     name: VS Code Extension (Nix)
     needs: [changes]
-    if: needs.changes.outputs.vscode == 'true'
+    if: needs.changes.outputs.vscode_nix == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      # `flake.nix` pins `npmDepsHash` for the extension, and NOTHING built
-      # that derivation — no workflow ran `nix build` or `nix flake check` at
-      # all. The hash went stale the moment `packages/vscode/package-lock.json`
-      # moved and stayed that way through two PRs and a release: it was set on
-      # 2026-08-09 (#2004), the lockfile changed on 2026-08-13 (#2038, a
-      # js-yaml advisory) and 2026-08-17 (#2079), and v0.22.0 shipped a flake
-      # that could not evaluate. It took an external report (#2109) to find.
-      #
-      # The npm job below builds the same extension through npm, which cannot
-      # see this: the hash only matters to Nix consumers.
       - name: Build the flake's VS Code extension package
         run: nix build .#vscode-extension --no-link --print-build-logs
 
@@ -393,6 +389,19 @@ jobs:
           fi
           echo "checked $found example plugin(s)"
 
+  # Build + test the MCP server. Nothing did, until now.
+  #
+  # `packages/mcp-server` is published to npm as `@rustledger/mcp-server` and
+  # was covered by no PR job at all — only the release workflows touched it. An
+  # SDK MAJOR migration (#1879, monolithic `@modelcontextprotocol/sdk` v1 to the
+  # scoped v2 packages) went through with zero automated verification; it was
+  # checked by hand, which does not scale and does not repeat.
+  #
+  # No `should_build` gate: that filter is for Rust sources, and this package
+  # is TypeScript. Path-filtering on `packages/mcp-server/**` was tempting but
+  # would miss the case that actually bites — the server calls into
+  # `@rustledger/wasm`, so a Rust change can break it without touching a single
+  # file here.
   mcp-server:
     name: MCP Server
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
             # every Rust PR pay for a Node install.
             vscode:
               - 'packages/vscode/**'
+              # `flake.nix` pins the extension's `npmDepsHash`, so a flake edit
+              # has to re-run the Nix build below even when the extension
+              # itself is untouched.
+              - 'flake.nix'
+              - 'flake.lock'
       - name: Decide if build needed
         id: decide
         env:
@@ -270,6 +275,29 @@ jobs:
   # would miss the case that actually bites — the server calls into
   # `@rustledger/wasm`, so a Rust change can break it without touching a single
   # file here.
+  vscode-nix:
+    name: VS Code Extension (Nix)
+    needs: [changes]
+    if: needs.changes.outputs.vscode == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      # `flake.nix` pins `npmDepsHash` for the extension, and NOTHING built
+      # that derivation — no workflow ran `nix build` or `nix flake check` at
+      # all. The hash went stale the moment `packages/vscode/package-lock.json`
+      # moved and stayed that way through two PRs and a release: it was set on
+      # 2026-08-09 (#2004), the lockfile changed on 2026-08-13 (#2038, a
+      # js-yaml advisory) and 2026-08-17 (#2079), and v0.22.0 shipped a flake
+      # that could not evaluate. It took an external report (#2109) to find.
+      #
+      # The npm job below builds the same extension through npm, which cannot
+      # see this: the hash only matters to Nix consumers.
+      - name: Build the flake's VS Code extension package
+        run: nix build .#vscode-extension --no-link --print-build-logs
+
   vscode-extension:
     name: VS Code Extension
     needs: [changes]
@@ -687,7 +715,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, uri-boundary, lsp-platform, mcp-server, vscode-extension, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, uri-boundary, lsp-platform, mcp-server, vscode-extension, vscode-nix, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
     steps:
       - name: Check results
         run: |
@@ -742,6 +770,17 @@ jobs:
           echo "vscode-extension result: $vscode"
           if [[ "$vscode" != "success" && "$vscode" != "skipped" ]]; then
             echo "vscode-extension must pass when packages/vscode changed"
+            exit 1
+          fi
+
+          # Same gating, same reason, for the Nix build of the same extension.
+          # It is a separate job because it catches a different failure: the
+          # npm build above cannot see a stale `npmDepsHash`, which is what
+          # shipped broken in v0.22.0 (#2109).
+          vscode_nix="${{ needs.vscode-nix.result }}"
+          echo "vscode-nix result: $vscode_nix"
+          if [[ "$vscode_nix" != "success" && "$vscode_nix" != "skipped" ]]; then
+            echo "vscode-nix must pass when packages/vscode or the flake changed"
             exit 1
           fi
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -142,6 +142,20 @@ jobs:
             echo "Version mismatch!"
             exit 1
           fi
+      - name: Test the flake's VS Code extension package
+        run: |
+          # `nix run` above builds the DEFAULT package only, so the tag's other
+          # flake outputs went unevaluated. v0.22.0 shipped a
+          # `vscode-extension` derivation that could not build at all — a
+          # stale `npmDepsHash` — and this job passed, because nothing here
+          # ever asked for that output (#2109).
+          #
+          # Per-PR CI covers this on main now, and the tag is cut from main, so
+          # this is belt-and-braces rather than the primary guard. It costs one
+          # build and closes the gap between "main is green" and "the thing
+          # users actually pin builds".
+          nix build "github:rustledger/rustledger/v${VERSION}#vscode-extension" \
+            --no-link --print-build-logs
       - name: Create test file
         run: echo '${{ env.TEST_BEANCOUNT }}' > /tmp/test.beancount
       - name: Test rledger check

--- a/flake.nix
+++ b/flake.nix
@@ -148,7 +148,7 @@
             pname = "rustledger-vscode-vsix";
             version = vscodeVersion;
             src = ./packages/vscode;
-            npmDepsHash = "sha256-+uUy4mzGgOyEv3e5O9oSkVZ/qZB1P6qaT+v4iBqfGuk=";
+            npmDepsHash = "sha256-rAiJeaxzfI0dZmHem8PE7ct3ssuee9FvXO6DVzIIkvc=";
 
             # esbuild's npm postinstall downloads a prebuilt binary for the host
             # platform, and the build sandbox has no network. Skip install scripts


### PR DESCRIPTION
Closes #2109.

`nix build .#vscode-extension` fails on v0.22.0 with a fixed-output hash
mismatch, so anyone pointing a flake input at the release cannot rebuild.

## What happened

The hash was set on **2026-08-09** (#2004, when the flake package was added)
and `packages/vscode/package-lock.json` moved **twice after it**:

- **2026-08-13** — #2038, a js-yaml advisory bump
- **2026-08-17** — #2079, a dependency roll-up

Neither updated `npmDepsHash`. v0.22.0 is the first release to contain this
derivation at all, so it shipped unbuildable.

I reproduced it locally before touching anything, and my `got:` hash matches
the reporter's byte for byte — which rules out a nixpkgs-version difference
between our two environments and confirms the recorded hash is simply stale.
`nix build .#vscode-extension` now completes.

## Why it rotted, which is the real fix

**No workflow ran `nix build` or `nix flake check` at all.** The flake was
entirely untested in CI.

The existing `VS Code Extension` job builds the same extension through npm and
**cannot catch this** — `npmDepsHash` only matters to Nix consumers, so the
npm build passes happily while the flake is broken. Two PRs changed the
lockfile, CI was green for both, and it took an external bug report eight days
later.

`VS Code Extension (Nix)` builds the derivation. It is gated on the same
`vscode` path filter, now widened to `flake.nix` / `flake.lock` since a flake
edit can invalidate the hash on its own, and required by the aggregating
`build` gate exactly the way its npm sibling is — tolerating `skipped` for
PRs the filter doesn't select, and checked ahead of the `should_build`
early-exit for the reason already documented there: a vscode-only PR has
`should_build` false, so a check placed after it would never run on the one
kind of PR it exists for.

## Verification

- Reproduced the reported failure, applied the hash, rebuilt to completion.
- `actionlint` on `ci.yml`: 10 shellcheck findings, identical to main — none
  introduced.

## Note for whoever reviews

This is the second thing v0.22.0 surfaced that had been broken for days with
green CI (the first being two crates never published to crates.io, fixed in
 #2108). Both had the same shape: a guard existed for the adjacent thing, and
the actual artifact went unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr