### PR TITLE
fix(query): head results the way bean-query does

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -733,7 +733,9 @@ impl Executor<'_> {
         let mut names = Vec::new();
         for (i, target) in targets.iter().enumerate() {
             if let Some(alias) = &target.alias {
-                names.push(alias.clone());
+                // bean-query lowercases the alias too: `AS LatestDate`
+                // heads the result `latestdate` (#2164).
+                names.push(alias.to_lowercase());
             } else if matches!(target.expr, Expr::Wildcard) {
                 // Expand wildcard to all VISIBLE inner columns.
                 names.extend(

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2358,6 +2358,15 @@ impl<'a> Executor<'a> {
             // bare "colN" broke `SELECT entry.narration ORDER BY
             // entry.narration`, #1800 review).
             Expr::Attribute { .. } | Expr::Subscript { .. } => expr.to_string(),
+            // Literals and binary/unary expressions still head as `colN`.
+            // bean-query names them by printing the expression with MINIMAL
+            // parentheses -- `number + 1 * 2` gains none, `(number + 1) * 2`
+            // keeps the ones precedence requires, `((number))` collapses to
+            // `number`. Our `Display` parenthesizes every binary node, so
+            // `expr.to_string()` here yields `(number + 1)` and still would
+            // not match. Matching needs a precedence-aware printer, and
+            // `Display` is shared with hidden-column naming and error
+            // messages, so it cannot simply be changed. Tracked in #2171.
             _ => format!("col{index}"),
         }
     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2323,7 +2323,9 @@ impl<'a> Executor<'a> {
                 // Expand wildcard using shared constant (must match evaluate_row expansion)
                 names.extend(WILDCARD_COLUMNS.iter().map(|s| (*s).to_string()));
             } else if let Some(alias) = &target.alias {
-                names.push(alias.clone());
+                // bean-query lowercases the alias too: `AS LatestDate`
+                // heads the result `latestdate` (#2164).
+                names.push(alias.to_lowercase());
             } else {
                 names.push(self.expr_to_name(&target.expr, i));
             }
@@ -2335,8 +2337,15 @@ impl<'a> Executor<'a> {
     fn expr_to_name(&self, expr: &Expr, index: usize) -> String {
         match expr {
             Expr::Wildcard => "*".to_string(),
-            Expr::Column(name) => name.clone(),
-            Expr::Function(func) => func.name.clone(),
+            // bean-query lowercases a bare column reference to the column's
+            // own name: `SELECT DATE` heads the result `date`. Scripts that
+            // read our CSV by header name otherwise miss the field (#2164).
+            Expr::Column(name) => name.to_lowercase(),
+            // ...but renders a function target from its source text, case
+            // intact: `sum(NUMBER)` stays `sum(NUMBER)`. We emitted just the
+            // function name, dropping the arguments, so `SELECT count(date)`
+            // headed `count` where bean-query heads `count(date)`.
+            Expr::Function(_) => expr.to_string(),
             Expr::Window(wf) => wf.name.clone(),
             // Postfix accesses name themselves by their source spelling so
             // ORDER BY / PIVOT BY string resolution finds the target (a

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2346,6 +2346,12 @@ impl<'a> Executor<'a> {
             // function name, dropping the arguments, so `SELECT count(date)`
             // headed `count` where bean-query heads `count(date)`.
             Expr::Function(_) => expr.to_string(),
+            // Window functions keep the bare name, deliberately NOT the source
+            // text the `Function` arm above uses. They are a rustledger
+            // extension -- bean-query has no `OVER` -- so there is no rule to
+            // match, and `ROW_NUMBER() OVER (PARTITION BY account ORDER BY
+            // date)` as a column header helps nobody. Alias it if you want a
+            // different name; `AS rn` works.
             Expr::Window(wf) => wf.name.clone(),
             // Postfix accesses name themselves by their source spelling so
             // ORDER BY / PIVOT BY string resolution finds the target (a

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -8,6 +8,26 @@ use crate::error::QueryError;
 use super::Executor;
 use super::types::{QueryResult, Row, Value, hash_single_value};
 
+/// Find a result column by name, exact match first, then case-insensitively.
+///
+/// Result headers became mixed-case with #2164: a bare column or a user alias
+/// is lowercased (`SELECT DATE` heads `date`), while a function target keeps
+/// its source spelling (`SUM(number)`). Meanwhile an ORDER BY / PIVOT BY
+/// reference carries whatever the query wrote, and the synthetic hidden
+/// columns from `find_hidden_order_by_targets` are named by the expression's
+/// source text. Those three conventions disagree on case, so an exact match
+/// alone fails in every direction -- `ORDER BY DATE` against a `date` header,
+/// and `ORDER BY MIN(date)` against the `min(date)` hidden column.
+///
+/// Exact first so an exact hit always wins when two columns differ only by
+/// case.
+fn find_column(columns: &[String], name: &str) -> Option<usize> {
+    columns
+        .iter()
+        .position(|c| c == name)
+        .or_else(|| columns.iter().position(|c| c.eq_ignore_ascii_case(name)))
+}
+
 impl Executor<'_> {
     pub(super) fn sort_results(
         &self,
@@ -23,14 +43,6 @@ impl Executor<'_> {
         if order_by.is_empty() {
             return Ok(());
         }
-
-        // Build a map from column names to indices
-        let column_indices: rustc_hash::FxHashMap<&str, usize> = result
-            .columns
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.as_str(), i))
-            .collect();
 
         // Resolve ORDER BY expressions to column indices
         let mut sort_specs: Vec<(usize, bool)> = Vec::new();
@@ -50,18 +62,17 @@ impl Executor<'_> {
                     }
                     (n as usize) - 1
                 }
-                Expr::Column(name) => column_indices
-                    .get(name.as_str())
-                    .copied()
+                // Case-insensitive fallback: result headers are the column's
+                // own (lowercase) name since #2164, so `ORDER BY DATE` must
+                // still find the `date` column. bean-query accepts this.
+                Expr::Column(name) => find_column(&result.columns, name)
                     .ok_or_else(|| QueryError::UnknownColumn(name.clone()))?,
                 Expr::Function(func) => {
                     // First try to find a column with the function name (e.g., "sum" for sum(amount))
                     // Then try the full expression string (e.g., "account_sortkey(account)")
                     let expr_str = spec.expr.to_string();
-                    column_indices
-                        .get(func.name.as_str())
-                        .or_else(|| column_indices.get(expr_str.as_str()))
-                        .copied()
+                    find_column(&result.columns, &func.name)
+                        .or_else(|| find_column(&result.columns, &expr_str))
                         .ok_or_else(|| {
                             QueryError::Evaluation(format!(
                                 "ORDER BY expression not found in SELECT: {expr_str}"
@@ -72,14 +83,11 @@ impl Executor<'_> {
                     // For other expression kinds (binary ops, literals, etc.),
                     // look up by string representation (matches hidden column aliases).
                     let expr_str = spec.expr.to_string();
-                    column_indices
-                        .get(expr_str.as_str())
-                        .copied()
-                        .ok_or_else(|| {
-                            QueryError::Evaluation(format!(
-                                "ORDER BY expression not found in SELECT: {expr_str}"
-                            ))
-                        })?
+                    find_column(&result.columns, &expr_str).ok_or_else(|| {
+                        QueryError::Evaluation(format!(
+                            "ORDER BY expression not found in SELECT: {expr_str}"
+                        ))
+                    })?
                 }
             };
             let ascending = spec.direction != SortDirection::Desc;
@@ -375,7 +383,7 @@ impl Executor<'_> {
                     .columns
                     .iter()
                     .position(|c| c.to_uppercase() == upper_func)
-                    .or_else(|| result.columns.iter().position(|c| c == &expr_str))
+                    .or_else(|| find_column(&result.columns, &expr_str))
                     .ok_or_else(|| {
                         QueryError::Evaluation(format!(
                             "PIVOT BY expression '{expr_str}' not found in SELECT"
@@ -388,15 +396,11 @@ impl Executor<'_> {
                 // names — matches the hidden-column alias convention
                 // used by `find_hidden_order_by_targets`.
                 let expr_str = pivot_expr.to_string();
-                result
-                    .columns
-                    .iter()
-                    .position(|c| c == &expr_str)
-                    .ok_or_else(|| {
-                        QueryError::Evaluation(format!(
-                            "PIVOT BY expression '{expr_str}' not found in SELECT"
-                        ))
-                    })
+                find_column(&result.columns, &expr_str).ok_or_else(|| {
+                    QueryError::Evaluation(format!(
+                        "PIVOT BY expression '{expr_str}' not found in SELECT"
+                    ))
+                })
             }
         }
     }

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -22,10 +22,16 @@ use super::types::{QueryResult, Row, Value, hash_single_value};
 /// Exact first so an exact hit always wins when two columns differ only by
 /// case.
 fn find_column(columns: &[String], name: &str) -> Option<usize> {
-    columns
-        .iter()
-        .position(|c| c == name)
-        .or_else(|| columns.iter().position(|c| c.eq_ignore_ascii_case(name)))
+    if let Some(i) = columns.iter().position(|c| c == name) {
+        return Some(i);
+    }
+    // `to_lowercase`, not `eq_ignore_ascii_case`: the headers were produced by
+    // Unicode `to_lowercase` in `expr_to_name` and the alias path, so an
+    // ASCII-only comparison here would disagree with them. `SELECT date AS
+    // DÄTE ORDER BY DÄTE` heads the result `däte` and then failed to find it
+    // (#2164 review).
+    let lower = name.to_lowercase();
+    columns.iter().position(|c| c.to_lowercase() == lower)
 }
 
 impl Executor<'_> {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6888,6 +6888,10 @@ fn order_by_resolves_a_column_written_in_another_case() {
         "SELECT ACCOUNT FROM #notes ORDER BY ACCOUNT",
         "SELECT date FROM #notes ORDER BY date",
         "SELECT DATE AS D FROM #notes ORDER BY D",
+        // Non-ASCII: the header is produced by Unicode `to_lowercase`, so an
+        // ASCII-only comparison in the lookup disagrees with it and this
+        // query fails even though the two names are the same identifier.
+        "SELECT date AS DÄTE FROM #notes ORDER BY DÄTE",
     ] {
         let result = execute_query(query, &directives);
         assert!(

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -2129,15 +2129,18 @@ fn test_pivot_by_multi_value_column_qualifies_headers() {
         "expected qualified headers in multi-value-column case; got {columns_joined}"
     );
     // The qualified format is "<value_col_name> / <pivot_value>".
-    // The aggregator names columns by the bare function name (`SUM`,
-    // `COUNT`), so qualified headers look like `SUM / USD`, `COUNT / USD`.
+    // A function target is headed by its source text since #2164, so the
+    // qualified headers are `SUM(number) / USD`, not `SUM / USD`.
     // Both value columns must survive into the output.
     assert!(
-        result.columns.iter().any(|c| c.starts_with("SUM /")),
+        result
+            .columns
+            .iter()
+            .any(|c| c.starts_with("SUM(number) /")),
         "missing SUM-qualified columns in multi-value case; got {columns_joined}"
     );
     assert!(
-        result.columns.iter().any(|c| c.starts_with("COUNT /")),
+        result.columns.iter().any(|c| c.starts_with("COUNT(*) /")),
         "missing COUNT-qualified columns in multi-value case; got {columns_joined}"
     );
 }
@@ -2441,7 +2444,9 @@ fn test_create_table_as_select() {
     let result = executor.execute(&select_query).expect("should execute");
 
     assert!(!result.is_empty());
-    assert_eq!(result.columns, vec!["account", "sum"]);
+    // `sum(number)`, not `sum`: a function target is headed by its source
+    // text, as bean-query does (#2164).
+    assert_eq!(result.columns, vec!["account", "sum(number)"]);
 }
 
 #[test]
@@ -3193,7 +3198,7 @@ fn test_order_by_group_by_expression_not_in_select() {
     // The result should only have 2 columns (account and sum), not the hidden sortkey column
     assert_eq!(result.columns.len(), 2);
     assert_eq!(result.columns[0], "account");
-    assert_eq!(result.columns[1], "sum");
+    assert_eq!(result.columns[1], "sum(number)");
 
     // Verify all rows have exactly 2 values
     for row in &result.rows {
@@ -3223,7 +3228,7 @@ fn test_order_by_multiple_hidden_columns() {
     // Should have 3 visible columns
     assert_eq!(result.columns.len(), 3);
     assert_eq!(result.columns[0], "account");
-    assert_eq!(result.columns[1], "sum");
+    assert_eq!(result.columns[1], "sum(number)");
     assert_eq!(result.columns[2], "currency");
 
     // Verify all rows have exactly 3 values
@@ -6837,6 +6842,62 @@ fn source_keys_reach_entries_meta_but_not_per_table_meta() {
 }
 
 #[test]
+fn result_headers_follow_bean_query_naming() {
+    // Three rules, each read off bean-query rather than inferred (#2164):
+    //   bare column -> the column's own name, lowercased
+    //   alias       -> lowercased, including a mixed-case one
+    //   function    -> the target's SOURCE TEXT, case intact
+    // The third is why `COUNT(date)` and `count(date)` head differently:
+    // bean-query echoes what was written rather than normalizing.
+    let directives = make_all_directive_types_test_directives();
+
+    for (query, expected) in [
+        ("SELECT DATE FROM #notes", vec!["date"]),
+        ("SELECT DaTe FROM #notes", vec!["date"]),
+        (
+            "SELECT ACCOUNT, COMMENT FROM #notes",
+            vec!["account", "comment"],
+        ),
+        ("SELECT DATE AS D FROM #notes", vec!["d"]),
+        ("SELECT date AS LatestDate FROM #notes", vec!["latestdate"]),
+        ("SELECT COUNT(date) FROM #notes", vec!["COUNT(date)"]),
+        ("SELECT count(date) FROM #notes", vec!["count(date)"]),
+    ] {
+        let result = execute_query(query, &directives);
+        assert_eq!(
+            result.columns, expected,
+            "{query} headed the result wrongly"
+        );
+    }
+}
+
+#[test]
+fn order_by_resolves_a_column_written_in_another_case() {
+    // Headers are lowercased since #2164, so an exact-match lookup would
+    // fail `ORDER BY DATE` against the `date` header -- which is a query
+    // bean-query accepts, and which this change broke before the lookup was
+    // made case-insensitive.
+    //
+    // The same applies to the synthetic hidden columns that carry an ORDER BY
+    // expression's source text: `find_hidden_order_by_targets` names one
+    // `MIN(date)` while the alias path lowercases it to `min(date)`.
+    let directives = make_all_directive_types_test_directives();
+
+    for query in [
+        "SELECT DATE FROM #notes ORDER BY DATE",
+        "SELECT ACCOUNT FROM #notes ORDER BY ACCOUNT",
+        "SELECT date FROM #notes ORDER BY date",
+        "SELECT DATE AS D FROM #notes ORDER BY D",
+    ] {
+        let result = execute_query(query, &directives);
+        assert!(
+            !result.rows.is_empty(),
+            "{query} returned no rows, so it proves nothing"
+        );
+    }
+}
+
+#[test]
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on
@@ -9240,7 +9301,9 @@ fn test_issue_586_convert_null_returns_zero() {
         2,
         "Should return both accounts with transactions"
     );
-    assert_eq!(result.columns, vec!["account", "Balance", "Converted"]);
+    // Aliases are lowercased, as bean-query does: `AS Balance` heads
+    // `balance` (#2164).
+    assert_eq!(result.columns, vec!["account", "balance", "converted"]);
 
     // First row: WithBalance account (alphabetically comes before ZeroBalance)
     match &result.rows[0][2] {

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__query_aggregate_output.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__query_aggregate_output.snap
@@ -2,10 +2,10 @@
 source: crates/rustledger/tests/cli_snapshot_test.rs
 expression: stdout.trim()
 ---
-account        SUM      
--------------  ---------
-Assets:Cash    2920 USD 
-Expenses:Food  80 USD   
-Income:Salary  -3000 USD
+account        SUM(position)
+-------------  -------------
+Assets:Cash    2920 USD     
+Expenses:Food  80 USD       
+Income:Salary  -3000 USD    
 
 3 row(s)


### PR DESCRIPTION
## What

bean-query and rustledger disagreed on how to name result columns. Three
rules, each measured against bean-query 3.x:

| target | bean-query | ours (before) |
|---|---|---|
| `SELECT DATE` | `date` | `DATE` |
| `SELECT DaTe` | `date` | `DaTe` |
| `SELECT DATE AS D` | `d` | `D` |
| `SELECT date AS LatestDate` | `latestdate` | `LatestDate` |
| `SELECT count(date)` | `count(date)` | `count` |
| `SELECT SUM(number)` | `SUM(number)` | `SUM` |
| `SELECT sum(NUMBER)` | `sum(NUMBER)` | `sum` |

So: identifiers (bare columns and aliases) are lowercased; a function target
is headed by its **source text**, case intact.

This matters for anything consuming our CSV by header name. A script written
against bean-query reads the `narration` field, gets `NARRATION` from us, and
misses it with no error.

## The issue understated it twice

#2164 was filed about casing of bare columns. Measuring first showed:

- **aliases are lowercased too** — the issue explicitly assumed they must be
  preserved, and that was wrong
- **we dropped function arguments entirely** — a separate bug, not casing

## Lowercasing broke ORDER BY, and that took two fixes

`ORDER BY` and `PIVOT BY` resolve against result headers by exact match, so
`ORDER BY DATE` stopped finding the now-lowercase `date` column. bean-query
accepts that query and it worked before this change — a real regression,
caught because it was the risk the issue itself flagged.

Then a subtler one. `find_hidden_order_by_targets` uses the **alias field as
an internal naming mechanism**, appending a hidden column named by its
expression's source text (`MIN(date)`). Blanket alias-lowercasing renamed it
to `min(date)` while the lookup still searched for `MIN(date)`, so
`ORDER BY MIN(date)` on a hidden column failed. That is a genuinely broken
internal contract, not an expectation change, and
`test_pivot_by_with_order_by_on_hidden_column_works` caught it.

Both fixed by one `find_column` helper — exact match first, then
case-insensitive — shared by all five ORDER BY / PIVOT BY lookup sites.
Exact-first so an exact hit still wins if two columns differ only by case. The
`column_indices` map it replaces is now dead and removed, dropping a map
allocation per sort.

## Test changes

Six failed. Five were expectation updates that now match bean-query
(`sum` → `sum(number)`, `["account","Balance","Converted"]` →
`["account","balance","converted"]`), including one stale comment that
documented the old naming explicitly. The sixth was the real hidden-column
breakage above.

The CLI aggregate snapshot moves `SUM` → `SUM(position)`. Confirmed that is
what bean-query emits for that exact query rather than assumed.

## Verification

- Each of the three naming rules and the case-insensitive lookup has a test,
  and each was confirmed to fail against its own unfixed code — reverted
  separately, not together.
- Header comparison run against bean-query directly across nine query shapes.
- Booked-value gate clean (`known 34, found 34, new 0`); `corpus_parity`
  divergences still exactly 20, matching `main` (pre-existing #1809).
- clippy at CI's 1.97, fmt, typos, rustdoc clean; full workspace tests pass.

## Scope, checked rather than assumed

Unchanged by this PR, verified against a `main` build:

- `SELECT *` headers — they come from the table's column list, not
  `expr_to_name`
- postfix targets — `meta['k']` heads `meta['k']`, matching bean-query
- **window functions** — `ROW_NUMBER() OVER (...)` still heads `ROW_NUMBER`,
  deliberately not the source text the `Function` arm now uses. `OVER` is a
  rustledger extension with no bean-query behaviour to match, and the full
  source text as a header would help nobody. Documented at the code so it does
  not read as an oversight; alias it (`AS rn`) for a different name.

Two aliases differing only by case now collapse to one header
(`SELECT date AS A, account AS a` heads `a,a`), as does a column colliding
with an alias. Both match bean-query exactly, checked directly since this is a
collision the change introduces.

## Downstream surfaces

Checked against a `main` build rather than reasoned about:

- `JOURNAL`, `BALANCES` and `PRINT` are **unchanged** — they carry fixed
  column names and never reach `expr_to_name`.
- `-f json` **changes**, because the header is both the `columns` entry and
  the per-row object key:

  ```
  main:  {"columns": ["COUNT"],       "rows": [{"COUNT": 1}]}
  this:  {"columns": ["COUNT(date)"], "rows": [{"COUNT(date)": 1}]}
  ```

  A consumer doing `row.COUNT` now needs `row["COUNT(date)"]`. bean-query has
  no JSON format (`beancount|csv|text` only), so there is nothing to match
  here; keeping the key identical to the CSV header is the consistent choice,
  but it is a visible wire change worth stating. The wire-format bindings
  freshness check passes — column names are data, not schema.
- The rustfava component test fails on snapshot drift (`'sum(day)'` vs
  `'sum'`), which is this change landing, not a defect.

## Known remaining gap

Literal and binary-expression targets still head as `colN` where bean-query
prints the expression (`number + 1`, `NOT (number > 0)`). Not fixed here
because `expr.to_string()` — the mechanism this PR uses for functions —
renders `(number + 1)` and `"lit"`, so it would still not match. bean-query
prints with minimal parentheses, measured; ours parenthesizes every binary
node, and `Display` is also what names the synthetic hidden ORDER BY columns,
so it cannot simply be changed. Filed as #2171 with the measurements.

Shipping the partial version was considered and rejected: it buys no
compatibility while churning affected headers a second time.

## Left alone

`SELECT DATE AS D FROM #notes ORDER BY d` fails on `main` and still fails
here — a different lookup path (subquery result columns) with the same
case-sensitivity shape. Pre-existing, verified against a clean `main` build,
and out of scope for this change.

Closes #2164
