### PR TITLE
Potential fix for code scanning alert no. 203: Unused variable, import, function or class

### DIFF
--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -17,7 +17,6 @@ import type {
 // that need a fresh `lastIndex` (recursion) build a new RegExp from this; the
 // module-level constant is used by `.replace()`, which manages `lastIndex`.
 const INCLUDE_PATTERN = '^\\uFEFF?include\\s+"([^"]+)"[ \\t]*(?:;[^\\r\\n]*)?[ \\t\\r]*$';
-const INCLUDE_REGEX = new RegExp(INCLUDE_PATTERN, 'gm');
 
 /** Glob metacharacters beancount honors in an `include`. */
 const GLOB_CHARS = /[*?[\]]/;


### PR DESCRIPTION
Potential fix for [https://github.com/rustledger/rustledger/security/code-scanning/203](https://github.com/rustledger/rustledger/security/code-scanning/203)

Remove the unused `INCLUDE_REGEX` declaration from `packages/mcp-server/src/helpers.ts`.

- **General approach:** for unused variable findings, delete the dead declaration when it is not required for behavior or API shape.
- **Best specific fix here:** delete line 20 (`const INCLUDE_REGEX = new RegExp(INCLUDE_PATTERN, 'gm');`) and keep `INCLUDE_PATTERN` unchanged. This preserves any logic that builds new `RegExp` objects from the pattern while eliminating the unused symbol.
- **File/region to edit:** `packages/mcp-server/src/helpers.ts`, immediately below `INCLUDE_PATTERN`.
- **No new imports, methods, or dependencies** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
