### PR TITLE
fix(query): MIN and MAX order booleans, false before true

### DIFF
--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -110,8 +110,24 @@ impl Executor<'_> {
 
     /// Check if left value is less than right value.
     ///
-    /// Ordering used by the `MIN`/`MAX` aggregates, and only by them -- see the
-    /// `Boolean` arm.
+    /// One of THREE comparison paths in this file, which deliberately disagree
+    /// about booleans. Anyone tempted to unify them should read this first:
+    ///
+    /// | function | used by | booleans |
+    /// |---|---|---|
+    /// | `compare_values` | the `<` `>` `<=` `>=` operators | rejected |
+    /// | `value_less_than` | the `MIN`/`MAX` aggregates | ordered, `false < true` |
+    /// | `compare_values_for_sort` | `ORDER BY` | ordered, and total |
+    ///
+    /// That is not drift, it is bean-query's shape. It answers
+    /// `max(number > 0)` and sorts a boolean column, and refuses
+    /// `(number > 0) < (number > 5)` with `operator "less(bool, bool)" not
+    /// supported`. Collapsing the three would either accept a query it rejects
+    /// or reject two it answers.
+    ///
+    /// `compare_values_for_sort` is also total where the other two are
+    /// fallible: sorting cannot fail partway through a result set, so it
+    /// orders NULL rather than erroring on it.
     pub(super) fn value_less_than(&self, left: &Value, right: &Value) -> Result<bool, QueryError> {
         let ord = match (left, right) {
             (Value::Number(a), Value::Number(b)) => a.cmp(b),

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -109,6 +109,9 @@ impl Executor<'_> {
     }
 
     /// Check if left value is less than right value.
+    ///
+    /// Ordering used by the `MIN`/`MAX` aggregates, and only by them -- see the
+    /// `Boolean` arm.
     pub(super) fn value_less_than(&self, left: &Value, right: &Value) -> Result<bool, QueryError> {
         let ord = match (left, right) {
             (Value::Number(a), Value::Number(b)) => a.cmp(b),
@@ -117,6 +120,20 @@ impl Executor<'_> {
             (Value::Integer(a), Value::Number(b)) => Decimal::from(*a).cmp(b),
             (Value::String(a), Value::String(b)) => a.cmp(b),
             (Value::Date(a), Value::Date(b)) => a.cmp(b),
+            // `false < true`, so `MAX` over booleans is `any` and `MIN` is
+            // `all` -- which is what bean-query gives, because Python's
+            // `max`/`min` order bools that way and it does not special-case
+            // them (#2183).
+            //
+            // Deliberately NOT added to `compare_values`, which backs the `<`
+            // and `>` operators. bean-query REFUSES those on booleans:
+            //
+            //     SELECT (number > 0) < (number > 5) FROM #postings
+            //     -> operator "less(bool, bool)" not supported
+            //
+            // so defining the order there would accept a query it rejects.
+            // The order exists for the aggregates and stops there.
+            (Value::Boolean(a), Value::Boolean(b)) => a.cmp(b),
             _ => return Err(QueryError::Type("cannot compare values".to_string())),
         };
         Ok(ord.is_lt())

--- a/crates/rustledger-query/tests/boolean_minmax_test.rs
+++ b/crates/rustledger-query/tests/boolean_minmax_test.rs
@@ -1,0 +1,96 @@
+//! `MIN`/`MAX` order booleans as `false < true`; the comparison OPERATORS
+//! still refuse them (#2183).
+//!
+//! bean-query gets the aggregate behavior for free: Python orders `False <
+//! True`, so `max` over booleans is `any` and `min` is `all`. It does NOT
+//! extend that to the operators —
+//!
+//! ```text
+//! $ bean-query f.bean "SELECT (number > 0) < (number > 5) FROM #postings"
+//! CompilationError: operator "less(bool, bool)" not supported
+//! ```
+//!
+//! — so the order is defined for the aggregate path only. Measured against
+//! beanquery 0.2.0 / beancount 3.2.3.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+/// One posting is positive and one is negative, so `number > 0` yields both
+/// booleans -- an aggregate over a single value would pass whatever the
+/// ordering did.
+fn fixture() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "in")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(10), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-10), "USD"),
+                )),
+        ),
+    ]
+}
+
+fn run(query_str: &str) -> Result<Value, String> {
+    let dirs = fixture();
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(&dirs);
+    executor
+        .execute(&query)
+        .map_err(|e| e.to_string())
+        .map(|r| {
+            r.rows
+                .first()
+                .and_then(|row| row.first())
+                .cloned()
+                .unwrap_or(Value::Null)
+        })
+}
+
+#[test]
+fn min_max_order_booleans_false_before_true() {
+    assert_eq!(
+        run("SELECT max(number > 0)").expect("max over booleans must work"),
+        Value::Boolean(true),
+        "one posting is positive, so MAX is true -- MAX over booleans is `any`",
+    );
+    assert_eq!(
+        run("SELECT min(number > 0)").expect("min over booleans must work"),
+        Value::Boolean(false),
+        "one posting is negative, so MIN is false -- MIN over booleans is `all`",
+    );
+}
+
+/// The order stops at the aggregates. Defining it for the operators too would
+/// accept a query bean-query rejects at compile time, which is a divergence in
+/// the opposite direction from the one being fixed.
+#[test]
+fn comparison_operators_still_refuse_booleans() {
+    let err = run("SELECT (number > 0) < (number > 5)")
+        .expect_err("`<` on two booleans must stay an error");
+    assert!(
+        err.contains("cannot compare"),
+        "expected a type error, got {err}",
+    );
+}
+
+/// Numbers still aggregate, so the new arm did not shadow the existing ones.
+#[test]
+fn min_max_over_numbers_are_unchanged() {
+    assert_eq!(
+        run("SELECT max(number)").expect("max over numbers"),
+        Value::Number(dec!(10)),
+    );
+    assert_eq!(
+        run("SELECT min(number)").expect("min over numbers"),
+        Value::Number(dec!(-10)),
+    );
+}

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -190,3 +190,7 @@ preserve_order = true
 # any PIVOT query, so a row-by-row diff would be permanently red.
 # Tracking the semantic reconciliation separately — see #1034.
 # ----------------------------------------------------------------------
+[[query]]
+name = "minmax-over-boolean"
+query = "SELECT MAX(number > 0), MIN(number > 0)"
+notes = "false < true, so MAX is `any` and MIN is `all` (#2183). Python orders bools that way and bean-query inherits it; we had to define the order explicitly, and only for the aggregates."


### PR DESCRIPTION
Closes #2183.

```
$ rledger query f.bean "SELECT max(number > 0) FROM #postings"
error: type error: cannot compare values        # before

$ bean-query -f csv f.bean "SELECT max(number > 0) FROM #postings"
TRUE
```

Python orders `False < True` and its `max`/`min` inherit that, so **MAX over booleans is `any` and MIN is `all`**. bean-query gets it for free; we had to define the order.

## The boundary is the interesting part

The order is defined for the **aggregate path only**, and that is measured, not assumed. bean-query refuses the operators on the very same values:

```
$ bean-query f.bean "SELECT (number > 0) < (number > 5) FROM #postings"
CompilationError: operator "less(bool, bool)" not supported
```

So `compare_values` — which backs `<` and `>` — keeps rejecting booleans. Defining the order there would accept a query bean-query rejects at compile time, a divergence in the *opposite* direction from the one being fixed.

That split is expressible only because `value_less_than` is reached from nowhere but `MIN`/`MAX`; I checked its call sites before touching it.

## Verification

End to end against **beanquery 0.2.0 / beancount 3.2.3**, through the real `bean-query` CLI:

```
SELECT MAX(number > 0), MIN(number > 0)
  bean-query:  TRUE,FALSE
  rustledger:  TRUE,FALSE
```

Byte for byte. That query joins `tests/compatibility/bql-queries.toml`, whose header asks for an entry whenever an aggregation function changes.

Worth noting: my first comparison used beanquery's **Python API** plus `csv.writer`, which printed `True`/`False` and looked like a mismatch. That bypasses bean-query's own renderer — the CLI prints `TRUE`/`FALSE`, matching #2182. The oracle has to be the CLI when output format is what's under test.

## Controls

| mutation | result |
|---|---|
| remove the boolean arm from `value_less_than` | fails |
| **also** add it to `compare_values` | **fails** |

The second is the one worth having: it stops the order being extended to the operators later as an obvious tidy-up.

Numbers still aggregate unchanged (`max(number)` → 10, `min(number)` → -10), so the new arm shadows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr