### PR TITLE
docs(wit): state the stability contract for meta.hash

### DIFF
--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -81,22 +81,23 @@ interface types {
   record meta {
     filename: string,
     lineno: u32,
-    /// Content digest identifying this directive within a single loaded
-    /// session.
+    /// Content digest identifying this directive.
     ///
-    /// The algorithm is an implementation detail, and the value is stable
-    /// only within a WIT package version: it hashes the directive's content,
-    /// so any change to what is hashed, or how, changes every digest. #1961
-    /// did exactly that — length-prefixing each field to fix collisions, the
-    /// worst being a transaction with a payee hashing identically to one
-    /// without — and every downstream snapshot pinning the old values broke
-    /// at once (#1967).
+    /// Deterministic: the same directive, loaded by the same build of
+    /// rustledger, always produces the same value. It covers the directive's
+    /// semantic content only — comments are deliberately excluded (#1968),
+    /// so two directives differing just in their comments share a digest.
     ///
-    /// So do not persist it, pin it in tests, or compare it across versions.
-    /// A consumer needing a durable identifier should derive its own.
+    /// It carries NO cross-version stability guarantee. The algorithm is an
+    /// implementation detail and has already changed in an ordinary release,
+    /// without a WIT package version bump: #1961 length-prefixed every hashed
+    /// field to fix real collisions — a transaction with a payee hashed
+    /// identically to one without — which changed every digest, and the
+    /// downstream snapshots pinning the old values all broke at once (#1967).
     ///
-    /// Comments are deliberately excluded (#1968): two directives differing
-    /// only in their comments share a digest.
+    /// So compare it within one loaded ledger; do not persist it, pin it in
+    /// tests, or compare it across rustledger versions. A consumer needing a
+    /// durable identifier should derive its own.
     hash: string,
     user: list<meta-entry>,
   }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -81,6 +81,22 @@ interface types {
   record meta {
     filename: string,
     lineno: u32,
+    /// Content digest identifying this directive within a single loaded
+    /// session.
+    ///
+    /// The algorithm is an implementation detail, and the value is stable
+    /// only within a WIT package version: it hashes the directive's content,
+    /// so any change to what is hashed, or how, changes every digest. #1961
+    /// did exactly that — length-prefixing each field to fix collisions, the
+    /// worst being a transaction with a payee hashing identically to one
+    /// without — and every downstream snapshot pinning the old values broke
+    /// at once (#1967).
+    ///
+    /// So do not persist it, pin it in tests, or compare it across versions.
+    /// A consumer needing a durable identifier should derive its own.
+    ///
+    /// Comments are deliberately excluded (#1968): two directives differing
+    /// only in their comments share a digest.
     hash: string,
     user: list<meta-entry>,
   }


### PR DESCRIPTION
Closes #2111.

`meta.hash` was declared as a bare `string` with no statement of what consumers may rely on:

```wit
    hash: string,
```

That silence is what made #1961 a surprise downstream. It length-prefixed every field fed into `compute_directive_hash` — correct, and it fixed three real collisions, the worst being a transaction *with* a payee hashing identically to one *without* — but it changed every digest, and rustfava was pinning them in committed snapshots (#1967).

## Why this is documentation and not a fix

rustfava#280 stopped pinning the digest rather than versioning it, which is the better outcome: a future format change no longer costs a regeneration downstream. So nothing is broken today. What's missing is the written contract, so the next person changing the hash format knows what they are and aren't promising.

The comment records that the algorithm is an implementation detail, that the value is stable only within a WIT package version, and that it must not be persisted, pinned in tests, or compared across versions. It also notes that comments are excluded (#1968), so two directives differing only in their comments share a digest — a property a consumer might otherwise discover the hard way.

Field-level doc comments are an established pattern in this file (3 of 37 records already use them).

## Verification

Comment-only, but the docs are not inert — `wit_bindgen::generate!` is a proc macro, so they expand into Rust doc comments and are lintable even though nothing lands on disk. Checked accordingly:

| check | result |
|---|---|
| `wasm-tools component wit` | parses |
| `cargo check -p rustledger-ffi-component` | builds |
| `cargo +1.97.0 clippy --all-targets -- -D warnings` | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |

I confirmed the WIT parse check can actually fail before trusting it, by appending a deliberate syntax error (exit 1) and restoring (exit 0).

Clippy was run under **1.97.0 via rustup**, not the nix shell's 0.1.96 — the toolchain skew that previously hid a `doc_markdown` red for several commits, and exactly the lint a prose-heavy doc comment would trip.