### PR TITLE
docs(migration): document the same-day repeated-lot divergence (#2118)

### DIFF
--- a/docs/migration/from-beancount.md
+++ b/docs/migration/from-beancount.md
@@ -64,6 +64,12 @@ See [Plugins Reference](../reference/plugins.md) for full list.
    them, the two engines then consume in different orders.
 
    ```beancount
+   option "booking_method" "FIFO"
+
+   2020-01-01 open Assets:Stock  ACME
+   2020-01-01 open Assets:Cash   USD
+   2020-01-01 open Income:Gains  USD
+
    2020-01-02 * "buy A"
      Assets:Stock  10 ACME {10.00 USD}
      Assets:Cash  -100.00 USD

--- a/docs/migration/from-beancount.md
+++ b/docs/migration/from-beancount.md
@@ -98,8 +98,23 @@ See [Plugins Reference](../reference/plugins.md) for full list.
    a date, not a time, so A and C are genuinely the same lot under its model
    and pooling is the only thing its inventory can represent.
 
+   It can also make a ledger **fail to load**, in either direction, not just
+   report different figures. Pooling changes which lots survive a reduction,
+   so a later reduction naming an explicit cost may find its lot already
+   drained on one engine and still present on the other:
+
+   ```
+   error[BOOK]: Not enough units in Assets:Stock: requested 14, available 6;
+   not enough to reduce (2020-02-04, "sell")
+   ```
+
+   Nothing in that message points at same-day repeated lots, so it is worth
+   knowing about before you meet it. The reverse happens too — a ledger
+   rustledger accepts can be one Python rejects.
+
    If you reconcile figures against Python and see a difference on a holding
-   you bought more than once in a day, this is the likely cause. Give the
+   you bought more than once in a day, or a reduction fails on a lot you
+   believe you still hold, this is the likely cause. Give the
    repeated purchases distinct labels (`{10.00 USD, "morning"}`) to make
    them separate lots in both engines. Tracked in
    [#2118](https://github.com/rustledger/rustledger/issues/2118).

--- a/docs/migration/from-beancount.md
+++ b/docs/migration/from-beancount.md
@@ -55,6 +55,49 @@ See [Plugins Reference](../reference/plugins.md) for full list.
 
 1. **Plugin loading**: Python plugins require WASM compilation.
 
+1. **Repeated same-day lots**: buying the same holding twice on one day at
+   the same cost can produce a different cost basis and different realized
+   gains than Python beancount. Python's inventory is keyed by
+   `(currency, cost)`, so two acquisitions sharing a cost, date and label
+   collapse into a single position; rustledger keeps one lot per
+   acquisition. When a third lot at a different cost was acquired between
+   them, the two engines then consume in different orders.
+
+   ```beancount
+   2020-01-02 * "buy A"
+     Assets:Stock  10 ACME {10.00 USD}
+     Assets:Cash  -100.00 USD
+
+   2020-01-02 * "buy B"
+     Assets:Stock  10 ACME {20.00 USD}
+     Assets:Cash  -200.00 USD
+
+   2020-01-02 * "buy C"          ; same cost and date as A
+     Assets:Stock  10 ACME {10.00 USD}
+     Assets:Cash  -100.00 USD
+
+   2020-03-01 * "sell 15"
+     Assets:Stock  -15 ACME {}
+     Assets:Cash   300.00 USD
+     Income:Gains
+   ```
+
+   Under FIFO, rustledger consumes A then B, leaving `10 @10.00` and
+   `5 @20.00`. Python pools A and C into one `20 @10.00` position and drains
+   it, consuming A then **C** and leaving `5 @10.00` and `10 @20.00` — B
+   untouched despite being acquired before C.
+
+   rustledger's answer respects acquisition order, which is why it is not
+   being changed to match. Python is not being careless: `Cost` carries only
+   a date, not a time, so A and C are genuinely the same lot under its model
+   and pooling is the only thing its inventory can represent.
+
+   If you reconcile figures against Python and see a difference on a holding
+   you bought more than once in a day, this is the likely cause. Give the
+   repeated purchases distinct labels (`{10.00 USD, "morning"}`) to make
+   them separate lots in both engines. Tracked in
+   [#2118](https://github.com/rustledger/rustledger/issues/2118).
+
 ## Migration Steps
 
 ### 1. Install rustledger


### PR DESCRIPTION
Closes the documentation half of #2118.

Python beancount's `Inventory` is keyed by `(currency, cost)`, so acquisitions sharing a cost, date and label pool into a single position. rustledger keeps one lot per acquisition. When a lot at a different cost was acquired *between* two that pool, the engines consume in different orders — and a holding bought more than once in a day reports a different cost basis and different realized gains.

We decided to keep rustledger's behavior: it respects acquisition order and Python's cannot, because `Cost` carries a date and no time, so the two purchases are genuinely one lot under its model. That decision makes documenting it the deliverable — anyone reconciling figures against Python needs to know why they differ, and nothing warned them.

Goes in `Known Differences` in the migration guide, which is where someone comparing the two engines will actually be looking.

**Both the example and the workaround were run, not reasoned about.**

The worked example reproduces exactly as written: rustledger leaves `10 @10.00` + `5 @20.00`, Python leaves `5 @10.00` + `10 @20.00` — Python consuming the third lot while the second, acquired earlier, goes untouched.

The suggested fix is advice users will follow, so I checked it rather than assuming: giving the repeated purchases distinct labels makes them separate lots on both sides and the two engines then agree (`10 @10.00` + `5 @20.00` each).

Independent of #2119 and #2120 — this documents behavior that is not changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr
