### PR TITLE
fix(query): give #entries.meta its source keys, and empty meta a map

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2113,9 +2113,10 @@ impl<'a> Executor<'a> {
 
     /// Convert a `Metadata` map to a `Value::Object` for table storage.
     fn metadata_to_value(meta: &rustledger_core::Metadata) -> Value {
-        if meta.is_empty() {
-            return Value::Null;
-        }
+        // An empty map, NOT Null. bean-query returns `{}` for a directive
+        // with no metadata and renders Null as an empty CSV field, so the
+        // two are distinguishable there: `meta IS NULL` is false where we
+        // used to make it true (#2162).
         let map: std::collections::BTreeMap<String, Value> = meta
             .iter()
             .map(|(k, v)| (k.clone(), Self::meta_value_to_value(Some(v))))

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -712,7 +712,11 @@ impl Executor<'_> {
             description,
             tags,
             links,
-            Self::metadata_to_value(directive.meta()),
+            // bean-query's `#entries.meta` carries `filename` and `lineno`
+            // alongside the user's keys; its per-table `meta` columns
+            // (#notes, #balances, ...) do NOT, so this augmentation belongs
+            // here and must not move into `metadata_to_value` (#2162).
+            Self::metadata_to_value(&Self::augmented_meta(directive.meta(), source_loc)),
             accounts,
         ]
     }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6694,6 +6694,76 @@ fn system_tables_preserve_source_order_within_a_date() {
 }
 
 #[test]
+fn empty_metadata_is_an_empty_map_not_null() {
+    // bean-query returns `{}` for a directive with no metadata, and renders
+    // Null as an empty CSV field, so the two are distinguishable there:
+    // `meta IS NULL` is false. We returned Null, making it true (#2162).
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Note(Note::new(date(2024, 1, 3), "Assets:Cash", "no meta")),
+        Directive::Event(Event::new(date(2024, 1, 4), "loc", "Rome")),
+    ];
+
+    for table in ["#notes", "#events"] {
+        let result = execute_query(&format!("SELECT meta FROM {table}"), &directives);
+        assert_eq!(result.len(), 1, "{table} returned no row to assert on");
+        assert_ne!(
+            result.rows[0][0],
+            Value::Null,
+            "{table} returned Null for absent metadata; bean-query returns an empty map"
+        );
+
+        let is_null = execute_query(&format!("SELECT meta IS NULL FROM {table}"), &directives);
+        assert_eq!(
+            is_null.rows[0][0],
+            Value::Boolean(false),
+            "{table}: `meta IS NULL` must be false for absent metadata"
+        );
+    }
+}
+
+#[test]
+fn entries_meta_carries_filename_and_lineno() {
+    // bean-query's `#entries.meta` includes `filename` and `lineno` next to
+    // the user's keys. Its per-table `meta` columns (#notes, #balances, ...)
+    // do NOT -- verified against bean-query -- so this augmentation must stay
+    // on #entries rather than moving into the shared conversion, which would
+    // break the five tables #2161 brought into agreement (#2162).
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+
+    let dirs = [Directive::Note(Note::new(
+        date(2024, 1, 3),
+        "Assets:Cash",
+        "n",
+    ))];
+    let spanned: Vec<Spanned<rustledger_core::Directive>> = dirs
+        .iter()
+        .cloned()
+        .map(|d| Spanned {
+            value: d,
+            span: Span::new(0, 50),
+            file_id: 0,
+        })
+        .collect();
+    let source_map = SourceMap::new();
+    let mut executor = Executor::new_with_sources(&spanned, &source_map);
+    let result = executor
+        .execute(&parse("SELECT meta FROM #entries").expect("should parse"))
+        .expect("query should execute");
+
+    let rendered = format!("{:?}", result.rows[0][0]);
+    assert!(
+        rendered.contains("lineno"),
+        "#entries.meta should carry lineno, got {rendered}"
+    );
+    assert!(
+        rendered.contains("filename"),
+        "#entries.meta should carry filename, got {rendered}"
+    );
+}
+
+#[test]
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6707,11 +6707,21 @@ fn empty_metadata_is_an_empty_map_not_null() {
     for table in ["#notes", "#events"] {
         let result = execute_query(&format!("SELECT meta FROM {table}"), &directives);
         assert_eq!(result.len(), 1, "{table} returned no row to assert on");
-        assert_ne!(
-            result.rows[0][0],
-            Value::Null,
-            "{table} returned Null for absent metadata; bean-query returns an empty map"
-        );
+        // Assert the exact value, not merely non-Null: a weaker check would
+        // also pass if per-table `meta` picked up the synthetic `filename` /
+        // `lineno` keys, which bean-query does NOT put there and which this
+        // change deliberately confines to #entries.
+        match &result.rows[0][0] {
+            Value::Object(map) => assert!(
+                map.is_empty(),
+                "{table} meta should be an EMPTY map for a directive with no \
+                 metadata; got {map:?}. Synthetic keys belong on #entries only."
+            ),
+            other => panic!(
+                "{table} meta should be an empty map, got {other:?}; \
+                 bean-query returns {{}} here"
+            ),
+        }
 
         let is_null = execute_query(&format!("SELECT meta IS NULL FROM {table}"), &directives);
         assert_eq!(
@@ -6752,15 +6762,78 @@ fn entries_meta_carries_filename_and_lineno() {
         .execute(&parse("SELECT meta FROM #entries").expect("should parse"))
         .expect("query should execute");
 
-    let rendered = format!("{:?}", result.rows[0][0]);
-    assert!(
-        rendered.contains("lineno"),
-        "#entries.meta should carry lineno, got {rendered}"
-    );
-    assert!(
-        rendered.contains("filename"),
-        "#entries.meta should carry filename, got {rendered}"
-    );
+    match &result.rows[0][0] {
+        Value::Object(map) => {
+            for key in ["filename", "lineno"] {
+                assert!(
+                    map.contains_key(key),
+                    "#entries.meta should carry `{key}`, got {map:?}"
+                );
+            }
+        }
+        other => panic!("#entries.meta should be a map, got {other:?}"),
+    }
+}
+
+#[test]
+fn source_keys_reach_entries_meta_but_not_per_table_meta() {
+    // The split this change depends on, pinned from both sides at once: the
+    // SAME directive, through the SAME executor, must carry `filename` /
+    // `lineno` in `#entries.meta` and must NOT carry them in `#notes.meta`.
+    // bean-query behaves exactly this way (measured), so putting the
+    // augmentation in the shared conversion instead would silently break the
+    // five per-table columns #2161 brought into agreement (#2162).
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+
+    let dirs = [Directive::Note(Note::new(
+        date(2024, 1, 3),
+        "Assets:Cash",
+        "n",
+    ))];
+    let spanned: Vec<Spanned<rustledger_core::Directive>> = dirs
+        .iter()
+        .cloned()
+        .map(|d| Spanned {
+            value: d,
+            span: Span::new(0, 50),
+            file_id: 0,
+        })
+        .collect();
+    let source_map = SourceMap::new();
+    let mut executor = Executor::new_with_sources(&spanned, &source_map);
+
+    let entries = executor
+        .execute(&parse("SELECT meta FROM #entries").expect("should parse"))
+        .expect("query should execute");
+    match &entries.rows[0][0] {
+        Value::Object(map) => {
+            for key in ["filename", "lineno"] {
+                assert!(
+                    map.contains_key(key),
+                    "#entries.meta lost `{key}`, got {map:?}"
+                );
+            }
+        }
+        other => panic!("#entries.meta should be a map, got {other:?}"),
+    }
+
+    let notes = executor
+        .execute(&parse("SELECT meta FROM #notes").expect("should parse"))
+        .expect("query should execute");
+    match &notes.rows[0][0] {
+        Value::Object(map) => {
+            for key in ["filename", "lineno"] {
+                assert!(
+                    !map.contains_key(key),
+                    "#notes.meta picked up `{key}`; bean-query keeps source keys \
+                     out of per-table meta. Did the augmentation move into the \
+                     shared conversion? got {map:?}"
+                );
+            }
+        }
+        other => panic!("#notes.meta should be a map, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What

Two ways metadata reached a query differently from bean-query.

### 1. `#entries.meta` dropped `filename` and `lineno`

bean-query carries them alongside the user's keys:

```
bc: {'filename': '/tmp/f.bean', 'lineno': 4, 'mtxn': 'tv', '__tolerances__': {...}}
rl: {mtxn: tv}                                                    <-- before
rl: {filename: /tmp/f.bean, lineno: 4, mtxn: tv}                  <-- after
```

`#postings` already did this through the existing `augmented_meta` helper.
`#entries` had the same `SourceLocation` in scope — it builds the `filename`
and `lineno` *columns* from it — and simply did not use it for `meta`.

### 2. Absent metadata produced `Null`, not `{}`

```
$ bean-query -f csv f.bean "SELECT meta FROM #notes"      # note with no metadata
{}
$ rledger query -f csv f.bean "SELECT meta FROM #notes"   # before
                                                          # (empty)
```

These are distinct values in bean-query, which renders Null as an empty CSV
field — so `meta IS NULL` answered `true` for us and `false` there.

## The scoping is the load-bearing part

The augmentation goes on `#entries` **only**. bean-query's per-table `meta`
columns — `#notes`, `#balances`, `#events`, `#documents`, `#commodities` —
exclude `filename`/`lineno`. Moving this into the shared `metadata_to_value`
would have broken the five tables #2161 just brought into agreement.

Verified explicitly, with a negative control so the check cannot pass
vacuously:

| | `filename`/`lineno` in `meta`? |
|---|---|
| `#entries` | bean-query yes, ours yes |
| the five per-table columns | bean-query no, ours no |

## Behaviour change worth stating

`meta IS NULL` now answers `false` for a directive with no metadata, where it
answered `true` before. That is the point of the fix on the bean-query-facing
columns, but it applies uniformly, including to our own hidden helper columns
`_entry_meta` / `_posting_meta`, which now report `{}` rather than Null for an
un-annotated transaction or posting. Those have no bean-query equivalent, so
there is nothing to match there; the uniform semantic is simply the correct
one. Verified on a file with four posting rows, two annotated and two not.

Nothing outside the query crate keys off metadata being Null — the
`MetaValue::None` handling in the FFI and core is about an individual metadata
*value*, not the map.

## Scope of the match

The keys are right; their **order** is not, and cannot be here. bean-query
emits `filename, lineno` first then declaration order; we emit alphabetical,
because `metadata_to_value` collects into a `BTreeMap`. That is load-bearing:
`Metadata` is an `FxHashMap`, so the `BTreeMap` is the only thing making
`SELECT meta` deterministic. Declaration order is lost at parse time, so the
query layer cannot recover it. Recorded in #2168.

A user key named `filename` or `lineno` correctly wins over the injected one,
matching bean-query — `augmented_meta` only fills keys that are absent.
Verified.

## Not replicated

bean-query also injects `__tolerances__` into `#entries.meta` — its internal
per-currency inference cache. That is an implementation detail rather than
ledger content, and mirroring it would put beancount's internals into user
query results. Same reasoning that closed #2166.

## Verification

- Both fixes were **uncovered**: reverting either one passed the entire suite
  before these tests existed. Each new test is confirmed to fail against its
  own unfixed code, checked separately rather than together.
- Empty-metadata output now matches bean-query on all five per-table columns,
  re-checked on merged `main` so the #2161 and #2165 interaction is included.
- Booked-value gate clean (`known 34, found 34, new 0`).
- clippy at CI's 1.97, fmt, typos, rustdoc all clean.

Closes #2162
