### PR TITLE
fix(query): expose meta on five system tables without breaking SELECT *

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -353,13 +353,15 @@ impl Executor<'_> {
             let table = Table {
                 columns: inner_result.columns,
                 rows: inner_result.rows,
+                // An inner result's columns are already wildcard-expanded.
+                hidden: Vec::new(),
             };
             return self.execute_aggregate_from_table(outer_query, &table, &inner_column_map);
         }
 
         // Determine outer column names
         let outer_column_names =
-            self.resolve_subquery_column_names(&outer_query.targets, &inner_result.columns)?;
+            self.resolve_subquery_column_names(&outer_query.targets, &inner_result.columns, &[])?;
         let mut result = QueryResult::new(outer_column_names);
 
         // Use FxHashSet for O(1) DISTINCT deduplication
@@ -384,6 +386,7 @@ impl Executor<'_> {
                 inner_row,
                 &inner_column_map,
                 &inner_result.columns,
+                &[],
             )?;
 
             if outer_query.distinct {
@@ -471,7 +474,8 @@ impl Executor<'_> {
         extended_targets.extend(hidden_targets);
 
         // Determine column names for the result (including hidden columns)
-        let column_names = self.resolve_subquery_column_names(&extended_targets, &table.columns)?;
+        let column_names =
+            self.resolve_subquery_column_names(&extended_targets, &table.columns, &table.hidden)?;
         let mut result = QueryResult::new(column_names);
 
         // Use FxHashSet for O(1) DISTINCT deduplication
@@ -538,8 +542,13 @@ impl Executor<'_> {
             };
 
             // Evaluate targets (including hidden columns)
-            let result_row =
-                self.evaluate_subquery_row(&extended_targets, row, &column_map, &table.columns)?;
+            let result_row = self.evaluate_subquery_row(
+                &extended_targets,
+                row,
+                &column_map,
+                &table.columns,
+                &table.hidden,
+            )?;
 
             if query.distinct {
                 // DISTINCT should only consider visible columns, not hidden sort columns.
@@ -595,7 +604,8 @@ impl Executor<'_> {
         use rustc_hash::FxHashMap as HashMap;
 
         // Determine column names for the result
-        let column_names = self.resolve_subquery_column_names(&query.targets, &table.columns)?;
+        let column_names =
+            self.resolve_subquery_column_names(&query.targets, &table.columns, &table.hidden)?;
         let mut result = QueryResult::new(column_names.clone());
 
         // Determine GROUP BY expressions.
@@ -718,6 +728,7 @@ impl Executor<'_> {
         &self,
         targets: &[Target],
         inner_columns: &[String],
+        hidden: &[String],
     ) -> Result<Vec<String>, QueryError> {
         let mut names = Vec::new();
         for (i, target) in targets.iter().enumerate() {
@@ -728,7 +739,7 @@ impl Executor<'_> {
                 names.extend(
                     inner_columns
                         .iter()
-                        .filter(|c| !Self::wildcard_hidden(c))
+                        .filter(|c| !Self::wildcard_hidden(c, hidden))
                         .cloned(),
                 );
             } else {
@@ -743,10 +754,15 @@ impl Executor<'_> {
     /// Upstream beanquery's wildcard omits the structured `entry` column,
     /// and our underscore-prefixed helper columns (`_entry_meta`,
     /// `_posting_meta`) were ALSO leaking into `SELECT *` before #1800 —
-    /// one rule now covers both. Every hidden column stays addressable by
-    /// explicit name. Pinned by `select_star_hides_structured_and_helper_columns`.
-    fn wildcard_hidden(name: &str) -> bool {
-        name.starts_with('_') || name == "entry"
+    /// one rule now covers both. The `table_hidden` list is per-table,
+    /// because bean-query's treatment of `meta` is not uniform — see
+    /// [`Table::hidden`]. Every hidden column stays addressable by explicit
+    /// name. Pinned by `select_star_hides_structured_and_helper_columns`
+    /// and `select_star_matches_bean_query_per_table`.
+    fn wildcard_hidden(name: &str, table_hidden: &[String]) -> bool {
+        name.starts_with('_')
+            || name == "entry"
+            || table_hidden.iter().any(|h| h.eq_ignore_ascii_case(name))
     }
 
     /// Evaluate a filter expression against a subquery row.
@@ -871,6 +887,7 @@ impl Executor<'_> {
         inner_row: &[Value],
         column_map: &FxHashMap<String, usize>,
         inner_columns: &[String],
+        hidden: &[String],
     ) -> Result<Row, QueryError> {
         let mut row = Vec::new();
         for target in targets {
@@ -881,7 +898,7 @@ impl Executor<'_> {
                     inner_row
                         .iter()
                         .zip(inner_columns)
-                        .filter(|(_, c)| !Self::wildcard_hidden(c))
+                        .filter(|(_, c)| !Self::wildcard_hidden(c, hidden))
                         .map(|(v, _)| v.clone()),
                 );
             } else {
@@ -1271,6 +1288,8 @@ impl Executor<'_> {
             Table {
                 columns: result.columns,
                 rows: result.rows,
+                // A CREATE TABLE ... AS SELECT result hides nothing.
+                hidden: Vec::new(),
             }
         } else {
             // CREATE TABLE ... (col1, col2, ...)

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -57,24 +57,38 @@ impl Executor<'_> {
 
     /// Build the #balances table from balance assertion directives.
     ///
-    /// The table has columns: date, account, amount
+    /// The table has columns: date, account, amount, tolerance, meta
     /// - date: The date of the balance assertion
     /// - account: The account being balanced
     /// - amount: The expected balance amount
+    /// - tolerance: The explicit `~` tolerance, or NULL if none was given
+    /// - meta: The directive's metadata (hidden from `SELECT *`)
+    ///
+    /// bean-query also exposes `discrepancy` here. It is not a field of the
+    /// directive — the balance checker computes it — so it is tracked
+    /// separately rather than faked from the data we have (#2154).
     pub(super) fn build_balances_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
             "account".to_string(),
             "amount".to_string(),
+            "tolerance".to_string(),
+            "meta".to_string(),
         ];
-        let mut table = Table::new(columns);
+        let mut table = Table::new(columns).with_hidden(&["meta"]);
 
         // Collect balance directives from either spanned or unspanned directives
         let mut balances: Vec<_> = self
             .resolved_directives()
             .filter_map(|d| {
                 if let Directive::Balance(b) = d {
-                    Some((b.date, b.account.as_ref(), b.amount.clone()))
+                    Some((
+                        b.date,
+                        b.account.as_ref(),
+                        b.amount.clone(),
+                        b.tolerance,
+                        &b.meta,
+                    ))
                 } else {
                     None
                 }
@@ -82,15 +96,17 @@ impl Executor<'_> {
             .collect();
 
         // Sort by (date, account) for consistent, deterministic output
-        balances.sort_by(|(date_a, account_a, _), (date_b, account_b, _)| {
+        balances.sort_by(|(date_a, account_a, ..), (date_b, account_b, ..)| {
             date_a.cmp(date_b).then_with(|| account_a.cmp(account_b))
         });
 
-        for (date, account, amount) in balances {
+        for (date, account, amount, tolerance, meta) in balances {
             let row = vec![
                 Value::Date(date),
                 Value::String(account.to_string()),
                 Value::Amount(amount),
+                tolerance.map_or(Value::Null, Value::Number),
+                Self::metadata_to_value(meta),
             ];
             table.add_row(row);
         }
@@ -100,11 +116,17 @@ impl Executor<'_> {
 
     /// Build the #commodities table from commodity directives.
     ///
-    /// The table has columns: date, name
+    /// The table has columns: meta, date, name
+    /// - meta: The directive's metadata
     /// - date: The date of the commodity declaration
     /// - name: The currency/commodity code
+    ///
+    /// `meta` leads, and is the one system table where bean-query's
+    /// `SELECT *` includes it — beanquery derives this table's columns from
+    /// the `Commodity` namedtuple, whose first field is `meta`. Verified
+    /// against bean-query rather than inferred (#2154).
     pub(super) fn build_commodities_table(&self) -> Table {
-        let columns = vec!["date".to_string(), "name".to_string()];
+        let columns = vec!["meta".to_string(), "date".to_string(), "name".to_string()];
         let mut table = Table::new(columns);
 
         // Collect commodity directives from either spanned or unspanned directives
@@ -112,7 +134,7 @@ impl Executor<'_> {
             .resolved_directives()
             .filter_map(|d| {
                 if let Directive::Commodity(c) = d {
-                    Some((c.date, c.currency.as_ref()))
+                    Some((c.date, c.currency.as_ref(), &c.meta))
                 } else {
                     None
                 }
@@ -120,12 +142,16 @@ impl Executor<'_> {
             .collect();
 
         // Sort by (date, name) for consistent output
-        commodities.sort_by(|(date_a, name_a), (date_b, name_b)| {
+        commodities.sort_by(|(date_a, name_a, _), (date_b, name_b, _)| {
             date_a.cmp(date_b).then_with(|| name_a.cmp(name_b))
         });
 
-        for (date, name) in commodities {
-            let row = vec![Value::Date(date), Value::String(name.to_string())];
+        for (date, name, meta) in commodities {
+            let row = vec![
+                Self::metadata_to_value(meta),
+                Value::Date(date),
+                Value::String(name.to_string()),
+            ];
             table.add_row(row);
         }
 
@@ -134,24 +160,26 @@ impl Executor<'_> {
 
     /// Build the #events table from event directives.
     ///
-    /// The table has columns: date, type, description
+    /// The table has columns: date, type, description, meta
     /// - date: The date of the event
     /// - type: The event type
     /// - description: The event value/description
+    /// - meta: The directive's metadata (hidden from `SELECT *`)
     pub(super) fn build_events_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
             "type".to_string(),
             "description".to_string(),
+            "meta".to_string(),
         ];
-        let mut table = Table::new(columns);
+        let mut table = Table::new(columns).with_hidden(&["meta"]);
 
         // Collect event directives
         let mut events: Vec<_> = self
             .resolved_directives()
             .filter_map(|d| {
                 if let Directive::Event(e) = d {
-                    Some((e.date, e.event_type.as_str(), e.value.as_str()))
+                    Some((e.date, e.event_type.as_str(), e.value.as_str(), &e.meta))
                 } else {
                     None
                 }
@@ -159,15 +187,16 @@ impl Executor<'_> {
             .collect();
 
         // Sort by (date, type) for consistent output
-        events.sort_by(|(date_a, type_a, _), (date_b, type_b, _)| {
+        events.sort_by(|(date_a, type_a, ..), (date_b, type_b, ..)| {
             date_a.cmp(date_b).then_with(|| type_a.cmp(type_b))
         });
 
-        for (date, event_type, description) in events {
+        for (date, event_type, description, meta) in events {
             let row = vec![
                 Value::Date(date),
                 Value::String(event_type.to_string()),
                 Value::String(description.to_string()),
+                Self::metadata_to_value(meta),
             ];
             table.add_row(row);
         }
@@ -177,24 +206,31 @@ impl Executor<'_> {
 
     /// Build the #notes table from note directives.
     ///
-    /// The table has columns: date, account, comment
+    /// The table has columns: date, account, comment, meta
     /// - date: The date of the note
     /// - account: The account the note is attached to
     /// - comment: The note text
+    /// - meta: The directive's metadata (hidden from `SELECT *`)
+    ///
+    /// bean-query also exposes `tags` and `links` here. Our `Note` model
+    /// drops them at parse time, so they cannot be surfaced until #2160
+    /// lands — a column census cannot see that, since the columns are
+    /// simply absent.
     pub(super) fn build_notes_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
             "account".to_string(),
             "comment".to_string(),
+            "meta".to_string(),
         ];
-        let mut table = Table::new(columns);
+        let mut table = Table::new(columns).with_hidden(&["meta"]);
 
         // Collect note directives
         let mut notes: Vec<_> = self
             .resolved_directives()
             .filter_map(|d| {
                 if let Directive::Note(n) = d {
-                    Some((n.date, n.account.as_ref(), n.comment.as_str()))
+                    Some((n.date, n.account.as_ref(), n.comment.as_str(), &n.meta))
                 } else {
                     None
                 }
@@ -202,15 +238,16 @@ impl Executor<'_> {
             .collect();
 
         // Sort by (date, account) for consistent output
-        notes.sort_by(|(date_a, account_a, _), (date_b, account_b, _)| {
+        notes.sort_by(|(date_a, account_a, ..), (date_b, account_b, ..)| {
             date_a.cmp(date_b).then_with(|| account_a.cmp(account_b))
         });
 
-        for (date, account, comment) in notes {
+        for (date, account, comment, meta) in notes {
             let row = vec![
                 Value::Date(date),
                 Value::String(account.to_string()),
                 Value::String(comment.to_string()),
+                Self::metadata_to_value(meta),
             ];
             table.add_row(row);
         }
@@ -220,12 +257,13 @@ impl Executor<'_> {
 
     /// Build the #documents table from document directives.
     ///
-    /// The table has columns: date, account, filename, tags, links
+    /// The table has columns: date, account, filename, tags, links, meta
     /// - date: The date of the document
     /// - account: The account the document is attached to
     /// - filename: The file path to the document
     /// - tags: The document tags (as a set)
     /// - links: The document links (as a set)
+    /// - meta: The directive's metadata (hidden from `SELECT *`)
     pub(super) fn build_documents_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
@@ -233,8 +271,9 @@ impl Executor<'_> {
             "filename".to_string(),
             "tags".to_string(),
             "links".to_string(),
+            "meta".to_string(),
         ];
-        let mut table = Table::new(columns);
+        let mut table = Table::new(columns).with_hidden(&["meta"]);
 
         // Collect document directives
         let mut documents: Vec<_> = self
@@ -247,6 +286,7 @@ impl Executor<'_> {
                         doc.path.as_str(),
                         &doc.tags,
                         &doc.links,
+                        &doc.meta,
                     ))
                 } else {
                     None
@@ -256,7 +296,7 @@ impl Executor<'_> {
 
         // Sort by (date, account, filename) for consistent output
         documents.sort_by(
-            |(date_a, account_a, file_a, _, _), (date_b, account_b, file_b, _, _)| {
+            |(date_a, account_a, file_a, ..), (date_b, account_b, file_b, ..)| {
                 date_a
                     .cmp(date_b)
                     .then_with(|| account_a.cmp(account_b))
@@ -264,7 +304,7 @@ impl Executor<'_> {
             },
         );
 
-        for (date, account, filename, tags, links) in documents {
+        for (date, account, filename, tags, links, meta) in documents {
             let tags_vec: Vec<String> = tags.iter().map(ToString::to_string).collect();
             let links_vec: Vec<String> = links.iter().map(ToString::to_string).collect();
             let row = vec![
@@ -273,6 +313,7 @@ impl Executor<'_> {
                 Value::String(filename.to_string()),
                 Value::StringSet(tags_vec),
                 Value::StringSet(links_vec),
+                Self::metadata_to_value(meta),
             ];
             table.add_row(row);
         }
@@ -544,13 +585,28 @@ impl Executor<'_> {
             } else {
                 // bean-query leaves description Null on a non-transaction, the
                 // same as payee and narration.
+                //
+                // Tags and links are NOT in that group. `note` and `document`
+                // carry them in beancount v3, and a document's already survive
+                // into our model -- `SELECT tags FROM #documents` returns them.
+                // Emptying them here made `#entries` disagree with `#documents`
+                // about the same directive (#2154). A column-presence census
+                // cannot see this: `tags` IS registered on `#entries`, it was
+                // just wrong for every directive except transactions.
+                let (tags, links) = match directive {
+                    Directive::Document(doc) => (
+                        doc.tags.iter().map(ToString::to_string).collect(),
+                        doc.links.iter().map(ToString::to_string).collect(),
+                    ),
+                    _ => (Vec::new(), Vec::new()),
+                };
                 (
                     Value::Null,
                     Value::Null,
                     Value::Null,
                     Value::Null,
-                    Value::StringSet(vec![]),
-                    Value::StringSet(vec![]),
+                    Value::StringSet(tags),
+                    Value::StringSet(links),
                     Value::StringSet(vec![]),
                 )
             };

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -436,6 +436,15 @@ pub struct Table {
     pub columns: Vec<String>,
     /// Rows of data.
     pub rows: Vec<Vec<Value>>,
+    /// Columns this table omits from `SELECT *`, though they stay
+    /// addressable by explicit name.
+    ///
+    /// Per-table because bean-query's own wildcard is per-table: `meta` is
+    /// excluded from `SELECT *` on `#balances`, `#notes`, `#events` and
+    /// `#documents`, yet included (first) on `#commodities`. A name-only
+    /// rule cannot express that split. Empty for every table that hides
+    /// nothing beyond the name-based rule in `Executor::wildcard_hidden`.
+    pub hidden: Vec<String>,
 }
 
 impl Table {
@@ -445,7 +454,19 @@ impl Table {
         Self {
             columns,
             rows: Vec::new(),
+            hidden: Vec::new(),
         }
+    }
+
+    /// Mark columns as omitted from `SELECT *` expansion.
+    ///
+    /// The columns stay selectable by explicit name -- exactly bean-query's
+    /// behavior, which answers `SELECT meta FROM #notes` while leaving
+    /// `meta` out of `SELECT *` on that table.
+    #[must_use]
+    pub fn with_hidden(mut self, hidden: &[&str]) -> Self {
+        self.hidden = hidden.iter().map(|s| (*s).to_string()).collect();
+        self
     }
 
     /// Add a row to the table.

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -463,8 +463,23 @@ impl Table {
     /// The columns stay selectable by explicit name -- exactly bean-query's
     /// behavior, which answers `SELECT meta FROM #notes` while leaving
     /// `meta` out of `SELECT *` on that table.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, if a named column is not in `columns`. Hiding is a
+    /// no-op for a name that does not exist, so a typo would silently leave
+    /// the column in `SELECT *` -- the exact failure this mechanism exists
+    /// to prevent, and one no test would catch except by asserting the full
+    /// wildcard set of that one table.
     #[must_use]
     pub fn with_hidden(mut self, hidden: &[&str]) -> Self {
+        debug_assert!(
+            hidden
+                .iter()
+                .all(|h| self.columns.iter().any(|c| c.eq_ignore_ascii_case(h))),
+            "with_hidden named a column this table does not have: {hidden:?} not all in {:?}",
+            self.columns
+        );
         self.hidden = hidden.iter().map(|s| (*s).to_string()).collect();
         self
     }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6295,7 +6295,12 @@ fn test_balances_table_select_all() {
     let result = execute_query("SELECT * FROM #balances", &directives);
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result.columns, vec!["date", "account", "amount"]);
+    // `tolerance` is in bean-query's wildcard here; `meta` is not. See
+    // select_star_matches_bean_query_per_table for the full per-table pinning.
+    assert_eq!(
+        result.columns,
+        vec!["date", "account", "amount", "tolerance"]
+    );
 }
 
 #[test]
@@ -6510,7 +6515,92 @@ fn test_commodities_table_with_where_clause() {
     let result = execute_query("SELECT * FROM #commodities WHERE name = 'EUR'", &directives);
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result.rows[0][1], Value::String("EUR".to_string()));
+    // #commodities leads with `meta`, so `name` is the third column -- this
+    // mirrors bean-query, whose columns follow the Commodity namedtuple.
+    assert_eq!(result.rows[0][2], Value::String("EUR".to_string()));
+}
+
+/// One directive of every kind the per-table wildcard tests inspect.
+///
+/// Each table MUST come out non-empty: a `SELECT *` against a zero-row table
+/// still reports its header, so an empty fixture would let these tests pass
+/// while proving nothing about the rows (the trap that made an earlier
+/// column census under-report by ten columns, #2154).
+fn make_all_directive_types_test_directives() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Commodity(Commodity::new(date(2024, 1, 2), "USD")),
+        Directive::Note(Note::new(date(2024, 1, 3), "Assets:Cash", "a note")),
+        Directive::Document(Document::new(
+            date(2024, 1, 4),
+            "Assets:Cash",
+            "/tmp/statement.pdf",
+        )),
+        Directive::Event(Event::new(date(2024, 1, 5), "location", "Paris")),
+        Directive::Balance(Balance::new(
+            date(2024, 1, 6),
+            "Assets:Cash",
+            Amount::new(dec!(0.00), "USD"),
+        )),
+    ]
+}
+
+#[test]
+fn select_star_matches_bean_query_per_table() {
+    // bean-query's wildcard is NOT uniform about `meta`: it omits the column
+    // on #balances/#notes/#events/#documents and includes it -- first -- on
+    // #commodities. Every set below was read off bean-query 3.x rather than
+    // reasoned about, because the split looks arbitrary and a name-based rule
+    // would silently get #commodities wrong (#2154).
+    let directives = make_all_directive_types_test_directives();
+
+    for (table, expected) in [
+        ("#balances", vec!["date", "account", "amount", "tolerance"]),
+        ("#notes", vec!["date", "account", "comment"]),
+        ("#events", vec!["date", "type", "description"]),
+        (
+            "#documents",
+            vec!["date", "account", "filename", "tags", "links"],
+        ),
+        ("#commodities", vec!["meta", "date", "name"]),
+    ] {
+        let result = execute_query(&format!("SELECT * FROM {table}"), &directives);
+        assert_eq!(
+            result.columns, expected,
+            "SELECT * FROM {table} drifted from bean-query"
+        );
+        assert!(
+            !result.rows.is_empty(),
+            "{table} has no rows, so this assertion proves nothing"
+        );
+    }
+}
+
+#[test]
+fn hidden_meta_is_still_selectable_by_name() {
+    // Hiding `meta` from the wildcard must not make it unreachable --
+    // bean-query answers `SELECT meta FROM #notes` even though `SELECT *`
+    // there omits the column.
+    let directives = make_all_directive_types_test_directives();
+
+    for table in [
+        "#balances",
+        "#notes",
+        "#events",
+        "#documents",
+        "#commodities",
+    ] {
+        let result = execute_query(&format!("SELECT meta FROM {table}"), &directives);
+        assert_eq!(
+            result.columns,
+            vec!["meta"],
+            "SELECT meta FROM {table} did not resolve"
+        );
+        assert!(
+            !result.rows.is_empty(),
+            "{table} has no rows, so this assertion proves nothing"
+        );
+    }
 }
 
 #[test]

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6520,26 +6520,43 @@ fn test_commodities_table_with_where_clause() {
     assert_eq!(result.rows[0][2], Value::String("EUR".to_string()));
 }
 
-/// One directive of every kind the per-table wildcard tests inspect.
+/// Two directives of every kind the per-table wildcard tests inspect.
 ///
 /// Each table MUST come out non-empty: a `SELECT *` against a zero-row table
 /// still reports its header, so an empty fixture would let these tests pass
 /// while proving nothing about the rows (the trap that made an earlier
 /// column census under-report by ten columns, #2154).
+///
+/// Two of each rather than one because every table here sorts its rows, and
+/// a single-row table never executes the comparison closure.
 fn make_all_directive_types_test_directives() -> Vec<Directive> {
     vec![
         Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
         Directive::Commodity(Commodity::new(date(2024, 1, 2), "USD")),
+        Directive::Commodity(Commodity::new(date(2024, 1, 2), "EUR")),
         Directive::Note(Note::new(date(2024, 1, 3), "Assets:Cash", "a note")),
+        Directive::Note(Note::new(date(2024, 1, 3), "Assets:Bank", "another note")),
         Directive::Document(Document::new(
             date(2024, 1, 4),
             "Assets:Cash",
             "/tmp/statement.pdf",
         )),
+        Directive::Document(Document::new(
+            date(2024, 1, 4),
+            "Assets:Bank",
+            "/tmp/other.pdf",
+        )),
         Directive::Event(Event::new(date(2024, 1, 5), "location", "Paris")),
+        Directive::Event(Event::new(date(2024, 1, 5), "employer", "Acme")),
         Directive::Balance(Balance::new(
             date(2024, 1, 6),
             "Assets:Cash",
+            Amount::new(dec!(0.00), "USD"),
+        )),
+        Directive::Balance(Balance::new(
+            date(2024, 1, 6),
+            "Assets:Bank",
             Amount::new(dec!(0.00), "USD"),
         )),
     ]
@@ -6549,25 +6566,51 @@ fn make_all_directive_types_test_directives() -> Vec<Directive> {
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on
-    // #commodities. Every set below was read off bean-query 3.x rather than
-    // reasoned about, because the split looks arbitrary and a name-based rule
-    // would silently get #commodities wrong (#2154).
+    // #commodities. That split is what this test pins, because no rule
+    // predicts it (beanquery derives #commodities' columns from the
+    // `Commodity` namedtuple, whose first field is `meta`; the other tables
+    // carry hand-written lists), so a name-based rule gets #commodities
+    // silently wrong.
+    //
+    // `gap` is the part of bean-query's set we do NOT produce yet. Where it
+    // is None the expectation IS bean-query's set, column for column. Where
+    // it is Some, closing that gap SHOULD fail this test -- the failure means
+    // the table moved toward bean-query, not away, so update the expectation
+    // rather than reverting the work (#2154).
     let directives = make_all_directive_types_test_directives();
 
-    for (table, expected) in [
-        ("#balances", vec!["date", "account", "amount", "tolerance"]),
-        ("#notes", vec!["date", "account", "comment"]),
-        ("#events", vec!["date", "type", "description"]),
+    for (table, expected, gap) in [
+        (
+            "#balances",
+            vec!["date", "account", "amount", "tolerance"],
+            Some("discrepancy, which the balance checker computes rather than stores"),
+        ),
+        (
+            "#notes",
+            vec!["date", "account", "comment"],
+            Some("tags and links, which our Note model drops at parse time (#2160)"),
+        ),
+        ("#events", vec!["date", "type", "description"], None),
         (
             "#documents",
             vec!["date", "account", "filename", "tags", "links"],
+            None,
         ),
-        ("#commodities", vec!["meta", "date", "name"]),
+        ("#commodities", vec!["meta", "date", "name"], None),
     ] {
         let result = execute_query(&format!("SELECT * FROM {table}"), &directives);
         assert_eq!(
-            result.columns, expected,
-            "SELECT * FROM {table} drifted from bean-query"
+            result.columns,
+            expected,
+            "{}",
+            gap.map_or_else(
+                || format!("SELECT * FROM {table} drifted from bean-query"),
+                |g| format!(
+                    "SELECT * FROM {table} changed. Note this is NOT full bean-query \
+                     parity: bean-query also returns {g}. If you just added it, update \
+                     this expectation."
+                ),
+            )
         );
         assert!(
             !result.rows.is_empty(),


### PR DESCRIPTION
## What

`SELECT meta FROM #balances` — and `#notes`, `#events`, `#documents`,
`#commodities` — failed, because the column did not exist. bean-query answers
all five. This adds them.

## Why it isn't a one-line column addition

bean-query's wildcard is **not uniform** about `meta`. Measured against
bean-query 3.x on a fixture where every table has rows:

| table | bean-query `SELECT *` | `meta` in wildcard? |
|---|---|---|
| `#balances` | `date, account, amount, tolerance, discrepancy` | no |
| `#notes` | `date, account, comment, tags, links` | no |
| `#events` | `date, type, description` | no |
| `#documents` | `date, account, filename, tags, links` | no |
| `#commodities` | **`meta`, `date, name`** | **yes, first** |

Registering `meta` as an ordinary column everywhere — the obvious
implementation — trades one missing column for four wildcards that return a
column more than bean-query. That is the worse bug, and it is what the first
cut of this change did; `test_balances_table_select_all` caught it.

The split looks arbitrary because it is. beanquery derives `#commodities`'
columns from the `Commodity` namedtuple, whose first field is `meta`, while
the other tables carry hand-written column lists. Every set in the table
above was read off bean-query rather than reasoned about, precisely because
no rule predicts it.

## How

`Table` gains a per-table `hidden` list: columns omitted from `SELECT *` but
still addressable by name. That is not a workaround — it is bean-query's own
behavior, which answers `SELECT meta FROM #notes` while omitting `meta` from
`SELECT *` on that same table (verified, with a negative control confirming a
genuinely absent column raises instead).

`Executor::wildcard_hidden` now combines that per-table list with the
existing name-based rule (`_`-prefixed helpers and `entry`). A name-only rule
cannot express the split above.

## Also: `#entries` disagreed with `#documents`

`#entries` emptied `tags`/`links` for every non-transaction. A document's tags
do survive into our model — `SELECT tags FROM #documents` returned them — so
the two tables reported different tags for the same directive.

A column-presence census cannot see this class of bug: `tags` **is**
registered on `#entries`; it was just wrong for every directive except
transactions.

## Result

`SELECT *` parity, same fixture: **6 of 10 tables match, up from 5**.
`#commodities` goes from mismatched to exact; `#events` and `#documents` are
preserved rather than regressed.

The four that still differ are all pre-existing and none are touched here:
`#postings` (31 columns vs 5) and `#accounts` (extra `currencies`, `booking`),
plus the two gaps below.

## Deliberately left open

Neither is reachable from directive data, so neither belongs in this PR:

- **`#balances.discrepancy`** — computed by the balance checker, not stored on
  the directive.
- **`#notes` tags/links** — our `Note` model drops them at parse time (#2160).

Both are documented at the point where a reader would otherwise assume an
oversight.

## Verification

- Both new tests were **confirmed to fail** on a mutation of the behavior they
  pin before being trusted (un-hiding `meta` on `#notes`; renaming `#events`'
  `meta` so it becomes unreachable), then confirmed green after restore.
- The fixture asserts every table is non-empty. A wildcard against a zero-row
  table still reports its header — that is how an earlier column census on
  #2154 under-reported by ten columns.
- Values checked against bean-query: metadata on all five, `tolerance` = 0.05,
  and `#entries` now reporting `document,dtag,dlink`.
- `corpus_parity` fails identically on this branch and on clean `main`
  (20 divergences each) — pre-existing wasm/native decimal formatting, #1809.
- clippy at CI's 1.97, `RUSTDOCFLAGS="-D warnings" cargo doc`, `typos`, and
  the booked-value gate (`known 34, found 34, new 0`) all clean.

Refs #2154
