### PR TITLE
ci(docs): install the website deps with bun, not npm ci

### DIFF
--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -23,7 +23,6 @@ jobs:
           path: rustledger
           sparse-checkout: |
             docs
-            .nvmrc
       - name: Checkout website repo (for VitePress config)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -32,14 +31,17 @@ jobs:
           sparse-checkout: |
             docs/.vitepress
             package.json
-            package-lock.json
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+            bun.lock
+      # The website repo moved to bun and dropped package-lock.json
+      # (rustledger.github.io#30), so `npm ci` here had nothing to install
+      # from. Match how that repo's own deploy workflow installs.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          node-version-file: 'rustledger/.nvmrc'
+          bun-version: latest
       - name: Install dependencies
         working-directory: website
-        run: npm ci
+        run: bun install --frozen-lockfile
       - name: Sync docs from PR to website
         run: |
           # Use rsync to properly sync docs, deleting files that don't exist in PR
@@ -49,4 +51,4 @@ jobs:
             rustledger/docs/ website/docs/
       - name: Build docs with VitePress
         working-directory: website
-        run: npx vitepress build docs
+        run: bunx vitepress build docs

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -43,7 +43,13 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # Pinned, not `latest`. An unpinned toolchain turns an unrelated
+          # contributor's PR red the day upstream ships a change, which is
+          # exactly how the ruff formatter took out pta-standards' CI. Nothing
+          # bumps this automatically -- dependabot updates the action SHA
+          # above, not this input -- so raise it deliberately when there is a
+          # reason to.
+          bun-version: 1.4.0
       - name: Install dependencies
         working-directory: website
         run: bun install --frozen-lockfile

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -3,10 +3,15 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      # So a change to this workflow tests itself. Without it the job that
+      # fixes a broken docs build cannot run the docs build, and the fix
+      # merges unverified.
+      - '.github/workflows/docs-validate.yml'
   push:
     branches: [main]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs-validate.yml'
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
`validate-docs` is red on every PR that touches `docs/**`:

```
npm error code EUSAGE
npm error The `npm ci` command can only install with an existing package-lock.json
```

## Cause

The job sparse-checks-out `package.json` and `package-lock.json` from `rustledger.github.io`, then runs `npm ci` against them. That repo moved to bun and deleted its lockfile in rustledger.github.io#30 (`9047afee2`, 2026-08-24), so the sparse checkout now requests a path that no longer exists and `npm ci` has nothing to install from.

Nothing in this repo changed. `docs-validate.yml` only triggers on `docs/**`, and no PR had touched docs since that deletion, so it stayed green-by-absence until the next docs change picked it up. Its last real runs, on 2026-08-24, predate the lockfile removal.

## Fix

Fetch `bun.lock` and install with `bun install --frozen-lockfile`, matching how `rustledger.github.io`'s own `deploy.yml` builds the same site. `--frozen-lockfile` preserves the "lockfile is the source of truth" property that `npm ci` was there for, rather than dropping to a resolving install. VitePress runs under `bunx`.

Also drops `.nvmrc` from the rustledger sparse checkout. It existed only to feed `setup-node`'s `node-version-file`, and there is no `setup-node` step any more.

`oven-sh/setup-bun` is pinned by SHA (`0c5077e5` = v2.2.0), matching the pinning convention of the other actions in this file.

## Scope

Not a required check (`build` and `Python-gated cargo tests` are the only two), so this was never blocking merges. It was simply going to be red on every docs PR from here on, which is the state that teaches people to ignore a red X.

Found while reviewing #2155, whose docs commit is the change that surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr