### PR TITLE
chore(deps): bump @rustledger/wasm to 0.22.0 in mcp-server

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
-        "@rustledger/wasm": "^0.21.0"
+        "@rustledger/wasm": "^0.22.0"
       },
       "bin": {
         "rustledger-mcp": "dist/index.js"
@@ -347,9 +347,9 @@
       "license": "MIT"
     },
     "node_modules/@rustledger/wasm": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@rustledger/wasm/-/wasm-0.21.0.tgz",
-      "integrity": "sha512-kGI/6PfRCL75OrYlcgkGqoy5eQ9DrnnEFEbHCT7HAmBOp5L8DLl9SlPsk0L6w53wsgo32/1bk6PM15njVvEq5A==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@rustledger/wasm/-/wasm-0.22.0.tgz",
+      "integrity": "sha512-XCHJdgcZkrEB4RUDdESg6rVyz3ZL1qcXBrj9Vqx7WjGZT/9o4yQzQkVtuMkk8C1kRBTrokUowjQX0fD6a9xPIw==",
       "license": "GPL-3.0-only"
     },
     "node_modules/@standard-schema/spec": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://rustledger.github.io",
   "dependencies": {
-    "@rustledger/wasm": "^0.21.0",
+    "@rustledger/wasm": "^0.22.0",
     "@modelcontextprotocol/server": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -949,12 +949,15 @@ describe('collectLedgerFiles', () => {
     // The loader now REPORTS the diamond, matching Python's
     // `Duplicate filename parsed`, so the result is no longer `valid`. The
     // sibling test above asserts that report directly; here it only means the
-    // verdict flipped, not that the collection doubled. Checking the message
-    // keeps this test honest about WHY it is invalid: a doubled balance would
-    // show up as a balance-assertion failure instead.
+    // verdict flipped, not that the collection doubled. Naming the specific
+    // message keeps this test honest about WHY it is invalid -- a doubled
+    // balance would surface as a balance-assertion failure, which this would
+    // not accept.
     const result = rustledger.validateMultiFile(files, entry);
     expect(result.valid).toBe(false);
-    expect(JSON.stringify(result)).toContain('Duplicate');
+    expect(
+      result.errors.some((e) => e.message.includes('Duplicate filename parsed')),
+    ).toBe(true);
   });
 
   it('collects every file a glob matches', () => {

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -409,23 +409,7 @@ describe('Tool Handlers', () => {
       expect(result.content[0].text).toContain('valid');
     });
 
-    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
-    // `validateSource` drops the loader's parse errors, so it answers
-    // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not.
-    //
-    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
-    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
-    // test, which is the point — the marker cannot outlive the defect, and
-    // whoever fixes the binding is told to delete the `.fails` rather than
-    // discovering a stale skip years later.
-    //
-    // #1884 is FIXED in the parser (EOF now terminates a line), but this
-    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
-    // clears on the next release rather than at that merge. When a release
-    // lands and this turns red, delete the `.fails` — that is the signal, not
-    // a regression.
-    it.fails('should report validation errors', () => {
+    it('should report validation errors', () => {
       const result = handleToolCall('validate', { source: '2024-01-01 invalid directive' });
       expect(result.content[0].text).toContain('error');
     });
@@ -531,23 +515,7 @@ describe('Tool Handlers', () => {
       expect(payload.transaction.date).toBe('2024-01-15');
     });
 
-    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
-    // `validateSource` drops the loader's parse errors, so it answers
-    // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not.
-    //
-    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
-    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
-    // test, which is the point — the marker cannot outlive the defect, and
-    // whoever fixes the binding is told to delete the `.fails` rather than
-    // discovering a stale skip years later.
-    //
-    // #1884 is FIXED in the parser (EOF now terminates a line), but this
-    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
-    // clears on the next release rather than at that merge. When a release
-    // lands and this turns red, delete the `.fails` — that is the signal, not
-    // a regression.
-    it.fails('returns an error response when parsing fails', () => {
+    it('returns an error response when parsing fails', () => {
       // Pre-fix this would have silently produced a categorization
       // prompt with an empty accounts list; now it surfaces the parser
       // diagnostic, matching `handleParse`'s behavior.
@@ -585,23 +553,7 @@ describe('Tool Handlers', () => {
       expect(payload.low_confidence).toBe(0);
     });
 
-    // `it.fails` — pinned to issue #1884, NOT a disabled test. The wasm's
-    // `validateSource` drops the loader's parse errors, so it answers
-    // `valid: true` for input `rledger check` rejects with P0012. These
-    // assertions are correct; the binding is not.
-    //
-    // `it.fails` inverts the verdict: the suite is GREEN while this assertion
-    // fails, and turns RED if it ever passes. So fixing #1884 breaks this
-    // test, which is the point — the marker cannot outlive the defect, and
-    // whoever fixes the binding is told to delete the `.fails` rather than
-    // discovering a stale skip years later.
-    //
-    // #1884 is FIXED in the parser (EOF now terminates a line), but this
-    // package depends on the PUBLISHED `@rustledger/wasm`, so the marker
-    // clears on the next release rather than at that merge. When a release
-    // lands and this turns red, delete the `.fails` — that is the signal, not
-    // a regression.
-    it.fails('returns an error response when parsing fails', () => {
+    it('returns an error response when parsing fails', () => {
       const result = handleToolCall('import_review', {
         source: '@@@ not beancount @@@',
       });
@@ -990,9 +942,19 @@ describe('collectLedgerFiles', () => {
     expect(Object.keys(files).sort()).toEqual([
       'main.beancount', 'sub/mid.beancount', 'sub/shared.beancount',
     ]);
-    // 100.00, not 200.00: the shared file contributes once.
+    // The map is unique by construction, so the shared file contributes once
+    // and the balance holds at 100.00 rather than doubling to 200.00. That is
+    // this test's subject and it is unchanged.
+    //
+    // The loader now REPORTS the diamond, matching Python's
+    // `Duplicate filename parsed`, so the result is no longer `valid`. The
+    // sibling test above asserts that report directly; here it only means the
+    // verdict flipped, not that the collection doubled. Checking the message
+    // keeps this test honest about WHY it is invalid: a doubled balance would
+    // show up as a balance-assertion failure instead.
     const result = rustledger.validateMultiFile(files, entry);
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(JSON.stringify(result)).toContain('Duplicate');
   });
 
   it('collects every file a glob matches', () => {
@@ -1071,18 +1033,7 @@ describe('collectLedgerFiles', () => {
     expect(result.errors[0].message).toContain('gone.beancount');
   });
 
-  // `it.fails` — pinned to the bundled wasm version, NOT a disabled test.
-  // The loader reports `Duplicate filename parsed` for a file reached twice
-  // (see the sibling change in `rustledger-loader`), but the `@rustledger/wasm`
-  // build pinned in package.json predates it, so `validateMultiFile` still
-  // answers `valid: true` here. The assertion is correct; the bundled binding
-  // is stale.
-  //
-  // `it.fails` inverts the verdict: the suite is GREEN while this fails and
-  // turns RED once the wasm is rebuilt — at which point delete the `.fails`.
-  // That is the point: the marker cannot outlive the staleness, and whoever
-  // bumps the dependency is told rather than finding a skip years later.
-  it.fails('reports a file reached twice, once the wasm carries the loader fix', () => {
+  it('reports a file reached twice, once the wasm carries the loader fix', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-dupwasm-'));
     fs.mkdirSync(path.join(dir, 'sub'), { recursive: true });
     fs.writeFileSync(path.join(dir, 'sub/shared.beancount'), '2020-01-01 open Assets:Cash USD\n');


### PR DESCRIPTION
Supersedes #2129, which can be closed.

## Why #2129 failed, and why that is good news

The bump does exactly what four `it.fails` tripwires were placed to detect: it makes them pass.

Those markers are not disabled tests. Each pins an assertion that is **correct** but that the bundled wasm could not yet satisfy, and each carries the same instruction in its comment:

> When a release lands and this turns red, delete the `.fails` — that is the signal, not a regression.

- **three** pinned to #1884, where `validateSource` dropped the loader's parse errors and answered `valid: true` for input `rledger check` rejects with P0012
- **one** pinned to the loader reporting a file reached twice

The v0.22.0 wasm carries both fixes, so all four unpinned at once. Cleared, along with their now-historical rationale. This is the mechanism working: whoever bumped the dependency was told what changed, rather than finding a stale skip years later.

## The fifth failure is a real behaviour change

The diamond-include test asserted `valid: true`. The loader now reports `Duplicate filename parsed` for a file reached twice, matching Python beancount, so the verdict flips.

Its **subject is unchanged**: the shared file still contributes once, so the balance holds at 100.00 rather than doubling to 200.00. I kept that intact and added a message check, so a doubled balance would still surface as a balance-assertion failure rather than passing quietly under the new verdict.

## Verification

* 121/121 tests pass
* `npm run build` clean
* `package-lock.json` resolves `@rustledger/wasm` at 0.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr
