### PR TITLE
test(core): pin STRICT_WITH_SIZE's two tie rules

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1826,6 +1826,58 @@ mod reduction_tests {
         );
     }
 
+    /// Two size matches sharing a date resolve by insertion order.
+    ///
+    /// The date comparison cannot separate these, so only the `i` in
+    /// `min_by_key`'s key decides — and the comment above it promises a
+    /// deterministic result. Nothing pinned that: reversing the slot tiebreak
+    /// to `Reverse(i)` leaves all 485 core tests passing.
+    ///
+    /// Determinism here is not decoration. `report capgains` splits short from
+    /// long on the surviving lot's acquisition date, and per-lot IRR keys
+    /// eligibility off it, so a reduction that picks arbitrarily between two
+    /// same-date lots moves tax figures between runs.
+    #[test]
+    fn strict_with_size_breaks_a_date_tie_by_insertion_order() {
+        // Same date, same size, different costs — so the choice is visible in
+        // the basis and nothing but the tiebreak can make it.
+        let inv = mk([lot(10, 100, 7), lot(10, 200, 7)]);
+        let r = try_reduce(&inv, &sell_stk(10), BookingMethod::StrictWithSize);
+        assert_eq!(
+            basis(&r),
+            dec!(1000),
+            "must take the FIRST of two same-date size matches (cost 100)",
+        );
+    }
+
+    /// A date-less size match loses to a dated one.
+    ///
+    /// `map_or((1, NaiveDate::MAX), ..)` sorts `None` last, on the reasoning
+    /// that a booked lot always carries a date and an unbooked one is not what
+    /// the user meant. That is a real decision — `None` sorts BEFORE `Some`
+    /// naturally, so the encoding exists precisely to override it — and it was
+    /// unpinned: flipping it to sort `None` first leaves the whole core suite
+    /// green.
+    #[test]
+    fn strict_with_size_prefers_a_dated_lot_over_a_date_less_one() {
+        let mut inv = Inventory::new();
+        // Date-less FIRST, so insertion order alone would pick it and cannot
+        // be what produces the expected answer.
+        inv.add(Position::with_cost(
+            Amount::new(d(10), "STK"),
+            Cost::new(d(100), "USD"),
+        ))
+        .expect("fixture fits in Decimal");
+        inv.add(lot(10, 200, 9)).expect("fixture fits in Decimal");
+
+        let r = try_reduce(&inv, &sell_stk(10), BookingMethod::StrictWithSize);
+        assert_eq!(
+            basis(&r),
+            dec!(2000),
+            "must take the DATED size match (cost 200), not the date-less one",
+        );
+    }
+
     #[test]
     fn strict_with_size_ambiguous_without_exact_or_total() {
         let inv = mk([lot(10, 100, 1), lot(10, 200, 2)]);

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1850,18 +1850,19 @@ mod reduction_tests {
         );
     }
 
-    /// A date-less size match loses to a dated one.
+    /// An undated size match loses to a dated one.
     ///
     /// `map_or((1, NaiveDate::MAX), ..)` sorts `None` last, on the reasoning
     /// that a booked lot always carries a date and an unbooked one is not what
     /// the user meant. That is a real decision — `None` sorts BEFORE `Some`
     /// naturally, so the encoding exists precisely to override it — and it was
     /// unpinned: flipping it to sort `None` first leaves the whole core suite
-    /// green.
+    /// green, along with `rustledger`, `rustledger-validate` and
+    /// `rustledger-query`.
     #[test]
-    fn strict_with_size_prefers_a_dated_lot_over_a_date_less_one() {
+    fn strict_with_size_prefers_a_dated_lot_over_an_undated_lot() {
         let mut inv = Inventory::new();
-        // Date-less FIRST, so insertion order alone would pick it and cannot
+        // Undated FIRST, so insertion order alone would pick it and cannot
         // be what produces the expected answer.
         inv.add(Position::with_cost(
             Amount::new(d(10), "STK"),
@@ -1874,7 +1875,7 @@ mod reduction_tests {
         assert_eq!(
             basis(&r),
             dec!(2000),
-            "must take the DATED size match (cost 200), not the date-less one",
+            "must take the DATED size match (cost 200), not the undated one",
         );
     }
 


### PR DESCRIPTION
Variant sweep from #2115 and #2122, looking for the same shape: an ordering whose secondary key nothing checks.

## `plan_strict_with_size` is correct — no bug here

It uses `min_by_key` on `(date_key, slot)` ascending, never reverses a walk, and *encodes* `None` dates to sort last rather than relying on `Option`'s natural order:

```rust
.map_or((1, NaiveDate::MAX), |d| (0, d)),
i,
```

That is the same house rule `order_key` follows — put the direction in the key, keep the tiebreak ascending. Reporting that as the result: the sibling defect I went looking for is not there.

## Both tie rules were unpinned

The comment above that key states each as a promise, and nothing held it:

- reversing the slot tiebreak to `Reverse(i)` left **all 485 core tests passing**, plus `rustledger`, `rustledger-validate` and `rustledger-query`
- flipping the `None` encoding so date-less lots sort **first** did the same

`strict_with_size_takes_the_oldest_of_several_exact_size_lots` covers the primary date order from #2097 and stops there. Two size matches that *share* a date, and a date-less size match, both fell through.

Each new test kills exactly its mutant and nothing else fails. Both fixtures put the lot that must **not** win first, so insertion order alone cannot produce the expected answer — otherwise they would pass for the wrong reason.

## Why it matters beyond determinism-for-its-own-sake

`report capgains` splits short from long on the surviving lot's acquisition date, and per-lot IRR keys eligibility off it. A reduction choosing arbitrarily between two same-date lots moves tax figures, silently — the postings still balance and no error is reported.

Tests only; no behavior change. Independent of #2119, #2120, #2121 and #2123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr
