### PR TITLE
test(compat): fail on NEW booked-value divergences against beancount

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1494,22 +1494,30 @@ jobs:
           echo "::error::Returns fuzz found a divergence (start-seed=${{ steps.returns_fuzz.outputs.start }}, runs=${{ steps.returns_fuzz.outputs.runs }}). EXTRACTION means the cash flows differ from beangrow's; SOLVER means the rate differs from an independent solve over the same flows. Reproduce one with: python3 scripts/compat-returns-fuzz.py --rledger ./target/release/rledger --seed <n>"
           exit 1
 
+      # Fails only on divergences outside the recorded baseline. Until this
+      # existed the booked-value comparison reported into a step summary and
+      # nothing ever went red, so a PR could introduce a fresh "right shape,
+      # wrong numbers" divergence and stay green (#2147).
+      #
+      # `!= '0'` rather than the `== '1'` the fuzz gates above use: those
+      # report a boolean, this forwards the script's exit code, and an
+      # argparse/usage error exits 2. `outcome != 'skipped'` keeps an empty
+      # output from reading as a divergence when an earlier step aborted the
+      # job -- `'' != '0'` is true, and a false "divergence found" annotation
+      # on an already-red run sends the next reader after a bug that is not
+      # there.
+      - name: Gate on booked-value divergences
+        if: ${{ !cancelled() && steps.booked_values.outcome != 'skipped' && steps.booked_values.outputs.failed != '0' }}
+        run: |
+          echo "::error::Booked-value comparison did not come back clean (exit ${{ steps.booked_values.outputs.failed }}). Divergences against beancount that are not in tests/compatibility/known-value-divergences.json are listed under '=== BASELINE ===' in the step log; any other exit code means the comparison itself failed. Investigate the divergence first -- this gate exists to catch wrong numbers. If it is genuinely intended, re-record with: python3 scripts/compat-values.py --rledger ./target/release/rledger --corpus tests/compatibility/files tests/regressions --write-baseline tests/compatibility/known-value-divergences.json"
+          exit 1
+
       # Mirrors the BQL step's `--baseline` (which exits non-zero on a BQL
       # regression). Previously check regressions were only printed and written
       # to compat-regressions.txt — a file that matched on the previous run and
       # mismatches now scrolled by silently. A one-shot red alert: the committed
       # baseline advances, and the details live in compat-regressions.txt on the
       # compatibility branch.
-      # Fails only on divergences outside the recorded baseline. Until this
-      # existed the booked-value comparison reported into a step summary and
-      # nothing ever went red, so a PR could introduce a fresh "right shape,
-      # wrong numbers" divergence and stay green (#2147).
-      - name: Gate on booked-value divergences
-        if: ${{ !cancelled() && steps.booked_values.outputs.failed != '0' }}
-        run: |
-          echo "::error::Booked-value comparison found a divergence against beancount that is not in tests/compatibility/known-value-divergences.json. The offending (file, field) pairs are listed under '=== BASELINE ===' in the step log. If the change is intended, regenerate with: python3 scripts/compat-values.py --rledger ./target/release/rledger --corpus tests/compatibility/files tests/regressions --write-baseline tests/compatibility/known-value-divergences.json"
-          exit 1
-
       - name: Gate on check regressions
         if: ${{ !cancelled() && steps.compat_test.outcome == 'success' && steps.compat_test.outputs.regression_count != '0' }}
         run: |

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -763,6 +763,7 @@ jobs:
           python3 scripts/compat-values.py \
             --rledger ./target/release/rledger --self-test
       - name: Compare booked values against beancount
+        id: booked_values
         continue-on-error: true
         run: |
           # `pipefail` because the pipe into `tee` would otherwise mask the
@@ -770,10 +771,21 @@ jobs:
           # compat-values.txt and a green step, which is exactly the
           # vacuous-pass shape this comparison exists to catch.
           set -o pipefail
+          # `--baseline` makes a NEW divergence fail, while the recorded
+          # backlog does not. Gating on ANY divergence was never an option:
+          # the existing set is largely rustledger carrying an exact value
+          # where Python's decimal context rounds an intermediate at 28
+          # significant digits, and failing on those would get the gate
+          # switched off again. Same shape as the BQL step's `--baseline`
+          # below. Regenerate with `--write-baseline` and review the diff
+          # (#2147).
+          rc=0
           python3 scripts/compat-values.py \
             --rledger ./target/release/rledger \
             --corpus tests/compatibility/files tests/regressions \
-            | tee compat-values.txt
+            --baseline tests/compatibility/known-value-divergences.json \
+            | tee compat-values.txt || rc=$?
+          echo "failed=$rc" >> "$GITHUB_OUTPUT"
           {
             echo "## Booked-value comparison"
             echo ""
@@ -1488,6 +1500,16 @@ jobs:
       # mismatches now scrolled by silently. A one-shot red alert: the committed
       # baseline advances, and the details live in compat-regressions.txt on the
       # compatibility branch.
+      # Fails only on divergences outside the recorded baseline. Until this
+      # existed the booked-value comparison reported into a step summary and
+      # nothing ever went red, so a PR could introduce a fresh "right shape,
+      # wrong numbers" divergence and stay green (#2147).
+      - name: Gate on booked-value divergences
+        if: ${{ !cancelled() && steps.booked_values.outputs.failed != '0' }}
+        run: |
+          echo "::error::Booked-value comparison found a divergence against beancount that is not in tests/compatibility/known-value-divergences.json. The offending (file, field) pairs are listed under '=== BASELINE ===' in the step log. If the change is intended, regenerate with: python3 scripts/compat-values.py --rledger ./target/release/rledger --corpus tests/compatibility/files tests/regressions --write-baseline tests/compatibility/known-value-divergences.json"
+          exit 1
+
       - name: Gate on check regressions
         if: ${{ !cancelled() && steps.compat_test.outcome == 'success' && steps.compat_test.outputs.regression_count != '0' }}
         run: |

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -1258,6 +1258,13 @@ def main() -> int:
 
     if not args.corpus:
         ap.error("--corpus is required unless --self-test is given")
+
+    # --limit truncates the corpus, so `found` would be a subset of reality.
+    # Writing under it silently shrinks the baseline; checking under it reports
+    # every unvisited entry as RESOLVED and passes. Both look like success.
+    if args.limit and (args.baseline or args.write_baseline):
+        ap.error("--limit cannot be combined with --baseline/--write-baseline: "
+                 "a truncated corpus yields a partial divergence set")
     files = sorted(p for d in args.corpus for p in Path(d).rglob("*.beancount"))
     if args.limit:
         files = files[: args.limit]
@@ -1522,17 +1529,30 @@ def _divergence_keys(value_div, posting_div, price_div):
     Basename, not full path: the corpus is fetched to different absolute
     locations in CI and locally, and a baseline keyed on absolute paths would
     match nothing. This mirrors how `KNOWN_POSTING_DIVERGENCES` is keyed.
-    """
-    import os
 
+    The key deliberately omits the two values. It pins WHERE we diverge, not
+    by how much, so a known-diverging cell whose numbers get worse still
+    passes. Pinning values was considered and rejected: CI installs beancount
+    from master, so its side of every pair can move without any change here,
+    and a baseline that churns on upstream commits gets regenerated
+    reflexively rather than read. The narrower guarantee -- no divergence in a
+    cell that agreed before -- is the one that survives that.
+
+    Note this is the second layer for the posting axis:
+    `KNOWN_POSTING_DIVERGENCES` already suppresses individually-reasoned
+    fields before they reach `posting_div`, and carries a rationale string per
+    entry. Prefer adding to that dict when a divergence has an explanation
+    worth writing down; this file is the generated catch-all for the value and
+    price axes, which have no such dict.
+    """
     keys = set()
     for path, diffs in value_div:
         for (acct, cur), _x, _y in diffs:
-            keys.add((os.path.basename(path), f"value:{acct} {cur}"))
+            keys.add((path.name, f"value:{acct} {cur}"))
     for axis, div in (("posting", posting_div), ("price", price_div)):
         for path, diffs in div:
             for where, _x, _y in diffs:
-                keys.add((os.path.basename(path), f"{axis}:{where}".rstrip(": ")))
+                keys.add((path.name, f"{axis}:{where}".rstrip(": ")))
     return keys
 
 

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -1238,6 +1238,17 @@ def main() -> int:
     ap.add_argument("--rledger", default="./target/release/rledger")
     ap.add_argument("--corpus", nargs="+")
     ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument(
+        "--baseline",
+        help="JSON file of divergences already known and accepted. Any "
+             "divergence NOT listed makes this exit non-zero, so a NEW one "
+             "fails the build while the existing backlog does not.",
+    )
+    ap.add_argument(
+        "--write-baseline",
+        help="write the divergences found in this run to PATH and exit 0. "
+             "Use to record the current state, then review the diff.",
+    )
     ap.add_argument("--self-test", action="store_true",
                     help="verify the error axis on fixtures with known answers")
     args = ap.parse_args()
@@ -1433,7 +1444,77 @@ def main() -> int:
         print(f"  {path}")
         for where, x, y in diffs[:6]:
             print(f"      {where}:  beancount={x}  rledger={y}")
+
+    # Gate on NEW divergences, not on any divergence.
+    #
+    # This comparison exists to catch "right shape, wrong numbers", which the
+    # module docstring calls the failure that matters most for an accounting
+    # tool -- and until now nothing failed when it found one. The step was
+    # `continue-on-error`, this function returned 0 unconditionally, and the
+    # results went to a summary. A PR introducing a fresh divergence stayed
+    # green (#2147).
+    #
+    # Gating on ANY divergence is not an option: there is an existing set that
+    # is arguably rustledger being MORE correct, where Python's decimal
+    # context rounds an intermediate at 28 significant digits and we carry the
+    # exact value. Failing on those would just get the gate switched off
+    # again. So this takes the shape the BQL step already uses in this
+    # workflow: a recorded baseline, and only departures from it fail.
+    found = _divergence_keys(divergent, posting_divergent, price_divergent)
+
+    if args.write_baseline:
+        with open(args.write_baseline, "w") as fh:
+            json.dump(sorted(found), fh, indent=2)
+            fh.write("\n")
+        print(f"\nwrote {len(found)} divergence key(s) to {args.write_baseline}")
+        return 0
+
+    if not args.baseline:
+        return 0
+
+    try:
+        with open(args.baseline) as fh:
+            known = set(map(tuple, json.load(fh)))
+    except FileNotFoundError:
+        print(f"\nERROR: baseline not found: {args.baseline}")
+        return 1
+
+    new = sorted(k for k in found if k not in known)
+    fixed = sorted(k for k in known if k not in found)
+    print("\n=== BASELINE ===")
+    print(f"known {len(known)}, found {len(found)}, "
+          f"new {len(new)}, no-longer-diverging {len(fixed)}")
+    for k in fixed:
+        # Not a failure: a divergence that went away is good news. It is
+        # printed so the baseline can be trimmed rather than silently
+        # accumulating entries that pin nothing.
+        print(f"  RESOLVED (drop from baseline): {k[0]} :: {k[1]}")
+    for k in new:
+        print(f"  NEW DIVERGENCE: {k[0]} :: {k[1]}")
+    if new:
+        print(f"\nERROR: {len(new)} divergence(s) not in the baseline")
+        return 1
     return 0
+
+
+def _divergence_keys(value_div, posting_div, price_div):
+    """Stable (basename, field) keys for every divergence found.
+
+    Basename, not full path: the corpus is fetched to different absolute
+    locations in CI and locally, and a baseline keyed on absolute paths would
+    match nothing. This mirrors how `KNOWN_POSTING_DIVERGENCES` is keyed.
+    """
+    import os
+
+    keys = set()
+    for path, diffs in value_div:
+        for (acct, cur), _x, _y in diffs:
+            keys.add((os.path.basename(path), f"value:{acct} {cur}"))
+    for axis, div in (("posting", posting_div), ("price", price_div)):
+        for path, diffs in div:
+            for where, _x, _y in diffs:
+                keys.add((os.path.basename(path), f"{axis}:{where}".rstrip(": ")))
+    return keys
 
 
 if __name__ == "__main__":

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -1474,10 +1474,29 @@ def main() -> int:
 
     try:
         with open(args.baseline) as fh:
-            known = set(map(tuple, json.load(fh)))
+            raw = json.load(fh)
     except FileNotFoundError:
         print(f"\nERROR: baseline not found: {args.baseline}")
         return 1
+    except json.JSONDecodeError as exc:
+        # Most likely an unresolved merge conflict: this file is generated, so
+        # two PRs recording divergences will collide in it. A stack trace in a
+        # CI log is a poor way to learn that. Regenerate with --write-baseline.
+        print(f"\nERROR: baseline is not valid JSON: {args.baseline}: {exc}")
+        return 1
+
+    # Shape matters as much as syntax. `tuple("value:x")` is a tuple of
+    # characters, not a key, so a hand-edit that leaves bare strings in the
+    # list would match nothing and report every real divergence as new.
+    if not isinstance(raw, list) or any(
+        not (isinstance(e, (list, tuple)) and len(e) == 2 and all(isinstance(x, str) for x in e))
+        for e in raw
+    ):
+        print(
+            f"\nERROR: baseline must be a list of [file, field] string pairs: {args.baseline}"
+        )
+        return 1
+    known = {tuple(e) for e in raw}
 
     new = sorted(k for k in found if k not in known)
     fixed = sorted(k for k in known if k not in found)

--- a/tests/compatibility/known-value-divergences.json
+++ b/tests/compatibility/known-value-divergences.json
@@ -1,0 +1,138 @@
+[
+  [
+    "examples_defs__rx_def_INITIAL_COPY.beancount",
+    "posting:Assets:US:Vanguard:Cash 2022-10-07 number"
+  ],
+  [
+    "examples_defs__rx_def_INITIAL_COPY.beancount",
+    "posting:Assets:US:Vanguard:RGAGX 2022-10-07 price_number"
+  ],
+  [
+    "examples_defs__rx_def_INITIAL_COPY.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "examples_defs_rx_def.beancount",
+    "posting:Assets:US:Vanguard:Cash 2022-10-07 number"
+  ],
+  [
+    "examples_defs_rx_def.beancount",
+    "posting:Assets:US:Vanguard:RGAGX 2022-10-07 price_number"
+  ],
+  [
+    "examples_defs_rx_def.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "examples_defs_rx_updated.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "examples_recon_rx_updated.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_data_cool_fund_example.beancount",
+    "posting:Assets:CoolFund:Total 2024-04-15 number"
+  ],
+  [
+    "tests_data_cool_fund_example.beancount",
+    "posting:Assets:CoolFund:Total 2024-04-15 price_number"
+  ],
+  [
+    "tests_data_cool_fund_example.beancount",
+    "price:COOL_FUND_USD 2024-04-11 price_number"
+  ],
+  [
+    "tests_data_cool_fund_example.beancount",
+    "value:Assets:CoolFund:Total COOL_FUND_USD"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "posting:Assets:SomeFund:Total 2024-03-07 cost_date"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "posting:Assets:SomeFund:Total 2024-03-07 cost_number"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "posting:Assets:SomeFund:Total 2024-03-07 number"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "posting:Assets:SomeFund:Total 2024-03-07 price_number"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "posting:Income:SomeFund:PnL 2024-03-07 number"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "price:SOME_FUND_USD 2024-03-05 price_number"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "value:Assets:SomeFund:Total SOME_FUND_USD"
+  ],
+  [
+    "tests_data_some_fund_example.beancount",
+    "value:Income:SomeFund:PnL USD"
+  ],
+  [
+    "tests_resources_defs_defs.beancount",
+    "posting:Assets:US:Vanguard:Cash 2022-10-07 number"
+  ],
+  [
+    "tests_resources_defs_defs.beancount",
+    "posting:Assets:US:Vanguard:RGAGX 2022-10-07 price_number"
+  ],
+  [
+    "tests_resources_defs_defs.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_defs_defs_opts.beancount",
+    "posting:Biens:US:Vanguard:Cash 2022-10-07 number"
+  ],
+  [
+    "tests_resources_defs_defs_opts.beancount",
+    "posting:Biens:US:Vanguard:RGAGX 2022-10-07 price_number"
+  ],
+  [
+    "tests_resources_defs_defs_opts.beancount",
+    "value:Biens:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_defs_defs_repeat_payee.beancount",
+    "posting:Assets:US:Vanguard:Cash 2022-10-07 number"
+  ],
+  [
+    "tests_resources_defs_defs_repeat_payee.beancount",
+    "posting:Assets:US:Vanguard:RGAGX 2022-10-07 price_number"
+  ],
+  [
+    "tests_resources_defs_defs_repeat_payee.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_defs_rx_221231.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_defs_rx_230630.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_defs_rx_opts_221231.beancount",
+    "value:Biens:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_example_rx.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ],
+  [
+    "tests_resources_recon_rx.beancount",
+    "value:Assets:US:Vanguard:Cash USD"
+  ]
+]


### PR DESCRIPTION
Closes #2147.

## The gap

`scripts/compat-values.py` compares booked values, per-posting cost/price/lot-date, error kinds and price directives against Python beancount. Its docstring states the case for existing: a bug producing the right number of postings with the wrong numbers in them "passes silently, which for an accounting tool is the failure that matters most."

Nothing failed when it found one. The step was `continue-on-error`, `main()` returned 0 unconditionally, and no gate read the result -- it went into `compat-values.txt` and the step summary. Every other comparison in `compat.yml` is gated (budget, booking, capgains, returns, check regressions, synthetic differential). This one was not, so a PR could introduce a fresh divergence and stay green.

## Why not just fail on any divergence

There are 34 today, and most are rustledger being the *more* correct side: Python's `decimal` context rounds an intermediate at 28 significant digits where rustledger carries the exact value.

```
number:       beancount=-720.0200000000000000000000001  rledger=-720.02
price_number: beancount=54.13684210526315789473684211
              rledger=54.136842105263157894736842105
```

A gate that went red on those would get switched off within a week, which is plausibly how it ended up ungated to begin with.

## Shape

The same recorded-baseline approach the BQL step in this workflow already uses:

- `--write-baseline FILE` records the current divergence set
- `--baseline FILE` exits 1 on anything outside it
- a divergence that **goes away** prints `RESOLVED` and does not fail, so the file can be trimmed rather than silently accumulating entries that pin nothing

Keys are `(basename, field)`, matching how `KNOWN_POSTING_DIVERGENCES` is already keyed. The corpus is fetched to different absolute paths in CI and locally; a baseline keyed on full paths would match nothing and pass everything.

## Verified in both directions

A gate is worth exactly what its failure case is worth, so both were run:

| scenario | result |
|---|---|
| against its own baseline | exit 0, `known 34, found 34, new 0, no-longer-diverging 0` |
| pre-#2139 binary, ledger exercising #2118 | **exit 1**, naming `value:Income:Gains USD` and `posting:<row count>` |

The script's own `--self-test` still passes across all four axes.

`actionlint` on the modified workflow: 3 findings, identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr