### PR TITLE
fix(query): head expression targets the way bean-query renders them

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -653,8 +653,11 @@ impl fmt::Display for Expr {
 ///
 /// Parentheses wrapping the whole target are dropped, matching bean-query:
 /// `SELECT ((number + 1))` heads `number + 1`.
+/// Crate-internal: this is how the executor names result columns, not
+/// something a consumer should reach for. `ast` is a `pub mod`, so a bare
+/// `pub` here would put a rendering helper in the crate's API.
 #[must_use]
-pub fn header_name(expr: &Expr) -> String {
+pub(crate) fn header_name(expr: &Expr) -> String {
     // Strip parens that wrap the entire target; nested ones are preserved by
     // `header_fragment`.
     let mut top = expr;

--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -670,7 +670,22 @@ fn header_fragment(expr: &Expr) -> String {
         Expr::Column(name) => name.clone(),
         Expr::Wildcard => "*".to_string(),
         // Single quotes, as bean-query writes them; `Display` uses double.
-        Expr::Literal(Literal::String(s)) => format!("'{s}'"),
+        // Switch to double when the value contains a single quote and no
+        // double, so the header stays a well-formed literal instead of the
+        // ambiguous `'o'clock'`.
+        //
+        // Exact parity is out of reach here: bean-query echoes the quote
+        // character the query WROTE (`"dq"` heads `"dq"`, `'dq'` heads
+        // `'dq'`), and `Literal::String` does not record which was used.
+        // Reproducing that needs the parser to keep the original style
+        // (#2176).
+        Expr::Literal(Literal::String(s)) => {
+            if s.contains('\'') && !s.contains('"') {
+                format!("\"{s}\"")
+            } else {
+                format!("'{s}'")
+            }
+        }
         Expr::Literal(lit) => lit.to_string(),
         Expr::Paren(inner) => format!("({})", header_fragment(inner)),
         Expr::Attribute { operand, name } => {

--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -637,6 +637,87 @@ impl fmt::Display for Expr {
     }
 }
 
+/// Render an expression the way bean-query heads a result column.
+///
+/// This is NOT `Display`, deliberately. `Display` parenthesizes every binary
+/// node and double-quotes strings, which is fine for the round-tripping it is
+/// used for -- naming the synthetic hidden ORDER BY columns -- but wrong as a
+/// header: bean-query heads `number + 1` as `number + 1`, not `(number + 1)`.
+///
+/// bean-query renders the parse tree FAITHFULLY. It preserves the parentheses
+/// the query actually wrote, including ones precedence does not require
+/// (`(number > 0) AND (number < 5)` keeps both pairs), and adds none of its
+/// own (`number + 1 * 2` gains nothing). Measured, not derived from a
+/// precedence table -- an earlier attempt at minimal parenthesization
+/// disagreed with it on exactly those two cases.
+///
+/// Parentheses wrapping the whole target are dropped, matching bean-query:
+/// `SELECT ((number + 1))` heads `number + 1`.
+#[must_use]
+pub fn header_name(expr: &Expr) -> String {
+    // Strip parens that wrap the entire target; nested ones are preserved by
+    // `header_fragment`.
+    let mut top = expr;
+    while let Expr::Paren(inner) = top {
+        top = inner;
+    }
+    header_fragment(top)
+}
+
+/// Render one node of a header expression, preserving parentheses as written.
+fn header_fragment(expr: &Expr) -> String {
+    match expr {
+        Expr::Column(name) => name.clone(),
+        Expr::Wildcard => "*".to_string(),
+        // Single quotes, as bean-query writes them; `Display` uses double.
+        Expr::Literal(Literal::String(s)) => format!("'{s}'"),
+        Expr::Literal(lit) => lit.to_string(),
+        Expr::Paren(inner) => format!("({})", header_fragment(inner)),
+        Expr::Attribute { operand, name } => {
+            format!("{}.{name}", header_fragment(operand))
+        }
+        Expr::Subscript { operand, key } => {
+            format!("{}['{key}']", header_fragment(operand))
+        }
+        Expr::BinaryOp(op) => format!(
+            "{} {} {}",
+            header_fragment(&op.left),
+            op.op,
+            header_fragment(&op.right)
+        ),
+        // `UnaryOperator`'s Display bakes in its own spacing and position:
+        // `Not` is "NOT " (prefix, trailing space), `Neg` is "-" (prefix, no
+        // space), and `IsNull` / `IsNotNull` are " IS NULL" / " IS NOT NULL"
+        // -- POSTFIX, with a leading space. Formatting them all as prefix
+        // produced "NOT  x" and, worse, "IS NULL x".
+        Expr::UnaryOp(op) => match op.op {
+            UnaryOperator::IsNull | UnaryOperator::IsNotNull => {
+                format!("{}{}", header_fragment(&op.operand), op.op)
+            }
+            UnaryOperator::Not | UnaryOperator::Neg => {
+                format!("{}{}", op.op, header_fragment(&op.operand))
+            }
+        },
+        Expr::Between { value, low, high } => format!(
+            "{} BETWEEN {} AND {}",
+            header_fragment(value),
+            header_fragment(low),
+            header_fragment(high)
+        ),
+        Expr::Set(items) => {
+            let inner: Vec<String> = items.iter().map(header_fragment).collect();
+            format!("({})", inner.join(", "))
+        }
+        Expr::Function(call) => {
+            let args: Vec<String> = call.args.iter().map(header_fragment).collect();
+            format!("{}({})", call.name, args.join(", "))
+        }
+        // Window functions keep the bare name (#2164): `OVER` is a rustledger
+        // extension with no bean-query rendering to match.
+        Expr::Window(call) => call.name.clone(),
+    }
+}
+
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -731,7 +731,7 @@ impl Executor<'_> {
         hidden: &[String],
     ) -> Result<Vec<String>, QueryError> {
         let mut names = Vec::new();
-        for (i, target) in targets.iter().enumerate() {
+        for target in targets {
             if let Some(alias) = &target.alias {
                 // bean-query lowercases the alias too: `AS LatestDate`
                 // heads the result `latestdate` (#2164).
@@ -745,7 +745,7 @@ impl Executor<'_> {
                         .cloned(),
                 );
             } else {
-                names.push(self.expr_to_name(&target.expr, i));
+                names.push(self.expr_to_name(&target.expr));
             }
         }
         Ok(names)

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2332,7 +2332,7 @@ impl<'a> Executor<'a> {
     /// Resolve column names from targets.
     fn resolve_column_names(&self, targets: &[Target]) -> Result<Vec<String>, QueryError> {
         let mut names = Vec::new();
-        for (i, target) in targets.iter().enumerate() {
+        for target in targets {
             if matches!(target.expr, Expr::Wildcard) {
                 // Check wildcard BEFORE alias to catch `SELECT * AS alias` edge case
                 if target.alias.is_some() {
@@ -2347,14 +2347,14 @@ impl<'a> Executor<'a> {
                 // heads the result `latestdate` (#2164).
                 names.push(alias.to_lowercase());
             } else {
-                names.push(self.expr_to_name(&target.expr, i));
+                names.push(self.expr_to_name(&target.expr));
             }
         }
         Ok(names)
     }
 
     /// Convert an expression to a column name.
-    fn expr_to_name(&self, expr: &Expr, index: usize) -> String {
+    fn expr_to_name(&self, expr: &Expr) -> String {
         match expr {
             Expr::Wildcard => "*".to_string(),
             // bean-query lowercases a bare column reference to the column's
@@ -2365,7 +2365,11 @@ impl<'a> Executor<'a> {
             // intact: `sum(NUMBER)` stays `sum(NUMBER)`. We emitted just the
             // function name, dropping the arguments, so `SELECT count(date)`
             // headed `count` where bean-query heads `count(date)`.
-            Expr::Function(_) => expr.to_string(),
+            //
+            // `header_name`, not `to_string`: `Display` parenthesizes every
+            // binary node, so `sum(number + 1)` headed `sum((number + 1))`
+            // where bean-query heads `sum(number + 1)` (#2171).
+            Expr::Function(_) => crate::ast::header_name(expr),
             // Window functions keep the bare name, deliberately NOT the source
             // text the `Function` arm above uses. They are a rustledger
             // extension -- bean-query has no `OVER` -- so there is no rule to
@@ -2378,16 +2382,11 @@ impl<'a> Executor<'a> {
             // bare "colN" broke `SELECT entry.narration ORDER BY
             // entry.narration`, #1800 review).
             Expr::Attribute { .. } | Expr::Subscript { .. } => expr.to_string(),
-            // Literals and binary/unary expressions still head as `colN`.
-            // bean-query names them by printing the expression with MINIMAL
-            // parentheses -- `number + 1 * 2` gains none, `(number + 1) * 2`
-            // keeps the ones precedence requires, `((number))` collapses to
-            // `number`. Our `Display` parenthesizes every binary node, so
-            // `expr.to_string()` here yields `(number + 1)` and still would
-            // not match. Matching needs a precedence-aware printer, and
-            // `Display` is shared with hidden-column naming and error
-            // messages, so it cannot simply be changed. Tracked in #2171.
-            _ => format!("col{index}"),
+            // Literals and binary/unary expressions are headed by rendering
+            // them, as bean-query does: `SELECT number + 1` heads
+            // `number + 1`, `SELECT 'lit'` heads `'lit'`. `colN` named
+            // nothing a reader or a script could use (#2171).
+            _ => crate::ast::header_name(expr),
         }
     }
 

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1789,6 +1789,22 @@ fn test_header_name_matches_bean_query_rendering() {
     assert_header("SELECT sum(number + 1) FROM #postings", "sum(number + 1)");
     assert_header("SELECT length(payee) FROM #postings", "length(payee)");
     assert_header("SELECT count(date) FROM #postings", "count(date)");
+    // Nesting in both directions, and the wildcard argument.
+    assert_header("SELECT sum(neg(number)) FROM #postings", "sum(neg(number))");
+    assert_header(
+        "SELECT length(payee) + 1 FROM #postings",
+        "length(payee) + 1",
+    );
+    assert_header("SELECT count(*) FROM #postings", "count(*)");
+
+    // Postfix targets. `expr_to_name` routes these through `Display` rather
+    // than here, for the reason in #1800 -- the ORDER BY lookup spells them
+    // the `Display` way. The two renderings agree on these shapes, checked
+    // against bean-query, so the split is not observable; pinned so it stays
+    // that way.
+    assert_header("SELECT entry.narration FROM #postings", "entry.narration");
+    assert_header("SELECT meta['k'] FROM #postings", "meta['k']");
+    assert_header("SELECT entry.meta['k'] FROM #postings", "entry.meta['k']");
 }
 
 /// Verify `query_calls_any_function` walks every query part and every

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1725,6 +1725,68 @@ fn test_date_add_with_interval() {
     );
 }
 
+/// Verify `ast::header_name` renders the way bean-query heads a column.
+///
+/// Every expectation was read off bean-query 3.x, not derived from a
+/// precedence table. That matters: bean-query renders the parse tree
+/// FAITHFULLY -- it keeps parentheses the query wrote even where precedence
+/// does not need them, and adds none of its own -- so a minimal-parenthesizing
+/// printer disagrees with it on `(number > 0) AND (number < 5)`, which was the
+/// first thing I tried (#2171).
+#[test]
+fn test_header_name_matches_bean_query_rendering() {
+    fn assert_header(sql: &str, expected: &str) {
+        let q = match parse(sql).unwrap() {
+            Query::Select(s) => s,
+            _ => panic!("expected Select for {sql:?}"),
+        };
+        assert_eq!(
+            crate::ast::header_name(&q.targets[0].expr),
+            expected,
+            "header_name wrong for {sql:?}"
+        );
+    }
+
+    // Literals: single-quoted strings, as bean-query writes them.
+    assert_header("SELECT 1 FROM #postings", "1");
+    assert_header("SELECT 'lit' FROM #postings", "'lit'");
+
+    // No parentheses invented.
+    assert_header("SELECT number + 1 FROM #postings", "number + 1");
+    assert_header("SELECT number + 1 * 2 FROM #postings", "number + 1 * 2");
+    assert_header("SELECT number - 1 - 2 FROM #postings", "number - 1 - 2");
+
+    // Parentheses the query wrote are kept, including unnecessary ones.
+    assert_header("SELECT (number + 1) * 2 FROM #postings", "(number + 1) * 2");
+    assert_header("SELECT number - (1 - 2) FROM #postings", "number - (1 - 2)");
+    assert_header(
+        "SELECT (number > 0) AND (number < 5) FROM #postings",
+        "(number > 0) AND (number < 5)",
+    );
+    assert_header("SELECT NOT (number > 0) FROM #postings", "NOT (number > 0)");
+    assert_header("SELECT NOT number > 0 FROM #postings", "NOT number > 0");
+
+    // ...except around the whole target, which bean-query drops.
+    assert_header("SELECT (number) FROM #postings", "number");
+    assert_header("SELECT ((number)) FROM #postings", "number");
+    assert_header("SELECT ((number + 1)) FROM #postings", "number + 1");
+
+    // Unary spacing and position: `NOT ` and `-` are prefix, `IS NULL` is
+    // postfix. Formatting them uniformly produced `NOT  x` and `IS NULL x`.
+    assert_header("SELECT -number FROM #postings", "-number");
+    assert_header("SELECT number IS NULL FROM #postings", "number IS NULL");
+    assert_header(
+        "SELECT number IS NOT NULL FROM #postings",
+        "number IS NOT NULL",
+    );
+
+    // Function arguments render the same way -- `Display` parenthesized them,
+    // so `sum(number + 1)` headed `sum((number + 1))` after #2164.
+    assert_header("SELECT sum(number + 1) FROM #postings", "sum(number + 1)");
+    assert_header("SELECT length(payee) FROM #postings", "length(payee)");
+    assert_header("SELECT count(date) FROM #postings", "count(date)");
+}
+
 /// Verify `query_calls_any_function` walks every query part and every
 /// expression shape.
 ///

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -1750,6 +1750,10 @@ fn test_header_name_matches_bean_query_rendering() {
     // Literals: single-quoted strings, as bean-query writes them.
     assert_header("SELECT 1 FROM #postings", "1");
     assert_header("SELECT 'lit' FROM #postings", "'lit'");
+    // ...but double-quoted when the value contains a single quote, so the
+    // header stays a well-formed literal rather than the ambiguous
+    // `'o'clock'`. Flagged by Copilot review on #2175.
+    assert_header("SELECT \"o'clock\" FROM #postings", "\"o'clock\"");
 
     // No parentheses invented.
     assert_header("SELECT number + 1 FROM #postings", "number + 1");

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -203,8 +203,13 @@ fn write_csv<W: Write>(
     // `ctx` already has `render_commas` resolved for this surface by the
     // dispatcher, so it is used verbatim here.
 
-    // Print header
-    writeln!(writer, "{}", result.columns.join(","))?;
+    // Print header, escaped like the values below. A header can contain a
+    // comma -- `SELECT number IN (1, 2)` heads `number IN (1, 2)` since
+    // #2171 -- and an unescaped one splits into two fields, so a consumer
+    // reads more headers than there are columns. Values were already
+    // escaped; only the header row was not.
+    let headers: Vec<String> = result.columns.iter().map(|c| escape_csv(c)).collect();
+    writeln!(writer, "{}", headers.join(","))?;
 
     // Print rows
     for row in &result.rows {
@@ -1040,6 +1045,29 @@ mod tests {
     /// is about ZERO-POSITION semantic suppression. Both happen to use
     /// `format_value`, but they target different value types and
     /// different concerns.
+    #[test]
+    fn test_csv_header_with_a_comma_is_escaped() {
+        // A header can contain a comma since #2171 -- `SELECT number IN (1, 2)`
+        // heads `number IN (1, 2)`. The header row was joined without
+        // `escape_csv` while the value rows used it, so a consumer parsed two
+        // headers for one column and silently misaligned every field after it.
+        use rustledger_query::QueryResult;
+
+        let ctx = DisplayContext::new();
+        let mut result = QueryResult::new(vec!["number IN (1, 2)".into()]);
+        result.add_row(vec![Value::String("x".into())]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_csv(&result, &mut buf, false, &ctx).expect("csv ok");
+        let csv = String::from_utf8(buf).expect("utf8");
+        let header = csv.lines().next().expect("a header line");
+
+        assert_eq!(
+            header, "\"number IN (1, 2)\"",
+            "a header containing a comma must be quoted, or it parses as two fields"
+        );
+    }
+
     #[test]
     fn test_csv_inventory_renders_sub_precision_positions() {
         use rustledger_query::QueryResult;


### PR DESCRIPTION
## What

`SELECT number + 1` headed `col0`. `SELECT 'lit'` headed `col0`. A name that
identifies nothing, and one a script reading our CSV by header cannot find.

| query | bean-query | before | after |
|---|---|---|---|
| `SELECT 1` | `1` | `col0` | `1` |
| `SELECT 'lit'` | `'lit'` | `col0` | `'lit'` |
| `SELECT number + 1` | `number + 1` | `col0` | `number + 1` |
| `SELECT (number + 1) * 2` | `(number + 1) * 2` | `col0` | `(number + 1) * 2` |
| `SELECT sum(number + 1)` | `sum(number + 1)` | `sum((number + 1))` | `sum(number + 1)` |

## bean-query renders the tree faithfully, not minimally

This is why #2171 was filed rather than fixed inline in #2164. The obvious
implementation — parenthesize by precedence — disagrees with bean-query:

```
(number > 0) AND (number < 5)   both pairs KEPT, though precedence needs neither
number + 1 * 2                  nothing added
NOT number > 0                  nothing added
number - (1 - 2)                kept
((number + 1))                  -> number + 1, only the outer pair dropped
```

So bean-query preserves the parentheses the query wrote and adds none, except
around the whole target. Every expectation here was read off bean-query 3.x
rather than derived.

## Why not just use `Display`

`Display` parenthesizes every binary node and double-quotes strings. That is
correct for what it is used for — naming the synthetic hidden ORDER BY columns,
where round-tripping is what matters, and which #2170 repaired — and wrong for
a header. `Display` is untouched; `ast::header_name` is separate.

## A divergence #2164 left behind

Function targets were headed with `Display`, so `sum(number + 1)` headed
`sum((number + 1))`. I did not catch it there because my testing used only
simple column arguments. Same renderer fixes it.

## Unary operators

`UnaryOperator`'s `Display` bakes in its own spacing **and position**: `NOT `
is prefix with a trailing space, `-` is prefix with none, and ` IS NULL` /
` IS NOT NULL` are **postfix** with a leading space. Formatting them uniformly
as prefix produced `NOT  x` and `IS NULL x`.

## A CSV bug this exposed

Headers could not contain a comma before this change — they were identifiers
or `colN`. Now `SELECT number IN (1, 2)` heads `number IN (1, 2)`, and
`write_csv` was joining header names **raw** while escaping every value:

```
ours:       ['number IN (1', ' 2)']      <-- two fields for one column
bean-query: ['number IN (1, 2)']
```

A consumer reads more headers than there are columns and misaligns every field
after it, with no error. Fixed with the same `escape_csv` the value rows
already used, which also brings the three `IN` shapes into agreement with
bean-query.

## Cleanup

`colN` is gone, so `expr_to_name` no longer needs the target index. The
parameter and both `enumerate()` calls went with it.

## Verification

- **24 header shapes** compared against bean-query, all matching, and re-run
  after each refactor rather than assumed.
- Unit tests cover the rendering rules directly, confirmed to fail when the
  parenthesizing, the postfix position, or the top-level stripping is reverted
  — checked one at a time.
- Booked-value gate clean (`known 34, found 34, new 0`); `corpus_parity`
  divergences still exactly 20, matching `main`.
- clippy at CI's 1.97, fmt, typos, rustdoc clean; 415 tests pass.

Closes #2171
