### PR TITLE
fix(format): keep currency, cost and price on a numberless posting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Shipped work, by area. Forward-looking plans live in [docs/roadmap/](docs/roadma
 
 ### Fixed
 
+- **`rledger format` no longer deletes a posting's currency, cost or price when it has no units number** — `emit_posting` rendered the amount only when a number was present, and the currency, cost spec and price annotation all sat inside that branch, so a posting without a number lost every one of them. The tokens were not reformatted, they were dropped, and what the author wrote could not be recovered from the output. `Assets:Other USD` is valid beancount that constrains interpolation to USD, so this was data loss on CORRECT input; the malformed shapes matter too, since `format` runs on editor save and mistyping a units number then saving deleted the rest of the line. Found by checking two properties across the 735-file compatibility corpus: formatting is idempotent, and it does not change the set of diagnostics a file produces (issue #2142).
+
+
 - **`report journal --limit N` no longer reverses the report** — the limit was reached with `.rev().take(n)`, which left the ROWS reversed as well as selecting the last N: the unlimited journal read oldest-first and adding a limit silently flipped it newest-first. `sort_by_key` is stable, so the same reversal also undid the file order of same-date transactions — the order booking itself uses (#2093) — so a limited journal disagreed with the ledger about which of two same-day entries came first. All three output formats were affected; they share the selection. Found by variant analysis from #2115, which was the same `.rev()`-over-a-sorted-list shape in the booking path (issue #2122).
 
 ### Performance

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -2056,7 +2056,34 @@ fn emit_posting(
                 out.push(' ');
                 out.push_str(&format_price_annotation(&pa, group));
             }
+        } else {
+            // No NUMBER, but the posting may still carry a currency, a cost
+            // spec or a price. `Assets:Other USD` is valid beancount that
+            // constrains interpolation to USD, and a units-less posting with
+            // a cost or price is malformed but is still what the author
+            // wrote. Emitting nothing here deleted all of it (#2142).
+            //
+            // Two spaces rather than the aligned number column: there is no
+            // number to align, and `compute_alignment` deliberately excludes
+            // these postings from the column width so a long currency-only
+            // account cannot widen the file.
+            for part in [
+                amt.currency().map(|c| c.text().to_string()),
+                p.cost_spec().map(|cs| format_cost_spec(&cs, group)),
+                p.price_annotation()
+                    .map(|pa| format_price_annotation(&pa, group)),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                out.push_str("  ");
+                out.push_str(&part);
+            }
         }
+    } else if let Some(cs) = p.cost_spec() {
+        // No amount node at all, yet a cost spec parsed. Same rule: keep it.
+        out.push_str("  ");
+        out.push_str(&format_cost_spec(&cs, group));
     }
     out.push('\n');
     // Splice the trailing comment in BEFORE the posting-line
@@ -3116,6 +3143,58 @@ mod tests {
             "number column must align to the numbered posting, not the longer \
              currency-only one; got:\n{out}"
         );
+    }
+
+    /// A posting with no NUMBER keeps its currency, cost and price.
+    ///
+    /// `emit_posting` renders the amount only when `amount_number_text`
+    /// yields a number, and everything else was inside that branch, so a
+    /// posting without one lost its currency, its cost spec and its price
+    /// annotation. The tokens were not reformatted, they were deleted, and
+    /// what the author wrote could not be recovered from the output (#2142).
+    ///
+    /// `Assets:Other USD` is VALID beancount that constrains interpolation to
+    /// USD, so this was data loss on correct input, not only on malformed
+    /// input. The malformed shapes matter too: `format` runs on editor save,
+    /// so mistyping a units number and saving deleted the rest of the line.
+    #[test]
+    fn issue_2142_numberless_posting_keeps_currency_cost_and_price() {
+        for (name, src, must_contain) in [
+            (
+                "currency only",
+                "2024-01-15 * \"x\"\n  Assets:Bank  -5.00 USD\n  Assets:Other USD\n",
+                "USD",
+            ),
+            (
+                "total price without units",
+                "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT @@ 2000.00 USD\n  Assets:Cash  -2000.00 USD\n",
+                "@@ 2000.00 USD",
+            ),
+            (
+                "cost without units",
+                "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT {12.00 USD}\n  Assets:Cash  -120.00 USD\n",
+                "{12.00 USD}",
+            ),
+            (
+                "per-unit price without units",
+                "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT @ 12.00 USD\n  Assets:Cash  -120.00 USD\n",
+                "@ 12.00 USD",
+            ),
+        ] {
+            let out = format_source(src);
+            assert!(
+                out.contains(must_contain),
+                "{name}: formatting deleted {must_contain:?}; got:\n{out}"
+            );
+            // And formatting the result again must not change it further: a
+            // fix that re-emitted the tokens in a shape it could not reparse
+            // would show up here rather than in the assertion above.
+            assert_eq!(
+                format_source(&out),
+                out,
+                "{name}: not idempotent; got:\n{out}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -2080,10 +2080,25 @@ fn emit_posting(
                 out.push_str(&part);
             }
         }
-    } else if let Some(cs) = p.cost_spec() {
-        // No amount node at all, yet a cost spec parsed. Same rule: keep it.
-        out.push_str("  ");
-        out.push_str(&format_cost_spec(&cs, group));
+    } else {
+        // No amount node at all, yet a cost spec or price annotation parsed:
+        // the CST attaches them after the account whether or not an AMOUNT
+        // was recognized. Same rule as above, keep whatever is there.
+        //
+        // An earlier version of this fix handled only the cost spec, so
+        // `Assets:MSFT @@ 2000.00 USD` still lost its price. Both are listed
+        // here so neither can be forgotten again.
+        for part in [
+            p.cost_spec().map(|cs| format_cost_spec(&cs, group)),
+            p.price_annotation()
+                .map(|pa| format_price_annotation(&pa, group)),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            out.push_str("  ");
+            out.push_str(&part);
+        }
     }
     out.push('\n');
     // Splice the trailing comment in BEFORE the posting-line
@@ -3159,26 +3174,42 @@ mod tests {
     /// so mistyping a units number and saving deleted the rest of the line.
     #[test]
     fn issue_2142_numberless_posting_keeps_currency_cost_and_price() {
+        // Each expectation names the WHOLE posting line, not a fragment.
+        // An earlier version asserted only `"USD"` for the currency-only
+        // case, which the OTHER posting (`-5.00 USD`) satisfies, so the test
+        // would have passed while the currency-only posting still lost its
+        // currency. A test written to prove content survives must not be
+        // satisfiable by unrelated content.
         for (name, src, must_contain) in [
             (
                 "currency only",
                 "2024-01-15 * \"x\"\n  Assets:Bank  -5.00 USD\n  Assets:Other USD\n",
-                "USD",
+                "Assets:Other  USD",
+            ),
+            (
+                "price with no amount node at all",
+                "2013-05-18 * \"x\"\n  Assets:MSFT @@ 2000.00 USD\n  Assets:Cash  -2000.00 USD\n",
+                "Assets:MSFT  @@ 2000.00 USD",
+            ),
+            (
+                "cost with no amount node at all",
+                "2013-05-18 * \"x\"\n  Assets:MSFT {12.00 USD}\n  Assets:Cash  -120.00 USD\n",
+                "Assets:MSFT  {12.00 USD}",
             ),
             (
                 "total price without units",
                 "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT @@ 2000.00 USD\n  Assets:Cash  -2000.00 USD\n",
-                "@@ 2000.00 USD",
+                "Assets:MSFT  MSFT  @@ 2000.00 USD",
             ),
             (
                 "cost without units",
                 "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT {12.00 USD}\n  Assets:Cash  -120.00 USD\n",
-                "{12.00 USD}",
+                "Assets:MSFT  MSFT  {12.00 USD}",
             ),
             (
                 "per-unit price without units",
                 "2013-05-18 * \"x\"\n  Assets:MSFT  MSFT @ 12.00 USD\n  Assets:Cash  -120.00 USD\n",
-                "@ 12.00 USD",
+                "Assets:MSFT  MSFT  @ 12.00 USD",
             ),
         ] {
             let out = format_source(src);

--- a/scripts/format-idempotence.sh
+++ b/scripts/format-idempotence.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
-# Format idempotence check (#1323).
+# Formatter property checks over the compatibility corpus.
+#
+# Two properties, both over the fetched corpus:
+#
+#   IDEMPOTENT (#1323)  re-formatting already-formatted output is
+#                       byte-identical.
+#   PRESERVING (#2142)  formatting does not change the set of diagnostic
+#                       CODES a file produces. Formatting is a layout
+#                       change; if `check` says something different
+#                       afterwards, content moved or vanished.
+#
+# The second was added after `format` was found to DELETE a posting's
+# currency, cost spec and price annotation when it had no units number
+# (#2142). That is invisible to the idempotence check, because deleting the
+# same tokens twice is perfectly stable.
 #
 # `rledger format` must be a fixed point: re-formatting an
 # already-formatted file must produce byte-identical output. This
@@ -39,11 +53,25 @@ fi
 
 once=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
 twice=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
-trap 'rm -f "$once" "$twice"' EXIT
+trap 'rm -f "$once" "$twice" "${sib:-}"' EXIT
+
+# Diagnostic CODES only, sorted: message wording and spans legitimately move
+# when layout does, but a code appearing or disappearing means the meaning
+# changed.
+codes_of() {
+  # `"code": "E3004"` — the JSON is pretty-printed, so there IS a space after
+  # the colon. Matching `"code":"` found nothing, both sides compared empty,
+  # and the check silently passed everything. Caught by running it against a
+  # binary with the bug it was written for.
+  "$RLEDGER" check --format json "$1" 2>/dev/null \
+    | grep -oE '"code":[[:space:]]*"[^"]*"' \
+    | sed 's/.*"\([^"]*\)"$/\1/' | sort | tr '\n' ' '
+}
 
 checked=0
 skipped=0
 fail=0
+drift=0
 failed_files=()
 
 while IFS= read -r -d '' f; do
@@ -67,11 +95,29 @@ while IFS= read -r -d '' f; do
     failed_files+=("$f")
     fail=$((fail + 1))
   fi
+
+  # Semantic preservation. The formatted copy is written BESIDE the original,
+  # not in /tmp: a relative `include` or plugin path resolves against the
+  # file's own directory, and moving the copy elsewhere breaks them and
+  # reports two false drifts.
+  sib="$(dirname "$f")/.fmtcheck.$$.beancount"
+  cp "$once" "$sib" 2>/dev/null || { rm -f "$sib"; continue; }
+  before=$(codes_of "$f")
+  after=$(codes_of "$sib")
+  rm -f "$sib"
+  if [ "$before" != "$after" ]; then
+    echo "FAIL (diagnostics changed): $f"
+    echo "  before: $before"
+    echo "  after:  $after"
+    failed_files+=("$f")
+    drift=$((drift + 1))
+  fi
 done < <(find "$CORPUS" -name '*.beancount' -type f -print0)
 
 echo "----"
-echo "format idempotence: checked=$checked skipped=$skipped non_idempotent=$fail"
+echo "format properties: checked=$checked skipped=$skipped non_idempotent=$fail diagnostics_changed=$drift"
 
+fail=$((fail + drift))
 if [ "$fail" -gt 0 ]; then
   {
     echo "non-idempotent files:"


### PR DESCRIPTION
Closes #2142.

`emit_posting` rendered the amount only when `amount_number_text` yielded a number, and the currency, cost spec and price annotation all sat inside that branch. A posting without a number lost every one of them — not reformatted, **deleted**:

```
  Assets:Investments:MSFT            MSFT @@ 2000.00 USD
```
```
  Assets:Investments:MSFT
```

## Worse than the issue first recorded

While fixing it I found the bug reaches **valid** input:

```beancount
2024-01-15 * "x"
  Assets:Bank  -5.00 USD
  Assets:Other USD          ; valid: constrains interpolation to USD
```

Both engines accept this and interpolate `Assets:Other 5.00 USD`. Formatting deleted the `USD`. So this was data loss on correct input, not only on malformed input — I filed the issue believing otherwise, and the fix and its tests cover both.

The malformed shapes still matter, because `format` runs on editor save: mistyping a units number and saving deleted the rest of the line, and the surviving diagnostic got *worse* for it (`BOOK` became `E1001` twice, once the evidence of intent was gone).

## The fix

Numberless postings emit their parts with two spaces rather than the aligned number column. There is no number to align, and `compute_alignment` deliberately excludes these postings from the column width so a long currency-only account cannot widen the file — the existing `transaction_currency_only_posting_does_not_widen_amount_column` test still passes.

## Testing

The regression test covers all four shapes — currency only, total price, cost, per-unit price — and **asserts idempotence on each**, so a fix that re-emitted tokens in a shape it could not reparse would fail here rather than silently.

Verified it fails against the old code: reverting gives `formatting deleted "@@ 2000.00 USD"`.

The corpus property sweep that found this now reports **3 fewer drifts** (5 → 2). The 2 remaining are artifacts of formatting to a temp file, which breaks relative `include` and plugin paths — not formatter bugs.

Parser tests green, workspace green except the pre-existing `corpus_parity` failure, clippy clean on 1.97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr
