### PR TITLE
fix(query): keep source order in five system tables, as bean-query does

### DIFF
--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -38,7 +38,13 @@ impl Executor<'_> {
         // lookups but hidden from the `#prices` table for bean-query
         // compat.
         let mut entries: Vec<_> = self.price_db.iter_explicit_entries().collect();
-        // Sort by (date, base_currency) for consistent, deterministic output
+        // Sort by (date, base_currency). NOT source order, unlike the other
+        // system tables: these rows come from `price_db`, whose outer map is
+        // an `FxHashMap` keyed by base currency, so iteration is grouped by
+        // currency in arbitrary order and no source position survives. The
+        // secondary key is what makes this table deterministic at all
+        // — dropping it to chase bean-query's source order would trade a wrong
+        // but stable order for an unstable one (#2163).
         entries.sort_by(|(currency_a, date_a, _, _), (currency_b, date_b, _, _)| {
             date_a.cmp(date_b).then_with(|| currency_a.cmp(currency_b))
         });
@@ -95,10 +101,12 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by (date, account) for consistent, deterministic output
-        balances.sort_by(|(date_a, account_a, ..), (date_b, account_b, ..)| {
-            date_a.cmp(date_b).then_with(|| account_a.cmp(account_b))
-        });
+        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
+        // yields source order, so this reproduces beancount's `(date, lineno)`
+        // entry order. A secondary key on account/type/name looked like
+        // determinism but reordered rows that share a date away from the
+        // order they were written in — bean-query preserves it (#2163).
+        balances.sort_by_key(|(date, ..)| *date);
 
         for (date, account, amount, tolerance, meta) in balances {
             let row = vec![
@@ -141,10 +149,12 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by (date, name) for consistent output
-        commodities.sort_by(|(date_a, name_a, _), (date_b, name_b, _)| {
-            date_a.cmp(date_b).then_with(|| name_a.cmp(name_b))
-        });
+        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
+        // yields source order, so this reproduces beancount's `(date, lineno)`
+        // entry order. A secondary key on account/type/name looked like
+        // determinism but reordered rows that share a date away from the
+        // order they were written in — bean-query preserves it (#2163).
+        commodities.sort_by_key(|(date, ..)| *date);
 
         for (date, name, meta) in commodities {
             let row = vec![
@@ -186,10 +196,12 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by (date, type) for consistent output
-        events.sort_by(|(date_a, type_a, ..), (date_b, type_b, ..)| {
-            date_a.cmp(date_b).then_with(|| type_a.cmp(type_b))
-        });
+        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
+        // yields source order, so this reproduces beancount's `(date, lineno)`
+        // entry order. A secondary key on account/type/name looked like
+        // determinism but reordered rows that share a date away from the
+        // order they were written in — bean-query preserves it (#2163).
+        events.sort_by_key(|(date, ..)| *date);
 
         for (date, event_type, description, meta) in events {
             let row = vec![
@@ -237,10 +249,12 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by (date, account) for consistent output
-        notes.sort_by(|(date_a, account_a, ..), (date_b, account_b, ..)| {
-            date_a.cmp(date_b).then_with(|| account_a.cmp(account_b))
-        });
+        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
+        // yields source order, so this reproduces beancount's `(date, lineno)`
+        // entry order. A secondary key on account/type/name looked like
+        // determinism but reordered rows that share a date away from the
+        // order they were written in — bean-query preserves it (#2163).
+        notes.sort_by_key(|(date, ..)| *date);
 
         for (date, account, comment, meta) in notes {
             let row = vec![
@@ -294,15 +308,12 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by (date, account, filename) for consistent output
-        documents.sort_by(
-            |(date_a, account_a, file_a, ..), (date_b, account_b, file_b, ..)| {
-                date_a
-                    .cmp(date_b)
-                    .then_with(|| account_a.cmp(account_b))
-                    .then_with(|| file_a.cmp(file_b))
-            },
-        );
+        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
+        // yields source order, so this reproduces beancount's `(date, lineno)`
+        // entry order. A secondary key on account/type/name looked like
+        // determinism but reordered rows that share a date away from the
+        // order they were written in — bean-query preserves it (#2163).
+        documents.sort_by_key(|(date, ..)| *date);
 
         for (date, account, filename, tags, links, meta) in documents {
             let tags_vec: Vec<String> = tags.iter().map(ToString::to_string).collect();

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -101,11 +101,16 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
-        // yields source order, so rows sharing a date come back in the order
-        // they were written. A secondary key on account/type/name looked like
-        // determinism but reordered them; bean-query preserves the source
-        // order (#2163).
+        // Sort by date ONLY, and stably. The loader already hands over
+        // directives in beancount's (date, SORT_ORDER, lineno) order -- which
+        // is why `#entries`, which never sorts, still comes back ordered -- so
+        // on that path this is a no-op that must not disturb what it receives.
+        // It does real work only when an `Executor` is built directly from a
+        // caller-supplied slice, where nothing has ordered anything.
+        //
+        // The bug was therefore not a missing sort but an extra one: a
+        // secondary key on account/type/name re-ordered rows that already
+        // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
         // does NOT match across an `include`: beancount compares the raw line
@@ -156,11 +161,16 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
-        // yields source order, so rows sharing a date come back in the order
-        // they were written. A secondary key on account/type/name looked like
-        // determinism but reordered them; bean-query preserves the source
-        // order (#2163).
+        // Sort by date ONLY, and stably. The loader already hands over
+        // directives in beancount's (date, SORT_ORDER, lineno) order -- which
+        // is why `#entries`, which never sorts, still comes back ordered -- so
+        // on that path this is a no-op that must not disturb what it receives.
+        // It does real work only when an `Executor` is built directly from a
+        // caller-supplied slice, where nothing has ordered anything.
+        //
+        // The bug was therefore not a missing sort but an extra one: a
+        // secondary key on account/type/name re-ordered rows that already
+        // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
         // does NOT match across an `include`: beancount compares the raw line
@@ -210,11 +220,16 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
-        // yields source order, so rows sharing a date come back in the order
-        // they were written. A secondary key on account/type/name looked like
-        // determinism but reordered them; bean-query preserves the source
-        // order (#2163).
+        // Sort by date ONLY, and stably. The loader already hands over
+        // directives in beancount's (date, SORT_ORDER, lineno) order -- which
+        // is why `#entries`, which never sorts, still comes back ordered -- so
+        // on that path this is a no-op that must not disturb what it receives.
+        // It does real work only when an `Executor` is built directly from a
+        // caller-supplied slice, where nothing has ordered anything.
+        //
+        // The bug was therefore not a missing sort but an extra one: a
+        // secondary key on account/type/name re-ordered rows that already
+        // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
         // does NOT match across an `include`: beancount compares the raw line
@@ -270,11 +285,16 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
-        // yields source order, so rows sharing a date come back in the order
-        // they were written. A secondary key on account/type/name looked like
-        // determinism but reordered them; bean-query preserves the source
-        // order (#2163).
+        // Sort by date ONLY, and stably. The loader already hands over
+        // directives in beancount's (date, SORT_ORDER, lineno) order -- which
+        // is why `#entries`, which never sorts, still comes back ordered -- so
+        // on that path this is a no-op that must not disturb what it receives.
+        // It does real work only when an `Executor` is built directly from a
+        // caller-supplied slice, where nothing has ordered anything.
+        //
+        // The bug was therefore not a missing sort but an extra one: a
+        // secondary key on account/type/name re-ordered rows that already
+        // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
         // does NOT match across an `include`: beancount compares the raw line
@@ -336,11 +356,16 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
-        // yields source order, so rows sharing a date come back in the order
-        // they were written. A secondary key on account/type/name looked like
-        // determinism but reordered them; bean-query preserves the source
-        // order (#2163).
+        // Sort by date ONLY, and stably. The loader already hands over
+        // directives in beancount's (date, SORT_ORDER, lineno) order -- which
+        // is why `#entries`, which never sorts, still comes back ordered -- so
+        // on that path this is a no-op that must not disturb what it receives.
+        // It does real work only when an `Executor` is built directly from a
+        // caller-supplied slice, where nothing has ordered anything.
+        //
+        // The bug was therefore not a missing sort but an extra one: a
+        // secondary key on account/type/name re-ordered rows that already
+        // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
         // does NOT match across an `include`: beancount compares the raw line

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -101,11 +101,18 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
-        // yields source order, so this reproduces beancount's `(date, lineno)`
-        // entry order. A secondary key on account/type/name looked like
-        // determinism but reordered rows that share a date away from the
-        // order they were written in — bean-query preserves it (#2163).
+        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
+        // yields source order, so rows sharing a date come back in the order
+        // they were written. A secondary key on account/type/name looked like
+        // determinism but reordered them; bean-query preserves the source
+        // order (#2163).
+        //
+        // This matches beancount's `(date, lineno)` within a single file. It
+        // does NOT match across an `include`: beancount compares the raw line
+        // number without regard to which file it came from, so line 1 of an
+        // included file sorts ahead of line 3 of its parent, while we keep
+        // each file's directives together. Pre-existing, unchanged here, and
+        // tracked separately (#2166).
         balances.sort_by_key(|(date, ..)| *date);
 
         for (date, account, amount, tolerance, meta) in balances {
@@ -149,11 +156,18 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
-        // yields source order, so this reproduces beancount's `(date, lineno)`
-        // entry order. A secondary key on account/type/name looked like
-        // determinism but reordered rows that share a date away from the
-        // order they were written in — bean-query preserves it (#2163).
+        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
+        // yields source order, so rows sharing a date come back in the order
+        // they were written. A secondary key on account/type/name looked like
+        // determinism but reordered them; bean-query preserves the source
+        // order (#2163).
+        //
+        // This matches beancount's `(date, lineno)` within a single file. It
+        // does NOT match across an `include`: beancount compares the raw line
+        // number without regard to which file it came from, so line 1 of an
+        // included file sorts ahead of line 3 of its parent, while we keep
+        // each file's directives together. Pre-existing, unchanged here, and
+        // tracked separately (#2166).
         commodities.sort_by_key(|(date, ..)| *date);
 
         for (date, name, meta) in commodities {
@@ -196,11 +210,18 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
-        // yields source order, so this reproduces beancount's `(date, lineno)`
-        // entry order. A secondary key on account/type/name looked like
-        // determinism but reordered rows that share a date away from the
-        // order they were written in — bean-query preserves it (#2163).
+        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
+        // yields source order, so rows sharing a date come back in the order
+        // they were written. A secondary key on account/type/name looked like
+        // determinism but reordered them; bean-query preserves the source
+        // order (#2163).
+        //
+        // This matches beancount's `(date, lineno)` within a single file. It
+        // does NOT match across an `include`: beancount compares the raw line
+        // number without regard to which file it came from, so line 1 of an
+        // included file sorts ahead of line 3 of its parent, while we keep
+        // each file's directives together. Pre-existing, unchanged here, and
+        // tracked separately (#2166).
         events.sort_by_key(|(date, ..)| *date);
 
         for (date, event_type, description, meta) in events {
@@ -249,11 +270,18 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
-        // yields source order, so this reproduces beancount's `(date, lineno)`
-        // entry order. A secondary key on account/type/name looked like
-        // determinism but reordered rows that share a date away from the
-        // order they were written in — bean-query preserves it (#2163).
+        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
+        // yields source order, so rows sharing a date come back in the order
+        // they were written. A secondary key on account/type/name looked like
+        // determinism but reordered them; bean-query preserves the source
+        // order (#2163).
+        //
+        // This matches beancount's `(date, lineno)` within a single file. It
+        // does NOT match across an `include`: beancount compares the raw line
+        // number without regard to which file it came from, so line 1 of an
+        // included file sorts ahead of line 3 of its parent, while we keep
+        // each file's directives together. Pre-existing, unchanged here, and
+        // tracked separately (#2166).
         notes.sort_by_key(|(date, ..)| *date);
 
         for (date, account, comment, meta) in notes {
@@ -308,11 +336,18 @@ impl Executor<'_> {
             })
             .collect();
 
-        // Sort by date ONLY. `sort_by` is stable and `resolved_directives`
-        // yields source order, so this reproduces beancount's `(date, lineno)`
-        // entry order. A secondary key on account/type/name looked like
-        // determinism but reordered rows that share a date away from the
-        // order they were written in — bean-query preserves it (#2163).
+        // Sort by date ONLY. `sort_by_key` is stable and `resolved_directives`
+        // yields source order, so rows sharing a date come back in the order
+        // they were written. A secondary key on account/type/name looked like
+        // determinism but reordered them; bean-query preserves the source
+        // order (#2163).
+        //
+        // This matches beancount's `(date, lineno)` within a single file. It
+        // does NOT match across an `include`: beancount compares the raw line
+        // number without regard to which file it came from, so line 1 of an
+        // included file sorts ahead of line 3 of its parent, while we keep
+        // each file's directives together. Pre-existing, unchanged here, and
+        // tracked separately (#2166).
         documents.sort_by_key(|(date, ..)| *date);
 
         for (date, account, filename, tags, links, meta) in documents {

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -113,11 +113,11 @@ impl Executor<'_> {
         // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
-        // does NOT match across an `include`: beancount compares the raw line
-        // number without regard to which file it came from, so line 1 of an
-        // included file sorts ahead of line 3 of its parent, while we keep
-        // each file's directives together. Pre-existing, unchanged here, and
-        // tracked separately (#2166).
+        // deliberately does NOT match across an `include`. beancount compares
+        // the raw line number with no record of which file it came from, so
+        // adding two comment lines to an included file reorders query results;
+        // measured, not assumed (#2166). We keep each file's directives
+        // together, which is stable under that edit. Divergence by choice.
         balances.sort_by_key(|(date, ..)| *date);
 
         for (date, account, amount, tolerance, meta) in balances {
@@ -173,11 +173,11 @@ impl Executor<'_> {
         // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
-        // does NOT match across an `include`: beancount compares the raw line
-        // number without regard to which file it came from, so line 1 of an
-        // included file sorts ahead of line 3 of its parent, while we keep
-        // each file's directives together. Pre-existing, unchanged here, and
-        // tracked separately (#2166).
+        // deliberately does NOT match across an `include`. beancount compares
+        // the raw line number with no record of which file it came from, so
+        // adding two comment lines to an included file reorders query results;
+        // measured, not assumed (#2166). We keep each file's directives
+        // together, which is stable under that edit. Divergence by choice.
         commodities.sort_by_key(|(date, ..)| *date);
 
         for (date, name, meta) in commodities {
@@ -232,11 +232,11 @@ impl Executor<'_> {
         // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
-        // does NOT match across an `include`: beancount compares the raw line
-        // number without regard to which file it came from, so line 1 of an
-        // included file sorts ahead of line 3 of its parent, while we keep
-        // each file's directives together. Pre-existing, unchanged here, and
-        // tracked separately (#2166).
+        // deliberately does NOT match across an `include`. beancount compares
+        // the raw line number with no record of which file it came from, so
+        // adding two comment lines to an included file reorders query results;
+        // measured, not assumed (#2166). We keep each file's directives
+        // together, which is stable under that edit. Divergence by choice.
         events.sort_by_key(|(date, ..)| *date);
 
         for (date, event_type, description, meta) in events {
@@ -297,11 +297,11 @@ impl Executor<'_> {
         // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
-        // does NOT match across an `include`: beancount compares the raw line
-        // number without regard to which file it came from, so line 1 of an
-        // included file sorts ahead of line 3 of its parent, while we keep
-        // each file's directives together. Pre-existing, unchanged here, and
-        // tracked separately (#2166).
+        // deliberately does NOT match across an `include`. beancount compares
+        // the raw line number with no record of which file it came from, so
+        // adding two comment lines to an included file reorders query results;
+        // measured, not assumed (#2166). We keep each file's directives
+        // together, which is stable under that edit. Divergence by choice.
         notes.sort_by_key(|(date, ..)| *date);
 
         for (date, account, comment, meta) in notes {
@@ -368,11 +368,11 @@ impl Executor<'_> {
         // shared a date, away from the order bean-query returns (#2163).
         //
         // This matches beancount's `(date, lineno)` within a single file. It
-        // does NOT match across an `include`: beancount compares the raw line
-        // number without regard to which file it came from, so line 1 of an
-        // included file sorts ahead of line 3 of its parent, while we keep
-        // each file's directives together. Pre-existing, unchanged here, and
-        // tracked separately (#2166).
+        // deliberately does NOT match across an `include`. beancount compares
+        // the raw line number with no record of which file it came from, so
+        // adding two comment lines to an included file reorders query results;
+        // measured, not assumed (#2166). We keep each file's directives
+        // together, which is stable under that edit. Divergence by choice.
         documents.sort_by_key(|(date, ..)| *date);
 
         for (date, account, filename, tags, links, meta) in documents {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6585,8 +6585,23 @@ fn system_tables_sort_unordered_directives_by_date() {
         Directive::Commodity(Commodity::new(date(2024, 3, 2), "AAA")),
         Directive::Event(Event::new(date(2024, 9, 3), "z", "z")),
         Directive::Event(Event::new(date(2024, 3, 3), "a", "a")),
+        Directive::Document(Document::new(date(2024, 9, 4), "Assets:Cash", "/z.pdf")),
+        Directive::Document(Document::new(date(2024, 3, 4), "Assets:Cash", "/a.pdf")),
+        Directive::Balance(Balance::new(
+            date(2024, 9, 5),
+            "Assets:Zebra",
+            Amount::new(dec!(0.00), "USD"),
+        )),
+        Directive::Balance(Balance::new(
+            date(2024, 3, 5),
+            "Assets:Alpha",
+            Amount::new(dec!(0.00), "USD"),
+        )),
     ];
 
+    // All five tables, so that deleting any one table's sort is caught. An
+    // earlier version of this test covered only three, and removing the
+    // #balances or #documents sort still passed the whole suite.
     for (query, expected) in [
         (
             "SELECT comment FROM #notes",
@@ -6594,6 +6609,11 @@ fn system_tables_sort_unordered_directives_by_date() {
         ),
         ("SELECT name FROM #commodities", vec!["AAA", "ZZZ"]),
         ("SELECT type FROM #events", vec!["a", "z"]),
+        ("SELECT filename FROM #documents", vec!["/a.pdf", "/z.pdf"]),
+        (
+            "SELECT account FROM #balances",
+            vec!["Assets:Alpha", "Assets:Zebra"],
+        ),
     ] {
         let result = execute_query(query, &directives);
         let got: Vec<String> = result

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6449,7 +6449,7 @@ fn test_balances_table_case_insensitive() {
 
 #[test]
 fn test_balances_table_deterministic_ordering() {
-    // Test: Multiple balances on the same date should have deterministic order by account
+    // Test: Multiple balances on the same date keep their source order
     let directives = vec![
         Directive::Balance(Balance::new(
             date(2024, 1, 1),
@@ -6469,14 +6469,18 @@ fn test_balances_table_deterministic_ordering() {
     ];
     let result = execute_query("SELECT account FROM #balances", &directives);
 
-    // Should be sorted by (date, account), so Apple, Banana, Zebra
+    // Declaration order, NOT alphabetical. beancount orders entries by
+    // (date, lineno), so bean-query returns rows sharing a date in the order
+    // they were written; sorting by account reordered them (#2163). The
+    // guarantee is still determinism -- `sort_by` is stable and the directive
+    // stream is source-ordered -- just anchored to the source, not the name.
     assert_eq!(result.len(), 3);
-    assert_eq!(result.rows[0][0], Value::String("Assets:Apple".to_string()));
+    assert_eq!(result.rows[0][0], Value::String("Assets:Zebra".to_string()));
+    assert_eq!(result.rows[1][0], Value::String("Assets:Apple".to_string()));
     assert_eq!(
-        result.rows[1][0],
+        result.rows[2][0],
         Value::String("Assets:Banana".to_string())
     );
-    assert_eq!(result.rows[2][0], Value::String("Assets:Zebra".to_string()));
 }
 
 // ============================================================================
@@ -6560,6 +6564,68 @@ fn make_all_directive_types_test_directives() -> Vec<Directive> {
             Amount::new(dec!(0.00), "USD"),
         )),
     ]
+}
+
+#[test]
+fn system_tables_preserve_source_order_within_a_date() {
+    // beancount orders entries by (date, lineno), so bean-query returns rows
+    // sharing a date in the order they were written. Each pair below is
+    // declared Zebra-then-Alpha so a secondary sort on account/type/name --
+    // which is what these tables used to do -- would visibly reverse it
+    // (#2163).
+    //
+    // #prices is deliberately absent: its rows come from an FxHashMap keyed
+    // by base currency, carry no source position, and are ordered by the
+    // secondary key on purpose. Asserting source order there would be
+    // asserting hash iteration order.
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Zebra")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Alpha")),
+        Directive::Commodity(Commodity::new(date(2024, 1, 2), "ZZZ")),
+        Directive::Commodity(Commodity::new(date(2024, 1, 2), "AAA")),
+        Directive::Note(Note::new(date(2024, 1, 3), "Assets:Zebra", "z")),
+        Directive::Note(Note::new(date(2024, 1, 3), "Assets:Alpha", "a")),
+        Directive::Event(Event::new(date(2024, 1, 4), "zeta", "z")),
+        Directive::Event(Event::new(date(2024, 1, 4), "alpha", "a")),
+        Directive::Document(Document::new(date(2024, 1, 5), "Assets:Zebra", "/z.pdf")),
+        Directive::Document(Document::new(date(2024, 1, 5), "Assets:Alpha", "/a.pdf")),
+        Directive::Balance(Balance::new(
+            date(2024, 1, 6),
+            "Assets:Zebra",
+            Amount::new(dec!(0.00), "USD"),
+        )),
+        Directive::Balance(Balance::new(
+            date(2024, 1, 6),
+            "Assets:Alpha",
+            Amount::new(dec!(0.00), "USD"),
+        )),
+    ];
+
+    for (query, first, second) in [
+        ("SELECT name FROM #commodities", "ZZZ", "AAA"),
+        ("SELECT account FROM #notes", "Assets:Zebra", "Assets:Alpha"),
+        ("SELECT type FROM #events", "zeta", "alpha"),
+        ("SELECT filename FROM #documents", "/z.pdf", "/a.pdf"),
+        (
+            "SELECT account FROM #balances",
+            "Assets:Zebra",
+            "Assets:Alpha",
+        ),
+    ] {
+        let result = execute_query(query, &directives);
+        assert_eq!(result.len(), 2, "{query} did not return both rows");
+        assert_eq!(
+            result.rows[0][0],
+            Value::String(first.to_string()),
+            "{query} lost source order (got {:?} first)",
+            result.rows[0][0]
+        );
+        assert_eq!(
+            result.rows[1][0],
+            Value::String(second.to_string()),
+            "{query} lost source order"
+        );
+    }
 }
 
 #[test]
@@ -6675,10 +6741,10 @@ fn test_commodities_table_deterministic_ordering() {
     ];
     let result = execute_query("SELECT name FROM #commodities", &directives);
 
-    // Should be sorted by (date, name)
-    assert_eq!(result.rows[0][0], Value::String("AAA".to_string()));
-    assert_eq!(result.rows[1][0], Value::String("MMM".to_string()));
-    assert_eq!(result.rows[2][0], Value::String("ZZZ".to_string()));
+    // Declaration order, not alphabetical -- see the #balances case above.
+    assert_eq!(result.rows[0][0], Value::String("ZZZ".to_string()));
+    assert_eq!(result.rows[1][0], Value::String("AAA".to_string()));
+    assert_eq!(result.rows[2][0], Value::String("MMM".to_string()));
 }
 
 // ============================================================================

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6567,6 +6567,51 @@ fn make_all_directive_types_test_directives() -> Vec<Directive> {
 }
 
 #[test]
+fn system_tables_sort_unordered_directives_by_date() {
+    // The date sort is a no-op on the loader path, which already hands over
+    // directives in beancount's (date, SORT_ORDER, lineno) order -- `#entries`
+    // never sorts and still comes back date-ordered. It matters only when an
+    // `Executor` is built directly from a caller-supplied slice, as these
+    // tests do, where nothing has ordered anything.
+    //
+    // Without this, removing the sort entirely passed the whole suite (#2165
+    // review), leaving the one path it exists for untested.
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Note(Note::new(date(2024, 9, 1), "Assets:Cash", "september")),
+        Directive::Note(Note::new(date(2024, 3, 1), "Assets:Cash", "march")),
+        Directive::Note(Note::new(date(2024, 6, 1), "Assets:Cash", "june")),
+        Directive::Commodity(Commodity::new(date(2024, 9, 2), "ZZZ")),
+        Directive::Commodity(Commodity::new(date(2024, 3, 2), "AAA")),
+        Directive::Event(Event::new(date(2024, 9, 3), "z", "z")),
+        Directive::Event(Event::new(date(2024, 3, 3), "a", "a")),
+    ];
+
+    for (query, expected) in [
+        (
+            "SELECT comment FROM #notes",
+            vec!["march", "june", "september"],
+        ),
+        ("SELECT name FROM #commodities", vec!["AAA", "ZZZ"]),
+        ("SELECT type FROM #events", vec!["a", "z"]),
+    ] {
+        let result = execute_query(query, &directives);
+        let got: Vec<String> = result
+            .rows
+            .iter()
+            .map(|r| match &r[0] {
+                Value::String(v) => v.clone(),
+                other => panic!("{query} returned a non-string: {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            got, expected,
+            "{query} did not sort unordered input by date"
+        );
+    }
+}
+
+#[test]
 fn system_tables_preserve_source_order_within_a_date() {
     // beancount orders entries by (date, lineno), so bean-query returns rows
     // sharing a date in the order they were written. Each pair below is


### PR DESCRIPTION
## What

`#balances`, `#commodities`, `#events`, `#notes` and `#documents` sorted by
`(date, account|type|name)`. beancount orders entries by `(date, lineno)`, so
bean-query returns rows sharing a date in the order they were written — and
ours came back reordered.

```beancount
2020-02-05 event "zeta" "z"
2020-01-20 event "alpha" "a"
2020-02-05 event "beta" "b"
```

| | row 1 | row 2 | row 3 |
|---|---|---|---|
| bean-query | alpha | **zeta** | **beta** |
| rledger (before) | alpha | **beta** | **zeta** |

## How

Sort by date alone. `sort_by_key` is stable and `resolved_directives` yields
source order, so rows sharing a date come back in the order they were written
— which is why `#entries` and `#transactions`, which never applied a secondary
key, already agreed with bean-query.

This matches beancount's `(date, lineno)` **within a single file**. It does
not match across an `include`: beancount compares the raw line number without
regard to which file it came from, so line 1 of an included file sorts ahead
of line 3 of its parent, while we keep each file's directives together.
`main` orders these the same way, so that gap is pre-existing and neither
caused nor fixed here — filed as #2166. An earlier draft of this PR claimed
an unqualified `(date, lineno)` match; that was wrong.

## What is NOT changed, and why

Two tables have the same shape but cannot be fixed this way. Both are
documented at the code rather than left to look like oversights.

**`#prices`** — its rows come from `price_db`, whose outer map is an
`FxHashMap` keyed by base currency. Iteration is grouped by currency in
arbitrary order and no source position survives, so the secondary key is the
only thing making that table deterministic at all. Dropping it would trade a
wrong-but-stable order for an unstable one.

I had already changed it before catching this. An empirical check against
bean-query *passed* — by coincidence, on a two-currency fixture — and
`test_prices_table_deterministic_ordering` is what actually caught it. That
test earned its keep.

**`#accounts`** — built from an `FxHashMap`, so there is no source order to
restore, and it diverges from bean-query more deeply than ordering:
bean-query's `open` column is a full `Open(...)` repr where ours is a date,
and we carry two extra columns. Separate problem.

## Verification

All seven sorted tables compared against bean-query on a fixture where source
order differs from every sort key — six match, `#prices` correctly still
differs.

- **Non-vacuous**: `#transactions` initially "passed" against an empty table;
  it now has real rows. Every assertion is on a table with rows.
- **Negative control** on the comparison harness before trusting a clean run.
- The new regression test was confirmed to fail on two separate mutations
  (restoring a secondary key on `#events`, then on `#notes`) before being
  trusted.
- Verified again after switching to `sort_by_key` at clippy's suggestion,
  rather than assuming stability carried over.
- Booked-value gate clean (`known 34, found 34, new 0`); `corpus_parity`
  divergences still exactly 20, matching `main` (pre-existing #1809).
- Checked the interaction with #2161 on merged `main`: `#commodities` now
  matches bean-query in both column order (`meta` first) and row order.

Two limits worth stating: the BQL compat suite exits 0 without running any
comparison unless a check phase ran first, so I am not counting it as a clean
signal here; and the local corpus has one file containing a `note` directive
and none containing `balance`, so it cannot exercise this change. CI runs the
full fetched corpus.

## Tests

`test_balances_table_deterministic_ordering` and
`test_commodities_table_deterministic_ordering` pinned the old order and now
pin the new one. They still test determinism — just anchored to the source
rather than to the name.

Closes #2163
