### PR TITLE
perf(query): stop #postings materializing balances no query reads

### DIFF
--- a/crates/rustledger-query/examples/profile_query.rs
+++ b/crates/rustledger-query/examples/profile_query.rs
@@ -53,6 +53,13 @@ fn main() {
         "SELECT account, position WHERE account ~ \"Expenses\"",
         "SELECT account, sum(position) GROUP BY account",
         "SELECT date, account, position ORDER BY date DESC",
+        // The `#postings` SYSTEM TABLE, not the default source. These are
+        // separate paths -- `build_postings_table` versus `collect_postings`
+        // -- and only the default one was profiled here, which is how a 7x
+        // gap went unnoticed: `SELECT count(account) FROM #postings` took
+        // 681ms against 93ms for the same query without the FROM (#2169).
+        "SELECT account FROM #postings",
+        "SELECT count(account) FROM #postings",
     ]
     .iter()
     .map(|q| parse_query(q).expect("parse query"))

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -431,7 +431,7 @@ impl Executor<'_> {
         let builtin_table;
         let table = if let Some(user_table) = self.tables.get(&table_name_upper) {
             user_table
-        } else if let Some(builtin) = self.get_builtin_table(table_name) {
+        } else if let Some(builtin) = self.get_builtin_table(table_name, Some(query)) {
             builtin_table = builtin;
             &builtin_table
         } else {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -431,7 +431,7 @@ impl Executor<'_> {
         let builtin_table;
         let table = if let Some(user_table) = self.tables.get(&table_name_upper) {
             user_table
-        } else if let Some(builtin) = self.get_builtin_table(table_name, Some(query)) {
+        } else if let Some(builtin) = self.get_builtin_table(table_name, query) {
             builtin_table = builtin;
             &builtin_table
         } else {

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2409,7 +2409,11 @@ impl<'a> Executor<'a> {
     /// compatibility (issue #632).
     ///
     /// Returns `None` if the table name is not a recognized built-in table.
-    pub(super) fn get_builtin_table(&self, table_name: &str) -> Option<Table> {
+    pub(super) fn get_builtin_table(
+        &self,
+        table_name: &str,
+        query: Option<&SelectQuery>,
+    ) -> Option<Table> {
         // Normalize table name: strip # prefix if present for Python beancount compatibility.
         // Both "#transactions" (rustledger) and "transactions" (beancount) work.
         // Using strip_prefix avoids allocation in the common case.
@@ -2426,7 +2430,7 @@ impl<'a> Executor<'a> {
             "ACCOUNTS" => Some(self.build_accounts_table()),
             "TRANSACTIONS" => Some(self.build_transactions_table()),
             "ENTRIES" => Some(self.build_entries_table()),
-            "POSTINGS" => Some(self.build_postings_table()),
+            "POSTINGS" => Some(self.build_postings_table(query)),
             _ => None,
         }
     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2409,11 +2409,7 @@ impl<'a> Executor<'a> {
     /// compatibility (issue #632).
     ///
     /// Returns `None` if the table name is not a recognized built-in table.
-    pub(super) fn get_builtin_table(
-        &self,
-        table_name: &str,
-        query: Option<&SelectQuery>,
-    ) -> Option<Table> {
+    pub(super) fn get_builtin_table(&self, table_name: &str, query: &SelectQuery) -> Option<Table> {
         // Normalize table name: strip # prefix if present for Python beancount compatibility.
         // Both "#transactions" (rustledger) and "transactions" (beancount) work.
         // Using strip_prefix avoids allocation in the common case.

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -724,7 +724,7 @@ impl Executor<'_> {
     /// Build the #postings table from transaction postings.
     ///
     /// Column schema matches Python beancount's `postings` table for compatibility.
-    pub(super) fn build_postings_table(&self, query: Option<&crate::ast::SelectQuery>) -> Table {
+    pub(super) fn build_postings_table(&self, query: &crate::ast::SelectQuery) -> Table {
         let columns = vec![
             // Entry-level columns
             "type".to_string(),
@@ -801,30 +801,21 @@ impl Executor<'_> {
                 // source -- whose `WILDCARD_COLUMNS` excludes both -- this
                 // table's `SELECT *` includes `balance` and
                 // `account_balance`, so it must force both on.
-                query.map_or(
+                {
+                    let wildcard = query
+                        .targets
+                        .iter()
+                        .any(|t| matches!(t.expr, crate::ast::Expr::Wildcard));
+                    let account_balance =
+                        wildcard || super::query_references_column(query, "account_balance");
                     super::ScanNeeds {
-                        balance: true,
-                        account_balance: true,
+                        balance: wildcard || super::query_references_column(query, "balance"),
+                        account_balance,
                         where_reads_balance: false,
                         where_reads_account_balance: false,
-                        output_reads_account_balance: true,
-                    },
-                    |q| {
-                        let wildcard = q
-                            .targets
-                            .iter()
-                            .any(|t| matches!(t.expr, crate::ast::Expr::Wildcard));
-                        let account_balance =
-                            wildcard || super::query_references_column(q, "account_balance");
-                        super::ScanNeeds {
-                            balance: wildcard || super::query_references_column(q, "balance"),
-                            account_balance,
-                            where_reads_balance: false,
-                            where_reads_account_balance: false,
-                            output_reads_account_balance: account_balance,
-                        }
-                    },
-                ),
+                        output_reads_account_balance: account_balance,
+                    }
+                },
                 true,
             )
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -724,7 +724,7 @@ impl Executor<'_> {
     /// Build the #postings table from transaction postings.
     ///
     /// Column schema matches Python beancount's `postings` table for compatibility.
-    pub(super) fn build_postings_table(&self) -> Table {
+    pub(super) fn build_postings_table(&self, query: Option<&crate::ast::SelectQuery>) -> Table {
         let columns = vec![
             // Entry-level columns
             "type".to_string(),
@@ -779,13 +779,52 @@ impl Executor<'_> {
             .scan_postings(
                 None,
                 None,
-                super::ScanNeeds {
-                    balance: true,
-                    account_balance: true,
-                    where_reads_balance: false,
-                    where_reads_account_balance: false,
-                    output_reads_account_balance: true,
-                },
+                // Gate the running-balance snapshots on whether the query
+                // reads them. These were hardcoded true, so
+                // `SELECT count(account) FROM #postings` paid for the
+                // cumulative `Inventory` clones per posting -- the #1080
+                // runaway -- on every system-table query (#2169).
+                //
+                // The flags do NOT mean what they mean in `collect_postings`,
+                // and reusing that computation verbatim was wrong twice over:
+                //
+                //   * This scan gets `where_clause: None`. The table is built
+                //     first and filtered afterwards, so nothing is read "at
+                //     WHERE time" and both `where_reads_*` are false.
+                //   * The table materializes `account_balance` into every row
+                //     regardless of the SELECT list, so the TABLE is the
+                //     output. Gating on `output_references_column` released
+                //     the snapshot before the row was built, and
+                //     `WHERE account_balance != 0` then matched nothing.
+                //
+                // A wildcard reads every column, and unlike the default
+                // source -- whose `WILDCARD_COLUMNS` excludes both -- this
+                // table's `SELECT *` includes `balance` and
+                // `account_balance`, so it must force both on.
+                query.map_or(
+                    super::ScanNeeds {
+                        balance: true,
+                        account_balance: true,
+                        where_reads_balance: false,
+                        where_reads_account_balance: false,
+                        output_reads_account_balance: true,
+                    },
+                    |q| {
+                        let wildcard = q
+                            .targets
+                            .iter()
+                            .any(|t| matches!(t.expr, crate::ast::Expr::Wildcard));
+                        let account_balance =
+                            wildcard || super::query_references_column(q, "account_balance");
+                        super::ScanNeeds {
+                            balance: wildcard || super::query_references_column(q, "balance"),
+                            account_balance,
+                            where_reads_balance: false,
+                            where_reads_account_balance: false,
+                            output_reads_account_balance: account_balance,
+                        }
+                    },
+                ),
                 true,
             )
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -785,6 +785,12 @@ impl Executor<'_> {
                 // cumulative `Inventory` clones per posting -- the #1080
                 // runaway -- on every system-table query (#2169).
                 //
+                // Worth 34% of the wall clock and 55% of peak RSS on a
+                // 40k-posting ledger (517MB -> 233MB), since the snapshots are
+                // retained `Inventory` copies. Both before and after scale
+                // linearly, so this is a constant factor, not a complexity
+                // fix -- the #1080 quadratic itself was already dealt with.
+                //
                 // The flags do NOT mean what they mean in `collect_postings`,
                 // and reusing that computation verbatim was wrong twice over:
                 //

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6964,6 +6964,46 @@ fn user_metadata_cannot_shadow_the_lineno_column() {
 }
 
 #[test]
+fn postings_table_materializes_balances_when_the_query_needs_them() {
+    // #postings gates the running-balance snapshots on whether the query
+    // reads them (#2169) -- they are the #1080 per-posting `Inventory`
+    // clones and cost ~34% of a `SELECT count(account) FROM #postings`.
+    //
+    // The gate is easy to get wrong in two ways, both of which produced
+    // silently EMPTY balances rather than an error, and both of which this
+    // pins:
+    //
+    //   * a WHERE that reads `account_balance` still needs it materialized,
+    //     even though the SELECT list does not mention it. Gating on the
+    //     output alone made this query return zero rows.
+    //   * `SELECT *` on this table includes `balance` and `account_balance`
+    //     -- unlike the default source, whose wildcard excludes both -- so a
+    //     wildcard must force them on. Otherwise the columns come back empty.
+    let directives = make_test_directives();
+
+    let filtered = execute_query(
+        "SELECT account FROM #postings WHERE account_balance != 0",
+        &directives,
+    );
+    assert!(
+        !filtered.rows.is_empty(),
+        "WHERE on account_balance returned nothing; the column was not materialized"
+    );
+
+    let starred = execute_query("SELECT * FROM #postings", &directives);
+    let ab = starred
+        .columns
+        .iter()
+        .position(|c| c == "account_balance")
+        .expect("#postings wildcard must include account_balance");
+    assert!(
+        starred.rows.iter().any(|r| r[ab] != Value::Null),
+        "SELECT * left account_balance empty on every row; the wildcard did not \
+         force materialization"
+    );
+}
+
+#[test]
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on


### PR DESCRIPTION
## What

`build_postings_table` hardcoded `ScanNeeds { balance: true, account_balance:
true, .. }`, so **every** `FROM #postings` query paid for the per-posting
cumulative `Inventory` clones — the #1080 runaway — even when nothing
referenced either column. The default source has gated this since #1085; the
system table never did.

40k-posting ledger, best of three, against a baseline binary built from the
same commit:

| query | base | this PR | |
|---|---|---|---|
| `SELECT count(account) FROM #postings` | 676 ms | **442 ms** | −34% |
| `SELECT account FROM #postings` | 719 ms | **479 ms** | −33% |
| `SELECT account … WHERE account_balance != 0` | 746 ms | **521 ms** | −30% |
| `SELECT count(balance) FROM #postings` | 686 ms | 588 ms | −14% |
| `SELECT * FROM #postings` | 1608 ms | 1620 ms | 0% |

`SELECT *` unchanged by design — a wildcard reads every column.

## Memory, which matters more than the time here

Peak RSS on the same 40k-posting ledger, three samples each and stable to
within 0.1%:

| | base | this PR |
|---|---|---|
| `SELECT count(account) FROM #postings` | 517 MB | **233 MB** (−55%) |
| `SELECT account, balance FROM #postings` | 780 MB | 757 MB (−3%) |

The snapshots are retained `Inventory` copies, so not taking them frees more
proportionally than it saves in time. The second row is the control: a query
that genuinely reads `balance` is essentially unchanged, as it must be.

## Constant factor, not a complexity fix

Measured at two workload sizes, because a 4× input should expose a changed
curve:

| | 5k txns | 20k txns | ratio |
|---|---|---|---|
| base | 165 ms | 671 ms | 4.06 |
| this PR | 106 ms | 435 ms | 4.10 |

Both linear on a 4× workload. This does not change the complexity class — the
#1080 quadratic was already dealt with elsewhere — it stops paying a constant
that nothing reads.

## The gate does not mean what it means on the default path

Reusing `collect_postings`'s computation verbatim was wrong twice, and both
mistakes produced **silently empty balances** rather than an error:

- This scan gets `where_clause: None`. The table is built first and filtered
  afterwards, so nothing is read "at WHERE time" and both `where_reads_*` are
  false.
- The table materializes `account_balance` into every row regardless of the
  SELECT list, so **the table is the output**. Gating on
  `output_references_column` released the snapshot before the row was built,
  and `WHERE account_balance != 0` returned **zero rows instead of twenty**.
- This table's `SELECT *` includes `balance` and `account_balance` — the
  default source's `WILDCARD_COLUMNS` excludes both — so a wildcard must force
  them on, or those columns come back empty.

## How they were caught

Not by the test suite, which passed throughout. By diffing query output
against a baseline binary across ten shapes — two differed, and the
`WHERE account_balance` one was returning nothing at all.

The new test pins both and was confirmed to fail against each mistake
separately.

## Profiling harness had a blind spot

`examples/profile_query.rs` only exercised the **default source**, never
`FROM #postings` — which is how a 7× gap went unnoticed:
`SELECT count(account) FROM #postings` took 681 ms against 93 ms for the same
query without the `FROM`. Adding two system-table shapes took the harness from
88.7M to 457.4M instructions, i.e. those two shapes are ~80% of the profile.

The callgrind profile is allocator-dominated — `_int_malloc` 18.8%,
`_int_free_chunk` 6.9%, `memcpy` 5.4%, `free` 5.2%, plus
`drop_glue::<Value>` 3.1%.

## Left for #2169

This fixes the balance half. The remaining gap to the default path is the
31-column row construction: `#postings` still builds every column regardless
of projection. Measured contributions — metadata columns are ~65 ms of 681 ms,
so the rest is spread across the string and position columns. That needs the
projection threaded into column construction, which is a larger change than
this one; #2169 stays open for it.

Refs #2169
