### PR TITLE
feat(query): add six missing beanquery BQL functions

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -36,14 +36,9 @@ impl Executor<'_> {
                             ));
                         }
                     };
-                    // Check if any posting matches the account pattern (using cache)
-                    let regex = self.require_regex(&pattern)?;
-                    for posting in &txn.postings {
-                        if regex.is_match(&posting.account) {
-                            return Ok(true);
-                        }
-                    }
-                    Ok(false)
+                    // Same helper the projection arm uses, so the two spellings
+                    // cannot drift.
+                    self.entry_has_account(txn, &pattern)
                 } else {
                     // For other functions, create a dummy context and evaluate
                     let dummy_ctx = PostingContext {

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -188,9 +188,11 @@ impl<'a> Executor<'a> {
                     info.close_date = Some(close.date);
                 }
                 Directive::Commodity(commodity) => {
-                    commodity_meta
-                        .entry(commodity.currency.to_string())
-                        .or_insert_with(|| commodity.meta.clone());
+                    // Last declaration wins, matching bean-query: a ledger
+                    // that declares `commodity USD` twice resolves to the
+                    // later directive's metadata. `or_insert_with` here kept
+                    // the FIRST and disagreed.
+                    commodity_meta.insert(commodity.currency.to_string(), commodity.meta.clone());
                 }
                 _ => {}
             }
@@ -280,9 +282,11 @@ impl<'a> Executor<'a> {
                     info.close_date = Some(close.date);
                 }
                 Directive::Commodity(commodity) => {
-                    commodity_meta
-                        .entry(commodity.currency.to_string())
-                        .or_insert_with(|| commodity.meta.clone());
+                    // Last declaration wins, matching bean-query: a ledger
+                    // that declares `commodity USD` twice resolves to the
+                    // later directive's metadata. `or_insert_with` here kept
+                    // the FIRST and disagreed.
+                    commodity_meta.insert(commodity.currency.to_string(), commodity.meta.clone());
                 }
                 _ => {}
             }
@@ -1998,21 +2002,17 @@ impl<'a> Executor<'a> {
                     ))),
                 }
             }
-            // The currency of an amount or position. beanquery types this as
-            // `commodity(Amount) -> str`; a `Position` is accepted too because
-            // `commodity(cost(position))` is the idiomatic call and `cost()`
-            // may hand back either depending on the posting (#2153).
+            // The currency of an amount. bean-query types this strictly as
+            // `commodity(Amount) -> str` and rejects a position, so
+            // `commodity(position)` is an error on both sides; the idiomatic
+            // spellings are `commodity(units(position))` and
+            // `commodity(cost(position))`, both of which yield an Amount.
             "COMMODITY" => {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
                     Value::Amount(amount) => Ok(Value::String(amount.currency.to_string())),
-                    Value::Position(position) => {
-                        Ok(Value::String(position.units.currency.to_string()))
-                    }
                     Value::Null => Ok(Value::Null),
-                    _ => Err(QueryError::Type(
-                        "COMMODITY expects an amount or position".to_string(),
-                    )),
+                    _ => Err(QueryError::Type("COMMODITY expects an amount".to_string())),
                 }
             }
             // `CURRENCY_META` is beanquery's own alias for `COMMODITY_META`;

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -410,6 +410,22 @@ impl<'a> Executor<'a> {
     }
 
     /// Get or compile a regex pattern, returning an error if invalid.
+    /// Does any posting on this entry have an account matching `pattern`?
+    ///
+    /// ONE implementation for both spellings of `HAS_ACCOUNT`: the FROM
+    /// predicate in `evaluate_from_filter` and the projection arm in
+    /// `evaluate_function`. They answer the same question about the same
+    /// entry, so a second copy is a divergence waiting to happen -- the
+    /// two already differed in their error text before this was extracted.
+    fn entry_has_account(
+        &self,
+        txn: &rustledger_core::Transaction,
+        pattern: &str,
+    ) -> Result<bool, QueryError> {
+        let regex = self.require_regex(pattern)?;
+        Ok(txn.postings.iter().any(|p| regex.is_match(&p.account)))
+    }
+
     fn require_regex(&self, pattern: &str) -> Result<Arc<Regex>, QueryError> {
         self.get_or_compile_regex(pattern)
             .ok_or_else(|| QueryError::Type(format!("invalid regex: {pattern}")))
@@ -864,12 +880,8 @@ impl<'a> Executor<'a> {
                         )),
                     };
                 };
-                let regex = self.require_regex(pattern)?;
                 Ok(Value::Boolean(
-                    ctx.transaction
-                        .postings
-                        .iter()
-                        .any(|posting| regex.is_match(&posting.account)),
+                    self.entry_has_account(ctx.transaction, pattern)?,
                 ))
             }
             // Aggregates evaluate to Null per row; real aggregation happens in
@@ -2062,9 +2074,11 @@ impl<'a> Executor<'a> {
                         )),
                     };
                 };
-                let candidates: Vec<String> = match haystack {
-                    Value::StringSet(items) => items.clone(),
-                    Value::String(single) => vec![single.clone()],
+                // Borrowed scan: only the matching element is cloned, so a hit
+                // on the first tag does not copy the whole set.
+                let candidates: &[String] = match haystack {
+                    Value::StringSet(items) => items,
+                    Value::String(single) => std::slice::from_ref(single),
                     Value::Null => return Ok(Value::Null),
                     _ => {
                         return Err(QueryError::Type(
@@ -2074,9 +2088,9 @@ impl<'a> Executor<'a> {
                 };
                 let regex = self.require_regex(pattern)?;
                 Ok(candidates
-                    .into_iter()
+                    .iter()
                     .find(|c| regex.is_match(c))
-                    .map_or(Value::Null, Value::String))
+                    .map_or(Value::Null, |c| Value::String(c.clone())))
             }
             // Truncate a date to the first of its month. beanquery returns a
             // date here, not a string, so `yearmonth(date)` stays orderable

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -127,6 +127,10 @@ pub struct Executor<'a> {
     regex_cache: RwLock<FxHashMap<String, Option<Arc<Regex>>>>,
     /// Account info cache from Open/Close directives.
     account_info: FxHashMap<String, AccountInfo>,
+    /// Metadata of each `commodity` directive, keyed by currency.
+    /// Backs `COMMODITY_META` / `CURRENCY_META`, which beanquery answers from
+    /// the commodity directive rather than from any posting (#2153).
+    commodity_meta: FxHashMap<String, rustledger_core::Metadata>,
     /// Source locations for directives (indexed by directive index).
     source_locations: Option<Vec<SourceLocation>>,
     /// The source map, kept so per-posting source locations (the `lineno` /
@@ -168,6 +172,7 @@ impl<'a> Executor<'a> {
 
         // Build account info cache from Open/Close directives
         let mut account_info: FxHashMap<String, AccountInfo> = FxHashMap::default();
+        let mut commodity_meta: FxHashMap<String, rustledger_core::Metadata> = FxHashMap::default();
         for directive in directives {
             match directive {
                 Directive::Open(open) => {
@@ -182,6 +187,11 @@ impl<'a> Executor<'a> {
                     let info = account_info.entry(account).or_default();
                     info.close_date = Some(close.date);
                 }
+                Directive::Commodity(commodity) => {
+                    commodity_meta
+                        .entry(commodity.currency.to_string())
+                        .or_insert_with(|| commodity.meta.clone());
+                }
                 _ => {}
             }
         }
@@ -195,6 +205,7 @@ impl<'a> Executor<'a> {
             account_types: rustledger_core::AccountTypes::default(),
             regex_cache: RwLock::new(FxHashMap::default()),
             account_info,
+            commodity_meta,
             source_locations: None,
             source_map: None,
             tables: FxHashMap::default(),
@@ -253,6 +264,7 @@ impl<'a> Executor<'a> {
 
         // Build account info cache from Open/Close directives
         let mut account_info: FxHashMap<String, AccountInfo> = FxHashMap::default();
+        let mut commodity_meta: FxHashMap<String, rustledger_core::Metadata> = FxHashMap::default();
         for spanned in spanned_directives {
             match &spanned.value {
                 Directive::Open(open) => {
@@ -267,6 +279,11 @@ impl<'a> Executor<'a> {
                     let info = account_info.entry(account).or_default();
                     info.close_date = Some(close.date);
                 }
+                Directive::Commodity(commodity) => {
+                    commodity_meta
+                        .entry(commodity.currency.to_string())
+                        .or_insert_with(|| commodity.meta.clone());
+                }
                 _ => {}
             }
         }
@@ -280,6 +297,7 @@ impl<'a> Executor<'a> {
             account_types: rustledger_core::AccountTypes::default(),
             regex_cache: RwLock::new(FxHashMap::default()),
             account_info,
+            commodity_meta,
             source_locations: Some(source_locations),
             source_map: Some(source_map),
             tables: FxHashMap::default(),
@@ -817,6 +835,39 @@ impl<'a> Executor<'a> {
             "WEIGHT" if Self::is_position_column(func) => Ok(compute_posting_weight(
                 &ctx.transaction.postings[ctx.posting_index],
             )),
+            // `HAS_ACCOUNT(regex)` asks about the whole ENTRY, so like the META
+            // family it needs the row's transaction rather than the evaluated
+            // argument list. It was already implemented for the FROM clause in
+            // `evaluate_from_filter`; without this arm the same name resolved
+            // there and raised `UnknownFunction` in a projection (#2153).
+            "HAS_ACCOUNT" => {
+                let args = func
+                    .args
+                    .iter()
+                    .map(|a| self.evaluate_expr(a, ctx))
+                    .collect::<Result<Vec<_>, _>>()?;
+                if args.len() != 1 {
+                    return Err(QueryError::InvalidArguments(
+                        "HAS_ACCOUNT".to_string(),
+                        "expected 1 argument".to_string(),
+                    ));
+                }
+                let Value::String(pattern) = &args[0] else {
+                    return match &args[0] {
+                        Value::Null => Ok(Value::Null),
+                        _ => Err(QueryError::Type(
+                            "HAS_ACCOUNT expects a string pattern".to_string(),
+                        )),
+                    };
+                };
+                let regex = self.require_regex(pattern)?;
+                Ok(Value::Boolean(
+                    ctx.transaction
+                        .postings
+                        .iter()
+                        .any(|posting| regex.is_match(&posting.account)),
+                ))
+            }
             // Aggregates evaluate to Null per row; real aggregation happens in
             // the aggregation pass.
             "SUM" | "COUNT" | "MIN" | "MAX" | "FIRST" | "LAST" | "AVG" => Ok(Value::Null),
@@ -1945,6 +1996,99 @@ impl<'a> Executor<'a> {
                     _ => Err(QueryError::Type(format!(
                         "{name_upper}: argument must be a string key"
                     ))),
+                }
+            }
+            // The currency of an amount or position. beanquery types this as
+            // `commodity(Amount) -> str`; a `Position` is accepted too because
+            // `commodity(cost(position))` is the idiomatic call and `cost()`
+            // may hand back either depending on the posting (#2153).
+            "COMMODITY" => {
+                Self::require_args_count(&name_upper, args, 1)?;
+                match &args[0] {
+                    Value::Amount(amount) => Ok(Value::String(amount.currency.to_string())),
+                    Value::Position(position) => {
+                        Ok(Value::String(position.units.currency.to_string()))
+                    }
+                    Value::Null => Ok(Value::Null),
+                    _ => Err(QueryError::Type(
+                        "COMMODITY expects an amount or position".to_string(),
+                    )),
+                }
+            }
+            // `CURRENCY_META` is beanquery's own alias for `COMMODITY_META`;
+            // both resolve against the `commodity` directive. One argument
+            // returns the whole metadata map, two return a single key, so a
+            // ledger with no matching directive yields Null either way.
+            "COMMODITY_META" | "CURRENCY_META" => {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(QueryError::InvalidArguments(
+                        name_upper.clone(),
+                        "expected 1 or 2 arguments".to_string(),
+                    ));
+                }
+                let Value::String(currency) = &args[0] else {
+                    return match &args[0] {
+                        Value::Null => Ok(Value::Null),
+                        _ => Err(QueryError::Type(format!(
+                            "{name_upper} expects a currency string"
+                        ))),
+                    };
+                };
+                let Some(meta) = self.commodity_meta.get(currency.as_str()) else {
+                    return Ok(Value::Null);
+                };
+                if args.len() == 1 {
+                    return Ok(Value::Metadata(Box::new(meta.clone())));
+                }
+                match &args[1] {
+                    Value::String(key) => Ok(Self::meta_value_to_value(meta.get(key.as_str()))),
+                    Value::Null => Ok(Value::Null),
+                    _ => Err(QueryError::Type(format!(
+                        "{name_upper}: key must be a string"
+                    ))),
+                }
+            }
+            // First element of a string set matching a regex. The set is
+            // scanned in its stored order, which for `tags`/`links` is the
+            // order the directive declares them, so the answer is stable
+            // rather than dependent on set iteration.
+            "FINDFIRST" => {
+                Self::require_args_count(&name_upper, args, 2)?;
+                let (Value::String(pattern), haystack) = (&args[0], &args[1]) else {
+                    return match (&args[0], &args[1]) {
+                        (Value::Null, _) => Ok(Value::Null),
+                        _ => Err(QueryError::Type(
+                            "FINDFIRST expects (regex_string, string_set)".to_string(),
+                        )),
+                    };
+                };
+                let candidates: Vec<String> = match haystack {
+                    Value::StringSet(items) => items.clone(),
+                    Value::String(single) => vec![single.clone()],
+                    Value::Null => return Ok(Value::Null),
+                    _ => {
+                        return Err(QueryError::Type(
+                            "FINDFIRST expects a string set as its second argument".to_string(),
+                        ));
+                    }
+                };
+                let regex = self.require_regex(pattern)?;
+                Ok(candidates
+                    .into_iter()
+                    .find(|c| regex.is_match(c))
+                    .map_or(Value::Null, Value::String))
+            }
+            // Truncate a date to the first of its month. beanquery returns a
+            // date here, not a string, so `yearmonth(date)` stays orderable
+            // and comparable against other dates.
+            "YEARMONTH" => {
+                Self::require_args_count(&name_upper, args, 1)?;
+                match &args[0] {
+                    Value::Date(date) => Ok(Value::Date(
+                        rustledger_core::CalendarPeriod::Month.start_of(*date),
+                    )),
+                    Value::Null => Ok(Value::Null),
+                    _ => Err(QueryError::Type("YEARMONTH expects a date".to_string())),
                 }
             }
             // Aggregate functions return Null when evaluated on a single row

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1966,7 +1966,7 @@ fn the_division_operator_matches_bean_query_scale() {
 /// `REPR` is deliberately NOT here: beanquery's `repr` returns Python's own
 /// object syntax (`Decimal('10.00')`, `datetime.date(2024, 2, 1)`,
 /// `frozenset({'t1'})`), which describes the `CPython` runtime rather
-/// than of the ledger. See the PR for why matching it was rejected.
+/// than the ledger. See the PR for why matching it was rejected.
 #[test]
 fn beanquery_functions_from_issue_2153_match_bean_query() {
     let mut usd_meta: Metadata = Metadata::default();
@@ -1994,10 +1994,24 @@ fn beanquery_functions_from_issue_2153_match_bean_query() {
         ),
     ];
 
+    // Asserts the value is the same on EVERY row, not just the first. These
+    // functions are evaluated per posting, and the fixture has two, so
+    // checking `rows[0][0]` alone would pass even if the second row
+    // disagreed.
     let one = |sql: &str| -> Value {
         let mut executor = Executor::new(&directives);
         let query = parse(sql).unwrap();
-        executor.execute(&query).unwrap().rows[0][0].clone()
+        let rows = executor.execute(&query).unwrap().rows;
+        assert!(!rows.is_empty(), "query returned no rows: {sql}");
+        let first = rows[0][0].clone();
+        for (index, row) in rows.iter().enumerate() {
+            assert_eq!(
+                row[0], first,
+                "row {index} disagrees with row 0 for `{sql}`; a per-row \
+                 function must answer identically for every posting here",
+            );
+        }
+        first
     };
 
     // COMMODITY(amount) -> currency. bean-query: 'USD'

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -2116,3 +2116,76 @@ fn commodity_meta_takes_the_last_declaration() {
         Value::String("Second".to_string()),
     );
 }
+
+/// Argument guards for the functions added in #2153.
+///
+/// These branches were verified by hand against bean-query while writing the
+/// feature, which is worth exactly nothing once someone refactors the match.
+/// Codecov flagged 36 uncovered lines in `evaluate_function_on_values`, and
+/// almost all of them were these arms.
+///
+/// The Null rows matter as much as the error rows: bean-query answers Null
+/// rather than raising for a Null input, so an arm that errored instead would
+/// turn a query over a ledger with one missing payee into a hard failure.
+#[test]
+fn issue_2153_functions_guard_their_arguments() {
+    let directives = vec![Directive::Transaction(
+        Transaction::new(date(2024, 2, 15), "t")
+            .with_flag('*')
+            .with_tag("t1")
+            .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(1.00), "USD")))
+            .with_synthesized_posting(Posting::new("Equity:O", Amount::new(dec!(-1.00), "USD"))),
+    )];
+
+    let run = |sql: &str| {
+        let mut executor = Executor::new(&directives);
+        let query = parse(sql).unwrap();
+        executor.execute(&query).map(|r| r.rows[0][0].clone())
+    };
+
+    // Wrong arity is an error, not a silent Null.
+    for sql in [
+        "SELECT COMMODITY_META()",
+        "SELECT COMMODITY_META(\"USD\", \"a\", \"b\")",
+        "SELECT FINDFIRST(\"x\")",
+        "SELECT YEARMONTH(date, date)",
+        "SELECT COMMODITY(units(position), units(position))",
+    ] {
+        assert!(run(sql).is_err(), "expected an arity error from `{sql}`");
+    }
+
+    // Wrong types are errors too, and each names the function so the message
+    // is actionable rather than a bare "type error".
+    for sql in [
+        "SELECT COMMODITY(1)",
+        "SELECT COMMODITY_META(1, 2)",
+        "SELECT FINDFIRST(1, tags)",
+        "SELECT YEARMONTH(\"notadate\")",
+    ] {
+        assert!(run(sql).is_err(), "expected a type error from `{sql}`");
+    }
+
+    // An invalid regex is reported rather than treated as "matches nothing",
+    // which would silently answer false/Null for a typo'd pattern.
+    assert!(run("SELECT FINDFIRST(\"[\", tags)").is_err());
+    assert!(run("SELECT HAS_ACCOUNT(\"[\")").is_err());
+
+    // Null in, Null out, matching bean-query. `payee` is Null on this
+    // transaction, so these are the real shapes a ledger produces.
+    for sql in [
+        "SELECT COMMODITY_META(payee, \"name\")",
+        "SELECT COMMODITY_META(\"USD\", payee)",
+        "SELECT FINDFIRST(payee, tags)",
+        "SELECT HAS_ACCOUNT(payee)",
+    ] {
+        assert_eq!(run(sql).unwrap(), Value::Null, "expected Null from `{sql}`");
+    }
+
+    // A currency with no `commodity` directive is Null in both the
+    // one-argument and two-argument forms.
+    assert_eq!(run("SELECT COMMODITY_META(\"USD\")").unwrap(), Value::Null);
+    assert_eq!(
+        run("SELECT COMMODITY_META(\"USD\", \"name\")").unwrap(),
+        Value::Null,
+    );
+}

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -2189,3 +2189,83 @@ fn issue_2153_functions_guard_their_arguments() {
         Value::Null,
     );
 }
+
+/// `COMMODITY_META` must work under `new_with_sources`, not just `new`.
+///
+/// The two constructors each build their own directive caches, so a lookup
+/// added to one and not the other fails only on the path that constructor
+/// serves. `new_with_sources` is the CLI and LSP path, which is where a user
+/// would actually hit this, and it is invisible to a test that only ever
+/// calls `Executor::new`.
+///
+/// Coverage said so plainly: the `Directive::Commodity` arm in this
+/// constructor was the one block of #2153's change with no test reaching it,
+/// even though the commit that added it claimed updating both constructors
+/// mattered.
+///
+/// This also covers the one-argument form returning a real metadata map
+/// rather than Null, which the other tests only exercise on the missing-
+/// currency path.
+#[test]
+fn commodity_meta_resolves_under_the_sourced_constructor() {
+    use rustledger_loader::SourceMap;
+
+    let mut source_map = SourceMap::new();
+    let source: std::sync::Arc<str> = "2024-01-01 commodity USD\n  name: \"US Dollar\"\n".into();
+    let file_id = source_map.add_file("test.beancount".into(), source);
+
+    let mut usd_meta: Metadata = Metadata::default();
+    usd_meta.insert(
+        "name".to_string(),
+        MetaValue::String("US Dollar".to_string()),
+    );
+
+    let spanned_directives = vec![
+        Spanned {
+            value: Directive::Commodity(rustledger_core::Commodity {
+                date: date(2024, 1, 1),
+                currency: "USD".into(),
+                meta: usd_meta,
+            }),
+            span: rustledger_parser::Span { start: 0, end: 40 },
+            file_id: file_id as u16,
+        },
+        Spanned {
+            value: Directive::Transaction(
+                Transaction::new(date(2024, 2, 15), "t")
+                    .with_flag('*')
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:A",
+                        Amount::new(dec!(1.00), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Equity:O",
+                        Amount::new(dec!(-1.00), "USD"),
+                    )),
+            ),
+            span: rustledger_parser::Span { start: 40, end: 90 },
+            file_id: file_id as u16,
+        },
+    ];
+
+    let run = |sql: &str| {
+        let mut executor = Executor::new_with_sources(&spanned_directives, &source_map);
+        let query = parse(sql).unwrap();
+        executor.execute(&query).unwrap().rows[0][0].clone()
+    };
+
+    assert_eq!(
+        run("SELECT COMMODITY_META(\"USD\", \"name\")"),
+        Value::String("US Dollar".to_string()),
+        "the sourced constructor must resolve commodity metadata too",
+    );
+
+    // One-argument form: the whole map, not Null, and carrying the key.
+    let Value::Metadata(meta) = run("SELECT COMMODITY_META(\"USD\")") else {
+        panic!("expected a metadata map from the one-argument form");
+    };
+    assert_eq!(
+        meta.get("name"),
+        Some(&MetaValue::String("US Dollar".to_string())),
+    );
+}

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1953,3 +1953,98 @@ fn the_division_operator_matches_bean_query_scale() {
         assert_eq!(n.to_string(), want, "{expr}");
     }
 }
+
+/// The six beanquery functions added in #2153, each pinned against the answer
+/// `bean-query` gives for the same ledger.
+///
+/// They were absent for different reasons and the tests are written to keep
+/// those reasons visible. `HAS_ACCOUNT` existed the whole time as a FROM-clause
+/// predicate and simply was not reachable from a projection, so the interesting
+/// assertion is that both spellings now agree. The other five had no
+/// implementation at all.
+///
+/// `REPR` is deliberately NOT here: beanquery's `repr` returns Python's own
+/// object syntax (`Decimal('10.00')`, `datetime.date(2024, 2, 1)`,
+/// `frozenset({'t1'})`), which describes the `CPython` runtime rather
+/// than of the ledger. See the PR for why matching it was rejected.
+#[test]
+fn beanquery_functions_from_issue_2153_match_bean_query() {
+    let mut usd_meta: Metadata = Metadata::default();
+    usd_meta.insert(
+        "name".to_string(),
+        MetaValue::String("US Dollar".to_string()),
+    );
+
+    let directives = vec![
+        Directive::Commodity(rustledger_core::Commodity {
+            date: date(2024, 1, 1),
+            currency: "USD".into(),
+            meta: usd_meta,
+        }),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 15), "t")
+                .with_flag('*')
+                .with_tag("t1")
+                .with_tag("zz")
+                .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(10.00), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:O",
+                    Amount::new(dec!(-10.00), "USD"),
+                )),
+        ),
+    ];
+
+    let one = |sql: &str| -> Value {
+        let mut executor = Executor::new(&directives);
+        let query = parse(sql).unwrap();
+        executor.execute(&query).unwrap().rows[0][0].clone()
+    };
+
+    // COMMODITY(amount) -> currency. bean-query: 'USD'
+    assert_eq!(
+        one("SELECT COMMODITY(units(position))"),
+        Value::String("USD".to_string()),
+    );
+
+    // COMMODITY_META / CURRENCY_META read the `commodity` directive, not the
+    // posting. bean-query: 'US Dollar' for both spellings.
+    assert_eq!(
+        one("SELECT COMMODITY_META(\"USD\", \"name\")"),
+        Value::String("US Dollar".to_string()),
+    );
+    assert_eq!(
+        one("SELECT CURRENCY_META(\"USD\", \"name\")"),
+        Value::String("US Dollar".to_string()),
+    );
+    // A currency with no `commodity` directive is Null, not an error.
+    assert_eq!(
+        one("SELECT COMMODITY_META(\"NOPE\", \"name\")"),
+        Value::Null
+    );
+
+    // FINDFIRST(regex, set) -> first match, or Null. bean-query: 'zz' / None.
+    assert_eq!(
+        one("SELECT FINDFIRST(\"z\", tags)"),
+        Value::String("zz".to_string()),
+    );
+    assert_eq!(one("SELECT FINDFIRST(\"nomatch\", tags)"), Value::Null);
+
+    // YEARMONTH truncates to the first of the month and stays a DATE, so it
+    // remains comparable and orderable. bean-query: datetime.date(2024, 2, 1).
+    assert_eq!(one("SELECT YEARMONTH(date)"), Value::Date(date(2024, 2, 1)),);
+
+    // HAS_ACCOUNT asks about the entry, so it must answer identically whether
+    // it is used as a projection or as the FROM predicate it always supported.
+    assert_eq!(one("SELECT HAS_ACCOUNT(\"Assets\")"), Value::Boolean(true));
+    assert_eq!(one("SELECT HAS_ACCOUNT(\"Nope\")"), Value::Boolean(false));
+
+    let from_rows = {
+        let mut executor = Executor::new(&directives);
+        let query = parse("SELECT account FROM has_account(\"Assets\")").unwrap();
+        executor.execute(&query).unwrap().rows.len()
+    };
+    assert_eq!(
+        from_rows, 2,
+        "the FROM predicate must still select the entry the projection reports true for",
+    );
+}

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -2047,4 +2047,58 @@ fn beanquery_functions_from_issue_2153_match_bean_query() {
         from_rows, 2,
         "the FROM predicate must still select the entry the projection reports true for",
     );
+
+    // `commodity` is typed `commodity(Amount)`. bean-query rejects a position
+    // outright, so accepting one here would be a silent extension -- and the
+    // idiomatic calls both already yield an Amount.
+    let mut executor = Executor::new(&directives);
+    let query = parse("SELECT COMMODITY(position)").unwrap();
+    assert!(
+        executor.execute(&query).is_err(),
+        "COMMODITY(position) must be rejected, as bean-query rejects it",
+    );
+}
+
+/// A currency declared twice resolves to the LAST `commodity` directive.
+///
+/// bean-query answers `'Second'` for the ledger below. Collecting these with
+/// `or_insert_with` keeps the first instead, which is the shape this pins:
+/// the two directives differ only in metadata, so nothing else in the query
+/// output would reveal which one was used.
+#[test]
+fn commodity_meta_takes_the_last_declaration() {
+    let meta_named = |name: &str| {
+        let mut m: Metadata = Metadata::default();
+        m.insert("name".to_string(), MetaValue::String(name.to_string()));
+        m
+    };
+
+    let directives = vec![
+        Directive::Commodity(rustledger_core::Commodity {
+            date: date(2024, 1, 1),
+            currency: "USD".into(),
+            meta: meta_named("First"),
+        }),
+        Directive::Commodity(rustledger_core::Commodity {
+            date: date(2024, 6, 1),
+            currency: "USD".into(),
+            meta: meta_named("Second"),
+        }),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 15), "t")
+                .with_flag('*')
+                .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(1.00), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:O",
+                    Amount::new(dec!(-1.00), "USD"),
+                )),
+        ),
+    ];
+
+    let mut executor = Executor::new(&directives);
+    let query = parse("SELECT COMMODITY_META(\"USD\", \"name\")").unwrap();
+    assert_eq!(
+        executor.execute(&query).unwrap().rows[0][0],
+        Value::String("Second".to_string()),
+    );
 }

--- a/docs/reference/bql.md
+++ b/docs/reference/bql.md
@@ -250,6 +250,7 @@ SELECT min(date), max(date)
 | `quarter(date)` | Extract quarter | `1` |
 | `weekday(date)` | Day-of-week name (`Mon`..`Sun`) | `Fri` |
 | `today()` | Current date | `2024-03-15` |
+| `yearmonth(date)` | First of that month, as a date | `2024-03-01` |
 
 ### Amount Functions
 
@@ -258,7 +259,16 @@ SELECT min(date), max(date)
 | `cost(position)` | Convert to cost basis |
 | `units(position)` | Get units (number + currency) |
 | `currency(position)` | Get currency |
+| `commodity(amount)` | Get the currency of an **amount** |
 | `number(amount)` | Extract number from amount |
+
+`commodity()` and `currency()` overlap but are not interchangeable.
+`commodity()` takes an amount, which is how `bean-query` spells it, so
+`commodity(units(position))` and `commodity(cost(position))` let you ask for
+the units currency and the cost currency separately — on `2 HOOL {10.00 USD}`
+they return `HOOL` and `USD`. `currency(position)` takes a position and always
+answers about its units; it is a rustledger extension that `bean-query`
+rejects. Prefer `commodity()` in queries you want to run under both.
 
 ### String Functions
 
@@ -270,6 +280,12 @@ SELECT min(date), max(date)
 | `root(account, n)` | First n account segments |
 | `leaf(account)` | Last account segment |
 | `parent(account)` | All but last segment |
+| `findfirst(regex, set)` | First element of a set matching a regex, else `NULL` |
+| `has_account(regex)` | True if **any** posting on the entry has a matching account |
+
+`has_account()` asks about the whole entry, not the current posting, so it is
+true on every row of a transaction that touches a matching account. It also
+works as an entry filter: `BALANCES FROM has_account('Assets')`.
 
 ### Metadata Functions
 
@@ -287,6 +303,19 @@ matters at query time:
 All three return `NULL` when the key is absent at the relevant level — so a
 `WHERE meta('foo') = 'bar'` filter quietly drops every row when `foo` was
 actually set on the transaction.
+
+Commodity metadata is separate, because it lives on a `commodity` directive
+rather than on any transaction or posting:
+
+| Function | Returns |
+|----------|---------|
+| `commodity_meta(currency)` | The whole metadata map of that currency's `commodity` directive |
+| `commodity_meta(currency, key)` | One key from it |
+| `currency_meta(...)` | Alias for `commodity_meta`, same two forms |
+
+Both return `NULL` for a currency with no `commodity` directive, and for a
+key that directive does not set. A currency declared more than once resolves
+to the **last** declaration.
 
 ```beancount
 2024-01-15 * "Grocery Store"


### PR DESCRIPTION
Closes #2153, except for `repr`, which I argue below should stay absent.

## What was missing, and why they differ

Five had no implementation at all: `COMMODITY`, `COMMODITY_META`, `CURRENCY_META`, `FINDFIRST`, `YEARMONTH`.

`HAS_ACCOUNT` is a different case and the more interesting one. It has always worked as a `FROM` predicate and was simply unreachable from a projection:

```
$ rledger query t.beancount "BALANCES FROM has_account('Assets')"     # worked
$ rledger query t.beancount "SELECT has_account('Assets')"            # no function matches
```

So this is one name that resolved on one path and not its sibling.

## Placement

`evaluate_function` already documents the split: functions needing the row's context stay on the lazy path, everything else goes through the shared value registry. `HAS_ACCOUNT` asks about the whole entry, so it joins `META` and `WEIGHT` on the lazy path. The other five need only their argument values.

`COMMODITY_META` / `CURRENCY_META` answer from the `commodity` directive rather than from any posting, so the executor now collects that metadata in the same directive walk that already builds `account_info`. **Both constructors were updated** -- missing `new_with_sources` would have left the sourced-directives path returning Null for every currency while the plain path worked.

## Verified against bean-query 3.2.3

| call | bean-query | rustledger |
|---|---|---|
| `commodity(units(position))` | `'USD'` | `USD` |
| `commodity_meta("USD","name")` | `'US Dollar'` | `US Dollar` |
| `commodity_meta("USD","asset-class")` | `'cash'` | `cash` |
| `currency_meta("HOOL","name")` | `'Hooli Inc'` | `Hooli Inc` |
| `commodity_meta("NOPE","name")` | `None` | `None` |
| `findfirst("z", tags)` | `'zz'` | `zz` |
| `findfirst("nomatch", tags)` | `None` | `None` |
| `yearmonth(date)` | `datetime.date(2024, 2, 1)` | `2024-02-01` |
| `has_account("Assets")` | `True` | `true` |
| `has_account("Nope")` | `False` | `false` |

The negative rows are deliberate. An early version of this check used a ledger with no `commodity` directive, so `commodity_meta` returned Null on both sides and the row proved nothing. The fixture now carries real `commodity` directives with metadata, and the Null cases are pinned separately.

Coverage, measured the same way #2153 was:

```
before: 7 of 67 beanquery functions unreachable
after:  1 of 67 (repr, deliberately)
```

## Why `repr` is not implemented

beanquery's `repr` returns Python's own object syntax:

```
repr(number)  ->  "Decimal('10.00')"
repr(date)    ->  'datetime.date(2024, 2, 1)'
repr(tags)    ->  "frozenset({'t1'})"
```

Matching that means emitting CPython type names from Rust. It describes another language's runtime rather than the ledger, and it would pin us to CPython's formatting for every value type we ever add. I would rather leave it absent and say so than ship a function whose contract is "guess what CPython prints".

The reasoning is recorded in the test that covers the other six, so the next person to notice the gap finds the argument rather than re-deriving it.

## One known difference

The one-argument form returns the directive's metadata without bean-query's synthetic `filename` / `lineno` keys. That difference is pre-existing and not specific to these functions, and it runs both ways: `entry_meta("filename")` returns a path here and `None` in bean-query. Aligning metadata modelling is a separate question from adding these functions.

## Review rounds

Two defects found reviewing my own first commit against bean-query, before the automated review landed:

- **Duplicate `commodity` directives resolved to the first, not the last.** `or_insert_with` kept January's metadata where bean-query answers with June's. Nothing else in query output reveals which directive was used, so this was invisible without a side-by-side run. Now `insert`, pinned by a test confirmed to fail against the old behaviour (`left: "First", right: "Second"`).
- **`COMMODITY` accepted a position.** bean-query types it `commodity(Amount)` and rejects `commodity(position)`, so we were accepting an input it refuses. The comment justifying the extra arm claimed `cost()` "may hand back either"; it does not, which `commodity(cost(position))` proves by returning the COST currency. Arm removed, and the rejection is now asserted.

From the automated review, four more:

- **`HAS_ACCOUNT` was implemented twice**, in the FROM predicate and the new projection arm, and had already drifted in error text after one commit. Both now call `Executor::entry_has_account`.
- **The test helper only asserted `rows[0][0]`.** These evaluate per posting and the fixture has two rows, so a disagreeing second row would have passed. It now pins every row and names the offending index; confirmed by pointing it at `SELECT account`, whose rows legitimately differ.
- **`FINDFIRST` cloned the whole string set** before scanning. Now scans borrowed and clones only the match.
- A doc-comment grammar fix, already resolved by an earlier `doc_markdown` rewrite.

## One residual asymmetry, pre-existing and left alone

`HAS_ACCOUNT` now shares its matching logic across both spellings, but argument handling still differs. The FROM path accepts an unquoted account, the projection path does not:

```
BALANCES FROM has_account(Assets)     rustledger: works      bean-query: CompilationError
SELECT HAS_ACCOUNT(Assets)            rustledger: error      bean-query: CompilationError
```

The projection side matches bean-query. The FROM side is more permissive than bean-query, and that is **pre-existing**: the same query behaves identically on `main`, before any change here. I left it rather than tighten it inside this PR, since rejecting it would break queries that work today and that is a compatibility decision worth making on its own.

## Checks

- New test asserts each function against the bean-query answer, plus the Null and false cases, plus that the `FROM` spelling still selects the entry the projection now reports true for.
- **The test was confirmed to fail before it was trusted**: poisoning the `YEARMONTH` expectation to `2024-02-15` produced `left: Date(2024-02-01), right: Date(2024-02-15)`, and restoring it returned to green.
- `cargo test -p rustledger-query`: 174 passed, 0 failed.
- Clippy clean under both the local nix 1.96 and CI's 1.97 (a `doc_markdown` finding on `CPython` only appeared under one of them).
- The 34 query shapes swept while finding #2153 are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr

