### PR TITLE
fix(parser): diagnose a balance tolerance that says two things at once

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -489,12 +489,20 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     WITHOUT this bump and 2 WITH it. The bump is what surfaces the
 ///     diagnostic.
 ///
+/// v35: a balance tolerance whose currency disagrees with the amount's, or
+///     which carries a second juxtaposed number, is diagnosed instead of
+///     read in part and discarded in part (#2193). Like v34 the DIRECTIVE is
+///     unchanged and the error list is what moves — and like v34 that is
+///     enough, because such a file used to parse clean and was therefore
+///     cacheable, so replaying its v34 blob skips the parse that now
+///     complains.
+///
 /// Public so `rustledger-wasm` can pin its own cache version against this one.
 /// Both caches archive the same `Vec<Directive>`, so a parser change that
 /// alters PARSER OUTPUT has to bump both — and on #1942 only this one was
 /// bumped, which review caught rather than any test. See
 /// `loader_cache_version_is_pinned` in `rustledger-wasm/src/cache.rs`.
-pub const CACHE_VERSION: u32 = 34;
+pub const CACHE_VERSION: u32 = 35;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1248,7 +1256,9 @@ mod tests {
         // directives -- the tagged `query` is still emitted, alongside a new
         // diagnostic. Either way it is not how a `CostNumber` is archived, so
         // the byte arrays below still hold.
-        const FIXTURE_VERSION: u32 = 34;
+        // v35 (#2193) is the same shape for balance tolerances: new errors,
+        // same archived `CostNumber` encoding.
+        const FIXTURE_VERSION: u32 = 35;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
@@ -1362,7 +1372,9 @@ mod tests {
         // v34 (#2194) adds a syntax error to a tagged `query` and keeps the
         // directive; no `MetaValue` is involved either way, so the hash below
         // is unchanged.
-        const FIXTURE_VERSION: u32 = 34;
+        // v35 (#2193) likewise adds errors on a balance tolerance and touches
+        // no `MetaValue`; the hash below is unchanged.
+        const FIXTURE_VERSION: u32 = 35;
         const META_VALUE_LAYOUT_HASH: &str =
             "43e3c258fe376cede6a6c2c975100bcf67ddda0ab84b21566b123c01e0a54b25";
         assert_eq!(

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -956,6 +956,23 @@ fn check_balance_tolerance(
         ));
     }
 
+    // A second `~` is its own mistake and deserves its own sentence. Without
+    // this it fell into the juxtaposed-numbers arm below, whose message says
+    // the numbers are "side by side" when a tilde sits between them --
+    // a diagnostic describing input the author did not write.
+    if let Some(extra) = tail.iter().find(|t| t.kind() == crate::SyntaxKind::TILDE) {
+        let range = extra.text_range();
+        let start: u32 = range.start().into();
+        let end: u32 = range.end().into();
+        errors.push(crate::ParseError::new(
+            crate::ParseErrorKind::SyntaxError(
+                "a balance takes one tolerance: `AMOUNT ~ TOLERANCE CURRENCY`".to_string(),
+            ),
+            Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
+        ));
+        return;
+    }
+
     // Numbers in the tolerance region, i.e. before its trailing CURRENCY.
     let region: Vec<&crate::SyntaxToken> = tail
         .iter()

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -878,8 +878,7 @@ fn convert_balance(
         })?;
     let currency = Currency::new(node.currency()?.text());
     let amount = Amount::new(number, currency);
-    check_balance_tolerance(node.syntax(), bom_offset, errors);
-    let tolerance = extract_balance_tolerance(node.syntax());
+    let tolerance = check_balance_tolerance(node.syntax(), bom_offset, errors);
     let meta = convert_meta_entries(node.syntax());
 
     let balance = rustledger_core::directive::Balance {
@@ -918,27 +917,33 @@ fn check_balance_tolerance(
     node: &crate::SyntaxNode,
     bom_offset: u32,
     errors: &mut Vec<crate::ParseError>,
-) {
-    // Most balance directives carry no tolerance at all, so answer that with
-    // an iterator rather than a Vec: this runs on every `balance` in every
-    // ledger, and the allocation is pure waste on the common path.
+) -> Option<Decimal> {
+    // Validate AND extract in one walk. Splitting them cost a second full
+    // token scan per `balance`, which measured +5.8% on a 56,000-balance
+    // ledger -- small in a real ledger, where most directives are
+    // transactions, but paid on every balance for nothing.
+    //
+    // Most balance directives carry no tolerance at all, so answer that
+    // first, from an iterator rather than a Vec.
+    // Answer "is there a tolerance at all" WITHOUT allocating: on a ledger of
+    // balances the overwhelming majority have none, and collecting their
+    // tokens first measured +4% against main, which reached the same answer
+    // through a `skip_while` that left an empty Vec. The collect below now
+    // happens only for the directives that actually carry a `~`.
     if !node
         .children_with_tokens()
         .any(|el| el.kind() == crate::SyntaxKind::TILDE)
     {
-        return;
+        return None;
     }
     let toks: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
         .filter(|t| !is_trivia_kind(t.kind()))
         .collect();
-    let Some(tilde) = toks
+    let tilde = toks
         .iter()
-        .position(|t| t.kind() == crate::SyntaxKind::TILDE)
-    else {
-        return;
-    };
+        .position(|t| t.kind() == crate::SyntaxKind::TILDE)?;
     let (head, tail) = toks.split_at(tilde);
     let tail = &tail[1..];
 
@@ -979,7 +984,7 @@ fn check_balance_tolerance(
             ),
             Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
         ));
-        return;
+        return None;
     }
 
     // Numbers in the tolerance region, i.e. before its trailing CURRENCY.
@@ -1033,37 +1038,27 @@ fn check_balance_tolerance(
             Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
         ));
     }
+
+    tolerance_value(region)
 }
 
-/// Balance directives may include an explicit tolerance via a
-/// `~` (TILDE) token followed by a NUMBER. The typed-AST surface
-/// surfaces NUMBER via `number()` (which returns the FIRST one,
-/// the asserted balance); the tolerance NUMBER comes second.
-/// Walk raw tokens until TILDE, then collect the next NUMBER.
-fn extract_balance_tolerance(node: &crate::SyntaxNode) -> Option<Decimal> {
-    // Everything after the TILDE, trivia dropped. The tolerance is its own
-    // expression region: `10.00 ~ 0.005 * 2 USD` asserts a tolerance of 0.010.
-    //
-    // Taking the first NUMBER instead (as this did) truncated it to 0.005 and
-    // REJECTED files beancount accepts — and the E2002 message printed the
-    // truncated figure, so the diagnostic advertised the bug (#1944). Same
-    // root cause as the cost-spec truncation in #1939: a number-bearing
-    // position that never reached the shared evaluator.
-    let tail: Vec<crate::SyntaxToken> = node
-        .children_with_tokens()
-        .filter_map(rowan::NodeOrToken::into_token)
-        .skip_while(|t| t.kind() != crate::SyntaxKind::TILDE)
-        .skip(1)
-        .filter(|t| !is_trivia_kind(t.kind()))
-        .collect();
-    if tail.is_empty() {
+/// Evaluate a tolerance region: an expression when it is one, else its first
+/// NUMBER.
+///
+/// `10.00 ~ 0.005 * 2 USD` asserts a tolerance of 0.010. Taking the first
+/// NUMBER instead truncated it to 0.005 and REJECTED files beancount accepts
+/// -- and the E2002 message printed the truncated figure, so the diagnostic
+/// advertised the bug (#1944). Same root cause as the cost-spec truncation in
+/// #1939: a number-bearing position that never reached the shared evaluator.
+fn tolerance_value(region: &[crate::SyntaxToken]) -> Option<Decimal> {
+    if region.is_empty() {
         return None;
     }
-    if let Some(value) = cost_region_value(&tail) {
+    if let Some(value) = cost_region_value(region) {
         return Some(value);
     }
-    // Not arithmetic: the plain first NUMBER, as before.
-    tail.iter()
+    region
+        .iter()
         .find(|t| t.kind() == crate::SyntaxKind::NUMBER)
         .and_then(|t| parse_decimal_token(t.text()))
 }

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -878,6 +878,7 @@ fn convert_balance(
         })?;
     let currency = Currency::new(node.currency()?.text());
     let amount = Amount::new(number, currency);
+    check_balance_tolerance(node.syntax(), bom_offset, errors);
     let tolerance = extract_balance_tolerance(node.syntax());
     let meta = convert_meta_entries(node.syntax());
 
@@ -890,6 +891,101 @@ fn convert_balance(
     };
     let span = node_span(node.syntax(), bom_offset);
     Some(Spanned::new(Directive::Balance(balance), span))
+}
+
+/// Diagnose a tolerance clause that says something the model cannot keep.
+///
+/// beancount's grammar is `NUMBER ~ NUMBER CURRENCY` — one currency, trailing —
+/// and rejects any currency before the `~`. We are deliberately laxer in one
+/// direction and stricter in another, on a single rule: **accept what has
+/// exactly one meaning, diagnose what has none or contradicts itself.**
+///
+/// - `1.00 USD ~ 0.01 USD` is ACCEPTED, though beancount calls it a syntax
+///   error. The currency is stated twice and agrees, so there is one reading;
+///   it canonicalizes to `1.00 ~ 0.01 USD` losslessly. Rejecting it would
+///   refuse a file whose meaning is not in doubt.
+/// - `1.00 USD ~ 0.01 EUR` is DIAGNOSED. A tolerance denominated in a
+///   different currency than the amount is not redundancy, it is an
+///   assertion the model has no field for — and `rledger format` used to
+///   erase the EUR from the file on its way past.
+/// - `1.00 ~ 0.001 0.02 USD` is DIAGNOSED. Two juxtaposed numbers with no
+///   operator have no reading at all; this took the first and dropped the
+///   rest silently. (`~ 0.005 + 0.005` is arithmetic and still evaluates.)
+///
+/// Recorded as a deliberate divergence in `docs/reference/compatibility.md`
+/// (#2193).
+fn check_balance_tolerance(
+    node: &crate::SyntaxNode,
+    bom_offset: u32,
+    errors: &mut Vec<crate::ParseError>,
+) {
+    let toks: Vec<crate::SyntaxToken> = node
+        .children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .filter(|t| !is_trivia_kind(t.kind()))
+        .collect();
+    let Some(tilde) = toks
+        .iter()
+        .position(|t| t.kind() == crate::SyntaxKind::TILDE)
+    else {
+        return;
+    };
+    let (head, tail) = toks.split_at(tilde);
+    let tail = &tail[1..];
+
+    let currency_of = |ts: &[crate::SyntaxToken]| {
+        ts.iter()
+            .find(|t| t.kind() == crate::SyntaxKind::CURRENCY)
+            .cloned()
+    };
+    if let (Some(before), Some(after)) = (currency_of(head), currency_of(tail))
+        && before.text() != after.text()
+    {
+        let range = after.text_range();
+        let start: u32 = range.start().into();
+        let end: u32 = range.end().into();
+        errors.push(crate::ParseError::new(
+            crate::ParseErrorKind::SyntaxError(format!(
+                "a balance tolerance must be in the same currency as the amount: \
+                 the amount is {} and the tolerance is {}. Drop the second \
+                 currency, or correct it",
+                before.text(),
+                after.text(),
+            )),
+            Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
+        ));
+    }
+
+    // Numbers in the tolerance region, i.e. before its trailing CURRENCY.
+    let region: Vec<&crate::SyntaxToken> = tail
+        .iter()
+        .take_while(|t| t.kind() != crate::SyntaxKind::CURRENCY)
+        .collect();
+    let numbers = region
+        .iter()
+        .filter(|t| t.kind() == crate::SyntaxKind::NUMBER)
+        .count();
+    let owned: Vec<crate::SyntaxToken> = region.iter().map(|t| (*t).clone()).collect();
+    if numbers > 1
+        && cost_region_value(&owned).is_none()
+        && let Some(second) = region
+            .iter()
+            .filter(|t| t.kind() == crate::SyntaxKind::NUMBER)
+            .nth(1)
+    {
+        let range = second.text_range();
+        let start: u32 = range.start().into();
+        let end: u32 = range.end().into();
+        errors.push(crate::ParseError::new(
+            crate::ParseErrorKind::SyntaxError(
+                "a balance tolerance takes one number, or an arithmetic \
+                 expression. Two numbers side by side have no reading, and the \
+                 second was being discarded"
+                    .to_string(),
+            ),
+            Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
+        ));
+    }
 }
 
 /// Balance directives may include an explicit tolerance via a

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -1000,6 +1000,23 @@ fn check_balance_tolerance(
         .iter()
         .filter(|t| t.kind() == crate::SyntaxKind::NUMBER)
         .count();
+
+    // A `~` with nothing after it announces a tolerance that is not there.
+    // It was accepted as though unwritten, and `rledger format` then deleted
+    // the tilde -- the same erase-the-difference behavior as the mismatched
+    // currency. beancount calls it a syntax error.
+    if numbers == 0 {
+        let range = toks[tilde].text_range();
+        let start: u32 = range.start().into();
+        let end: u32 = range.end().into();
+        errors.push(crate::ParseError::new(
+            crate::ParseErrorKind::SyntaxError(
+                "a `~` must be followed by a tolerance: `AMOUNT ~ TOLERANCE CURRENCY`".to_string(),
+            ),
+            Span::new((start + bom_offset) as usize, (end + bom_offset) as usize),
+        ));
+        return None;
+    }
     // Stay quiet unless the region is made only of things an expression can
     // contain. On `~ .005 + .005` the lexer already reports the real problem
     // (a number with no integer part, which we reject and beancount accepts)

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -919,6 +919,15 @@ fn check_balance_tolerance(
     bom_offset: u32,
     errors: &mut Vec<crate::ParseError>,
 ) {
+    // Most balance directives carry no tolerance at all, so answer that with
+    // an iterator rather than a Vec: this runs on every `balance` in every
+    // ledger, and the allocation is pure waste on the common path.
+    if !node
+        .children_with_tokens()
+        .any(|el| el.kind() == crate::SyntaxKind::TILDE)
+    {
+        return;
+    }
     let toks: Vec<crate::SyntaxToken> = node
         .children_with_tokens()
         .filter_map(rowan::NodeOrToken::into_token)
@@ -974,17 +983,38 @@ fn check_balance_tolerance(
     }
 
     // Numbers in the tolerance region, i.e. before its trailing CURRENCY.
-    let region: Vec<&crate::SyntaxToken> = tail
+    // Sliced out of `tail` rather than collected: `cost_region_value` takes
+    // the same `&[SyntaxToken]`, so the two Vecs this used to build (one of
+    // references, one cloning every token back out) bought nothing.
+    let end = tail
         .iter()
-        .take_while(|t| t.kind() != crate::SyntaxKind::CURRENCY)
-        .collect();
+        .position(|t| t.kind() == crate::SyntaxKind::CURRENCY)
+        .unwrap_or(tail.len());
+    let region = &tail[..end];
     let numbers = region
         .iter()
         .filter(|t| t.kind() == crate::SyntaxKind::NUMBER)
         .count();
-    let owned: Vec<crate::SyntaxToken> = region.iter().map(|t| (*t).clone()).collect();
-    if numbers > 1
-        && cost_region_value(&owned).is_none()
+    // Stay quiet unless the region is made only of things an expression can
+    // contain. On `~ .005 + .005` the lexer already reports the real problem
+    // (a number with no integer part, which we reject and beancount accepts)
+    // and this would add "the second was being discarded" on top -- a claim
+    // about input that never parsed, next to the diagnostic that explains it.
+    let expression_shaped = region.iter().all(|t| {
+        matches!(
+            t.kind(),
+            crate::SyntaxKind::NUMBER
+                | crate::SyntaxKind::PLUS
+                | crate::SyntaxKind::MINUS
+                | crate::SyntaxKind::STAR
+                | crate::SyntaxKind::SLASH
+                | crate::SyntaxKind::L_PAREN
+                | crate::SyntaxKind::R_PAREN
+        )
+    });
+    if expression_shaped
+        && numbers > 1
+        && cost_region_value(region).is_none()
         && let Some(second) = region
             .iter()
             .filter(|t| t.kind() == crate::SyntaxKind::NUMBER)

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -2527,8 +2527,15 @@ fn balance_tolerance(
             .collect();
         group.groups(run_currency(&toks))
     };
+    // The tolerance is an EXPRESSION, not a number: `~ 0.005 + 0.005 USD` and
+    // `~ 0.005 * 2 USD` are both legal and both mean 0.010. Keeping only the
+    // first NUMBER -- which this did -- rewrote them as `~ 0.005 USD`, halving
+    // the tolerance. That reparsed cleanly and asserted something else, so
+    // `rledger format` could turn a passing ledger into a failing one with no
+    // diagnostic on either side. Same bug as #1944 in the parser's
+    // `extract_balance_tolerance`, which was fixed there and left here.
     let mut past_tilde = false;
-    let mut number: Option<String> = None;
+    let mut expr: Vec<String> = Vec::new();
     let mut currency: Option<String> = None;
     for el in node.children_with_tokens() {
         let rowan::NodeOrToken::Token(t) = el else {
@@ -2541,16 +2548,36 @@ fn balance_tolerance(
             continue;
         }
         match t.kind() {
-            crate::SyntaxKind::NUMBER if number.is_none() => {
-                number = Some(canonical_number(t.text(), run_group).into_owned());
+            crate::SyntaxKind::NUMBER => {
+                expr.push(canonical_number(t.text(), run_group).into_owned());
             }
-            crate::SyntaxKind::CURRENCY if number.is_some() && currency.is_none() => {
+            crate::SyntaxKind::PLUS
+            | crate::SyntaxKind::MINUS
+            | crate::SyntaxKind::STAR
+            | crate::SyntaxKind::SLASH => expr.push(t.text().to_string()),
+            // Parens bind to their neighbors rather than taking spaces, so
+            // they are joined below rather than pushed as operands.
+            crate::SyntaxKind::L_PAREN => expr.push("(".to_string()),
+            crate::SyntaxKind::R_PAREN => expr.push(")".to_string()),
+            crate::SyntaxKind::CURRENCY if !expr.is_empty() && currency.is_none() => {
                 currency = Some(t.text().to_string());
             }
             _ => {}
         }
     }
-    number.map(|n| (n, currency))
+    if expr.is_empty() {
+        return None;
+    }
+    let mut rendered = String::new();
+    for (i, tok) in expr.iter().enumerate() {
+        let prev = i.checked_sub(1).and_then(|j| expr.get(j));
+        let needs_space = i > 0 && tok != ")" && prev.is_none_or(|p| p != "(");
+        if needs_space {
+            rendered.push(' ');
+        }
+        rendered.push_str(tok);
+    }
+    Some((rendered, currency))
 }
 
 // ---- Metadata --------------------------------------------------
@@ -5457,6 +5484,61 @@ mod tests {
             format_source(src),
             "no declared grouping must be byte-identical to the default path"
         );
+    }
+
+    /// Formatting must not change what a balance ASSERTS.
+    ///
+    /// The tolerance is an expression: `~ 0.005 + 0.005 USD` and
+    /// `~ 0.005 * 2 USD` both mean 0.010. `balance_tolerance` kept only the
+    /// first NUMBER and rewrote them as `~ 0.005 USD`, halving the tolerance.
+    /// The output reparsed cleanly and asserted something else, so `rledger
+    /// format` could turn a passing ledger into a failing one with nothing to
+    /// show for it -- the same truncation #1944 fixed in the parser and left
+    /// standing here.
+    ///
+    /// Asserted on the parsed TOLERANCE VALUE rather than the text, because a
+    /// text comparison would pass on any spelling that happens to round-trip
+    /// while still meaning something new.
+    #[test]
+    fn formatting_preserves_the_tolerance_value() {
+        for (src, want) in [
+            ("2024-01-15 balance Assets:C 1.00 ~ 0.01 USD\n", "0.01"),
+            (
+                "2024-01-15 balance Assets:C 1.00 ~ 0.005 + 0.005 USD\n",
+                "0.010",
+            ),
+            (
+                "2024-01-15 balance Assets:C 1.00 ~ (0.005 + 0.005) USD\n",
+                "0.010",
+            ),
+            (
+                "2024-01-15 balance Assets:C 1.00 ~ 0.005 * 2 USD\n",
+                "0.010",
+            ),
+        ] {
+            let tolerance = |text: &str| {
+                crate::parse(text)
+                    .directives
+                    .iter()
+                    .find_map(|d| match &d.value {
+                        rustledger_core::Directive::Balance(b) => Some(b.tolerance),
+                        _ => None,
+                    })
+                    .flatten()
+                    .map(|t| t.to_string())
+            };
+            assert_eq!(
+                tolerance(src).as_deref(),
+                Some(want),
+                "fixture itself must parse to {want}: {src}"
+            );
+            let formatted = format_source(src);
+            assert_eq!(
+                tolerance(&formatted).as_deref(),
+                Some(want),
+                "formatting changed the asserted tolerance\n  {src}  -> {formatted}"
+            );
+        }
     }
 
     /// `format` must not duplicate a balance tolerance.

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -2568,14 +2568,22 @@ fn balance_tolerance(
     if expr.is_empty() {
         return None;
     }
+    // A `+`/`-` is UNARY when nothing that can end an operand precedes it, and
+    // a unary sign binds to its number: `~ -0.01`, not `~ - 0.01`. The amount
+    // on the same line already renders `-1.00` tight, so spacing it here made
+    // one directive disagree with itself (`-1.00 ~ - 0.01 USD`).
+    let ends_operand = |t: &str| t == ")" || t.starts_with(|c: char| c.is_ascii_digit());
     let mut rendered = String::new();
+    let mut tight_next = false;
     for (i, tok) in expr.iter().enumerate() {
         let prev = i.checked_sub(1).and_then(|j| expr.get(j));
-        let needs_space = i > 0 && tok != ")" && prev.is_none_or(|p| p != "(");
+        let unary = matches!(tok.as_str(), "+" | "-") && prev.is_none_or(|p| !ends_operand(p));
+        let needs_space = i > 0 && tok != ")" && !tight_next && prev.is_none_or(|p| p != "(");
         if needs_space {
             rendered.push(' ');
         }
         rendered.push_str(tok);
+        tight_next = unary;
     }
     Some((rendered, currency))
 }
@@ -4098,7 +4106,23 @@ mod tests {
                 formatted.contains(link),
                 "formatter dropped {link}\n{formatted}"
             );
+            // Every one of these is already canonical, so formatting must be a
+            // no-op on the text too. Without this the value assertion above
+            // would accept any spelling that happens to evaluate the same.
+            assert_eq!(formatted, src, "already-canonical input was rewritten");
         }
+
+        // A unary sign binds to its number; a binary one keeps its spaces.
+        // Rendering `~ - 0.01` evaluates the same but makes one directive
+        // disagree with itself, since the amount renders `-1.00` tight.
+        assert_eq!(
+            format_source("2024-01-15 balance Assets:C -1.00 ~ -0.01 USD\n"),
+            "2024-01-15 balance Assets:C -1.00 ~ -0.01 USD\n",
+        );
+        assert_eq!(
+            format_source("2024-01-15 balance Assets:C 1.00 ~ (-0.005 + 0.015) USD\n"),
+            "2024-01-15 balance Assets:C 1.00 ~ (-0.005 + 0.015) USD\n",
+        );
     }
 
     #[test]
@@ -5515,6 +5539,17 @@ mod tests {
                 "2024-01-15 balance Assets:C 1.00 ~ 0.005 * 2 USD\n",
                 "0.010",
             ),
+            // main dropped this MINUS entirely, so `~ -0.01` formatted to
+            // `~ 0.01` -- a second changed value in the same function.
+            ("2024-01-15 balance Assets:C 1.00 ~ -0.01 USD\n", "-0.01"),
+            (
+                "2024-01-15 balance Assets:C 1.00 ~ 0.02 - 0.01 USD\n",
+                "0.01",
+            ),
+            (
+                "2024-01-15 balance Assets:C 1.00 ~ -0.005 + 0.015 USD\n",
+                "0.010",
+            ),
         ] {
             let tolerance = |text: &str| {
                 crate::parse(text)
@@ -5538,6 +5573,13 @@ mod tests {
                 Some(want),
                 "formatting changed the asserted tolerance\n  {src}  -> {formatted}"
             );
+            // Every one of these is already canonical, so formatting must be a
+            // no-op on the TEXT too. Without this the value assertions accept
+            // any spelling that happens to evaluate the same -- and one did:
+            // rendering a unary minus as `~ - 0.01` keeps the value and makes
+            // the directive disagree with itself, since the amount on the same
+            // line renders `-1.00` tight.
+            assert_eq!(formatted, src, "already-canonical input was rewritten");
         }
     }
 

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -215,6 +215,68 @@ fn every_directive_either_keeps_tags_or_refuses_them() {
     }
 }
 
+/// The divergence table in the docs must describe what actually ships.
+///
+/// `docs/reference/compatibility.md` is where a user goes to find out why
+/// their file loads here and not in beancount, and it restates the same rows
+/// the test below pins. Two copies of one table drift, and the copy that goes
+/// stale is the prose one, because nothing runs it.
+///
+/// So this runs it: every row of the markdown table is parsed and checked
+/// against the behavior it claims. It does NOT re-check beancount -- that
+/// column is a recorded measurement, not something reproducible without the
+/// container -- only our own half, which is the half that can change under
+/// the document.
+#[test]
+fn the_documented_tolerance_table_matches_behavior() {
+    let doc = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/reference/compatibility.md"),
+    )
+    .expect("compatibility.md must be readable from the parser crate");
+
+    let section = doc
+        .split("### 6. Balance Tolerance Grammar")
+        .nth(1)
+        .and_then(|s| s.split("### 7.").next())
+        .expect("the tolerance section must exist under that heading");
+
+    let mut rows = 0;
+    for line in section.lines() {
+        let cells: Vec<&str> = line.split('|').map(str::trim).collect();
+        // `| form | beancount | rustledger |` -> ["", form, bc, rl, ""]
+        if cells.len() != 5 || !cells[1].starts_with('`') {
+            continue;
+        }
+        let form = cells[1].trim_matches('`');
+        let claim = cells[3].replace('*', "");
+        let claim = claim.trim();
+        let expect_ok = match claim {
+            "ok" | "accepted" | "ok (kept)" | "accepted (kept)" => true,
+            "diagnosed" => false,
+            other => panic!("unrecognized claim {other:?} for `{form}` -- add it here"),
+        };
+
+        let src = format!("2024-01-15 balance Assets:C {form}\n");
+        let result = rustledger_parser::parse(&src);
+        assert_eq!(
+            result.errors.is_empty(),
+            expect_ok,
+            "docs say `{form}` is {claim}, but parsing gave {:?}",
+            result.errors,
+        );
+        rows += 1;
+    }
+
+    // A table that stopped being found, or whose format changed, would make
+    // every assertion above vacuous.
+    assert!(
+        rows >= 8,
+        "only {rows} rows recognized in the documented table; the format \
+         probably changed and this test stopped checking anything",
+    );
+}
+
 #[test]
 fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
     // beancount's grammar is `NUMBER ~ NUMBER CURRENCY` -- one currency,

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -304,6 +304,26 @@ fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
         msg_for("1.00 ~ 0.01 ~ 0.02 USD"),
     );
 
+    // A malformed tolerance gets the diagnostic that explains it, and not
+    // ours on top. `.005` is a number beancount accepts and our lexer does
+    // not (filed separately); on that input the region is not
+    // expression-shaped, so the juxtaposed-numbers check stays quiet rather
+    // than claiming a second number "was being discarded" from something that
+    // never parsed.
+    let dotted = rustledger_parser::parse("2024-01-15 balance Assets:C 1.00 ~ .005 + .005 USD\n");
+    assert!(
+        !dotted.errors.is_empty(),
+        "fixture must still be rejected for the real reason",
+    );
+    assert!(
+        !dotted.errors.iter().any(|e| matches!(
+            &e.kind,
+            rustledger_parser::ParseErrorKind::SyntaxError(m) if m.contains("Two numbers side by side")
+        )),
+        "must not add a tolerance complaint to input the lexer already refused: {:?}",
+        dotted.errors,
+    );
+
     // And a tolerance that is arithmetic still evaluates, so the new check
     // does not catch the multi-number case it is supposed to allow.
     let arith = rustledger_parser::parse("2024-01-15 balance Assets:C 1.00 ~ 0.005 + 0.005 USD\n");

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -305,6 +305,10 @@ fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
         ("1.00 USD ~ 0.01 EUR", false, "syntax error"),
         ("1.00 ~ 0.001 0.02 USD", false, "syntax error"),
         ("1.00 ~ 0.01 ~ 0.02 USD", false, "syntax error"),
+        // A `~` announcing a tolerance that is not there. Accepted as though
+        // unwritten, and `rledger format` then deleted the tilde.
+        ("1.00 USD ~", false, "syntax error"),
+        ("1.00 ~ USD", false, "syntax error"),
     ];
 
     for (form, accepted, bc) in cases {
@@ -359,6 +363,11 @@ fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
         msg_for("1.00 ~ 0.001 0.02 USD").contains("Two numbers side by side"),
         "juxtaposed numbers must say so: {}",
         msg_for("1.00 ~ 0.001 0.02 USD"),
+    );
+    assert!(
+        msg_for("1.00 USD ~").contains("must be followed by a tolerance"),
+        "a dangling tilde must say so: {}",
+        msg_for("1.00 USD ~"),
     );
     assert!(
         msg_for("1.00 ~ 0.01 ~ 0.02 USD").contains("one tolerance"),

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -215,6 +215,75 @@ fn every_directive_either_keeps_tags_or_refuses_them() {
     }
 }
 
+#[test]
+fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
+    // beancount's grammar is `NUMBER ~ NUMBER CURRENCY` -- one currency,
+    // trailing -- and it rejects any currency before the `~`. We differ in
+    // both directions on one rule: accept what has exactly one meaning,
+    // diagnose what has none or contradicts itself (#2193).
+    //
+    // Every row below was checked against beancount 3.2.3; the `bc` column
+    // records what it does, so a future reader can see which way each row
+    // diverges and why.
+    let cases: &[(&str, bool, &str)] = &[
+        // form, accepted by us, what beancount does
+        ("1.00 USD", true, "ok"),
+        ("1.00 ~ 0.01 USD", true, "ok"),
+        ("0.25 + 0.75 ~ 0.01 USD", true, "ok"),
+        ("(0.25 + 0.75) ~ 0.01 USD", true, "ok"),
+        ("1.00 ~ 0.005 + 0.005 USD", true, "ok"),
+        ("1.00 ~ 0.005 * 2 USD", true, "ok"),
+        // Laxer than beancount ON PURPOSE: the currency is stated twice and
+        // agrees, so there is one reading, and it canonicalizes to
+        // `1.00 ~ 0.01 USD` losslessly.
+        ("1.00 USD ~ 0.01 USD", true, "syntax error"),
+        ("0.25 + 0.75 USD ~ 0.01 USD", true, "syntax error"),
+        // Stricter than we used to be: these say something unkeepable and
+        // were being read in part and discarded in part.
+        ("1.00 USD ~ 0.01 EUR", false, "syntax error"),
+        ("1.00 ~ 0.001 0.02 USD", false, "syntax error"),
+    ];
+
+    for (form, accepted, bc) in cases {
+        let src = format!("2024-01-15 balance Assets:C {form}\n");
+        let result = rustledger_parser::parse(&src);
+        assert_eq!(
+            result.errors.is_empty(),
+            *accepted,
+            "`{form}` (beancount: {bc}) -- errors were {:?}",
+            result.errors,
+        );
+    }
+
+    // The accepted redundant form must mean exactly what the canonical one
+    // means, or "one reading" is not true.
+    let redundant = rustledger_parser::parse("2024-01-15 balance Assets:C 1.00 USD ~ 0.01 USD\n");
+    let canonical = rustledger_parser::parse("2024-01-15 balance Assets:C 1.00 ~ 0.01 USD\n");
+    let bal = |r: &rustledger_parser::ParseResult| {
+        r.directives
+            .iter()
+            .find_map(|d| match &d.value {
+                Directive::Balance(b) => Some((b.amount.clone(), b.tolerance)),
+                _ => None,
+            })
+            .expect("a balance")
+    };
+    assert_eq!(
+        bal(&redundant),
+        bal(&canonical),
+        "the redundant spelling must parse to the same amount and tolerance",
+    );
+
+    // And a tolerance that is arithmetic still evaluates, so the new check
+    // does not catch the multi-number case it is supposed to allow.
+    let arith = rustledger_parser::parse("2024-01-15 balance Assets:C 1.00 ~ 0.005 + 0.005 USD\n");
+    assert_eq!(
+        bal(&arith).1,
+        Some(dec_str("0.010")),
+        "`~ 0.005 + 0.005` must evaluate, not be rejected as two numbers",
+    );
+}
+
 fn dec_str(s: &str) -> rustledger_core::Decimal {
     s.parse().expect("test decimal")
 }

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -242,6 +242,7 @@ fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
         // were being read in part and discarded in part.
         ("1.00 USD ~ 0.01 EUR", false, "syntax error"),
         ("1.00 ~ 0.001 0.02 USD", false, "syntax error"),
+        ("1.00 ~ 0.01 ~ 0.02 USD", false, "syntax error"),
     ];
 
     for (form, accepted, bc) in cases {
@@ -272,6 +273,35 @@ fn balance_tolerance_accepts_one_reading_and_diagnoses_none() {
         bal(&redundant),
         bal(&canonical),
         "the redundant spelling must parse to the same amount and tolerance",
+    );
+
+    // Each rejection must be diagnosed for the RIGHT reason. The second
+    // tilde used to fall into the juxtaposed-numbers arm, whose message
+    // says the numbers are "side by side" when a `~` sits between them.
+    let msg_for = |form: &str| {
+        rustledger_parser::parse(&format!("2024-01-15 balance Assets:C {form}\n"))
+            .errors
+            .iter()
+            .find_map(|e| match &e.kind {
+                rustledger_parser::ParseErrorKind::SyntaxError(m) => Some(m.clone()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    assert!(
+        msg_for("1.00 USD ~ 0.01 EUR").contains("same currency as the amount"),
+        "currency mismatch must say so: {}",
+        msg_for("1.00 USD ~ 0.01 EUR"),
+    );
+    assert!(
+        msg_for("1.00 ~ 0.001 0.02 USD").contains("Two numbers side by side"),
+        "juxtaposed numbers must say so: {}",
+        msg_for("1.00 ~ 0.001 0.02 USD"),
+    );
+    assert!(
+        msg_for("1.00 ~ 0.01 ~ 0.02 USD").contains("one tolerance"),
+        "a second tilde must say so, not blame juxtaposed numbers: {}",
+        msg_for("1.00 ~ 0.01 ~ 0.02 USD"),
     );
 
     // And a tolerance that is arithmetic still evaluates, so the new check

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -103,7 +103,11 @@ use crate::types::{Error, LedgerOptions};
 /// therefore cacheable, and replaying its blob skips the parse that now
 /// complains. Verified against a pre-#2194 binary's cache: 0 errors without
 /// this bump, 2 with it.
-pub const CACHE_VERSION: u32 = 19;
+/// v20: a balance tolerance in a currency the amount does not use, or
+/// carrying a second juxtaposed number, is diagnosed rather than partly read
+/// and partly discarded (#2193). Loader v35. Same shape as v19: the archived
+/// directive is identical and the diagnostic is what a stale blob would hide.
+pub const CACHE_VERSION: u32 = 20;
 
 /// The `rustledger-loader` cache version this one was last reconciled with.
 ///
@@ -135,7 +139,7 @@ pub const CACHE_VERSION: u32 = 19;
 /// than in the test module so a reader of this file meets the contract next
 /// to `CACHE_VERSION`, which is the thing they came to change.
 #[cfg(test)]
-const LOADER_CACHE_VERSION_PIN: u32 = 34;
+const LOADER_CACHE_VERSION_PIN: u32 = 35;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -105,6 +105,8 @@ diagnose what has none or contradicts itself.**
 | `0.25 + 0.75 USD ~ 0.01 USD` | syntax error | **accepted** |
 | `1.00 USD ~ 0.01 EUR` | syntax error | **diagnosed** |
 | `1.00 ~ 0.001 0.02 USD` | syntax error | **diagnosed** |
+| `1.00 ~ 0.01 ~ 0.02 USD` | syntax error | **diagnosed** |
+| `1.00 USD ~ 0.01` | syntax error | **accepted** |
 
 **Laxer, deliberately.** `1.00 USD ~ 0.01 USD` states the currency twice and
 agrees with itself. There is one reading, and `rledger format` canonicalizes it
@@ -117,6 +119,11 @@ has no field for, and a second juxtaposed number has no reading at all. Both
 used to be accepted, read in part, and the remainder discarded without a word —
 and `rledger format` then wrote that loss back to the file, turning
 `1.00 USD ~ 0.01 EUR` into `1.00 ~ 0.01 USD`.
+
+`1.00 USD ~ 0.01` follows from the same rule: the currency is stated once and
+the tolerance inherits it, so there is one reading. Each rejection is diagnosed
+for its own reason rather than a generic one — a second `~` is reported as a
+second tolerance, not as juxtaposed numbers.
 
 **Portability note.** A file using the accepted-but-non-standard spelling loads
 in rustledger and is a syntax error in beancount and tools built on it. Prefer

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -89,7 +89,43 @@ Rustledger shows:        111.11 USD
 
 This is a display-only difference - actual values are identical. Rustledger preserves the original precision, which is technically more accurate.
 
-### 6. Cross-File Booking Order
+### 6. Balance Tolerance Grammar
+
+Beancount's tolerance grammar is `NUMBER ~ NUMBER CURRENCY` — one currency,
+trailing — and it rejects any currency written before the `~`. Rustledger
+differs in both directions, on one rule: **accept what has exactly one meaning,
+diagnose what has none or contradicts itself.**
+
+| form | beancount 3.2.3 | rustledger |
+|---|---|---|
+| `1.00 ~ 0.01 USD` | ok | ok |
+| `0.25 + 0.75 ~ 0.01 USD` | ok | ok |
+| `1.00 ~ 0.005 + 0.005 USD` | ok | ok |
+| `1.00 USD ~ 0.01 USD` | syntax error | **accepted** |
+| `0.25 + 0.75 USD ~ 0.01 USD` | syntax error | **accepted** |
+| `1.00 USD ~ 0.01 EUR` | syntax error | **diagnosed** |
+| `1.00 ~ 0.001 0.02 USD` | syntax error | **diagnosed** |
+
+**Laxer, deliberately.** `1.00 USD ~ 0.01 USD` states the currency twice and
+agrees with itself. There is one reading, and `rledger format` canonicalizes it
+to `1.00 ~ 0.01 USD` losslessly, so refusing it would reject a file whose
+meaning is not in doubt.
+
+**Stricter, deliberately.** The other two are not redundancy. A tolerance
+denominated in a currency the amount does not use asserts something the model
+has no field for, and a second juxtaposed number has no reading at all. Both
+used to be accepted, read in part, and the remainder discarded without a word —
+and `rledger format` then wrote that loss back to the file, turning
+`1.00 USD ~ 0.01 EUR` into `1.00 ~ 0.01 USD`.
+
+**Portability note.** A file using the accepted-but-non-standard spelling loads
+in rustledger and is a syntax error in beancount and tools built on it. Prefer
+the single trailing currency if the file needs to load elsewhere.
+
+Pinned by `balance_tolerance_accepts_one_reading_and_diagnoses_none`, whose
+table records what beancount does for each row (issue #2193).
+
+### 7. Cross-File Booking Order
 
 Directives sharing a date and type keep the order they were parsed in. Within
 one file that matches Python's `(date, type_priority, lineno)`. Across

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -107,6 +107,7 @@ diagnose what has none or contradicts itself.**
 | `1.00 ~ 0.001 0.02 USD` | syntax error | **diagnosed** |
 | `1.00 ~ 0.01 ~ 0.02 USD` | syntax error | **diagnosed** |
 | `1.00 USD ~ 0.01` | syntax error | **accepted** |
+| `1.00 USD ~` | syntax error | **diagnosed** |
 
 **Laxer, deliberately.** `1.00 USD ~ 0.01 USD` states the currency twice and
 agrees with itself. There is one reading, and `rledger format` canonicalizes it


### PR DESCRIPTION
Closes #2193.

## The rule

Beancount's tolerance grammar is `NUMBER ~ NUMBER CURRENCY` — one currency, trailing — and it rejects any currency written before the `~`. This PR differs in **both** directions, on a single rule: **accept what has exactly one meaning, diagnose what has none or contradicts itself.**

| form | beancount 3.2.3 | before | after |
|---|---|---|---|
| `1.00 ~ 0.01 USD` | ok | ok | ok |
| `0.25 + 0.75 ~ 0.01 USD` | ok | ok | ok |
| `1.00 ~ 0.005 + 0.005 USD` | ok | ok | ok |
| `1.00 USD ~ 0.01 USD` | syntax error | ok | **ok** (kept) |
| `0.25 + 0.75 USD ~ 0.01 USD` | syntax error | ok | **ok** (kept) |
| `1.00 USD ~ 0.01 EUR` | syntax error | ok, EUR discarded | **diagnosed** |
| `1.00 ~ 0.001 0.02 USD` | syntax error | ok, `0.02` discarded | **diagnosed** |

**Laxer on purpose.** `1.00 USD ~ 0.01 USD` states the currency twice and agrees with itself. One reading, and `rledger format` canonicalizes it to `1.00 ~ 0.01 USD` losslessly — refusing a file whose meaning is not in doubt buys nothing.

**Stricter because the other two are not redundancy.** A tolerance denominated in a currency the amount does not use asserts something the model has no field for; two juxtaposed numbers have no reading at all. Both were accepted, read in part, and the remainder dropped in silence — and `rledger format` then wrote that loss back to the file:

```
$ rledger format m.bean          # before this PR
2024-01-15 balance Assets:C 1.00 ~ 0.01 USD     <- the EUR is gone from the file
```

## Arithmetic is untouched

`~ 0.005 + 0.005` and `~ 0.005 * 2` still evaluate. That is why the second check asks whether the tolerance region **fails to parse as an expression**, rather than merely counting numbers — counting would have caught the legitimate arithmetic forms too. Verified by value, not just by acceptance: against an account off by 0.007, `~ 0.005 + 0.005` passes and bare `~ 0.005` fails.

## Controls

| mutation | result |
|---|---|
| disable the currency-mismatch check | fails |
| disable the juxtaposed-number check | fails |
| over-strict: also reject the agreeing-currency form | **fails** |

The third is the one worth having. It stops "just match beancount" being applied later without noticing that it is a decision rather than a cleanup.

## Also

- Every row of the test table was run against **beancount 3.2.3** and records what it does, so the divergence is legible where someone would change it.
- `docs/reference/compatibility.md` gains a section, including the portability note: a file using the accepted-but-non-standard spelling loads here and is a syntax error in beancount and tools built on it.
- Cache versions move for the same reason as v34 — the archived directive is identical, and the diagnostic is what a stale blob would hide. **Loader 34 → 35, wasm 19 → 20, pin 35.**
- Workspace green, clippy 1.97 clean, fmt/typos/rustdoc clean, corpus baseline unchanged, `format-idempotence.sh` reports `checked=693 non_idempotent=0 diagnostics_changed=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr