### PR TITLE
docs(core): cross-file booking order is not Python's, on purpose

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -648,9 +648,35 @@ impl Directive {
 
 /// Sort directives by date, then type priority.
 ///
-/// This is a stable sort, so directives sharing a date and type keep their
-/// file order — which is the order they are booked in, matching Python's
-/// `(date, type_priority, lineno)`.
+/// This is a stable sort, so directives sharing a date and type keep the
+/// order they were parsed in, which is the order they are booked in.
+///
+/// **Within one file that matches Python's `(date, type_priority, lineno)`.
+/// Across `include`s it deliberately does not**, and the difference is
+/// observable in reported gains rather than merely cosmetic.
+///
+/// Python compares `lineno` values taken from different files, so a directive
+/// on line 1 of a file included second sorts ahead of one on line 5 of a file
+/// included first. This sort keeps include order: everything from the first
+/// included file, in its own order, then the second.
+///
+/// Two same-date lots therefore enter the inventory in different orders under
+/// the two rules, and a FIFO sale whose lot-date comparison ties falls through
+/// to that order. Measured against beancount 3.2.3 on the fixture in
+/// `tests/fixtures/cross-file-order/` — one buy at 10.00 on line 5 of the
+/// first included file, one at 20.00 on line 1 of the second — selling one
+/// unit reports a 2x difference in realized gain, with no error either side.
+///
+/// Include order is kept on purpose. Ordering two directives by comparing a
+/// line number from one file against a line number from a different file is
+/// not a fact about the ledger: adding a comment to one file silently changes
+/// which lot a sale in another file consumes. Include order at least reflects
+/// how the author assembled the ledger. Beancount's own rule is not purely
+/// `lineno` driven either — directives sharing a line number across files
+/// fall back to include order through its stable sort.
+///
+/// Pinned by `cross_file_same_date_directives_keep_include_order` and recorded
+/// in `docs/reference/compatibility.md` (#2149).
 pub fn sort_directives(directives: &mut [Directive]) {
     directives.sort_by_cached_key(booking_sort_key);
 }
@@ -658,9 +684,12 @@ pub fn sort_directives(directives: &mut [Directive]) {
 /// The canonical booking-order sort key: `(date, priority)`.
 ///
 /// Deliberately WITHOUT a reduction tiebreak. Same-date directives book in
-/// file order (the sorts through this key are stable), which is what Python
-/// does — its `entry_sortkey` is `(date, type_priority, lineno)` and has no
-/// notion of augmentations going first.
+/// parse order (the sorts through this key are stable), and Python likewise
+/// has no notion of augmentations going first — its `entry_sortkey` is
+/// `(date, type_priority, lineno)`.
+///
+/// That equivalence holds within a file and NOT across `include`s; see
+/// [`sort_directives`] for what differs and why include order is kept.
 ///
 /// This key used to carry a third component, `has_cost_reduction`, which
 /// floated cost augmentations ahead of the reductions matching against them

--- a/crates/rustledger-loader/tests/cross_file_booking_order.rs
+++ b/crates/rustledger-loader/tests/cross_file_booking_order.rs
@@ -19,7 +19,7 @@
 //! | second, first | -10.00 | -10.00 |
 //!
 //! beancount is invariant because it re-sorts by line number; ours tracks how
-//! the ledger was assembled. Neither errors or warns.
+//! the ledger was assembled. Neither errors nor warns.
 //!
 //! We keep include order deliberately. Comparing a line number from one file
 //! against a line number from a different file is not a fact about the ledger:

--- a/crates/rustledger-loader/tests/cross_file_booking_order.rs
+++ b/crates/rustledger-loader/tests/cross_file_booking_order.rs
@@ -1,0 +1,84 @@
+//! Same-date directives from different included files book in include order,
+//! not in line-number order (#2149).
+//!
+//! `sort_directives` is a stable sort over `(date, priority)`, so directives
+//! sharing both keep the order they were parsed in. Within one file that is
+//! the same thing as Python's `(date, type_priority, lineno)`. Across
+//! `include`s it is not: Python compares line numbers taken from DIFFERENT
+//! files, so a directive on line 1 of a file included second sorts ahead of
+//! one on line 5 of a file included first.
+//!
+//! The difference is observable in money. Two same-date buys enter the
+//! inventory in different orders under the two rules, and a FIFO sale whose
+//! lot-date comparison ties falls through to that order. Measured against
+//! beancount 3.2.3 on this fixture:
+//!
+//! | include order | beancount | rustledger |
+//! |---|---|---|
+//! | first, second | -10.00 | **-20.00** |
+//! | second, first | -10.00 | -10.00 |
+//!
+//! beancount is invariant because it re-sorts by line number; ours tracks how
+//! the ledger was assembled. Neither errors or warns.
+//!
+//! We keep include order deliberately. Comparing a line number from one file
+//! against a line number from a different file is not a fact about the ledger:
+//! adding a comment to one file silently changes which lot a sale in another
+//! file consumes. Beancount's rule is not purely line-number driven either --
+//! directives sharing a line number across files fall back to include order
+//! through its own stable sort.
+//!
+//! This test exists because nothing pinned the behavior in either direction.
+//! The three tests that exercise this ordering
+//! (`test_sort_directives_by_date`, `test_sort_directives_by_type_same_date`,
+//! `test_sort_directives_pad_before_balance`) do not mention a file or an
+//! include, and the compatibility corpus cannot reach it: of 761 `.beancount`
+//! files, one contains a single `include` and none contains two, so no corpus
+//! file can express the shape.
+
+use rustledger_core::Directive;
+use rustledger_loader::{LoadOptions, Loader, process};
+
+fn realized_gains(ledger: &std::path::Path) -> String {
+    let raw = Loader::new().load(ledger).expect("fixture loads");
+    let processed = process(raw, &LoadOptions::default()).expect("fixture books");
+    let mut total = rustledger_core::Decimal::ZERO;
+    let mut seen = false;
+    for d in &processed.directives {
+        if let Directive::Transaction(txn) = &d.value {
+            for p in &txn.postings {
+                if p.account.as_str() == "Income:Gains"
+                    && let Some(n) = p
+                        .units
+                        .as_ref()
+                        .and_then(rustledger_core::IncompleteAmount::number)
+                {
+                    total += n;
+                    seen = true;
+                }
+            }
+        }
+    }
+    assert!(seen, "fixture must produce an Income:Gains posting");
+    total.to_string()
+}
+
+/// The fixture ships in-tree because the compatibility corpus cannot express
+/// this shape, and because the number is only meaningful next to beancount's.
+#[test]
+fn cross_file_same_date_directives_keep_include_order() {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/cross-file-order/ledger.beancount");
+
+    // -20.00 means the 10.00 lot was consumed, i.e. the first INCLUDED file's
+    // buy went in first. -10.00 would mean the 20.00 lot was consumed, which
+    // is what sorting by line number across files produces and what beancount
+    // reports. If this flips, the rule changed: update
+    // `docs/reference/compatibility.md` and `sort_directives` with it, rather
+    // than just re-pinning the number.
+    assert_eq!(
+        realized_gains(&fixture),
+        "-20.00",
+        "same-date buys from two included files must book in include order",
+    );
+}

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -89,6 +89,57 @@ Rustledger shows:        111.11 USD
 
 This is a display-only difference - actual values are identical. Rustledger preserves the original precision, which is technically more accurate.
 
+### 6. Cross-File Booking Order
+
+Directives sharing a date and type keep the order they were parsed in. Within
+one file that matches Python's `(date, type_priority, lineno)`. Across
+`include`s it does not, and the difference shows up in reported gains.
+
+Python compares `lineno` values taken from different files, so a directive on
+line 1 of a file included second sorts ahead of one on line 5 of a file
+included first. Rustledger keeps include order: everything from the first
+included file, in its own order, then the second.
+
+Two same-date lots therefore enter the inventory in different orders, and a
+FIFO sale whose lot-date comparison ties falls through to that order:
+
+```beancount
+; first.beancount, included FIRST, buy on line 5
+2024-06-01 * "buy-at-10"
+  Assets:S      1 HOOL {10.00 USD}
+  Assets:Cash            -10.00 USD
+
+; second.beancount, included SECOND, buy on line 1
+2024-06-01 * "buy-at-20"
+  Assets:S      1 HOOL {20.00 USD}
+  Assets:Cash            -20.00 USD
+```
+
+Selling one unit at 30.00:
+
+| | lot consumed | `Income:Gains` |
+|---|---|---|
+| beancount 3.2.3 | 20.00 | -10.00 USD |
+| rustledger | 10.00 | -20.00 USD |
+
+Swapping the two `include` lines pins each rule down: beancount is invariant
+and reports -10.00 either way; rustledger tracks include order and reports
+-20.00 in one arrangement, -10.00 in the other. Neither errors or warns.
+
+This one is deliberate. Ordering two directives by comparing a line number from
+one file against a line number from a different file is not a fact about the
+ledger -- adding a comment to one file silently changes which lot a sale in
+another file consumes. Include order at least reflects how the author assembled
+the ledger. Beancount's rule is not purely line-number driven either:
+directives sharing a line number across files fall back to include order
+through its own stable sort.
+
+Ledgers that need a specific lot should name it (`{10.00 USD, 2024-06-01}`, or
+a label) rather than relying on either tiebreak.
+
+Fixture: `tests/fixtures/cross-file-order/`. Pinned by
+`cross_file_same_date_directives_keep_include_order` (issue #2149).
+
 ## BQL Query Compatibility
 
 BQL (Beancount Query Language) compatibility was tested with 11 standard queries on 50 files:

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -124,7 +124,7 @@ Selling one unit at 30.00:
 
 Swapping the two `include` lines pins each rule down: beancount is invariant
 and reports -10.00 either way; rustledger tracks include order and reports
--20.00 in one arrangement, -10.00 in the other. Neither errors or warns.
+-20.00 in one arrangement, -10.00 in the other. Neither errors nor warns.
 
 This one is deliberate. Ordering two directives by comparing a line number from
 one file against a line number from a different file is not a fact about the

--- a/tests/fixtures/cross-file-order/first.beancount
+++ b/tests/fixtures/cross-file-order/first.beancount
@@ -1,0 +1,7 @@
+; Included FIRST, but its transaction sits on line 5 on purpose.
+;
+;
+;
+2024-06-01 * "buy-at-10"
+  Assets:S      1 HOOL {10.00 USD}
+  Assets:Cash            -10.00 USD

--- a/tests/fixtures/cross-file-order/ledger.beancount
+++ b/tests/fixtures/cross-file-order/ledger.beancount
@@ -1,0 +1,24 @@
+; Cross-file booking order (#2149).
+;
+; Two same-date buys in two included files, at differing line numbers. A FIFO
+; sale ties on lot date and falls through to the order they entered the
+; inventory, so this fixture reports which ordering rule is in force:
+;
+;   include order (rustledger) -> consumes the 10.00 lot -> gains -20.00 USD
+;   lineno order  (beancount)  -> consumes the 20.00 lot -> gains -10.00 USD
+;
+; The difference is deliberate. See `sort_directives` in rustledger-core and
+; docs/reference/compatibility.md.
+option "booking_method" "FIFO"
+
+2024-01-01 open Assets:S HOOL
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Gains USD
+
+include "first.beancount"
+include "second.beancount"
+
+2024-09-01 * "sell one unit"
+  Assets:S     -1 HOOL {}
+  Assets:Cash   30.00 USD
+  Income:Gains

--- a/tests/fixtures/cross-file-order/second.beancount
+++ b/tests/fixtures/cross-file-order/second.beancount
@@ -1,0 +1,3 @@
+2024-06-01 * "buy-at-20"
+  Assets:S      1 HOOL {20.00 USD}
+  Assets:Cash            -20.00 USD


### PR DESCRIPTION
Closes #2149.

## The wrong claim

`sort_directives` said its stable sort matched Python's `(date, type_priority, lineno)`. That holds inside one file, where parse order and line number rise together. Across `include`s it does not — and `booking_sort_key`, the doc comment that calls itself the single source of the booking order, repeated it.

Python compares line numbers taken from **different files**, so a directive on line 1 of a file included second sorts ahead of one on line 5 of a file included first. This sort keeps include order.

## Measured against real beancount

Not taken from the issue — reproduced against **beancount 3.2.3**. One buy at 10.00 on line 5 of the first included file, one at 20.00 on line 1 of the second, then a FIFO sale of one unit:

| include order | beancount | rustledger |
|---|---|---|
| first, second | -10.00 | **-20.00** |
| second, first | -10.00 | -10.00 |

Swapping the includes pins each rule down: beancount is invariant because it re-sorts by line number; ours tracks how the ledger was assembled. A 2x difference in reported gain, decided by which file a buy lives in and what line it happens to sit on, with no error or warning either side.

## Which rule stands

Include order, deliberately. Ordering two directives by comparing a line number from one file against a line number from a different file is not a fact about the ledger: **adding a comment to one file silently changes which lot a sale in another file consumes.** Include order at least reflects how the author assembled the ledger.

Beancount's rule is not purely line-number driven either — directives sharing a line number across files fall back to include order through its own stable sort. So this is not "match upstream or not", it is choosing between two tiebreaks neither of which is a fact.

## Why nothing caught it

- The three tests that exercise this ordering (`test_sort_directives_by_date`, `test_sort_directives_by_type_same_date`, `test_sort_directives_pad_before_balance`) do not mention a file or an `include`.
- The compatibility corpus **cannot** reach it: of 761 `.beancount` files, one contains a single `include` and none contains two. The divergence needs two included files with same-date directives at differing line numbers, so no corpus file can express the shape. This is not a gap the corpus happens to miss — it is one it cannot currently express, which is why the fixture ships in-tree.

## What this changes

No behavior change. Both doc comments corrected, an in-tree fixture, a test pinning the rule, and an entry in `docs/reference/compatibility.md` alongside the other deliberate divergences.

**The test is verified to fail**: dropping `file_id` from `canonical_sort_key` so the span offset decides across files produces `-10.00` — beancount's answer exactly, not merely a different one. So the control lands on the real alternative rather than on noise.

Workspace green, clippy 1.97 clean, fmt/typos/rustdoc clean, `corpus_parity` clean against a freshly built wasip2 component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr