### PR TITLE
docs(query): record the two metadata divergences as decisions

### DIFF
--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -90,6 +90,16 @@ impl Executor<'_> {
     }
 
     /// The synthetic `lineno` source-location column value, as an `Integer`.
+    /// Reads the `SourceLocation`, never the directive's metadata.
+    ///
+    /// bean-query stores the location in the same dict users write to, so a
+    /// directive carrying `lineno: 999` makes its `lineno` COLUMN report 999
+    /// instead of the real line. We do not match that: a column named
+    /// `lineno` should say where the directive is, not what someone typed.
+    /// Immune by construction rather than by a guard (#2168).
+    ///
+    /// The `meta` map itself does let the user's value win, which DOES match
+    /// bean-query -- `augmented_meta` only fills keys that are absent.
     pub(crate) fn source_lineno_value(loc: Option<&SourceLocation>) -> Value {
         loc.map_or(Value::Null, |l| Value::Integer(Self::lineno_i64(l)))
     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2117,6 +2117,20 @@ impl<'a> Executor<'a> {
         // with no metadata and renders Null as an empty CSV field, so the
         // two are distinguishable there: `meta IS NULL` is false where we
         // used to make it true (#2162).
+        // Alphabetical, deliberately NOT bean-query's order. bean-query emits
+        // `filename`/`lineno` first and then the user's keys in declaration
+        // order; we cannot reproduce either half. `Metadata` is an
+        // `FxHashMap`, so declaration order is already lost at parse time,
+        // and `Value::Object` is a `BTreeMap`, so the query layer cannot
+        // impose an order even if it knew one. Matching would mean an
+        // order-preserving map in `rustledger-core` -- a new dependency, rkyv
+        // support for the cache format, and a shifted `meta.hash` that
+        // rustfava pins -- to change the order keys print in. Measured and
+        // declined in #2168.
+        //
+        // The sort is also what makes `SELECT meta` deterministic at all,
+        // given the hash-map source. Same shape as the `#prices` ordering
+        // in #2163.
         let map: std::collections::BTreeMap<String, Value> = meta
             .iter()
             .map(|(k, v)| (k.clone(), Self::meta_value_to_value(Some(v))))

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2123,10 +2123,16 @@ impl<'a> Executor<'a> {
         // `FxHashMap`, so declaration order is already lost at parse time,
         // and `Value::Object` is a `BTreeMap`, so the query layer cannot
         // impose an order even if it knew one. Matching would mean an
-        // order-preserving map in `rustledger-core` -- a new dependency, rkyv
-        // support for the cache format, and a shifted `meta.hash` that
-        // rustfava pins -- to change the order keys print in. Measured and
-        // declined in #2168.
+        // order-preserving map in `rustledger-core`: a new dependency
+        // (`indexmap` is not one today) and a changed rkyv layout, since
+        // `Metadata` is part of the archived cache payload and rkyv is a
+        // default feature -- so a `CACHE_VERSION` bump too. All to change the
+        // order keys print in. Measured and declined in #2168.
+        //
+        // `meta.hash` is NOT at risk, contrary to an earlier draft of this
+        // comment: `rustledger-ffi-wasi::hash` sorts the keys itself before
+        // hashing, precisely because `Metadata` is a hash map, so the digest
+        // is already independent of iteration order.
         //
         // The sort is also what makes `SELECT meta` deterministic at all,
         // given the hash-map source. Same shape as the `#prices` ordering

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6902,6 +6902,64 @@ fn order_by_resolves_a_column_written_in_another_case() {
 }
 
 #[test]
+fn user_metadata_cannot_shadow_the_lineno_column() {
+    // bean-query stores the source location in the same dict users write to,
+    // so a directive carrying `lineno: 999` makes its `lineno` COLUMN report
+    // 999 rather than the real line. We deliberately do not match that
+    // (#2168): a column named `lineno` should say where the directive is.
+    //
+    // The `meta` map is the other way round -- the user's value wins there,
+    // which DOES match bean-query, because `augmented_meta` only fills keys
+    // that are absent. Both halves are asserted so neither can drift.
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+
+    let mut note = Note::new(date(2024, 1, 3), "Assets:Cash", "n");
+    note.meta.insert(
+        "lineno".to_string(),
+        rustledger_core::MetaValue::String("999".to_string()),
+    );
+    let dirs = [Directive::Note(note)];
+    let spanned: Vec<Spanned<rustledger_core::Directive>> = dirs
+        .iter()
+        .cloned()
+        .map(|d| Spanned {
+            value: d,
+            span: Span::new(0, 50),
+            file_id: 0,
+        })
+        .collect();
+    let source_map = SourceMap::new();
+    let mut executor = Executor::new_with_sources(&spanned, &source_map);
+
+    let col = executor
+        .execute(&parse("SELECT lineno FROM #entries").expect("should parse"))
+        .expect("query should execute");
+    assert!(
+        matches!(col.rows[0][0], Value::Integer(_)),
+        "the lineno column must come from the source location, not metadata; got {:?}",
+        col.rows[0][0]
+    );
+    assert_ne!(
+        col.rows[0][0],
+        Value::Integer(999),
+        "user metadata shadowed the lineno column"
+    );
+
+    let meta = executor
+        .execute(&parse("SELECT meta FROM #entries").expect("should parse"))
+        .expect("query should execute");
+    match &meta.rows[0][0] {
+        Value::Object(map) => assert_eq!(
+            map.get("lineno"),
+            Some(&Value::String("999".to_string())),
+            "the user's value must win inside `meta`, as bean-query does"
+        ),
+        other => panic!("#entries.meta should be a map, got {other:?}"),
+    }
+}
+
+#[test]
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6914,36 +6914,40 @@ fn user_metadata_cannot_shadow_the_lineno_column() {
     use rustledger_loader::SourceMap;
     use rustledger_parser::{Span, Spanned};
 
+    // A real file in the SourceMap, with the note on a known line. With an
+    // empty map the column resolves to 0, which satisfies "an integer that
+    // is not 999" and would let a broken source-location path pass (#2172
+    // review).
+    let source = "; line 1\n; line 2\n2024-01-03 note Assets:Cash \"n\"\n";
+    let note_offset = source
+        .find("2024-01-03")
+        .expect("fixture must contain the note");
+    let mut source_map = SourceMap::new();
+    let file_id = source_map.add_file("ledger.beancount".into(), source.into());
+
     let mut note = Note::new(date(2024, 1, 3), "Assets:Cash", "n");
-    note.meta.insert(
-        "lineno".to_string(),
-        rustledger_core::MetaValue::String("999".to_string()),
-    );
+    note.meta
+        .insert("lineno".to_string(), rustledger_core::MetaValue::Int(999));
     let dirs = [Directive::Note(note)];
     let spanned: Vec<Spanned<rustledger_core::Directive>> = dirs
         .iter()
         .cloned()
         .map(|d| Spanned {
             value: d,
-            span: Span::new(0, 50),
-            file_id: 0,
+            span: Span::new(note_offset, note_offset + 30),
+            file_id: u16::try_from(file_id).expect("one file fits in u16"),
         })
         .collect();
-    let source_map = SourceMap::new();
     let mut executor = Executor::new_with_sources(&spanned, &source_map);
 
     let col = executor
         .execute(&parse("SELECT lineno FROM #entries").expect("should parse"))
         .expect("query should execute");
-    assert!(
-        matches!(col.rows[0][0], Value::Integer(_)),
-        "the lineno column must come from the source location, not metadata; got {:?}",
-        col.rows[0][0]
-    );
-    assert_ne!(
+    assert_eq!(
         col.rows[0][0],
-        Value::Integer(999),
-        "user metadata shadowed the lineno column"
+        Value::Integer(3),
+        "the lineno column must be the note's real line (3), taken from the \
+         source location and not from metadata"
     );
 
     let meta = executor
@@ -6952,7 +6956,7 @@ fn user_metadata_cannot_shadow_the_lineno_column() {
     match &meta.rows[0][0] {
         Value::Object(map) => assert_eq!(
             map.get("lineno"),
-            Some(&Value::String("999".to_string())),
+            Some(&Value::Integer(999)),
             "the user's value must win inside `meta`, as bean-query does"
         ),
         other => panic!("#entries.meta should be a map, got {other:?}"),


### PR DESCRIPTION
## What

#2168 raised two metadata divergences from bean-query. Both are deliberate,
but neither was written down where a reader would look, so both read as gaps.
This records them at the code and pins the one that can silently drift.

## 1. Metadata key order stays alphabetical

bean-query emits `filename`/`lineno` first, then the user's keys in
declaration order. We emit alphabetical:

```
bc: {'filename': ..., 'lineno': 4, 'aaa': ..., 'zzz': ...}
rl: {aaa: ..., filename: ..., lineno: 4, zzz: ...}
```

**We can reproduce neither half.** `Metadata` is `FxHashMap<String,
MetaValue>`, so declaration order is lost at parse time; and `Value::Object`
is a `BTreeMap`, so the query layer cannot impose an order even if it had one.
Matching means an order-preserving map in `rustledger-core`: a new dependency
(`indexmap` is not one today) and a changed rkyv layout, since `Metadata` is
part of the archived cache payload and rkyv is a default feature — so a
`CACHE_VERSION` bump as well. All to change the order keys print in.

**Correction to an earlier draft of this PR:** I claimed this would also shift
`meta.hash`, which rustfava pins. That is wrong — `rustledger-ffi-wasi::hash`
sorts the metadata keys itself before hashing, precisely because `Metadata` is
a hash map, so the digest is already independent of iteration order. The
recommendation is unchanged, but that reason was not real and I had asserted
it without checking.

The sort is also the only thing making `SELECT meta` deterministic over a hash
map. Same shape as the `#prices` ordering in #2163: removing it to chase
bean-query would trade a stable order for an unstable one.

## 2. `lineno` metadata does not shadow the `lineno` column

bean-query stores the source location in the same dict users write to, so:

```beancount
2020-01-03 * "p" "n"
  lineno: 999
```

```
$ bean-query ... "SELECT lineno FROM #entries"   ->  999      the user's value
$ rledger query ... "SELECT lineno FROM #entries" ->  4        the real line
```

We read the `SourceLocation` directly, so ours is immune by construction
rather than by a guard. A column named `lineno` should report where the
directive is, not what someone typed.

The `meta` map is the other way round: the user's value wins there, which
**does** match bean-query, because `augmented_meta` only fills absent keys.

## Test

`user_metadata_cannot_shadow_the_lineno_column` asserts both halves, so
neither can drift toward the other — someone "fixing" this toward bean-query
would have to delete an assertion that says why not.

Confirmed to fail when the column is made to prefer metadata, which is
bean-query's behaviour.

## Verification

413 tests, clippy at CI's 1.97, fmt, typos, rustdoc all clean.

Closes #2168
