### PR TITLE
fix(loader): options in an included file no longer govern the ledger

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -451,12 +451,21 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     This is a layout change rather than a content change, so unlike the
 ///     entries above nothing about the ledger's meaning moved.
 ///
+///   v30: options declared in an INCLUDED file are no longer applied unless
+///     they accumulate across includes (#2151). `Options` is part of the
+///     cached payload, so a v29 cache replays the old resolution and
+///     resurrects the behavior: a sub-ledger's `booking_method` still
+///     changing lot selection, a sub-ledger's `inferred_tolerance_default`
+///     still letting an unbalanced transaction pass. Caught exactly that way
+///     while testing the fix -- the matrices kept diverging until the stale
+///     caches were cleared.
+///
 /// Public so `rustledger-wasm` can pin its own cache version against this one.
 /// Both caches archive the same `Vec<Directive>`, so a parser change that
 /// alters PARSER OUTPUT has to bump both — and on #1942 only this one was
 /// bumped, which review caught rather than any test. See
 /// `loader_cache_version_is_pinned` in `rustledger-wasm/src/cache.rs`.
-pub const CACHE_VERSION: u32 = 29;
+pub const CACHE_VERSION: u32 = 30;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1189,7 +1198,11 @@ mod tests {
         // v25 (#2008) is another v15: transaction headers beancount rejects now
         // produce a parse error. That changes WHICH errors are emitted, not how
         // a `CostNumber` is archived, so the byte arrays are still valid.
-        const FIXTURE_VERSION: u32 = 29;
+        // v30 (#2151) is the same shape again: options declared in an included
+        // file stop being applied. That changes which OPTIONS a load resolves,
+        // not how a `CostNumber` is archived, so the byte arrays below are
+        // untouched and only FIXTURE_VERSION moves.
+        const FIXTURE_VERSION: u32 = 30;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
@@ -1290,7 +1303,9 @@ mod tests {
         // an UNSIGNED zero. Like v19 that changes which VALUE a source text
         // produces, not the variants or their encodings, so the hash below
         // must still match — and the assertion, not this comment, proves it.
-        const FIXTURE_VERSION: u32 = 29;
+        // v30 (#2151) changes which options an included file contributes,
+        // not how a `MetaValue` is archived; the hash below is unchanged.
+        const FIXTURE_VERSION: u32 = 30;
         const META_VALUE_LAYOUT_HASH: &str =
             "43e3c258fe376cede6a6c2c975100bcf67ddda0ab84b21566b123c01e0a54b25";
         assert_eq!(

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -564,9 +564,16 @@ impl Loader {
             });
         }
 
-        // Process options
+        // Process options.
+        //
+        // `include_stack` was pushed with this file just above, so a length of
+        // one means we are in the top-level ledger. Options outside
+        // `ACCUMULATE_ACROSS_INCLUDES` are taken from that file only: an
+        // included sub-ledger must not silently change how the whole tree
+        // books or what counts as balanced (#2151).
+        let top_level = self.include_stack.len() == 1;
         for (key, value, _span) in result.options {
-            options.set(&key, &value);
+            options.set_scoped(&key, &value, top_level);
         }
 
         // Process plugins

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -277,6 +277,26 @@ impl Options {
         self.set_scoped(key, value, true);
     }
 
+    /// Raise E7004 if `key` is deprecated, reporting whether it was.
+    ///
+    /// The three arms that handle deprecated options and the include-scope
+    /// branch all need this, and all four previously spelled it out. Reaching
+    /// for `deprecation_message(key).unwrap_or_default()` in the arms was the
+    /// worst of those: an entry dropped from the table would have produced an
+    /// E7004 with an EMPTY message rather than any visible failure.
+    fn warn_if_deprecated(&mut self, key: &str, value: &str) -> bool {
+        let Some(message) = deprecation_message(key) else {
+            return false;
+        };
+        self.warnings.push(OptionWarning {
+            code: "E7004",
+            message: message.to_string(),
+            option: key.to_string(),
+            value: value.to_string(),
+        });
+        true
+    }
+
     /// Apply an option, knowing whether it came from the top-level file.
     ///
     /// See the `ACCUMULATE_ACROSS_INCLUDES` list. An option outside it, seen in
@@ -290,14 +310,7 @@ impl Options {
             // and E7004 is an error where the notice below is a warning. Raise
             // it first so scoping cannot quietly downgrade the severity of a
             // diagnostic that existed before this check did.
-            if let Some(message) = deprecation_message(key) {
-                self.warnings.push(OptionWarning {
-                    code: "E7004",
-                    message: message.to_string(),
-                    option: key.to_string(),
-                    value: value.to_string(),
-                });
-            }
+            self.warn_if_deprecated(key, value);
             // Its own code, not E7003. That one means "specified twice, last
             // wins" and is mapped downstream to `ErrorCode::DuplicateOption`;
             // this option may be the only one of its name in the tree.
@@ -435,12 +448,7 @@ impl Options {
             }
             "inferred_tolerance_multiplier" => {
                 // Deprecated: renamed to tolerance_multiplier in Python beancount
-                self.warnings.push(OptionWarning {
-                    code: "E7004",
-                    message: deprecation_message(key).unwrap_or_default().to_string(),
-                    option: key.to_string(),
-                    value: value.to_string(),
-                });
+                self.warn_if_deprecated(key, value);
                 if let Ok(d) = Decimal::from_str(value) {
                     self.inferred_tolerance_multiplier = d;
                 } else {
@@ -646,12 +654,7 @@ impl Options {
             }
             "allow_pipe_separator" => {
                 // This option is deprecated in Python beancount
-                self.warnings.push(OptionWarning {
-                    code: "E7004",
-                    message: deprecation_message(key).unwrap_or_default().to_string(),
-                    option: key.to_string(),
-                    value: value.to_string(),
-                });
+                self.warn_if_deprecated(key, value);
                 self.allow_pipe_separator = value.eq_ignore_ascii_case("true");
             }
             "long_string_maxlines" => {
@@ -696,12 +699,7 @@ impl Options {
             }
             "plugin" => {
                 // Deprecated: should use `plugin` directive instead of `option "plugin"`
-                self.warnings.push(OptionWarning {
-                    code: "E7004",
-                    message: deprecation_message(key).unwrap_or_default().to_string(),
-                    option: key.to_string(),
-                    value: value.to_string(),
-                });
+                self.warn_if_deprecated(key, value);
             }
             _ => {
                 // Unknown options go to custom map

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -40,7 +40,20 @@ const KNOWN_OPTIONS: &[&str] = &[
     "tolerance_multiplier", // Renamed from inferred_tolerance_multiplier
 ];
 
-/// Options that can be specified multiple times.
+/// The E7004 message for a deprecated option, if it is one.
+///
+/// One table rather than three inline strings: the include-scope check has to
+/// report deprecation as well, and a second copy of these messages would drift
+/// from the arms that raise them.
+fn deprecation_message(key: &str) -> Option<&'static str> {
+    match key {
+        "inferred_tolerance_multiplier" => Some("Renamed to 'tolerance_multiplier'."),
+        "allow_pipe_separator" => Some("Option 'allow_pipe_separator' is deprecated"),
+        "plugin" => Some("Option 'plugin' is deprecated; use the 'plugin' directive instead"),
+        _ => None,
+    }
+}
+
 /// Options that survive an `include` boundary.
 ///
 /// Everything else is taken from the TOP-LEVEL file only. The split is by what
@@ -72,6 +85,7 @@ const ACCUMULATE_ACROSS_INCLUDES: &[&str] = &[
     "display_precision",
 ];
 
+/// Options that can be specified multiple times.
 const REPEATABLE_OPTIONS: &[&str] = &[
     "operating_currency",
     "insert_pythonpath",
@@ -265,8 +279,23 @@ impl Options {
     pub fn set_scoped(&mut self, key: &str, value: &str, top_level: bool) {
         if !top_level && KNOWN_OPTIONS.contains(&key) && !ACCUMULATE_ACROSS_INCLUDES.contains(&key)
         {
+            // A deprecated option is still deprecated when it is also ignored,
+            // and E7004 is an error where the notice below is a warning. Raise
+            // it first so scoping cannot quietly downgrade the severity of a
+            // diagnostic that existed before this check did.
+            if let Some(message) = deprecation_message(key) {
+                self.warnings.push(OptionWarning {
+                    code: "E7004",
+                    message: message.to_string(),
+                    option: key.to_string(),
+                    value: value.to_string(),
+                });
+            }
+            // Its own code, not E7003. That one means "specified twice, last
+            // wins" and is mapped downstream to `ErrorCode::DuplicateOption`;
+            // this option may be the only one of its name in the tree.
             self.warnings.push(OptionWarning {
-                code: "E7003",
+                code: "E7009",
                 message: format!(
                     "Option \"{key}\" set in an included file is ignored; \
                      the top-level ledger's value governs"
@@ -401,7 +430,7 @@ impl Options {
                 // Deprecated: renamed to tolerance_multiplier in Python beancount
                 self.warnings.push(OptionWarning {
                     code: "E7004",
-                    message: "Renamed to 'tolerance_multiplier'.".to_string(),
+                    message: deprecation_message(key).unwrap_or_default().to_string(),
                     option: key.to_string(),
                     value: value.to_string(),
                 });
@@ -612,7 +641,7 @@ impl Options {
                 // This option is deprecated in Python beancount
                 self.warnings.push(OptionWarning {
                     code: "E7004",
-                    message: "Option 'allow_pipe_separator' is deprecated".to_string(),
+                    message: deprecation_message(key).unwrap_or_default().to_string(),
                     option: key.to_string(),
                     value: value.to_string(),
                 });
@@ -662,8 +691,7 @@ impl Options {
                 // Deprecated: should use `plugin` directive instead of `option "plugin"`
                 self.warnings.push(OptionWarning {
                     code: "E7004",
-                    message: "Option 'plugin' is deprecated; use the 'plugin' directive instead"
-                        .to_string(),
+                    message: deprecation_message(key).unwrap_or_default().to_string(),
                     option: key.to_string(),
                     value: value.to_string(),
                 });
@@ -856,11 +884,45 @@ mod tests {
         );
         assert_eq!(opts.warnings.len(), 2, "each ignored option is reported");
         assert!(
+            opts.warnings.iter().all(|w| w.code == "E7009"),
+            "must not reuse E7003: that one means specified-twice-last-wins and \
+             maps downstream to DuplicateOption, but an ignored option may be \
+             the only one of its name in the tree",
+        );
+        assert!(
             opts.warnings
                 .iter()
                 .all(|w| w.message.contains("is ignored")),
             "the warning has to say the value was dropped, or the user cannot \
              tell why their setting had no effect",
+        );
+    }
+
+    /// Scoping must not downgrade a diagnostic that already existed.
+    ///
+    /// `option "plugin"` is deprecated and raises E7004, which `rledger check`
+    /// treats as an error. Reporting only the E7009 notice would silently turn
+    /// that into a warning, making an included file the one place a deprecated
+    /// option stopped failing the build.
+    #[test]
+    fn scoping_out_an_option_still_reports_its_deprecation() {
+        let mut opts = Options::new();
+        opts.set_scoped("plugin", "some.module", false);
+
+        let codes: Vec<&str> = opts.warnings.iter().map(|w| w.code).collect();
+        assert!(
+            codes.contains(&"E7004"),
+            "deprecation survives scoping: {codes:?}"
+        );
+        assert!(
+            codes.contains(&"E7009"),
+            "and the ignore is still reported: {codes:?}"
+        );
+        assert!(
+            opts.warnings
+                .iter()
+                .any(|w| w.code == "E7004" && w.message.contains("deprecated")),
+            "the message must come from the shared table, not an empty default",
         );
     }
 

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -74,10 +74,17 @@ fn deprecation_message(key: &str) -> Option<&'static str> {
 /// cross an include, which is exactly the combination that let an unbalanced
 /// transaction pass.
 ///
-/// `plugin` is absent because it never routes through here; plugins are
-/// collected separately and already accumulate. That is deliberate — bean-query
-/// discards plugins declared in included files, which leaves the user with
-/// errors about accounts a plugin they did declare would have opened.
+/// Plugins are absent for a reason that needs the two spellings kept apart.
+/// The `plugin "name"` DIRECTIVE never reaches this function: it is collected
+/// separately and already accumulates from any file, which is deliberate.
+/// bean-query discards plugins declared in included files, leaving the user
+/// with errors about accounts a plugin they did declare would have opened.
+///
+/// The deprecated `option "plugin"` form is a different thing and IS a known
+/// option, so it does route through here and is scoped out like the rest.
+/// That is why the include-scope branch re-raises E7004: the option was
+/// already an error before this list existed, and being ignored must not
+/// quietly downgrade it.
 const ACCUMULATE_ACROSS_INCLUDES: &[&str] = &[
     "operating_currency",
     "documents",

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -277,16 +277,16 @@ impl Options {
         self.set_scoped(key, value, true);
     }
 
-    /// Raise E7004 if `key` is deprecated, reporting whether it was.
+    /// Raise E7004 if `key` is deprecated.
     ///
     /// The three arms that handle deprecated options and the include-scope
     /// branch all need this, and all four previously spelled it out. Reaching
     /// for `deprecation_message(key).unwrap_or_default()` in the arms was the
     /// worst of those: an entry dropped from the table would have produced an
     /// E7004 with an EMPTY message rather than any visible failure.
-    fn warn_if_deprecated(&mut self, key: &str, value: &str) -> bool {
+    fn warn_if_deprecated(&mut self, key: &str, value: &str) {
         let Some(message) = deprecation_message(key) else {
-            return false;
+            return;
         };
         self.warnings.push(OptionWarning {
             code: "E7004",
@@ -294,7 +294,6 @@ impl Options {
             option: key.to_string(),
             value: value.to_string(),
         });
-        true
     }
 
     /// Apply an option, knowing whether it came from the top-level file.

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -41,6 +41,37 @@ const KNOWN_OPTIONS: &[&str] = &[
 ];
 
 /// Options that can be specified multiple times.
+/// Options that survive an `include` boundary.
+///
+/// Everything else is taken from the TOP-LEVEL file only. The split is by what
+/// an option governs, not by one blanket rule (#2151):
+///
+/// * These describe the file that declares them. A sub-ledger naming its own
+///   operating currency or document root is describing itself, not overriding
+///   its includer, so they accumulate.
+/// * Everything else defines global computation or the ledger's identity.
+///   `booking_method` decides which lot a sale consumes and
+///   `inferred_tolerance_default` decides what counts as balanced, so letting
+///   an included file set them means a sub-ledger silently changes results for
+///   every other entity in the tree — including the master's own transactions.
+///
+/// Note this is NOT the same list as [`REPEATABLE_OPTIONS`]. Repeating within
+/// one file and carrying across an include are different properties:
+/// `inferred_tolerance_default` accumulates within a file and must still not
+/// cross an include, which is exactly the combination that let an unbalanced
+/// transaction pass.
+///
+/// `plugin` is absent because it never routes through here; plugins are
+/// collected separately and already accumulate. That is deliberate — bean-query
+/// discards plugins declared in included files, which leaves the user with
+/// errors about accounts a plugin they did declare would have opened.
+const ACCUMULATE_ACROSS_INCLUDES: &[&str] = &[
+    "operating_currency",
+    "documents",
+    "insert_pythonpath",
+    "display_precision",
+];
+
 const REPEATABLE_OPTIONS: &[&str] = &[
     "operating_currency",
     "insert_pythonpath",
@@ -222,6 +253,33 @@ impl Options {
     ///
     /// Validates the option and collects any warnings in `self.warnings`.
     pub fn set(&mut self, key: &str, value: &str) {
+        self.set_scoped(key, value, true);
+    }
+
+    /// Apply an option, knowing whether it came from the top-level file.
+    ///
+    /// See the `ACCUMULATE_ACROSS_INCLUDES` list. An option outside it, seen in
+    /// an INCLUDED file, is reported and dropped rather than applied: the
+    /// top-level file's value governs, so an included sub-ledger cannot change
+    /// how the whole tree books or balances.
+    pub fn set_scoped(&mut self, key: &str, value: &str, top_level: bool) {
+        if !top_level && KNOWN_OPTIONS.contains(&key) && !ACCUMULATE_ACROSS_INCLUDES.contains(&key)
+        {
+            self.warnings.push(OptionWarning {
+                code: "E7003",
+                message: format!(
+                    "Option \"{key}\" set in an included file is ignored; \
+                     the top-level ledger's value governs"
+                ),
+                option: key.to_string(),
+                value: value.to_string(),
+            });
+            return;
+        }
+        self.set_inner(key, value);
+    }
+
+    fn set_inner(&mut self, key: &str, value: &str) {
         // Check for unknown options (E7001)
         let is_known = KNOWN_OPTIONS.contains(&key);
         if !is_known {
@@ -256,7 +314,7 @@ impl Options {
         if is_known && !is_repeatable && self.set_options.contains(key) {
             self.warnings.push(OptionWarning {
                 code: "E7003",
-                message: format!("Option \"{key}\" can only be specified once"),
+                message: format!("Option \"{key}\" is set more than once; the last value wins"),
                 option: key.to_string(),
                 value: value.to_string(),
             });
@@ -758,7 +816,74 @@ mod tests {
 
         assert_eq!(opts.warnings.len(), 1);
         assert_eq!(opts.warnings[0].code, "E7003");
-        assert!(opts.warnings[0].message.contains("only be specified once"));
+        // Wording matters here: the old text said the option "can only be
+        // specified once", which is not true -- bean-check accepts a
+        // redefinition and takes the last value, which is why #1546 asked for
+        // this to stop being an error. Saying so is the difference between a
+        // warning a reader can act on and one that looks like a rule.
+        assert!(
+            opts.warnings[0].message.contains("the last value wins"),
+            "got: {}",
+            opts.warnings[0].message,
+        );
+        // ...and last-wins is what actually happened.
+        assert_eq!(opts.title.as_deref(), Some("Second Title"));
+    }
+
+    /// An option set in an INCLUDED file does not govern the ledger.
+    ///
+    /// The value-changing cases are the point. `booking_method` decides which
+    /// lot a sale consumes and `inferred_tolerance_default` decides what
+    /// counts as balanced, so a sub-ledger setting either used to change
+    /// results for every other entity in the tree, including the master's own
+    /// transactions (#2151).
+    #[test]
+    fn included_files_do_not_govern_scoped_options() {
+        let mut opts = Options::new();
+        opts.set_scoped("title", "Master", true);
+        opts.set_scoped("booking_method", "LIFO", false);
+        opts.set_scoped("title", "Sub-ledger", false);
+
+        assert_eq!(
+            opts.title.as_deref(),
+            Some("Master"),
+            "the top-level ledger names the combined result, not whichever \
+             sub-ledger was included last",
+        );
+        assert!(
+            !opts.set_options.contains("booking_method"),
+            "an included booking_method must not reach the booker",
+        );
+        assert_eq!(opts.warnings.len(), 2, "each ignored option is reported");
+        assert!(
+            opts.warnings
+                .iter()
+                .all(|w| w.message.contains("is ignored")),
+            "the warning has to say the value was dropped, or the user cannot \
+             tell why their setting had no effect",
+        );
+    }
+
+    /// Options that describe the file declaring them still accumulate.
+    ///
+    /// A sub-ledger naming its own operating currency or document root is
+    /// describing itself rather than overriding its includer, so scoping must
+    /// not swallow these.
+    #[test]
+    fn included_files_still_contribute_accumulating_options() {
+        let mut opts = Options::new();
+        opts.set_scoped("operating_currency", "USD", true);
+        opts.set_scoped("operating_currency", "EUR", false);
+        opts.set_scoped("documents", "docs-from-include", false);
+
+        assert!(
+            opts.operating_currency.iter().any(|c| c == "EUR"),
+            "an included operating_currency must still be collected",
+        );
+        assert!(
+            opts.documents.iter().any(|d| d == "docs-from-include"),
+            "an included documents root must still be collected",
+        );
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -101,7 +101,7 @@ pub const CACHE_VERSION: u32 = 15;
 /// than in the test module so a reader of this file meets the contract next
 /// to `CACHE_VERSION`, which is the thing they came to change.
 #[cfg(test)]
-const LOADER_CACHE_VERSION_PIN: u32 = 29;
+const LOADER_CACHE_VERSION_PIN: u32 = 30;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -489,11 +489,19 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     // that pattern and disagreed with our own loader/`validate` (issue #1546).
     // The value is already last-wins (the loader applies the latest). Pinned by
     // `cli_commands_test::test_check_duplicate_option_warns`.
+    //
+    // E7009 (option in an included file is ignored) is a warning for the same
+    // reason, and the reason is the same LEDGER: #1546's repro declares a
+    // title in the master and in each sub-ledger. Once #2151 stopped the
+    // included values from governing, that layout started reporting E7009 —
+    // so leaving this list at E7003 alone made the exact file #1546 was about
+    // exit non-zero again. The unit tests all passed; only running its repro
+    // end to end caught it.
     let main_file_str = file.display().to_string();
     let mut option_error_count = 0;
     let mut option_warning_count = 0;
     for warning in &load_result.options.warnings {
-        let is_error = warning.code != "E7003";
+        let is_error = !matches!(warning.code, "E7003" | "E7009");
         let severity = if is_error { "error" } else { "warning" };
         if json_mode {
             diagnostics.push(JsonDiagnostic {

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1821,6 +1821,26 @@ fn test_check_multi_entity_include_duplicate_option_ok() {
         "multi-entity include tree with per-entity `option \"title\"` must pass check; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+
+    // Since #2151 the included titles no longer govern, which is what this
+    // ledger wanted all along: it names itself "Combined" and used to resolve
+    // to "Entity B", whichever file happened to be included last.
+    //
+    // This assertion is also the guard that caught a regression while #2151
+    // was being written. Giving the ignore-notice its own code (E7009) made it
+    // an error, because `cmd::check` treated everything except E7003 as one,
+    // and this exact ledger started exiting non-zero again -- the very thing
+    // #1546 was filed about. Every unit test still passed.
+    let options = Command::new(&rledger)
+        .args(["doctor", "print-options"])
+        .arg(&master)
+        .output()
+        .expect("Failed to run rledger doctor print-options");
+    let printed = String::from_utf8_lossy(&options.stdout);
+    assert!(
+        printed.contains("Combined"),
+        "the master ledger names the combined result; got: {printed}"
+    );
 }
 
 /// Conversely, a single non-repeatable option must NOT be flagged (no false

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -270,9 +270,25 @@ Only directives rledger is confident are budgets get reported. Ownership is one 
 
 ### E7003: Duplicate Option
 
-**Cause**: Non-repeatable option specified multiple times.
+**Cause**: Non-repeatable option specified multiple times. The last value wins,
+matching `bean-check`, so this is a warning rather than an error.
 
-**Fix**: Remove duplicate option directives.
+**Fix**: Remove duplicate option directives, or rely on the last one deliberately.
+
+### E7009: Option in an Included File Is Ignored
+
+**Cause**: An option was set in an `include`d file rather than the top-level
+ledger. Most options are taken from the top-level file only, so the included
+value has no effect.
+
+Options that describe the file declaring them still apply from anywhere:
+`operating_currency`, `documents`, `insert_pythonpath`, `display_precision`,
+and `plugin` directives. Everything else, notably `booking_method` and
+`inferred_tolerance_default`, comes from the top-level ledger, so a sub-ledger
+cannot change how the whole tree books or what counts as balanced.
+
+**Fix**: Move the option to the top-level ledger if it should govern, or remove
+it if the sub-ledger only needed it when loaded standalone.
 
 ### E7007: Option Accepted but Has No Effect
 


### PR DESCRIPTION
Closes #2151.

An option set in an included sub-ledger applied to the whole tree, last one included winning. Two of those change numbers:

| option in an included file | bean-query | before | after |
|---|---|---|---|
| `booking_method "LIFO"` | error, ambiguous reduction | books the 20.00 lot, exit 0 | error, exit 1 |
| `inferred_tolerance_default "USD:0.05"` | 0.04 residual fails | **balances** | fails |
| `title` | master's value | last include's value | master's value |

An included file could make an unbalanced transaction pass, and could change which lot every other entity's sales consumed.

## Scoped per option, not by one blanket rule

Options that describe the file declaring them still accumulate: `operating_currency`, `documents`, `insert_pythonpath`, `display_precision`, and plugins (which never routed through here). Everything else comes from the top-level ledger.

The split is deliberately **not** the repeatable-option list. Repeating within one file and crossing an include are different properties, and conflating them is the bug: `inferred_tolerance_default` accumulates within a file and must still not cross an include.

## This does not undo #1546, and its implementation was not at fault

#1546 asked for two things. The first is right and stays: E7003 should not be a hard error. The second, last-wins extended to include trees, it requested **explicitly**:

> Implement beancount last-wins ... **For an include tree this gives natural precedence — the most-recently-included / nearest declaration wins.**

That rested on "beancount permits redefining a scalar option with last-wins" -- true inside one file, false across `include`, where the loader takes the top-level file's options and aggregates only three (`operating_currency`, `dcontext`, `insert_pythonpath`). The request was reasonable; the belief behind it was not. This is a decision to revisit, not a regression to revert.

**#1546's own repro is the evidence.** It has `option "title" "Combined"` in the master and a title in each sub-ledger. It already exited 0 before this change, so its actual complaint was fixed by the warning alone -- and it resolved to `"Entity B"`, whichever file was included last. It now resolves to `"Combined"`, matching bean-check, still exiting 0.

## Deliberately not copying beancount wholesale

Its uniform rule also discards **plugins** from included files:

```
plugin "beancount.plugins.auto_accounts"   (declared in the include)

beancount:  plugin list [], does not run, 2 ValidationErrors for unopened accounts
rustledger: runs, accounts auto-opened, exit 0
```

A sub-ledger declaring the transformation it needs is legitimate. We are right here, so "match beancount" could not be the rule. That behaviour is unchanged and tested.

## E7003's wording was wrong

"Option X can only be specified once" is false -- bean-check accepts a redefinition and takes the last value, which is why #1546 asked for it to stop being an error. Within a file it now says the last value wins; across an include it says the value was ignored and the top-level ledger governs, so a reader can tell why their setting had no effect.

## CACHE_VERSION 29 -> 30

`Options` is part of the cached payload, so a v29 cache replays the old resolution and resurrects the leak. **Found the hard way**: the verification matrices kept diverging until the stale caches were cleared, which is exactly the failure the version exists to prevent.

The two archived-layout tripwires advance to fixture version 30 with their **byte arrays untouched** -- this changes which options resolve, not how anything is encoded. That is the point of those tripwires, and they forced the question rather than letting it pass.

## Checks

- Every row of all four matrices verified against bean-query 3.2.3.
- **Booked-value gate: `known 34, found 34, new 0`** across 761 files.
- Both proofs real: reverting the scope flag brings the leak back end-to-end (`exit 0` again), and disabling the check fails the new unit tests.
- Full workspace tests green; 104 in `rustledger-loader`.
- Clippy clean on 1.96 and CI's 1.97; `RUSTDOCFLAGS="-D warnings" cargo doc` clean -- it caught a private intra-doc link that `cargo test` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr