### PR TITLE
fix(ci): do not call a file deleted when its clone may have failed

### DIFF
--- a/scripts/corpus-baseline-drift.py
+++ b/scripts/corpus-baseline-drift.py
@@ -57,6 +57,20 @@ CORPUS_ROOT = "tests/compatibility/files"
 CORPUS_SLACK = 50
 
 
+def fetch_failures() -> int | None:
+    """How many repository clones failed during the last fetch.
+
+    `None` when the marker is absent, which means the corpus on disk did not
+    come from a run of `fetch-compat-test-files.sh` that knows how to record
+    it -- an older script, or a corpus assembled some other way.
+    """
+    try:
+        with open(f"{CORPUS_ROOT}/.fetch-failures", encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
 def corpus_size() -> int:
     """Count `.beancount` files the way the baseline test discovers them."""
     n = 0
@@ -305,6 +319,38 @@ def self_test() -> int:
     if any(classify("+# regenerated\n").values()):
         failures.append("comment lines must not count as drift")
 
+    # The fetch-failure marker, which decides whether "this file is gone" is
+    # a fact or a guess.
+    import tempfile
+
+    real_root = globals()["CORPUS_ROOT"]
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            globals()["CORPUS_ROOT"] = d
+            if fetch_failures() is not None:
+                failures.append("a missing marker must read as None, not 0")
+            with open(f"{d}/.fetch-failures", "w", encoding="utf-8") as fh:
+                fh.write("0\n")
+            if fetch_failures() != 0:
+                failures.append("a clean fetch must read as 0")
+            with open(f"{d}/.fetch-failures", "w", encoding="utf-8") as fh:
+                fh.write("4\n")
+            if fetch_failures() != 4:
+                failures.append("a failed fetch must read its count back")
+            with open(f"{d}/.fetch-failures", "w", encoding="utf-8") as fh:
+                fh.write("not a number\n")
+            if fetch_failures() is not None:
+                failures.append("garbage in the marker must read as None")
+    finally:
+        globals()["CORPUS_ROOT"] = real_root
+
+    # None and 0 must behave the same at the use site (report everything), and
+    # both differ from a non-zero count. `if failures:` is what does that, so
+    # pin it: `None` is falsy and 0 is falsy, 4 is not.
+    for value, suppress in ((None, False), (0, False), (1, True), (4, True)):
+        if bool(value) != suppress:
+            failures.append(f"marker {value!r} must {'' if suppress else 'not '}suppress")
+
     # The partial-fetch guard, which is the difference between reporting
     # drift and inventing it. Fresh-fetching into an empty checkout means a
     # tolerated clone failure looks exactly like an upstream deletion.
@@ -458,6 +504,36 @@ def main() -> int:
 
     regenerate()
     groups = classify(manifest_diff())
+
+    # A failed clone leaves files missing that still exist upstream, and they
+    # are indistinguishable here from files upstream actually deleted. It can
+    # only produce a false "removed" -- a clone that did not happen cannot
+    # invent a new file or change a hash -- so drop exactly that group rather
+    # than the whole report.
+    #
+    # The file-count slack cannot substitute for this. The first live run
+    # fetched 734 of 735 with 4 clone failures -- one file short, nowhere near
+    # the 50-file floor -- and reported three deletions. A later complete
+    # fetch found all three present, and also lacked the two files that run
+    # called new, so upstream moved in between and the report cannot be
+    # adjudicated either way now.
+    #
+    # That is the argument, not a caveat to it: after the fact there is no way
+    # to tell a clone that failed from a file that was deleted. The marker is
+    # the only moment the difference is knowable, so it is recorded there and
+    # read here.
+    failures = fetch_failures()
+    if failures:
+        dropped = len(groups["removed"])
+        groups["removed"] = []
+        if dropped:
+            print(
+                f"{failures} clone(s) failed during the fetch; suppressing "
+                f"{dropped} 'file is gone' entr"
+                f"{'y' if dropped == 1 else 'ies'} that may just be missing.",
+                file=sys.stderr,
+            )
+
     drifted = any(groups.values())
 
     if args.dry_run:

--- a/scripts/fetch-compat-test-files.sh
+++ b/scripts/fetch-compat-test-files.sh
@@ -367,6 +367,12 @@ fi
 
 echo ""
 echo "Total: $total beancount files"
+# Record the count where a later step can read it. A consumer that regenerates
+# the baseline needs to know the corpus is incomplete: files missing because a
+# clone failed are indistinguishable, by inspection alone, from files deleted
+# upstream, and reporting the first as the second is a confident lie.
+echo "$FETCH_FAILURES" > "$DEST/.fetch-failures"
+
 if [ "$FETCH_FAILURES" -gt 0 ]; then
   echo "Note: $FETCH_FAILURES repository clone(s) failed (under the abort threshold of $MAX_FETCH_FAILURES). The corpus may be slightly smaller than usual."
 fi


### PR DESCRIPTION
The corpus-drift job from #2196 had its first live run and filed #2199. Chasing that report found a hole in it.

## A failed clone and a deleted file look identical

Once the fetch has finished, both leave a manifest path with nothing on disk. That run had **4 clone failures** and reported **3 files as gone upstream**.

The file-count slack cannot substitute for knowing: it fetched **734 of 735** — one file short, nowhere near the 50-file floor — so nothing fired.

## That it can't be adjudicated now IS the argument

A later complete fetch found **all three "gone" files present**, and also lacked **both files that run called new**. So upstream moved between the two fetches, and there is no way to tell today which half of #2199 was real.

The marker is written at the only moment the difference is knowable — during the fetch, by the code that watched the clone fail.

## The fix

`fetch-compat-test-files.sh` already counts its failures and prints them; it now writes the count into the corpus directory (gitignored). The drift script reads it and, on any failure, drops the **"file is gone"** group and logs why.

**Only that group.** A clone that did not happen cannot invent a new file or change a hash — it can only fail to produce one. So `added` and the two hash-change groups stay, and a run with failures still reports everything it can legitimately see.

## Self-test

| marker state | reads as | suppresses |
|---|---|---|
| absent (older script, corpus assembled another way) | `None` | no |
| `0` | `0` | no |
| `4` | `4` | yes |
| garbage | `None` | no |

Ignoring the marker fails the test. The absent-vs-zero distinction matters: both must report everything, and conflating them with a default of `0` would silently disable the guard on any corpus the updated script didn't produce.

## Note on #2199

I could not resolve it as filed. Against a complete corpus today the manifest has **no drift** — 735 files, 735 entries, regeneration yields no diff — so there is nothing to regenerate. The next scheduled run will re-report against whatever upstream looks like then, now without the deletion half being guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr