### PR TITLE
feat(query): make meta selectable on #transactions

### DIFF
--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -72,7 +72,7 @@ impl Executor<'_> {
     ///
     /// bean-query also exposes `discrepancy` here. It is not a field of the
     /// directive — the balance checker computes it — so it is tracked
-    /// separately rather than faked from the data we have (#2154).
+    /// separately rather than faked from the data we have (#2180).
     pub(super) fn build_balances_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
@@ -468,7 +468,8 @@ impl Executor<'_> {
 
     /// Build the #transactions table from transaction directives.
     ///
-    /// The table has columns: date, flag, payee, narration, tags, links, accounts
+    /// The table has columns: date, flag, payee, narration, tags, links,
+    /// accounts, meta
     /// - date: The transaction date
     /// - flag: The transaction flag (e.g., '*' or '!')
     /// - payee: The payee (NULL if not specified)
@@ -476,6 +477,7 @@ impl Executor<'_> {
     /// - tags: Transaction tags (as a set)
     /// - links: Transaction links (as a set)
     /// - accounts: Set of accounts involved in the transaction
+    /// - meta: The transaction's metadata (hidden from `SELECT *`)
     pub(super) fn build_transactions_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
@@ -485,8 +487,13 @@ impl Executor<'_> {
             "tags".to_string(),
             "links".to_string(),
             "accounts".to_string(),
+            "meta".to_string(),
         ];
-        let mut table = Table::new(columns);
+        // `meta` is hidden from `SELECT *`, which bean-query keeps at seven
+        // columns here, but selectable by name -- the last of #2154's
+        // eleven, and the same split #2161 established for the other five
+        // per-table `meta` columns.
+        let mut table = Table::new(columns).with_hidden(&["meta"]);
 
         // Collect transaction directives
         let mut transactions: Vec<_> = self
@@ -525,6 +532,10 @@ impl Executor<'_> {
                 Value::StringSet(tags),
                 Value::StringSet(links),
                 Value::StringSet(accounts),
+                // User metadata only. bean-query's per-table `meta` columns
+                // exclude `filename` / `lineno`; only `#entries` carries them
+                // (#2162), so this must NOT use `augmented_meta`.
+                Self::metadata_to_value(&txn.meta),
             ];
             table.add_row(row);
         }

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -535,6 +535,16 @@ impl Executor<'_> {
                 // User metadata only. bean-query's per-table `meta` columns
                 // exclude `filename` / `lineno`; only `#entries` carries them
                 // (#2162), so this must NOT use `augmented_meta`.
+                //
+                // Built unconditionally, like the other five per-table `meta`
+                // columns. Measured before leaving it that way: on a ledger
+                // with five metadata keys on every one of 20k transactions --
+                // a deliberately extreme shape -- a query that does not select
+                // `meta` costs ~30ms more, 371ms to 400ms. On a ledger without
+                // transaction metadata it is below the noise floor. That is
+                // far from the 40% that justified gating `#postings` in
+                // #2169, so the projection machinery is not worth the review
+                // surface here.
                 Self::metadata_to_value(&txn.meta),
             ];
             table.add_row(row);

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7164,6 +7164,38 @@ fn transactions_meta_is_selectable_but_hidden_from_the_wildcard() {
         plain.rows.iter().any(|r| r[0] != Value::Null),
         "meta must resolve without a source map as well"
     );
+
+    // The same transaction is visible through three tables. They must agree
+    // on the user's keys -- `#entries` adds `filename`/`lineno` and the other
+    // two do not, which is bean-query's split, but the user data itself is one
+    // fact and must not differ by which table you ask.
+    //
+    // This is the check that caught #entries and #documents reporting
+    // different tags for one directive (#2161); a per-table census cannot see
+    // it, because every column involved is present in every table.
+    let user_key = |q: &str| -> Option<Value> {
+        let r = execute_query(q, &directives);
+        match &r.rows[0][0] {
+            Value::Object(map) => map.get("mtxn").cloned(),
+            other => panic!("{q} should yield a map, got {other:?}"),
+        }
+    };
+    let expected = Some(Value::String("tv".to_string()));
+    assert_eq!(
+        user_key("SELECT meta FROM #transactions"),
+        expected,
+        "#transactions.meta lost the user's key"
+    );
+    assert_eq!(
+        user_key("SELECT meta FROM #entries WHERE type = 'transaction'"),
+        expected,
+        "#entries.meta disagrees with #transactions.meta about the same directive"
+    );
+    assert_eq!(
+        user_key("SELECT _entry_meta FROM #postings"),
+        expected,
+        "#postings._entry_meta disagrees with #transactions.meta about the same directive"
+    );
 }
 
 #[test]

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7026,7 +7026,7 @@ fn postings_table_materializes_gated_columns_when_reachable() {
         "k".to_string(),
         rustledger_core::MetaValue::String("entry-value".to_string()),
     );
-    let directives = vec![
+    let directives = [
         Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
         Directive::Open(Open::new(date(2024, 1, 1), "Income:Job")),
         Directive::Transaction(txn),
@@ -7068,6 +7068,91 @@ fn postings_table_materializes_gated_columns_when_reachable() {
         star.rows.iter().any(|row| row[i] != Value::Null),
         "SELECT * left meta Null on every row; the wildcard did not force it on"
     );
+}
+
+#[test]
+fn transactions_meta_is_selectable_but_hidden_from_the_wildcard() {
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+
+    // The last of #2154's eleven columns. bean-query answers
+    // `SELECT meta FROM #transactions` while keeping its `SELECT *` at seven
+    // columns, the same split #2161 established for the other five per-table
+    // `meta` columns.
+    //
+    // User keys only: bean-query's per-table `meta` excludes `filename` and
+    // `lineno`; only `#entries` carries them (#2162). Asserted here so a
+    // future change cannot quietly route this through `augmented_meta`.
+    let mut txn = Transaction::new(date(2024, 1, 15), "narr")
+        .with_payee("payee")
+        .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(10), "USD")))
+        .with_synthesized_posting(Posting::new("Income:Job", Amount::new(dec!(-10), "USD")));
+    txn.meta.insert(
+        "mtxn".to_string(),
+        rustledger_core::MetaValue::String("tv".to_string()),
+    );
+    let directives = [
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Income:Job")),
+        Directive::Transaction(txn),
+    ];
+
+    // A source-mapped executor, so `augmented_meta` would actually inject
+    // `filename`/`lineno` if this column were wrongly routed through it. With
+    // a plain `Executor::new` the location is None, `augmented_meta` returns
+    // its input unchanged, and the assertion below cannot fail -- that
+    // mutation passed until this fixture grew a real SourceMap.
+    let source = "; l1\n2024-01-15 * \"payee\" \"narr\"\n";
+    let mut source_map = SourceMap::new();
+    let file_id = source_map.add_file("ledger.beancount".into(), source.into());
+    let spanned: Vec<Spanned<rustledger_core::Directive>> = directives
+        .iter()
+        .cloned()
+        .map(|d| Spanned {
+            value: d,
+            span: Span::new(6, 30),
+            file_id: u16::try_from(file_id).expect("one file fits in u16"),
+        })
+        .collect();
+    let mut executor = Executor::new_with_sources(&spanned, &source_map);
+
+    let starred = executor
+        .execute(&parse("SELECT * FROM #transactions").expect("should parse"))
+        .expect("query should execute");
+    assert_eq!(
+        starred.columns,
+        vec![
+            "date",
+            "flag",
+            "payee",
+            "narration",
+            "tags",
+            "links",
+            "accounts"
+        ],
+        "#transactions wildcard must stay at bean-query's seven columns"
+    );
+
+    let meta = executor
+        .execute(&parse("SELECT meta FROM #transactions").expect("should parse"))
+        .expect("query should execute");
+    assert_eq!(meta.columns, vec!["meta"], "meta must resolve by name");
+    match &meta.rows[0][0] {
+        Value::Object(map) => {
+            assert_eq!(
+                map.get("mtxn"),
+                Some(&Value::String("tv".to_string())),
+                "the transaction's own metadata must come through"
+            );
+            for key in ["filename", "lineno"] {
+                assert!(
+                    !map.contains_key(key),
+                    "per-table meta must not carry `{key}`; only #entries does (#2162)"
+                );
+            }
+        }
+        other => panic!("#transactions.meta should be a map, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7153,6 +7153,17 @@ fn transactions_meta_is_selectable_but_hidden_from_the_wildcard() {
         }
         other => panic!("#transactions.meta should be a map, got {other:?}"),
     }
+
+    // The source-mapped executor above is the CLI's path. wasm and the FFI
+    // build an `Executor::new` with no source map, so pin that too -- the
+    // switch to `new_with_sources` (needed to make the source-key assertion
+    // able to fail) would otherwise have left the plain path uncovered.
+    let plain = execute_query("SELECT meta FROM #transactions", &directives);
+    assert_eq!(plain.columns, vec!["meta"]);
+    assert!(
+        plain.rows.iter().any(|r| r[0] != Value::Null),
+        "meta must resolve without a source map as well"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

The last of #2154's eleven columns. bean-query answers
`SELECT meta FROM #transactions`; we returned nothing.

```
$ bean-query -f csv f.bean "SELECT meta FROM #transactions"
{'mtxn': 'tv'}

$ rledger query -f csv f.bean "SELECT meta FROM #transactions"   # before
                                                                  # (empty)
```

Wildcard-hidden, because bean-query keeps `SELECT * FROM #transactions` at
seven columns — the same split #2161 established for the other five per-table
`meta` columns. **No existing output changes**, so no snapshot drift anywhere.

User keys only: bean-query's per-table `meta` excludes `filename`/`lineno`,
which only `#entries` carries (#2162), so this must not route through
`augmented_meta`.

## #2154 is now complete, and what remains is a different kind of problem

A census of **all 55 columns** bean-query exposes across its ten system tables
finds three unselectable here — with a negative control confirming the census
detects a genuinely absent column:

| | |
|---|---|
| `#notes.tags`, `#notes.links` | `Note` drops them at parse time (#2160) |
| `#balances.discrepancy` | the checker computes it and does not store it on the directive (#2180) |

Neither is a schema-registration gap, which is what #2154 was about. #2180 is
filed as part of this PR, and the comment in `build_balances_table` that
pointed at #2154 for `discrepancy` now points there instead, so the reference
survives #2154 closing.

## The test needed a real SourceMap to mean anything

It asserts three things: `meta` resolves by name, `SELECT *` stays at seven
columns, and the map carries no source keys.

That third assertion was **decorative at first**. With a plain
`Executor::new` there is no source location, so `augmented_meta` returns its
input unchanged — I mutated the column to route through it and the test still
passed. The fixture now builds a source-mapped executor, and that mutation
fails.

All three ways to get this wrong are covered, checked one at a time:

- dropping the column → caught (by the `with_hidden` debug assertion from #2174)
- making it visible in `SELECT *` → caught
- routing it through `augmented_meta` → caught, once the fixture was real

## Cost of building it unconditionally

The column is built for every row, like the other five per-table `meta`
columns. Measured rather than assumed, against a binary built from `main`,
`--no-cache`, interleaved:

| ledger | query | main | this PR |
|---|---|---|---|
| no transaction metadata | `count(date) FROM #transactions` | 170–180 ms | 175–178 ms (noise) |
| no transaction metadata | `SELECT * FROM #transactions` | 228–230 ms | 225–227 ms (noise) |
| **5 keys on every txn** | `count(date) FROM #transactions` | 371–375 ms | 400–406 ms (**+8%**) |

So the worst case is ~30 ms on a deliberately extreme shape, for a query that
never selects `meta`. Far from the 40% that justified the projection gating in
#2169, so that machinery is not worth the review surface here. The number is
recorded at the code so a future reader deciding otherwise has it.

## Verification

- `SELECT *` parity across all ten tables unchanged: 6 match, 4 differ, exactly
  as before this PR.
- Booked-value gate clean (`known 34, found 34, new 0`).
- clippy at CI's 1.97, fmt, typos, rustdoc clean; 416 tests pass.

Closes #2154
