### PR TITLE
ci: report corpus baseline drift on a cadence instead of by accident

### DIFF
--- a/.github/workflows/corpus-baseline-drift.yml
+++ b/.github/workflows/corpus-baseline-drift.yml
@@ -1,0 +1,78 @@
+# Report parser-baseline drift that no pull request would otherwise carry.
+#
+# The baseline gate in `parser-baselines.yml` runs on every PR, but it cannot
+# catch this class, for two reasons that are both deliberate:
+#
+#   * A downloaded corpus file with no manifest entry is a WARNING there, not
+#     a failure. Upstream can add a file at any moment and failing would fire
+#     on unrelated PRs. The warning goes to a log nobody reads, so such a file
+#     sits with no parser-output coverage at all.
+#
+#   * That job restores `tests/compatibility/files` from a cache keyed on the
+#     FETCH SCRIPT, and skips the fetch on an exact key hit. CI's corpus is
+#     therefore frozen at whatever was fetched when that key was created,
+#     while the upstream repositories it mirrors keep moving. Every PR sees
+#     the same stale corpus and agrees there is no drift.
+#
+# So drift accumulated until somebody changed the parser, whose PR then had to
+# carry and explain churn that had nothing to do with it (#2186).
+#
+# This job exists to break that silence: it fetches the corpus FRESH -- no
+# cache, which is the whole point -- and turns any drift into an issue. It
+# reports; it does not gate, and it never fails on drift. Same shape as
+# `nightly-health.yml`, for the same reason: a result nobody sees is not a
+# result.
+
+name: Corpus Baseline Drift
+
+on:
+  schedule:
+    # Mondays 05:00 UTC. Weekly is enough for upstream corpus churn, and it
+    # avoids the nightly band (kani 06:00 Sun, nightly-health 08:00 daily).
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: corpus-baseline-drift
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  drift:
+    name: Corpus baseline drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
+        with:
+          toolchain: 1.97.0 # pinned stable — bump deliberately, IN LOCKSTEP with rust-toolchain.toml (see #1745, #1750)
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+
+      # Runs BEFORE the live check and IS allowed to fail the job. The live
+      # check exits 0 whatever it finds, so a logic bug in the classifier
+      # would otherwise surface as a permanently reassuring "no drift" — the
+      # same silence this workflow exists to break, wearing a green check.
+      - name: Self-test
+        run: python3 scripts/corpus-baseline-drift.py --self-test
+
+      # Deliberately NOT the `actions/cache` step the other corpus jobs use.
+      # A cached corpus is the frozen input that hides this drift; fetching
+      # fresh is the entire reason this workflow exists.
+      - name: Fetch compatibility test files (no cache)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/fetch-compat-test-files.sh
+
+      - name: Report drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/corpus-baseline-drift.py

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -83,6 +83,14 @@ def fetch_is_complete(count: int, expected: int) -> bool:
     A short corpus cannot manufacture a false "added" or "rehashed" either,
     but it does mean the run saw an unrepresentative corpus, so the honest
     answer is to report nothing and say why.
+
+    This is deliberately stricter than the backstop inside the test itself,
+    which refuses to write a manifest below `MIN_FULL_CORPUS_SIZE` (100). That
+    one exists to stop a catastrophic fetch truncating the committed manifest
+    to the three in-tree fixtures, and it fires as a panic. At a corpus of
+    ~735 this check trips at ~685, so a merely partial fetch gets a sentence
+    explaining itself rather than a cargo stack trace, and the test's assert
+    stays what it was written to be: a last resort.
     """
     return count >= expected - CORPUS_SLACK
 

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -258,6 +258,16 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true", help="print, do not touch issues")
     args = ap.parse_args()
 
+    # Every path here is repo-relative, and so is the `git checkout --` that
+    # --dry-run uses to put the manifest back. Run from anywhere else and that
+    # either fails confusingly or, worse, resolves somewhere unintended.
+    if not os.path.isfile(MANIFEST):
+        print(
+            f"{MANIFEST} not found: run this from the repository root.",
+            file=sys.stderr,
+        )
+        return 2
+
     # Whether the manifest was already modified before we touched it. If it
     # was, --dry-run must NOT restore it: `git checkout --` would throw away
     # edits the caller made, and a reporting script has no business deleting
@@ -330,8 +340,13 @@ def main() -> int:
     else:
         print("no drift")
 
-    # Always 0: this reports, it does not gate. A red X here would be one more
-    # failing scheduled workflow for nobody to notice.
+    # Always 0 for what this measures: drift is reported, not gated, and a red
+    # X here would be one more failing scheduled workflow for nobody to notice.
+    #
+    # Infrastructure failure is different and is deliberately NOT swallowed:
+    # `regenerate()` runs under `check=True`, so a corpus file that panics the
+    # parser, or a build that will not compile, fails the step. That is a real
+    # problem on main, and `nightly-health.yml` picks it up from there.
     return 0
 
 

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -87,11 +87,22 @@ def fetch_is_complete(count: int, expected: int) -> bool:
     return count >= expected - CORPUS_SLACK
 
 
+class GhError(RuntimeError):
+    """A `gh` invocation failed.
+
+    Raised rather than returning an empty string, which is what the first
+    version did and is indistinguishable from a successful empty result. That
+    conflation is not cosmetic here: a failed `issue list` would look like
+    "no existing issue" and open a duplicate, and a failed `issue create`
+    would print a blank URL and leave the workflow GREEN having reported
+    nothing at all -- the exact silence this job exists to break.
+    """
+
+
 def gh(*args: str) -> str:
     proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
     if proc.returncode != 0:
-        print(f"gh {' '.join(args)} failed: {proc.stderr.strip()}", file=sys.stderr)
-        return ""
+        raise GhError(f"gh {' '.join(args)} failed: {proc.stderr.strip()}")
     return proc.stdout
 
 
@@ -137,17 +148,27 @@ def classify(diff: str) -> dict[str, list[str]]:
     }
 
 
+def _summary(n: int) -> str:
+    """Lead paragraph. Built here rather than as adjacent literals in the body
+    list, where two strings on consecutive lines read as a missing comma
+    (CodeQL `py/implicit-string-concatenation-in-list`)."""
+    plural = "y" if n == 1 else "ies"
+    return (
+        f"A fresh fetch of the compatibility corpus moves **{n}** manifest"
+        f" entr{plural}. Nothing on a pull request would report this: the"
+        " baseline gate treats an unmanifested downloaded file as a warning,"
+        " and CI restores the corpus from a cache keyed on the fetch script"
+        " rather than on upstream state, so every PR sees the same frozen"
+        " corpus."
+    )
+
+
 def render(groups: dict[str, list[str]]) -> str:
     n = sum(len(v) for v in groups.values())
     body = [
         MARKER,
         "",
-        f"A fresh fetch of the compatibility corpus moves **{n}** manifest "
-        f"entr{'y' if n == 1 else 'ies'}. Nothing on a pull request would "
-        "report this: the baseline gate treats an unmanifested downloaded "
-        "file as a warning, and CI restores the corpus from a cache keyed on "
-        "the fetch script rather than on upstream state, so every PR sees the "
-        "same frozen corpus.",
+        _summary(n),
         "",
     ]
 
@@ -189,8 +210,10 @@ def render(groups: dict[str, list[str]]) -> str:
         "git diff tests/baselines/              # review",
         "```",
         "",
-        "Maintained by `.github/workflows/corpus-baseline-drift.yml`. "
-        "Closes itself when the manifest matches a fresh corpus again.",
+        (
+            "Maintained by `.github/workflows/corpus-baseline-drift.yml`."
+            " Closes itself when the manifest matches a fresh corpus again."
+        ),
     ]
     return "\n".join(body)
 
@@ -246,6 +269,47 @@ def self_test() -> int:
         failures.append("a corpus short by more than the slack must be refused")
     if fetch_is_complete(0, 735):
         failures.append("an empty corpus must be refused")
+
+    # A failing `gh` must raise, not return "". The first version returned an
+    # empty string, which reads as "no issues exist" to the dedupe check and
+    # as a blank URL to the create path -- a green run that reported nothing.
+    real_run = subprocess.run
+
+    def failing_run(*a, **kw):
+        class P:
+            returncode = 1
+            stdout = ""
+            stderr = "gh: HTTP 403"
+        return P()
+
+    try:
+        subprocess.run = failing_run
+        try:
+            gh("issue", "list")
+            failures.append("gh must raise GhError when the command fails")
+        except GhError:
+            pass
+    finally:
+        subprocess.run = real_run
+
+    # ...and must NOT raise on a successful empty result, which is a real and
+    # different answer.
+    def empty_run(*a, **kw):
+        class P:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return P()
+
+    try:
+        subprocess.run = empty_run
+        try:
+            if gh("issue", "list") != "":
+                failures.append("gh must pass through an empty success")
+        except GhError:
+            failures.append("gh must not raise on a successful empty result")
+    finally:
+        subprocess.run = real_run
 
     for f in failures:
         print(f"self-test FAIL: {f}", file=sys.stderr)
@@ -312,15 +376,29 @@ def main() -> int:
         print(render(groups) if drifted else "no drift")
         return 0
 
-    existing = gh(
-        "issue", "list", "--repo", REPO, "--state", "open",
-        "--search", ISSUE_TITLE, "--json", "number,body", "--limit", "20",
-    )
+    try:
+        existing = gh(
+            "issue", "list", "--repo", REPO, "--state", "open",
+            "--search", ISSUE_TITLE, "--json", "number,body", "--limit", "20",
+        )
+    except GhError as e:
+        # Cannot dedupe without this, and guessing "none exist" opens a
+        # duplicate every week. Fail the step instead.
+        print(e, file=sys.stderr)
+        return 1
     try:
         issues = [i for i in json.loads(existing or "[]") if MARKER in (i.get("body") or "")]
     except json.JSONDecodeError:
         issues = []
 
+    try:
+        return _report(drifted, groups, issues)
+    except GhError as e:
+        print(e, file=sys.stderr)
+        return 1
+
+
+def _report(drifted: bool, groups: dict[str, list[str]], issues: list) -> int:
     if drifted:
         text = render(groups)
         if issues:
@@ -340,13 +418,15 @@ def main() -> int:
     else:
         print("no drift")
 
-    # Always 0 for what this measures: drift is reported, not gated, and a red
-    # X here would be one more failing scheduled workflow for nobody to notice.
+    # 0 for what this measures: drift is reported, not gated, and a red X for
+    # finding drift would be one more failing scheduled workflow for nobody to
+    # notice.
     #
-    # Infrastructure failure is different and is deliberately NOT swallowed:
-    # `regenerate()` runs under `check=True`, so a corpus file that panics the
-    # parser, or a build that will not compile, fails the step. That is a real
-    # problem on main, and `nightly-health.yml` picks it up from there.
+    # Failing to REPORT is the opposite case and returns non-zero, as does
+    # `regenerate()` running under `check=True` when a corpus file panics the
+    # parser or the build will not compile. Those are real problems on main,
+    # and `nightly-health.yml` picks them up from there. A job that cannot say
+    # what it found must not look like a job that found nothing.
     return 0
 
 

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -148,10 +148,25 @@ def classify(diff: str) -> dict[str, list[str]]:
             continue
         path = body.split("\t")[0]
         (added if line.startswith("+") else removed)[path] = body
-    rehashed = sorted(set(added) & set(removed))
+    # A path on both sides had a hash change, and WHICH hash moved is the
+    # whole question. A changed source hash is upstream churn and expected. A
+    # changed output hash with an UNCHANGED source hash means this repository
+    # produces different output for identical input than the committed
+    # baseline says -- a parser change that reached main without regenerating.
+    # The body used to promise "the diff says which" and then print only
+    # paths, which told the reader to go find something it already knew.
+    upstream, unregenerated = [], []
+    for path in sorted(set(added) & set(removed)):
+        before = removed[path].split("\t")
+        after = added[path].split("\t")
+        if len(before) >= 2 and len(after) >= 2 and before[1] != after[1]:
+            upstream.append(path)
+        else:
+            unregenerated.append(path)
     return {
-        "rehashed": rehashed,
+        "unregenerated": unregenerated,
         "added": sorted(set(added) - set(removed)),
+        "upstream": upstream,
         "removed": sorted(set(removed) - set(added)),
     }
 
@@ -196,11 +211,16 @@ def render(groups: dict[str, list[str]]) -> str:
         "appeared upstream.",
     )
     section(
-        "rehashed", "Changed hashes",
-        "Either the upstream source changed, or this repository's parser "
-        "output for it did. The diff says which: a changed source hash is "
-        "upstream churn; a changed output hash with an unchanged source hash "
-        "is a parser change that reached main without regenerating.",
+        "unregenerated", "Parser output changed on UNCHANGED input",
+        "The source hash is identical and the output hash is not: this "
+        "repository now produces different output for the same bytes than "
+        "the committed baseline records. A parser change reached main without "
+        "regenerating. **This is the group to look at first.**",
+    )
+    section(
+        "upstream", "Upstream source changed",
+        "The file's own contents moved upstream, so a different output hash "
+        "is expected. Routine churn; regenerate when convenient.",
     )
     section(
         "removed", "Manifest entries whose file is gone",
@@ -226,6 +246,10 @@ def render(groups: dict[str, list[str]]) -> str:
     return "\n".join(body)
 
 
+def _empty() -> dict[str, list[str]]:
+    return {"unregenerated": [], "added": [], "upstream": [], "removed": []}
+
+
 def self_test() -> int:
     """Prove the classifier can report drift, and can report its absence.
 
@@ -248,8 +272,11 @@ def self_test() -> int:
     )
     got = classify(sample)
     want = {
-        "rehashed": ["tests/compatibility/files/a/x.beancount"],
+        # x.beancount keeps source hash AAA and changes output BBB -> CCC:
+        # same input, different output, which is the serious case.
+        "unregenerated": ["tests/compatibility/files/a/x.beancount"],
         "added": ["tests/compatibility/files/a/new.beancount"],
+        "upstream": [],
         "removed": ["tests/compatibility/files/a/gone.beancount"],
     }
     if got != want:
@@ -261,6 +288,18 @@ def self_test() -> int:
             failures.append(f"rendered body omits {needle}")
     if "**3**" not in text:
         failures.append("rendered body does not count all three entries")
+
+    # The split is the point of the section: an upstream content change and a
+    # parser change that skipped regeneration look identical in a path list
+    # and mean entirely different things.
+    upstream_only = classify(
+        "-tests/compatibility/files/a/y.beancount\tAAA\tBBB\n"
+        "+tests/compatibility/files/a/y.beancount\tZZZ\tCCC\n"
+    )
+    if upstream_only["upstream"] != ["tests/compatibility/files/a/y.beancount"]:
+        failures.append(f"changed source hash must read as upstream: {upstream_only}")
+    if upstream_only["unregenerated"]:
+        failures.append("a changed source hash must NOT read as unregenerated")
 
     # A comment-only diff is not drift.
     if any(classify("+# regenerated\n").values()):
@@ -330,7 +369,7 @@ def self_test() -> int:
         return "https://github.com/x/y/issues/1\n"
 
     real_gh = globals()["gh"]
-    drift = {"rehashed": ["a"], "added": [], "removed": []}
+    drift = {"unregenerated": ["a"], "added": [], "upstream": [], "removed": []}
     # `_report` narrates to stdout. Left alone it prints "opened
     # https://github.com/x/y/issues/1" into a self-test log, which is exactly
     # the sort of line someone skims and believes.
@@ -357,13 +396,13 @@ def self_test() -> int:
             failures.append("edit must target the existing issue number")
 
         calls.clear()
-        _report(False, {"rehashed": [], "added": [], "removed": []}, [{"number": 7}])
+        _report(False, _empty(), [{"number": 7}])
         verbs = [c[1] for c in calls]
         if verbs != ["comment", "close"]:
             failures.append(f"clean with an open issue must comment then close, got {verbs}")
 
         calls.clear()
-        _report(False, {"rehashed": [], "added": [], "removed": []}, [])
+        _report(False, _empty(), [])
         if calls:
             failures.append(f"clean with no issue must touch nothing, got {calls}")
     finally:

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -178,11 +178,11 @@ def _summary(n: int) -> str:
     plural = "y" if n == 1 else "ies"
     return (
         f"A fresh fetch of the compatibility corpus moves **{n}** manifest"
-        f" entr{plural}. Nothing on a pull request would report this: the"
-        " baseline gate treats an unmanifested downloaded file as a warning,"
-        " and CI restores the corpus from a cache keyed on the fetch script"
-        " rather than on upstream state, so every PR sees the same frozen"
-        " corpus."
+        + f" entr{plural}. Nothing on a pull request would report this: the"
+        + " baseline gate treats an unmanifested downloaded file as a warning,"
+        + " and CI restores the corpus from a cache keyed on the fetch script"
+        + " rather than on upstream state, so every PR sees the same frozen"
+        + " corpus."
     )
 
 
@@ -208,19 +208,19 @@ def render(groups: dict[str, list[str]]) -> str:
     section(
         "added", "New corpus files with no baseline",
         "These have had **no parser-output coverage at all** since they "
-        "appeared upstream.",
+        + "appeared upstream.",
     )
     section(
         "unregenerated", "Parser output changed on UNCHANGED input",
         "The source hash is identical and the output hash is not: this "
-        "repository now produces different output for the same bytes than "
-        "the committed baseline records. A parser change reached main without "
-        "regenerating. **This is the group to look at first.**",
+        + "repository now produces different output for the same bytes than "
+        + "the committed baseline records. A parser change reached main without "
+        + "regenerating. **This is the group to look at first.**",
     )
     section(
         "upstream", "Upstream source changed",
         "The file's own contents moved upstream, so a different output hash "
-        "is expected. Routine churn; regenerate when convenient.",
+        + "is expected. Routine churn; regenerate when convenient.",
     )
     section(
         "removed", "Manifest entries whose file is gone",
@@ -240,7 +240,7 @@ def render(groups: dict[str, list[str]]) -> str:
         "",
         (
             "Maintained by `.github/workflows/corpus-baseline-drift.yml`."
-            " Closes itself when the manifest matches a fresh corpus again."
+            + " Closes itself when the manifest matches a fresh corpus again."
         ),
     ]
     return "\n".join(body)
@@ -264,11 +264,11 @@ def self_test() -> int:
 
     sample = (
         "--- a/tests/baselines/parser-corpus.manifest\n"
-        "+++ b/tests/baselines/parser-corpus.manifest\n"
-        "-tests/compatibility/files/a/x.beancount\tAAA\tBBB\n"
-        "+tests/compatibility/files/a/x.beancount\tAAA\tCCC\n"
-        "+tests/compatibility/files/a/new.beancount\tDDD\tEEE\n"
-        "-tests/compatibility/files/a/gone.beancount\tFFF\tGGG\n"
+        + "+++ b/tests/baselines/parser-corpus.manifest\n"
+        + "-tests/compatibility/files/a/x.beancount\tAAA\tBBB\n"
+        + "+tests/compatibility/files/a/x.beancount\tAAA\tCCC\n"
+        + "+tests/compatibility/files/a/new.beancount\tDDD\tEEE\n"
+        + "-tests/compatibility/files/a/gone.beancount\tFFF\tGGG\n"
     )
     got = classify(sample)
     want = {
@@ -294,7 +294,7 @@ def self_test() -> int:
     # and mean entirely different things.
     upstream_only = classify(
         "-tests/compatibility/files/a/y.beancount\tAAA\tBBB\n"
-        "+tests/compatibility/files/a/y.beancount\tZZZ\tCCC\n"
+        + "+tests/compatibility/files/a/y.beancount\tZZZ\tCCC\n"
     )
     if upstream_only["upstream"] != ["tests/compatibility/files/a/y.beancount"]:
         failures.append(f"changed source hash must read as upstream: {upstream_only}")
@@ -335,6 +335,9 @@ def self_test() -> int:
             gh("issue", "list")
             failures.append("gh must raise GhError when the command fails")
         except GhError:
+            # Raising IS the expected outcome, so there is nothing to record:
+            # the `except` arm reaching at all is what the check asserts, and
+            # the `failures.append` above it is what runs when it does not.
             pass
     finally:
         subprocess.run = real_run
@@ -446,9 +449,9 @@ def main() -> int:
     if not fetch_is_complete(count, expected):
         print(
             f"corpus has {count} files, manifest expects ~{expected} "
-            f"(slack {CORPUS_SLACK}): the fetch came up short, so a "
-            "regeneration here would report its own missing files as "
-            "upstream deletions. Reporting nothing this run.",
+            + f"(slack {CORPUS_SLACK}): the fetch came up short, so a "
+            + "regeneration here would report its own missing files as "
+            + "upstream deletions. Reporting nothing this run.",
             file=sys.stderr,
         )
         return 0
@@ -466,7 +469,7 @@ def main() -> int:
         if dirty_before:
             print(
                 f"note: {MANIFEST} had uncommitted changes before this ran, "
-                "so it was regenerated in place and NOT restored.",
+                + "so it was regenerated in place and NOT restored.",
                 file=sys.stderr,
             )
         else:

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Report parser-baseline drift that no PR would otherwise carry.
+
+`tests/baselines/parser-corpus.manifest` pins the parser's output for every
+file in the downloaded compatibility corpus. Two things keep it from staying
+current on its own:
+
+  * The baseline gate treats a downloaded corpus file with no manifest entry
+    as a WARNING, not a failure, and deliberately so -- upstream can add a
+    file at any moment and failing would fire on unrelated PRs. The warning
+    goes to a CI log nobody reads, so such a file can sit with no baseline
+    coverage indefinitely.
+
+  * CI restores the corpus from a cache keyed on the FETCH SCRIPT, not on
+    upstream state, so the fetch step is skipped on an exact key hit. CI's
+    corpus is therefore frozen at whatever was fetched when that key was
+    first created, while the upstream repositories it mirrors keep moving.
+    Every PR sees the same stale corpus and reports no drift.
+
+Together those mean drift accumulates silently until somebody changes the
+parser, whose PR then has to carry and explain unrelated churn (#2186).
+
+This runs on a schedule against a FRESHLY FETCHED corpus and turns the
+result into an issue -- a signal a human sees. It reports; it does not gate.
+
+The oracle is the repository's own regeneration path (`BASELINE_UPDATE=1`)
+plus `git diff`, deliberately: reimplementing the fingerprint in Python
+would be a second implementation of the thing under test, free to disagree
+with the Rust one in exactly the cases that matter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+REPO = "rustledger/rustledger"
+ISSUE_TITLE = "Parser corpus baseline has drifted"
+MARKER = "<!-- corpus-baseline-drift -->"
+MANIFEST = "tests/baselines/parser-corpus.manifest"
+
+REGEN = [
+    "cargo", "test", "-p", "rustledger-parser",
+    "--test", "corpus_baseline", "parser_output_matches_baseline",
+]
+
+
+def gh(*args: str) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        print(f"gh {' '.join(args)} failed: {proc.stderr.strip()}", file=sys.stderr)
+        return ""
+    return proc.stdout
+
+
+def regenerate() -> None:
+    """Rewrite the manifest from the corpus currently on disk."""
+    subprocess.run(REGEN, env={**os.environ, "BASELINE_UPDATE": "1"}, check=True)
+
+
+def manifest_diff() -> str:
+    """Unified diff of the manifest after regeneration, empty if unchanged."""
+    return subprocess.run(
+        ["git", "diff", "--unified=0", "--", MANIFEST],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def classify(diff: str) -> dict[str, list[str]]:
+    """Split a manifest diff into added / removed / rehashed paths.
+
+    A manifest line is `path<TAB>source_hash<TAB>output_hash`. A path on both
+    sides of the diff had a hash change; a path on one side only was added or
+    removed from the corpus.
+    """
+    added, removed = {}, {}
+    for line in diff.splitlines():
+        if line.startswith(("+++", "---")):
+            continue
+        if line.startswith("+"):
+            body = line[1:]
+        elif line.startswith("-"):
+            body = line[1:]
+        else:
+            continue
+        if not body or body.startswith("#"):
+            continue
+        path = body.split("\t")[0]
+        (added if line.startswith("+") else removed)[path] = body
+    rehashed = sorted(set(added) & set(removed))
+    return {
+        "rehashed": rehashed,
+        "added": sorted(set(added) - set(removed)),
+        "removed": sorted(set(removed) - set(added)),
+    }
+
+
+def render(groups: dict[str, list[str]]) -> str:
+    n = sum(len(v) for v in groups.values())
+    body = [
+        MARKER,
+        "",
+        f"A fresh fetch of the compatibility corpus moves **{n}** manifest "
+        f"entr{'y' if n == 1 else 'ies'}. Nothing on a pull request would "
+        "report this: the baseline gate treats an unmanifested downloaded "
+        "file as a warning, and CI restores the corpus from a cache keyed on "
+        "the fetch script rather than on upstream state, so every PR sees the "
+        "same frozen corpus.",
+        "",
+    ]
+
+    def section(key: str, title: str, why: str) -> None:
+        paths = groups[key]
+        if not paths:
+            return
+        body.extend([f"### {title} ({len(paths)})", "", why, ""])
+        body.extend(f"- `{p}`" for p in paths[:40])
+        if len(paths) > 40:
+            body.append(f"- _...and {len(paths) - 40} more_")
+        body.append("")
+
+    section(
+        "added", "New corpus files with no baseline",
+        "These have had **no parser-output coverage at all** since they "
+        "appeared upstream.",
+    )
+    section(
+        "rehashed", "Changed hashes",
+        "Either the upstream source changed, or this repository's parser "
+        "output for it did. The diff says which: a changed source hash is "
+        "upstream churn; a changed output hash with an unchanged source hash "
+        "is a parser change that reached main without regenerating.",
+    )
+    section(
+        "removed", "Manifest entries whose file is gone",
+        "Upstream deleted or renamed these; the entries are dead weight.",
+    )
+
+    body += [
+        "---",
+        "",
+        "To resolve, on a clean checkout:",
+        "",
+        "```sh",
+        "./scripts/fetch-compat-test-files.sh   # refresh the corpus",
+        "./scripts/regen-corpus-baselines.sh",
+        "git diff tests/baselines/              # review",
+        "```",
+        "",
+        "Maintained by `.github/workflows/corpus-baseline-drift.yml`. "
+        "Closes itself when the manifest matches a fresh corpus again.",
+    ]
+    return "\n".join(body)
+
+
+def self_test() -> int:
+    """Prove the classifier can report drift, and can report its absence.
+
+    A drift reporter that always says "clean" is worse than none: it is the
+    same silence it exists to break, wearing a green check.
+    """
+    failures = []
+
+    clean = classify("")
+    if any(clean.values()):
+        failures.append(f"empty diff must be clean, got {clean}")
+
+    sample = (
+        "--- a/tests/baselines/parser-corpus.manifest\n"
+        "+++ b/tests/baselines/parser-corpus.manifest\n"
+        "-tests/compatibility/files/a/x.beancount\tAAA\tBBB\n"
+        "+tests/compatibility/files/a/x.beancount\tAAA\tCCC\n"
+        "+tests/compatibility/files/a/new.beancount\tDDD\tEEE\n"
+        "-tests/compatibility/files/a/gone.beancount\tFFF\tGGG\n"
+    )
+    got = classify(sample)
+    want = {
+        "rehashed": ["tests/compatibility/files/a/x.beancount"],
+        "added": ["tests/compatibility/files/a/new.beancount"],
+        "removed": ["tests/compatibility/files/a/gone.beancount"],
+    }
+    if got != want:
+        failures.append(f"classify mismatch:\n  got  {got}\n  want {want}")
+
+    text = render(got)
+    for needle in ("new.beancount", "x.beancount", "gone.beancount", MARKER):
+        if needle not in text:
+            failures.append(f"rendered body omits {needle}")
+    if "**3**" not in text:
+        failures.append("rendered body does not count all three entries")
+
+    # A comment-only diff is not drift.
+    if any(classify("+# regenerated\n").values()):
+        failures.append("comment lines must not count as drift")
+
+    for f in failures:
+        print(f"self-test FAIL: {f}", file=sys.stderr)
+    print("self-test: ok" if not failures else f"self-test: {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="print, do not touch issues")
+    args = ap.parse_args()
+
+    regenerate()
+    groups = classify(manifest_diff())
+    drifted = any(groups.values())
+
+    if args.dry_run:
+        print(render(groups) if drifted else "no drift")
+        return 0
+
+    existing = gh(
+        "issue", "list", "--repo", REPO, "--state", "open",
+        "--search", ISSUE_TITLE, "--json", "number,body", "--limit", "20",
+    )
+    try:
+        issues = [i for i in json.loads(existing or "[]") if MARKER in (i.get("body") or "")]
+    except json.JSONDecodeError:
+        issues = []
+
+    if drifted:
+        text = render(groups)
+        if issues:
+            num = str(issues[0]["number"])
+            gh("issue", "edit", num, "--repo", REPO, "--body", text)
+            print(f"updated issue #{num}")
+        else:
+            url = gh("issue", "create", "--repo", REPO,
+                     "--title", ISSUE_TITLE, "--body", text).strip()
+            print(f"opened {url}")
+    elif issues:
+        num = str(issues[0]["number"])
+        gh("issue", "comment", num, "--repo", REPO, "--body",
+           "The manifest matches a freshly fetched corpus again. Closing automatically.")
+        gh("issue", "close", num, "--repo", REPO)
+        print(f"no drift; closed issue #{num}")
+    else:
+        print("no drift")
+
+    # Always 0: this reports, it does not gate. A red X here would be one more
+    # failing scheduled workflow for nobody to notice.
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        raise SystemExit(self_test())
+    sys.exit(main())

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -48,6 +48,45 @@ REGEN = [
 ]
 
 
+CORPUS_ROOT = "tests/compatibility/files"
+
+# Same slack as the "Verify corpus is populated" step in
+# `parser-baselines.yml`, and for the same reason: the fetch tolerates up to
+# 15 best-effort clone failures, so a legitimately complete run can still come
+# up a little short.
+CORPUS_SLACK = 50
+
+
+def corpus_size() -> int:
+    """Count `.beancount` files the way the baseline test discovers them."""
+    n = 0
+    for _, _, files in os.walk(CORPUS_ROOT):
+        n += sum(1 for f in files if f.endswith(".beancount"))
+    return n
+
+
+def manifest_entries() -> int:
+    with open(MANIFEST, encoding="utf-8") as fh:
+        return sum(1 for line in fh if line.strip() and not line.startswith("#"))
+
+
+def fetch_is_complete(count: int, expected: int) -> bool:
+    """Is this corpus whole enough to trust a "file disappeared" verdict?
+
+    This matters here in a way it does not for the PR gate. That job restores
+    a cached corpus, so it always has a complete one; this one fetches fresh
+    into an empty checkout, so every tolerated clone failure is simply missing
+    files. Regenerating against a partial corpus drops their manifest entries,
+    and reporting that as "upstream deleted these" would be a confident lie --
+    the more repositories failed, the longer and more alarming the list.
+
+    A short corpus cannot manufacture a false "added" or "rehashed" either,
+    but it does mean the run saw an unrepresentative corpus, so the honest
+    answer is to report nothing and say why.
+    """
+    return count >= expected - CORPUS_SLACK
+
+
 def gh(*args: str) -> str:
     proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
     if proc.returncode != 0:
@@ -196,6 +235,18 @@ def self_test() -> int:
     if any(classify("+# regenerated\n").values()):
         failures.append("comment lines must not count as drift")
 
+    # The partial-fetch guard, which is the difference between reporting
+    # drift and inventing it. Fresh-fetching into an empty checkout means a
+    # tolerated clone failure looks exactly like an upstream deletion.
+    if not fetch_is_complete(735, 735):
+        failures.append("a complete corpus must be accepted")
+    if not fetch_is_complete(735 - CORPUS_SLACK, 735):
+        failures.append("a corpus short by exactly the slack must be accepted")
+    if fetch_is_complete(735 - CORPUS_SLACK - 1, 735):
+        failures.append("a corpus short by more than the slack must be refused")
+    if fetch_is_complete(0, 735):
+        failures.append("an empty corpus must be refused")
+
     for f in failures:
         print(f"self-test FAIL: {f}", file=sys.stderr)
     print("self-test: ok" if not failures else f"self-test: {len(failures)} failure(s)")
@@ -207,11 +258,47 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true", help="print, do not touch issues")
     args = ap.parse_args()
 
+    # Whether the manifest was already modified before we touched it. If it
+    # was, --dry-run must NOT restore it: `git checkout --` would throw away
+    # edits the caller made, and a reporting script has no business deleting
+    # someone's work to keep its own promise about not leaving a diff.
+    dirty_before = bool(
+        subprocess.run(
+            ["git", "diff", "--name-only", "--", MANIFEST],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+
+    expected = manifest_entries()
+    count = corpus_size()
+    if not fetch_is_complete(count, expected):
+        print(
+            f"corpus has {count} files, manifest expects ~{expected} "
+            f"(slack {CORPUS_SLACK}): the fetch came up short, so a "
+            "regeneration here would report its own missing files as "
+            "upstream deletions. Reporting nothing this run.",
+            file=sys.stderr,
+        )
+        return 0
+
     regenerate()
     groups = classify(manifest_diff())
     drifted = any(groups.values())
 
     if args.dry_run:
+        # Regenerating rewrote the manifest in the working tree. On CI that is
+        # a throwaway checkout, but --dry-run is for humans, and a flag named
+        # dry-run must not leave a modified file behind for someone to commit
+        # by accident. Unless it was already modified when we arrived, in
+        # which case restoring it would delete their edits instead.
+        if dirty_before:
+            print(
+                f"note: {MANIFEST} had uncommitted changes before this ran, "
+                "so it was regenerated in place and NOT restored.",
+                file=sys.stderr,
+            )
+        else:
+            subprocess.run(["git", "checkout", "--", MANIFEST], check=True)
         print(render(groups) if drifted else "no drift")
         return 0
 

--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -311,6 +311,57 @@ def self_test() -> int:
     finally:
         subprocess.run = real_run
 
+    # `_report` is the only code that does anything: it decides between
+    # opening, updating and closing. `--dry-run` returns before reaching it,
+    # and a scheduled run exercises exactly one branch per week, so without
+    # this the working part of the script ships unexecuted.
+    calls: list[tuple[str, ...]] = []
+
+    def recording_gh(*args: str) -> str:
+        calls.append(args)
+        return "https://github.com/x/y/issues/1\n"
+
+    real_gh = globals()["gh"]
+    drift = {"rehashed": ["a"], "added": [], "removed": []}
+    # `_report` narrates to stdout. Left alone it prints "opened
+    # https://github.com/x/y/issues/1" into a self-test log, which is exactly
+    # the sort of line someone skims and believes.
+    import contextlib
+    import io
+
+    try:
+        globals()["gh"] = recording_gh
+        sink = contextlib.redirect_stdout(io.StringIO())
+        sink.__enter__()
+
+        calls.clear()
+        _report(True, drift, [])
+        verbs = [c[1] for c in calls]
+        if verbs != ["create"]:
+            failures.append(f"drift with no open issue must create one, got {verbs}")
+
+        calls.clear()
+        _report(True, drift, [{"number": 7}])
+        verbs = [c[1] for c in calls]
+        if verbs != ["edit"]:
+            failures.append(f"drift with an open issue must edit it, got {verbs}")
+        if calls and "7" not in calls[0]:
+            failures.append("edit must target the existing issue number")
+
+        calls.clear()
+        _report(False, {"rehashed": [], "added": [], "removed": []}, [{"number": 7}])
+        verbs = [c[1] for c in calls]
+        if verbs != ["comment", "close"]:
+            failures.append(f"clean with an open issue must comment then close, got {verbs}")
+
+        calls.clear()
+        _report(False, {"rehashed": [], "added": [], "removed": []}, [])
+        if calls:
+            failures.append(f"clean with no issue must touch nothing, got {calls}")
+    finally:
+        sink.__exit__(None, None, None)
+        globals()["gh"] = real_gh
+
     for f in failures:
         print(f"self-test FAIL: {f}", file=sys.stderr)
     print("self-test: ok" if not failures else f"self-test: {len(failures)} failure(s)")

--- a/tests/baselines/README.md
+++ b/tests/baselines/README.md
@@ -60,6 +60,41 @@ Strict mode is what makes the gate a gate. In default mode (no env
 var), the test passes when no entries overlap; local devs without
 the corpus see the test skip, not fail.
 
+## Drift nobody would otherwise see
+
+The gate above catches a parser change. It cannot catch the manifest
+falling behind the corpus, for two reasons that are both deliberate:
+
+- A downloaded corpus file with **no manifest entry** is a warning there,
+  not a failure. Upstream can add a file at any moment and failing would
+  redden unrelated PRs. But the warning goes to a log nobody reads, so
+  such a file can sit with no parser-output coverage at all.
+- The job restores the corpus from a cache keyed on
+  `scripts/fetch-compat-test-files.sh`, and skips the fetch on an exact
+  key hit. That key changes when the *script* changes, never when
+  *upstream* does, so CI replays the corpus that existed when the key was
+  created while the repositories it mirrors keep moving. Every PR sees
+  the same frozen corpus and agrees there is no drift.
+
+So drift accumulated until somebody changed the parser, whose PR then
+carried unrelated churn it had to explain (#2186).
+
+`Corpus Baseline Drift` (`.github/workflows/corpus-baseline-drift.yml`)
+covers that gap. Weekly, it fetches the corpus **fresh — deliberately not
+from the cache, which is the whole point** — regenerates, and opens an
+issue describing any drift, separating new-file/changed-hash/removed-file
+cases because they need different responses. It reports; it never gates,
+and it closes its own issue when the manifest matches a fresh corpus
+again.
+
+It refuses to report at all when the fetch comes up more than 50 files
+short. Fetching into an empty checkout means each tolerated clone failure
+is simply missing files, and regenerating against a partial corpus would
+present them as upstream deletions.
+
+Run it yourself with `python3 scripts/corpus-baseline-drift.py --dry-run`,
+which prints what it would file and leaves the manifest as it found it.
+
 ## Regenerating the manifest
 
 When a parser change shifts output bytes intentionally:


### PR DESCRIPTION
Refs #2186.

## Part 1 is already done

The manifest is **current**. On a clean checkout with a freshly fetched corpus:

- `./scripts/fetch-compat-test-files.sh` → 735 files
- `./scripts/regen-corpus-baselines.sh` → **zero diff**
- discovered files 735, manifest entries 735, **0 missing, 0 orphaned**

#2185/#2189 carried the 3 modified hashes and 20 additions the issue lists. Nothing left to regenerate.

## The stated cause isn't the cause

The issue says the gate is path-filtered. It isn't — `parser-baselines.yml` has no `paths:` filter and its header says it runs on every PR. The real mechanism is two deliberate decisions meeting:

1. **An unmanifested downloaded file is a warning, not a failure.** That's correct as written: upstream can add a file at any moment, and failing would turn unrelated PRs red. But the warning goes to a CI log nobody reads, so the file sits with no parser-output coverage at all.

2. **CI's corpus is frozen.** The job restores `tests/compatibility/files` from a cache keyed on `hashFiles('scripts/fetch-compat-test-files.sh')`, and the fetch step is skipped on an exact key hit. The key changes when the *script* changes — never when *upstream* does. So CI keeps replaying whatever corpus existed when that key was created, and every PR agrees there's no drift.

Neither is wrong alone, and tightening either costs exactly what its own comment explains. What's missing is a third thing that looks at a corpus nobody has frozen.

## What this adds

A weekly job that fetches the corpus **fresh — no cache, which is the entire point** — regenerates, and turns any drift into an issue. It reports; it never gates; it closes its own issue when the manifest matches again.

The issue body separates the three cases, because they need different responses:

| group | meaning |
|---|---|
| **New corpus files with no baseline** | no parser-output coverage at all since they appeared |
| **Changed hashes** | source hash moved = upstream churn; output hash moved with source unchanged = a parser change reached main without regenerating |
| **Entries whose file is gone** | upstream deleted or renamed; dead weight |

**The oracle is the repository's own `BASELINE_UPDATE=1` path plus `git diff`** — not a Python reimplementation of the fingerprint, which would be a second implementation of the thing under test, free to disagree with the Rust one in precisely the cases that matter.

## Self-test

Modeled on `nightly-health.yml`, including the self-test that runs **before** the live check and **is** allowed to fail the job. The live check exits 0 whatever it finds, so a broken classifier would otherwise report a permanently reassuring "no drift" — the same silence this workflow exists to break, wearing a green check.

Verified it can fail, two ways:

| break | caught |
|---|---|
| rehash detection disabled (`rehashed = []`) | 3 failures |
| classifier returns clean for everything | 5 failures |

It also pins that an empty diff reports clean and that comment-only lines aren't drift, so it can report *both* answers rather than only the alarming one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr