### PR TITLE
fix(booking): stop padding a balance on the pad's own date

### DIFF
--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -449,6 +449,13 @@ where
 {
     let mut end_of_group = 0;
     for (index, directive) in sorted.into_iter().enumerate() {
+        // Leftover from before #2150: this exists to put a synth AHEAD of a
+        // balance on the pad's own date. Such a pad no longer synthesizes at
+        // all -- the balance is checked first and the pad is unused -- so this
+        // arm now only fires for an UNRELATED same-date balance, where placing
+        // the synth ahead of it contradicts the Balance-before-Pad order.
+        // Removing it changes synth placement on the FFI path, which is its
+        // own decision; tracked in #2188 rather than ridden in here.
         if directive.date() == date && matches!(directive, Directive::Balance(_)) {
             return index;
         }

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -899,16 +899,12 @@ mod tests {
 
         let merged = merge_with_padding(&directives);
 
-        let synths: Vec<_> = merged
+        let synths = merged
             .iter()
-            .filter_map(|d| match d {
-                Directive::Transaction(t) if is_synthesized_pad(t) => Some(t),
-                _ => None,
-            })
-            .collect();
+            .filter(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t)))
+            .count();
         assert_eq!(
-            synths.len(),
-            1,
+            synths, 1,
             "the pad must satisfy the LATER balance, producing exactly one synth"
         );
     }

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -142,7 +142,6 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
     let mut padding_transactions = Vec::with_capacity(num_directives.min(16));
     let mut errors = Vec::with_capacity(4);
 
-    // Sort directives by date for processing
     let mut sorted: Vec<&Directive> = directives.iter().collect();
     // Sort by the canonical booking key, not by date alone. Date-only left
     // same-date directives in source order, so a `pad` written above the

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -144,7 +144,13 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
 
     // Sort directives by date for processing
     let mut sorted: Vec<&Directive> = directives.iter().collect();
-    sorted.sort_by_key(|d| d.date());
+    // Sort by the canonical booking key, not by date alone. Date-only left
+    // same-date directives in source order, so a `pad` written above the
+    // `balance` it targets was processed first and the balance consumed it --
+    // synthesizing a padding transaction beancount does not (#2150). The key
+    // puts Balance before Pad, so that balance is seen first and the pad ends
+    // up with nothing to satisfy.
+    sorted.sort_by_key(|d| rustledger_core::booking_sort_key(d));
 
     for directive in sorted {
         match directive {
@@ -339,12 +345,20 @@ fn create_padding_transaction(
 ///
 /// # Sort ordering on date ties
 ///
-/// Synth transactions carry the pad's date, not the balance's date.
-/// On a same-date pad+balance pair (legal in beancount), the synth must
-/// appear BEFORE the balance so any consumer that checks balance assertions
-/// mid-stream sees the correct inventory. This is achieved by prepending
-/// the synth list to the original directives before the stable sort:
-/// synths land at the front of their date-group, originals follow.
+/// Synth transactions carry the pad's date, not the balance's date. When a
+/// pad precedes its balance by at least a day, the synth must appear BEFORE
+/// that balance so any consumer checking assertions mid-stream sees the
+/// padded inventory. This is achieved by prepending the synth list to the
+/// original directives before the stable sort: synths land at the front of
+/// their date-group, originals follow.
+///
+/// A pad and the balance it targets on the SAME date produce no synth at
+/// all. beancount checks a balance at the start of the day, so it is ordered
+/// ahead of a same-date pad and consumes nothing; the pad is reported unused.
+/// This doc previously called that pairing "legal in beancount" and required
+/// the synth to precede the balance -- which is what produced a padding
+/// transaction beancount does not, leaving the account richer by the
+/// difference while our own validator called the pad unused (#2150).
 ///
 /// # Errors are discarded
 ///
@@ -822,11 +836,17 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_with_padding_same_date_pad_balance_synth_comes_first() {
-        // Pad and balance share the same date. The synth (which carries
-        // the pad's date) must appear BEFORE the Balance in the merged
-        // view so any mid-stream balance-assertion check sees the
-        // correct inventory.
+    fn test_merge_with_padding_same_date_pad_balance_synthesizes_nothing() {
+        // A pad and the balance it targets on the SAME date produce NO synth.
+        // beancount checks a balance at the start of the day, so it is ordered
+        // ahead of a same-date pad and consumes nothing; the pad is reported
+        // "Unused Pad entry" and the account keeps its real figure (#2150).
+        //
+        // This test previously asserted the opposite -- that a synth exists and
+        // precedes the Balance -- which is what let the bug through. On the
+        // fixture below beancount reports 40.00 for the account where we
+        // reported 100.00, and our own validator called the pad unused in the
+        // same run that booked it.
         let directives = vec![
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
             Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
@@ -840,18 +860,47 @@ mod tests {
 
         let merged = merge_with_padding(&directives);
 
-        // Find indices of the synth and the Balance.
+        assert!(
+            !merged
+                .iter()
+                .any(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t))),
+            "a same-date pad+balance must synthesize nothing; beancount leaves \
+             the pad unused"
+        );
+        // The Pad itself survives, so `WHERE type = 'pad'` audits still see it.
+        assert!(merged.iter().any(|d| matches!(d, Directive::Pad(_))));
+    }
+
+    #[test]
+    fn test_merge_with_padding_earlier_pad_still_synthesizes_before_balance() {
+        // The day-earlier case is the one that DOES pad, and the synth still
+        // has to precede the balance so a mid-stream assertion check sees the
+        // padded inventory. That ordering guarantee is what the old same-date
+        // test was really protecting; it belongs here, where a synth exists.
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Pad(Pad::new(date(2024, 1, 2), "Assets:Bank", "Equity:Opening")),
+            Directive::Balance(Balance::new(
+                date(2024, 1, 3),
+                "Assets:Bank",
+                Amount::new(dec!(1000), "USD"),
+            )),
+        ];
+
+        let merged = merge_with_padding(&directives);
+
         let synth_idx = merged
             .iter()
             .position(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t)))
-            .expect("synth present");
+            .expect("an earlier pad must still synthesize");
         let balance_idx = merged
             .iter()
             .position(|d| matches!(d, Directive::Balance(_)))
             .expect("balance present");
         assert!(
             synth_idx < balance_idx,
-            "synth pad (idx {synth_idx}) must appear before Balance (idx {balance_idx}) on same date",
+            "synth (idx {synth_idx}) must precede the Balance (idx {balance_idx})",
         );
     }
 

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -872,6 +872,48 @@ mod tests {
     }
 
     #[test]
+    fn test_pad_after_a_same_date_balance_still_serves_a_later_balance() {
+        // A pad written after a balance on the same date is NOT consumed by
+        // that balance -- it stays pending and satisfies the next one. Found
+        // while reviewing #2150, and it was broken worse than the reported
+        // case: the account came back with no balance at all and `check`
+        // reported nothing, on a ledger bean-check accepts silently.
+        //
+        // Under the old Pad-before-Balance order the same-date balance ate the
+        // pad, leaving the later assertion with nothing.
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:A")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:O")),
+            Directive::Balance(Balance::new(
+                date(2024, 6, 15),
+                "Assets:A",
+                Amount::new(dec!(0), "USD"),
+            )),
+            Directive::Pad(Pad::new(date(2024, 6, 15), "Assets:A", "Equity:O")),
+            Directive::Balance(Balance::new(
+                date(2024, 7, 1),
+                "Assets:A",
+                Amount::new(dec!(50), "USD"),
+            )),
+        ];
+
+        let merged = merge_with_padding(&directives);
+
+        let synths: Vec<_> = merged
+            .iter()
+            .filter_map(|d| match d {
+                Directive::Transaction(t) if is_synthesized_pad(t) => Some(t),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            synths.len(),
+            1,
+            "the pad must satisfy the LATER balance, producing exactly one synth"
+        );
+    }
+
+    #[test]
     fn test_merge_with_padding_earlier_pad_still_synthesizes_before_balance() {
         // The day-earlier case is the one that DOES pad, and the synth still
         // has to precede the balance so a mid-stream assertion check sees the

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -487,10 +487,19 @@ pub enum DirectivePriority {
     Open = 0,
     /// Commodities declared before use
     Commodity = 1,
-    /// Padding before balance assertions
-    Pad = 2,
-    /// Balance assertions checked at start of day
-    Balance = 3,
+    /// Balance assertions are checked at the START of the day, so they
+    /// precede a same-date pad -- which is what makes such a pad UNUSED
+    /// rather than applied (#2150).
+    ///
+    /// beancount's `entry_sortkey` gives Balance `-1` and Pad the default
+    /// `0`. Ours had Pad first, with a comment asserting "padding before
+    /// balance assertions"; the effect was that a `pad` and the `balance`
+    /// it targets on the same date synthesized a padding transaction
+    /// beancount does not, leaving the account richer by the difference
+    /// while our own validator reported the pad as unused in the same run.
+    Balance = 2,
+    /// Padding, after the same-date balance that would have consumed it.
+    Pad = 3,
     /// Main entries
     Transaction = 4,
     /// Annotations after transactions
@@ -1744,7 +1753,10 @@ mod tests {
     fn test_directive_priority() {
         // Test that priorities are ordered correctly
         assert!(DirectivePriority::Open < DirectivePriority::Transaction);
-        assert!(DirectivePriority::Pad < DirectivePriority::Balance);
+        // Balance BEFORE Pad: a balance is checked at the start of the day,
+        // so a same-date pad has nothing left to satisfy and is unused
+        // (#2150). This assertion previously ran the other way.
+        assert!(DirectivePriority::Balance < DirectivePriority::Pad);
         assert!(DirectivePriority::Balance < DirectivePriority::Transaction);
         assert!(DirectivePriority::Transaction < DirectivePriority::Close);
         assert!(DirectivePriority::Price < DirectivePriority::Close);
@@ -1788,8 +1800,15 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_directives_pad_before_balance() {
-        // Pad must come before balance assertion on the same day
+    fn test_sort_directives_balance_before_pad() {
+        // A balance is checked at the START of its day, so it precedes a
+        // same-date pad -- and that is exactly why such a pad has nothing left
+        // to satisfy and is reported unused (#2150).
+        //
+        // This test asserted the reverse, down to its name. Under that order a
+        // pad and the balance it targets on one date synthesized a padding
+        // transaction beancount does not: on the issue's fixture beancount
+        // reports 40.00 USD for the account and we reported 100.00.
         let mut directives = vec![
             Directive::Balance(Balance::new(
                 date(2024, 1, 1),
@@ -1805,8 +1824,8 @@ mod tests {
 
         sort_directives(&mut directives);
 
-        assert_eq!(directives[0].type_name(), "pad");
-        assert_eq!(directives[1].type_name(), "balance");
+        assert_eq!(directives[0].type_name(), "balance");
+        assert_eq!(directives[1].type_name(), "pad");
     }
 
     #[test]

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -616,6 +616,45 @@ option \"operating_currency\" \"USD\"
 2024-01-21 balance Assets:SomeName 42 USD
 ";
 
+    /// A `pad` and the `balance` it targets on ONE date.
+    ///
+    /// `SAME_DATE_LEDGER` above shares a date between a pad and an *unrelated*
+    /// transaction, with the balance a day later, so it never exercised this.
+    /// #2150 was reported against the CLI and explicitly left the FFI path
+    /// unverified, noting that `expand_pads` runs its own date-only sort and
+    /// could diverge either way.
+    const SAME_DATE_PAD_BALANCE_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2024-01-01 open Assets:A USD
+2024-01-01 open Equity:Opening-balances
+2024-01-05 * \"some activity\"
+  Assets:A  40.00 USD
+  Equity:Opening-balances
+2024-06-15 pad Assets:A Equity:Opening-balances
+2024-06-15 balance Assets:A 100.00 USD
+";
+
+    #[test]
+    fn expand_pads_synthesizes_nothing_for_a_same_date_pad_balance() {
+        // beancount checks a balance at the start of its day, so a same-date
+        // pad has nothing to satisfy and is reported unused. The FFI path must
+        // agree with the CLI here: before #2150 both padded, leaving the
+        // account 60.00 richer than beancount reports.
+        let load = load_source(SAME_DATE_PAD_BALANCE_LEDGER);
+        let (expanded, _lines) = expand_pads(load.directives, load.directive_lines, &0u32);
+
+        let synths = expanded
+            .iter()
+            .filter(|d| {
+                matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t))
+            })
+            .count();
+        assert_eq!(
+            synths, 0,
+            "a same-date pad+balance must synthesize nothing on the FFI path too",
+        );
+    }
+
     #[test]
     fn expand_pads_does_not_displace_unrelated_same_date_directives() {
         let load = load_source(SAME_DATE_LEDGER);

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -77,7 +77,22 @@ use crate::types::{Error, LedgerOptions};
 /// #2160 holds the two-field-shorter `ArchivedNote`, one written by a dev
 /// build after it holds the new shape, and both claim v15. Rejecting every
 /// v15 blob is the only reading that is safe for either.
-pub const CACHE_VERSION: u32 = 16;
+/// v17: `Pad` and `Balance` swap `DirectivePriority`, so a same-date pad and
+/// balance come out of the pipeline in the other order (#2179). Loader v32,
+/// unchanged -- and this is the first entry here that moves neither the
+/// parser's output nor an archived layout. Every directive archives to the
+/// same bytes; the LIST this cache holds is a different list. `LedgerPayload`
+/// stores the output of `process()`, which sorts by `canonical_sort_key`, and
+/// that key reads `DirectivePriority`.
+///
+/// What a stale blob costs is narrower than it first looks, and worth stating
+/// exactly: `process_pads` re-sorts its input by `booking_sort_key`, which is
+/// the same `(date, priority)`, so pad AMOUNTS computed from a v16 blob would
+/// still come out right. What differs is the order of the directives this
+/// cache hands back, which is what every order-sensitive consumer reads --
+/// journal output, `SELECT` row order, the FFI directive stream. A cache that
+/// returns a different sequence than a fresh run is stale by definition.
+pub const CACHE_VERSION: u32 = 17;
 
 /// The `rustledger-loader` cache version this one was last reconciled with.
 ///
@@ -319,16 +334,19 @@ mod tests {
 
         // Every variant, or the pin has a blind spot exactly where a new
         // variant would be added.
-        let kinds: std::collections::BTreeSet<_> = parsed
+        // `Directive::type_name`, not `Debug` on `mem::Discriminant`: that
+        // format is not a documented guarantee, and a std that printed every
+        // discriminant identically would turn this coverage check into a
+        // baffling failure. `type_name` also names the missing variant.
+        let kinds: std::collections::BTreeSet<&str> = parsed
             .directives
             .iter()
-            .map(|d| std::mem::discriminant(&d.value))
-            .map(|d| format!("{d:?}"))
+            .map(|d| d.value.type_name())
             .collect();
         assert_eq!(
             kinds.len(),
             12,
-            "fixture must cover all 12 Directive variants"
+            "fixture must cover all 12 Directive variants, got {kinds:?}"
         );
 
         // FNV-1a: a checked-in constant needs an algorithm that is stable
@@ -374,7 +392,11 @@ mod tests {
     /// and a priority swap changes nothing here.
     #[test]
     fn processed_ledger_archived_form_is_pinned() {
-        const PROCESSED_LAYOUT_HASH: u64 = 0x051d_b37b_7095_87c5;
+        // Moved once so far: swapping `Pad` and `Balance` in
+        // `DirectivePriority` (#2179) reorders the same-date pair in the
+        // fixture. That is the change this test was written to catch, and it
+        // caught it on the rebase rather than in review.
+        const PROCESSED_LAYOUT_HASH: u64 = 0xa8a8_b0cf_5355_f95d;
 
         let src = "\
 2024-01-01 open Assets:Bank USD\n\
@@ -390,6 +412,9 @@ mod tests {
 2024-01-06 balance Assets:Bank  15.00 USD\n";
 
         let processed = crate::helpers::load_and_book(src);
+        for d in &processed.directives {
+            eprintln!("PROBE {} {:?}", d.type_name(), d.date());
+        }
         assert!(
             processed.directives.len() >= 6,
             "fixture must survive the pipeline, else the digest pins an early \


### PR DESCRIPTION
## What

A `pad` and the `balance` it targets **on the same date** synthesized a padding
transaction beancount does not:

| | pad applied | final `Assets:A` |
|---|---|---|
| beancount 3.x | no — "Unused Pad entry" | **40.00 USD** |
| rustledger (before) | yes, 60.00 USD | **100.00 USD** |

`check` exited non-zero, but every read path — `query`, `report balances` —
returned the padded figure. And it reported the pad as **unused in the same run
that booked it**.

## Cause

beancount checks a balance at the **start** of its day: `entry_sortkey` gives
Balance `-1` and Pad the default `0`, so a same-date balance is evaluated
before the pad exists and consumes nothing.

Two places disagreed with that:

- `DirectivePriority` had `Pad = 2` before `Balance = 3`, with a comment
  asserting *"padding before balance assertions"* — the wrong belief, written
  down.
- `process_pads` sorted by **date alone**, so same-date directives kept source
  order: a pad written above its balance was processed first and the balance
  consumed it.

Both fixed — Balance now precedes Pad, and `process_pads` sorts by the
canonical `booking_sort_key`.

## Two tests pinned the old behavior

Both are inverted, with the evidence in their comments:

- `test_merge_with_padding_same_date_pad_balance_synth_comes_first` asserted a
  same-date synth exists. The *ordering* guarantee it was really protecting —
  that a synth precedes its balance — is preserved in a new test on the
  day-earlier case, which is where a synth actually exists.
- `test_sort_directives_pad_before_balance`, wrong down to its name.

## Verification

- The fixture returns **40.00**, matching beancount. A pad one day earlier
  still pads to **100.00**, also matching — so the fix is specific to the
  same-date case rather than disabling padding.
- `check` still emits E2003 **and** E2001, which is exactly what `bean-check`
  emits for this file. The difference is that we no longer book the pad we call
  unused.
- **Booked values unchanged across all 23 pad-bearing corpus files**, compared
  against a `main`-built binary — with a negative control confirming the
  comparison detects the issue's own fixture changing.
- **The validator and the booker now agree.** On the reported file we emit
  E2003 *and* synthesize nothing; on the three padding cases we emit no E2003
  and do pad. All four match `bean-check`'s judgement. That contradiction —
  calling a pad unused in the same run that booked it — was the issue's third
  complaint.
- **Blast radius confined to pad-bearing files**: 59 pad-free files produce
  byte-identical `#entries` output.
- The four new `corpus_parity` divergences are the prebuilt component still
  using the old order — `native=(balance) component=(pad)` — which is what a
  correct engine change looks like against a stale component.

## Two things I want to be explicit about

**The booked-value gate reports clean, and that is not evidence here.** Its
axis is prices; it does not compare balances, so it cannot see this change. I
verified values by diffing per-account sums against a `main` binary instead.

**Synth placement within a date is still not beancount's, and this PR moved it.**
For a pad sharing a date with an *unrelated* balance, `#entries` gives
`transaction balance pad` where bean-query gives `balance pad transaction`;
before this PR it was `pad transaction balance`. All three produce the same
account total, so it is placement rather than arithmetic — filed as #2188,
along with the now-stale `pad_insertion_index` special case that favours a
same-date balance.

**Same-date ordering is still not fully beancount's.** beancount interleaves
pads and transactions by `lineno` (both sort at `0`); we group by type. This PR
fixes Balance-before-Pad only. The interleaving is #2149, unchanged here.

Closes #2150
