### PR TITLE
perf(query): skip #postings columns the query cannot observe

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2545,7 +2545,10 @@ fn expr_calls_any_function(expr: &Expr, names: &[&str]) -> bool {
             names.iter().any(|n| call.name.eq_ignore_ascii_case(n)) || call.args.iter().any(hit)
         }
         // Mirrors `expr_references_column`: the OVER clause's PARTITION BY and
-        // ORDER BY are expressions too, and a call can hide in either.
+        // ORDER BY are expressions too, and a call can hide in either. Not
+        // reachable from `#postings`, whose only caller today rejects window
+        // functions outright -- kept so the two helpers stay interchangeable
+        // rather than because this call site needs it.
         Expr::Window(call) => {
             names.iter().any(|n| call.name.eq_ignore_ascii_case(n))
                 || call.args.iter().any(hit)

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2536,6 +2536,91 @@ fn output_references_column(query: &SelectQuery, name: &str) -> bool {
 /// ORDER BY, and the FROM filter expression. A subquery in FROM is
 /// treated as opaque — its inner references don't surface to the
 /// outer query's posting iterator.
+/// Walk an [`Expr`] tree, returning `true` if any [`Expr::Function`] call has
+/// one of `names` (compared case-insensitively).
+///
+/// Needed because some functions read a column the query never names: the four
+/// metadata functions are dispatched by name and then read the hidden
+/// `_entry_meta` / `_posting_meta` columns off the row, so a projection that
+/// gated on column references alone would drop the data they need (#2169).
+fn expr_calls_any_function(expr: &Expr, names: &[&str]) -> bool {
+    let hit = |e: &Expr| expr_calls_any_function(e, names);
+    match expr {
+        Expr::Function(call) => {
+            names.iter().any(|n| call.name.eq_ignore_ascii_case(n)) || call.args.iter().any(hit)
+        }
+        // Mirrors `expr_references_column`: the OVER clause's PARTITION BY and
+        // ORDER BY are expressions too, and a call can hide in either.
+        Expr::Window(call) => {
+            names.iter().any(|n| call.name.eq_ignore_ascii_case(n))
+                || call.args.iter().any(hit)
+                || call
+                    .over
+                    .partition_by
+                    .as_ref()
+                    .is_some_and(|ps| ps.iter().any(hit))
+                || call
+                    .over
+                    .order_by
+                    .as_ref()
+                    .is_some_and(|os| os.iter().any(|o| hit(&o.expr)))
+        }
+        Expr::Attribute { operand, .. } | Expr::Subscript { operand, .. } => hit(operand),
+        Expr::BinaryOp(op) => hit(&op.left) || hit(&op.right),
+        Expr::UnaryOp(op) => hit(&op.operand),
+        Expr::Paren(inner) => hit(inner),
+        Expr::Between { value, low, high } => hit(value) || hit(low) || hit(high),
+        Expr::Set(items) => items.iter().any(hit),
+        Expr::Column(_) | Expr::Wildcard | Expr::Literal(_) => false,
+    }
+}
+
+/// Whether any clause of `query` calls one of `names`.
+///
+/// Mirrors [`query_references_column`]'s clause coverage; the two are used
+/// together to decide what a system table has to materialize.
+fn query_calls_any_function(query: &SelectQuery, names: &[&str]) -> bool {
+    if query
+        .targets
+        .iter()
+        .any(|t| expr_calls_any_function(&t.expr, names))
+    {
+        return true;
+    }
+    if let Some(w) = &query.where_clause
+        && expr_calls_any_function(w, names)
+    {
+        return true;
+    }
+    if let Some(g) = &query.group_by
+        && g.iter().any(|e| expr_calls_any_function(e, names))
+    {
+        return true;
+    }
+    if let Some(h) = &query.having
+        && expr_calls_any_function(h, names)
+    {
+        return true;
+    }
+    if let Some(p) = &query.pivot_by
+        && p.iter().any(|e| expr_calls_any_function(e, names))
+    {
+        return true;
+    }
+    if let Some(o) = &query.order_by
+        && o.iter().any(|sp| expr_calls_any_function(&sp.expr, names))
+    {
+        return true;
+    }
+    if let Some(from) = &query.from
+        && let Some(f) = &from.filter
+        && expr_calls_any_function(f, names)
+    {
+        return true;
+    }
+    false
+}
+
 fn query_references_column(query: &SelectQuery, name: &str) -> bool {
     if query
         .targets

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2531,11 +2531,6 @@ fn output_references_column(query: &SelectQuery, name: &str) -> bool {
             .is_some_and(|o| o.iter().any(|s| expr_references_column(&s.expr, name)))
 }
 
-/// Return `true` if any part of a `SelectQuery` references the given
-/// column. Walks SELECT targets, WHERE, GROUP BY, HAVING, PIVOT BY,
-/// ORDER BY, and the FROM filter expression. A subquery in FROM is
-/// treated as opaque — its inner references don't surface to the
-/// outer query's posting iterator.
 /// Walk an [`Expr`] tree, returning `true` if any [`Expr::Function`] call has
 /// one of `names` (compared case-insensitively).
 ///
@@ -2621,6 +2616,11 @@ fn query_calls_any_function(query: &SelectQuery, names: &[&str]) -> bool {
     false
 }
 
+/// Return `true` if any part of a `SelectQuery` references the given
+/// column. Walks SELECT targets, WHERE, GROUP BY, HAVING, PIVOT BY,
+/// ORDER BY, and the FROM filter expression. A subquery in FROM is
+/// treated as opaque — its inner references don't surface to the
+/// outer query's posting iterator.
 fn query_references_column(query: &SelectQuery, name: &str) -> bool {
     if query
         .targets

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -827,11 +827,12 @@ impl Executor<'_> {
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
             .postings;
 
-        // Five columns hold ~40% of this table's build time and ~47% of its
+        // Four columns hold ~40% of this table's build time and ~47% of its
         // peak RSS: the structured `entry` object and the three metadata maps
         // (`meta`, `_entry_meta`, `_posting_meta`). Skip them when the query
         // cannot observe them (#2169). Everything else is cheap enough that
-        // gating it would cost more in review surface than it saves.
+        // gating it would cost more in review surface than it saves --
+        // stubbing both `StringSet` columns moved 443ms to 437ms.
         //
         // A wildcard forces on only what it can actually SHOW. This table's
         // `SELECT *` emits `meta` but omits `entry` and the two `_`-prefixed

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -834,6 +834,10 @@ impl Executor<'_> {
         // gating it would cost more in review surface than it saves --
         // stubbing both `StringSet` columns moved 443ms to 437ms.
         //
+        // Callgrind on `examples/profile_query.rs` puts the whole #2169 +
+        // #2173 effect at 457.4M -> 244.2M instructions, which does not move
+        // with machine load the way the wall clock does.
+        //
         // A wildcard forces on only what it can actually SHOW. This table's
         // `SELECT *` emits `meta` but omits `entry` and the two `_`-prefixed
         // metadata helpers -- `Executor::wildcard_hidden` drops the structured

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -827,6 +827,41 @@ impl Executor<'_> {
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
             .postings;
 
+        // Five columns hold ~40% of this table's build time and ~47% of its
+        // peak RSS: the structured `entry` object and the three metadata maps
+        // (`meta`, `_entry_meta`, `_posting_meta`). Skip them when the query
+        // cannot observe them (#2169). Everything else is cheap enough that
+        // gating it would cost more in review surface than it saves.
+        //
+        // A wildcard forces on only what it can actually SHOW. This table's
+        // `SELECT *` emits `meta` but omits `entry` and the two `_`-prefixed
+        // metadata helpers -- `Executor::wildcard_hidden` drops the structured
+        // entry column to match beanquery, and underscore columns with it. So
+        // a bare `SELECT *` never observes those three, and forcing them on
+        // would be pure waste. Reaching them from a wildcard query still
+        // works, because `ORDER BY entry.narration` or `meta('k')` names or
+        // calls its way in and is picked up below.
+        let wildcard = query
+            .targets
+            .iter()
+            .any(|t| matches!(t.expr, crate::ast::Expr::Wildcard));
+        // `entry` is reachable as a bare column and as `entry.narration`;
+        // `expr_references_column` recurses into `Attribute`/`Subscript`
+        // operands, so the bare name covers both.
+        let needs_entry = super::query_references_column(query, "entry");
+        let needs_meta = wildcard || super::query_references_column(query, "meta");
+        // The hidden metadata columns are read by FUNCTION, not by name:
+        // `eval_meta_on_table_row` is dispatched for exactly these four, and
+        // reads `_posting_meta` / `_entry_meta` off the row. A query calling
+        // `meta('key')` never mentions either column, so gating on column
+        // references alone would break it silently.
+        let needs_hidden_meta = super::query_references_column(query, "_entry_meta")
+            || super::query_references_column(query, "_posting_meta")
+            || super::query_calls_any_function(
+                query,
+                &["META", "ENTRY_META", "ANY_META", "POSTING_META"],
+            );
+
         // Entry objects are per-TRANSACTION; postings of one transaction are
         // contiguous in the scan, so memoize the last built object instead of
         // rebuilding (strings, tags/links vectors, full meta conversion) for
@@ -844,13 +879,17 @@ impl Executor<'_> {
             // Transaction-level location — the per-posting fallback below.
             let source_loc = self.get_source_location(dir_idx);
 
-            let entry_val = match &last_entry {
-                Some((idx, value)) if *idx == dir_idx => value.clone(),
-                _ => {
-                    let value = Self::entry_object(txn, source_loc);
-                    last_entry = Some((dir_idx, value.clone()));
-                    value
+            let entry_val = if needs_entry {
+                match &last_entry {
+                    Some((idx, value)) if *idx == dir_idx => value.clone(),
+                    _ => {
+                        let value = Self::entry_object(txn, source_loc);
+                        last_entry = Some((dir_idx, value.clone()));
+                        value
+                    }
                 }
+            } else {
+                Value::Null
             };
 
             let tags: Vec<String> = txn.tags.iter().map(ToString::to_string).collect();
@@ -986,15 +1025,27 @@ impl Executor<'_> {
                 balance_val,
                 account_balance_val,
                 // Metadata and collection
-                Value::Metadata(Box::new(Self::augmented_meta(
-                    &posting.meta,
-                    posting_loc.as_ref(),
-                ))),
+                if needs_meta {
+                    Value::Metadata(Box::new(Self::augmented_meta(
+                        &posting.meta,
+                        posting_loc.as_ref(),
+                    )))
+                } else {
+                    Value::Null
+                },
                 Value::StringSet(all_accounts),
                 entry_val,
                 // Hidden metadata columns
-                Self::metadata_to_value(&txn.meta),
-                Self::metadata_to_value(&posting.meta),
+                if needs_hidden_meta {
+                    Self::metadata_to_value(&txn.meta)
+                } else {
+                    Value::Null
+                },
+                if needs_hidden_meta {
+                    Self::metadata_to_value(&posting.meta)
+                } else {
+                    Value::Null
+                },
             ];
             table.add_row(row);
         }

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1725,6 +1725,81 @@ fn test_date_add_with_interval() {
     );
 }
 
+/// Verify `query_calls_any_function` walks every query part and every
+/// expression shape.
+///
+/// The `#postings` column projection in #2169 hinges on this: the metadata
+/// functions read hidden columns the query never names, so a false negative
+/// here materializes nothing and `meta('k')` silently returns Null.
+///
+/// Several shapes below cannot be reached end-to-end through `#postings` --
+/// `meta('k') BETWEEN ...` type-errors before it matters, and window
+/// functions are rejected with an explicit `FROM #postings` -- so a direct
+/// test is the only way to cover those arms.
+#[test]
+fn test_query_calls_any_function_covers_all_shapes() {
+    const METAS: &[&str] = &["META", "ENTRY_META", "ANY_META", "POSTING_META"];
+
+    fn assert_calls(sql: &str, expected: bool) {
+        let q = match parse(sql).unwrap() {
+            Query::Select(s) => s,
+            _ => panic!("expected Select for {sql:?}"),
+        };
+        assert_eq!(
+            query_calls_any_function(&q, METAS),
+            expected,
+            "query_calls_any_function wrong for {sql:?}"
+        );
+    }
+
+    // Negative: no metadata call anywhere.
+    assert_calls("SELECT account FROM #postings", false);
+    assert_calls("SELECT count(account) FROM #postings", false);
+    assert_calls("SELECT meta FROM #postings", false);
+
+    // All four dispatched names.
+    for f in ["meta", "entry_meta", "any_meta", "posting_meta"] {
+        assert_calls(&format!("SELECT {f}('k') FROM #postings"), true);
+    }
+    // Case-insensitive, like the dispatch itself.
+    assert_calls("SELECT META('k') FROM #postings", true);
+
+    // Every clause.
+    assert_calls(
+        "SELECT account FROM #postings WHERE meta('k') IS NULL",
+        true,
+    );
+    assert_calls("SELECT account FROM #postings GROUP BY meta('k')", true);
+    assert_calls("SELECT account FROM #postings ORDER BY meta('k')", true);
+    assert_calls(
+        "SELECT account, count(account) FROM #postings GROUP BY account HAVING meta('k') IS NULL",
+        true,
+    );
+
+    // Nested expression shapes, including the ones unreachable end-to-end.
+    assert_calls("SELECT length(meta('k')) FROM #postings", true);
+    assert_calls(
+        "SELECT account FROM #postings WHERE (meta('k')) IS NULL",
+        true,
+    );
+    assert_calls(
+        "SELECT account FROM #postings WHERE NOT (meta('k') IS NULL)",
+        true,
+    );
+    assert_calls(
+        "SELECT account FROM #postings WHERE meta('k') IN ('a', 'b')",
+        true,
+    );
+    assert_calls(
+        "SELECT account FROM #postings WHERE meta('k') BETWEEN 'a' AND 'z'",
+        true,
+    );
+    assert_calls(
+        "SELECT account FROM #postings WHERE account = 'x' OR meta('k') IS NULL",
+        true,
+    );
+}
+
 /// Verify `query_references_column` walks every relevant query
 /// part. The `collect_postings` optimization in #1080 hinges on
 /// this — a false negative here would skip the cumulative-balance

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7004,6 +7004,70 @@ fn postings_table_materializes_balances_when_the_query_needs_them() {
 }
 
 #[test]
+fn postings_table_materializes_gated_columns_when_reachable() {
+    // #postings skips the structured `entry` object and the three metadata
+    // maps when the query cannot observe them -- together ~40% of its build
+    // time and ~47% of its peak RSS (#2169). Each way of reaching them is
+    // pinned here, because every one of them fails SILENTLY: a gate that is
+    // too tight yields Null, not an error.
+    // Metadata at BOTH levels: `META` / `POSTING_META` read the posting's,
+    // `ENTRY_META` the transaction's, `ANY_META` falls back from one to the
+    // other. With only one level a correct Null looks like a gating failure.
+    let mut posting = Posting::new("Assets:Cash", Amount::new(dec!(10), "USD"));
+    posting.meta.insert(
+        "k".to_string(),
+        rustledger_core::MetaValue::String("posting-value".to_string()),
+    );
+    let mut txn = Transaction::new(date(2024, 1, 15), "narr")
+        .with_payee("payee")
+        .with_synthesized_posting(posting)
+        .with_synthesized_posting(Posting::new("Income:Job", Amount::new(dec!(-10), "USD")));
+    txn.meta.insert(
+        "k".to_string(),
+        rustledger_core::MetaValue::String("entry-value".to_string()),
+    );
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Income:Job")),
+        Directive::Transaction(txn),
+    ];
+
+    // The metadata functions are the subtle case: they are dispatched by NAME
+    // and then read the hidden `_entry_meta` / `_posting_meta` columns, which
+    // the query never mentions. Gating on column references alone drops them.
+    for func in ["meta", "entry_meta", "any_meta"] {
+        let r = execute_query(&format!("SELECT {func}('k') FROM #postings"), &directives);
+        assert!(
+            r.rows.iter().any(|row| row[0] != Value::Null),
+            "{func}('k') returned Null everywhere; the hidden metadata columns \
+             were not materialized"
+        );
+    }
+
+    // `entry` reached through an attribute, not as a bare column.
+    let attr = execute_query("SELECT entry.narration FROM #postings", &directives);
+    assert!(
+        attr.rows.iter().any(|row| row[0] != Value::Null),
+        "entry.narration returned Null; the entry object was not materialized"
+    );
+
+    // And the wildcard, which names nothing at all.
+    // `SELECT *` shows `meta` but NOT `entry` or the `_`-prefixed helpers --
+    // `wildcard_hidden` omits them -- so only `meta` has to be forced on for a
+    // bare wildcard. `entry` is covered by the attribute case above.
+    let star = execute_query("SELECT * FROM #postings", &directives);
+    let i = star
+        .columns
+        .iter()
+        .position(|c| c == "meta")
+        .expect("#postings wildcard must include meta");
+    assert!(
+        star.rows.iter().any(|row| row[i] != Value::Null),
+        "SELECT * left meta Null on every row; the wildcard did not force it on"
+    );
+}
+
+#[test]
 fn select_star_matches_bean_query_per_table() {
     // bean-query's wildcard is NOT uniform about `meta`: it omits the column
     // on #balances/#notes/#events/#documents and includes it -- first -- on

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7035,7 +7035,10 @@ fn postings_table_materializes_gated_columns_when_reachable() {
     // The metadata functions are the subtle case: they are dispatched by NAME
     // and then read the hidden `_entry_meta` / `_posting_meta` columns, which
     // the query never mentions. Gating on column references alone drops them.
-    for func in ["meta", "entry_meta", "any_meta"] {
+    // All FOUR dispatched names, not three: `POSTING_META` routes to
+    // `_posting_meta` like `META` does, and omitting it would let a gate that
+    // forgets it pass.
+    for func in ["meta", "posting_meta", "entry_meta", "any_meta"] {
         let r = execute_query(&format!("SELECT {func}('k') FROM #postings"), &directives);
         assert!(
             r.rows.iter().any(|row| row[0] != Value::Null),


### PR DESCRIPTION
## What

Four of `#postings`' 31 columns hold most of its cost — the structured `entry`
object and the three metadata maps (`meta`, `_entry_meta`, `_posting_meta`).
They are now built only when the query can observe them.

40k-posting ledger, best of three, against a binary built from `main`:

| query | before | after |
|---|---|---|
| `SELECT count(account) FROM #postings` | 433 ms / 227 MB | **240 ms / 131 MB** |
| `SELECT account FROM #postings` | 484 ms / 229 MB | 296 ms / 133 MB |
| `SELECT meta('k') FROM #postings` | 482 ms / 228 MB | 290 ms / 135 MB |
| `SELECT * FROM #postings` | 1617 ms / 844 MB | 1419 ms / 766 MB |

With #2173 already merged, the first is **681 ms / 517 MB → 240 ms / 131 MB**:
−65% time, −75% peak RSS.

## Why only four columns

Measured, not guessed. Stubbing both `StringSet` columns moved 443 ms to
437 ms — noise. The other 26 are cheap enough that gating them would cost more
in review surface than it saves. A floor experiment (one real column of 31)
sits at 227 ms, so these four recover nearly all of what is available.

## Three ways to reach a gated column

Each fails **silently** when the gate is too tight — a missed reader gets Null,
not an error — so each is pinned by a test:

- **By name, including through an attribute.** `entry.narration` reaches
  `entry` because `expr_references_column` recurses into `Attribute` /
  `Subscript` operands.
- **By function.** `META`, `ENTRY_META`, `ANY_META` and `POSTING_META` are
  dispatched by name and then read `_posting_meta` / `_entry_meta` off the row.
  A query calling `meta('key')` names neither column, so gating on column
  references alone drops what it needs. New `query_calls_any_function` mirrors
  `query_references_column`'s clause coverage, including the `OVER` clause —
  though that arm is not reachable from `#postings`, which rejects window
  functions outright; it is there so the two helpers stay interchangeable.

  The `match` is exhaustive with no catch-all, so a future `Expr` variant
  fails to compile rather than silently returning `false`. Two arms
  (`Between`, `Window`) cannot be exercised end-to-end here —
  `meta('k') BETWEEN …` type-errors first — so a direct unit test covers
  every shape, and each was confirmed to fail when its arm is made to
  return `false`.
- **By wildcard**, which forces on only what `SELECT *` can actually SHOW.
  This table's wildcard emits `meta` but omits `entry` and the underscore
  helpers, because `wildcard_hidden` drops the structured entry column to match
  beanquery. Forcing all four on was my first attempt and left `SELECT *` with
  **no improvement at all**; narrowing it to what the wildcard emits is what
  made that row faster too.

## Instruction counts, independent of the clock

`examples/profile_query.rs` under callgrind, same 3000-directive workload, on
the system-table shapes #2173 added to it:

```
pre-#2173:  457,416,198 Ir
this PR:    244,239,383 Ir      -47%
```

Instruction counts do not move with machine load or allocator behaviour, so
this corroborates the wall-clock table above rather than repeating it. It also
closes the loop on the harness gap: the shapes added in #2173 are exactly the
ones that improved.

## Verification

- Query output diffed against a `main`-built binary across **17 shapes**,
  including `SELECT *, entry.narration` and
  `SELECT * ORDER BY entry.narration` — the cases where a wildcard and a named
  reference interact. All identical, with a negative control confirming the
  comparison discriminates.
- Re-run after the clippy refactor rather than assuming a refactor preserves
  behaviour.
- Each of the three gates confirmed to fail its own assertion when removed,
  checked one at a time.
- Booked-value gate clean (`known 34, found 34, new 0`); `corpus_parity`
  divergences still exactly 20, matching `main` (pre-existing #1809).
- clippy at CI's 1.97, fmt, typos, rustdoc clean.

Closes #2169
