### PR TITLE
fix(query): ORDER BY an expression finds the column it names

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -305,7 +305,11 @@ impl Executor<'_> {
             // output column is named by the alias, so `sort_results` would fail
             // a literal name lookup for the raw column (#1627). In that case we
             // still append a hidden column carrying the raw name.
-            let expr_str = spec.expr.to_string();
+            // Same spelling the header uses, and the same one `sort_results`
+            // now looks up. These two have to agree: a hidden column named by
+            // `Display` would be invisible to a lookup by `header_name`, so
+            // changing one alone trades one miss for another (#2177).
+            let expr_str = crate::ast::header_name(&spec.expr);
             let in_select = query.targets.iter().any(|t| {
                 (t.expr == spec.expr && t.alias.is_none())
                     || t.alias.as_deref() == Some(expr_str.as_str())

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -76,7 +76,14 @@ impl Executor<'_> {
                 Expr::Function(func) => {
                     // First try to find a column with the function name (e.g., "sum" for sum(amount))
                     // Then try the full expression string (e.g., "account_sortkey(account)")
-                    let expr_str = spec.expr.to_string();
+                    //
+                    // `header_name`, not `Display`, for the same reason as the
+                    // arm below: `Display` parenthesizes a binary argument, so
+                    // `abs(number + 1)` looked for `abs((number + 1))` against
+                    // an `abs(number + 1)` header. `abs(number)` worked, which
+                    // is why the bug hid here -- an argument has to be compound
+                    // before the two spellings part company (#2177 review).
+                    let expr_str = crate::ast::header_name(&spec.expr);
                     find_column(&result.columns, &func.name)
                         .or_else(|| find_column(&result.columns, &expr_str))
                         .ok_or_else(|| {

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -87,8 +87,18 @@ impl Executor<'_> {
                 }
                 _ => {
                     // For other expression kinds (binary ops, literals, etc.),
-                    // look up by string representation (matches hidden column aliases).
-                    let expr_str = spec.expr.to_string();
+                    // look up by the name the HEADER uses.
+                    //
+                    // `Display` is not that name and never was: it parenthesizes,
+                    // so `ORDER BY number + 1` looked for `(number + 1)` while the
+                    // header said `number + 1`, and the sort failed on a query
+                    // bean-query answers. Before #2175 the header was `col0`, so
+                    // the lookup missed for a different reason -- the query has
+                    // never worked (#2177).
+                    //
+                    // `find_column`'s case-insensitive fallback cannot bridge it:
+                    // the two spellings differ by punctuation, not case.
+                    let expr_str = crate::ast::header_name(&spec.expr);
                     find_column(&result.columns, &expr_str).ok_or_else(|| {
                         QueryError::Evaluation(format!(
                             "ORDER BY expression not found in SELECT: {expr_str}"

--- a/crates/rustledger-query/tests/order_by_expression_test.rs
+++ b/crates/rustledger-query/tests/order_by_expression_test.rs
@@ -1,0 +1,128 @@
+//! `ORDER BY <expression>` finds its target (#2177).
+//!
+//! The header and the lookup used to spell the same expression two different
+//! ways. `ast::header_name` produces `number + 1`; `Display` parenthesizes and
+//! produces `(number + 1)`, and `sort_results` looked up by `Display`. So a
+//! query bean-query answers failed here:
+//!
+//! ```text
+//! $ bean-query -f csv f.bean "SELECT number + 1 FROM #postings ORDER BY number + 1"
+//! number + 1
+//! -9.00
+//! ...
+//!
+//! $ rledger query f.bean "SELECT number + 1 FROM #postings ORDER BY number + 1"
+//! error: ORDER BY expression not found in SELECT: (number + 1)
+//! ```
+//!
+//! `find_column`'s case-insensitive fallback cannot bridge it: the two
+//! spellings differ by punctuation, not case. Before #2175 the header was
+//! `col0`, so the lookup missed for a different reason -- the query has never
+//! worked.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+fn fixture() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "one")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(10), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-10), "USD"),
+                )),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 3), "two")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-3), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(3), "USD"),
+                )),
+        ),
+    ]
+}
+
+fn run(query_str: &str) -> Result<(Vec<String>, Vec<Vec<Value>>), String> {
+    let dirs = fixture();
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(&dirs);
+    executor
+        .execute(&query)
+        .map(|r| (r.columns, r.rows))
+        .map_err(|e| e.to_string())
+}
+
+#[test]
+fn order_by_a_binary_expression_finds_its_column() {
+    let (columns, rows) = run("SELECT number + 1 ORDER BY number + 1")
+        .expect("ORDER BY on the selected expression must resolve");
+    assert_eq!(columns, vec!["number + 1".to_string()]);
+    let got: Vec<String> = rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::Number(n) => n.to_string(),
+            other => panic!("expected a number, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec!["-9", "-2", "4", "11"],
+        "rows must come back sorted by the expression",
+    );
+}
+
+/// The comparison target is a boolean here, which the sort comparator already
+/// handled -- this is the lookup, not the ordering.
+#[test]
+fn order_by_a_comparison_expression_finds_its_column() {
+    let (_, rows) = run("SELECT number > 0 ORDER BY number > 0")
+        .expect("ORDER BY on a comparison must resolve");
+    let got: Vec<bool> = rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::Boolean(b) => *b,
+            other => panic!("expected a boolean, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec![false, false, true, true], "false sorts first");
+}
+
+/// The hidden-column path: the SELECT target is aliased, so the ORDER BY
+/// expression is not reachable by name and a synthetic column is appended.
+/// That column is named by the same function the lookup uses -- naming it one
+/// way and looking it up the other is exactly the bug, moved.
+#[test]
+fn order_by_an_expression_not_in_select_uses_a_hidden_column() {
+    let (columns, rows) = run("SELECT account AS a ORDER BY number + 1")
+        .expect("ORDER BY on an unselected expression must resolve");
+    assert_eq!(
+        columns,
+        vec!["a".to_string()],
+        "the hidden sort column must not surface in the output",
+    );
+    assert_eq!(rows.len(), 4);
+}
+
+/// Ordinals resolve by position and must not be turned into a hidden constant
+/// column; regression cover for the path this change walks past.
+#[test]
+fn order_by_ordinal_still_resolves_by_position() {
+    let (_, rows) = run("SELECT account, number ORDER BY 2").expect("ORDER BY 2");
+    let got: Vec<String> = rows
+        .iter()
+        .map(|r| match &r[1] {
+            Value::Number(n) => n.to_string(),
+            other => panic!("expected a number, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec!["-10", "-3", "3", "10"]);
+}

--- a/crates/rustledger-query/tests/order_by_expression_test.rs
+++ b/crates/rustledger-query/tests/order_by_expression_test.rs
@@ -112,6 +112,39 @@ fn order_by_an_expression_not_in_select_uses_a_hidden_column() {
     assert_eq!(rows.len(), 4);
 }
 
+/// A FUNCTION whose argument is compound. The `Expr::Function` arm had its own
+/// `Display` lookup, so this stayed broken after the binary-expression arm was
+/// fixed: `abs(number + 1)` looked for `abs((number + 1))`.
+///
+/// `abs(number)` resolves either way, which is why the gap hid -- an argument
+/// has to be compound before the two spellings part company. Flagged in review
+/// on #2177.
+#[test]
+fn order_by_a_function_over_an_expression_finds_its_column() {
+    let (columns, rows) = run("SELECT abs(number + 1) ORDER BY abs(number + 1)")
+        .expect("ORDER BY on a function over an expression must resolve");
+    assert_eq!(columns, vec!["abs(number + 1)".to_string()]);
+    let got: Vec<String> = rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::Number(n) => n.to_string(),
+            other => panic!("expected a number, got {other:?}"),
+        })
+        .collect();
+    // bean-query answers 2.00, 4.00, 9.00, 11.00 for the same query.
+    assert_eq!(got, vec!["2", "4", "9", "11"]);
+}
+
+/// The simple-argument form, which resolved before this change too. Here so a
+/// regression that breaks it is distinguishable from one that only breaks the
+/// compound case above.
+#[test]
+fn order_by_a_function_over_a_bare_column_still_resolves() {
+    let (columns, _) =
+        run("SELECT abs(number) ORDER BY abs(number)").expect("ORDER BY abs(number)");
+    assert_eq!(columns, vec!["abs(number)".to_string()]);
+}
+
 /// Ordinals resolve by position and must not be turned into a hidden constant
 /// column; regression cover for the path this change walks past.
 #[test]

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -194,3 +194,8 @@ preserve_order = true
 name = "minmax-over-boolean"
 query = "SELECT MAX(number > 0), MIN(number > 0)"
 notes = "false < true, so MAX is `any` and MIN is `all` (#2183). Python orders bools that way and bean-query inherits it; we had to define the order explicitly, and only for the aggregates."
+[[query]]
+name = "order-by-expression"
+query = "SELECT number + 1 ORDER BY number + 1 LIMIT 20"
+preserve_order = true
+notes = "The header and the ORDER BY lookup must spell the expression the same way (#2177). `Display` parenthesizes and `header_name` does not, so this failed with `ORDER BY expression not found in SELECT: (number + 1)`."


### PR DESCRIPTION
Closes #2177.

```
$ rledger query f.bean "SELECT number + 1 FROM #postings ORDER BY number + 1"
error: ORDER BY expression not found in SELECT: (number + 1)

$ bean-query -f csv f.bean "SELECT number + 1 FROM #postings ORDER BY number + 1"
number + 1
-9.00
-2.00
 4.00
11.00
```

The header and the lookup spelled the same expression two ways: `ast::header_name` gives `number + 1`, `Display` parenthesizes and gives `(number + 1)`, and `sort_results` looked up by `Display`. `find_column`'s case-insensitive fallback cannot bridge that — the spellings differ by **punctuation, not case**. Before #2175 the header was `col0`, so the lookup missed for a different reason; the query has never worked.

## Why both sites move together

`sort_results` **looks the target up**. `find_hidden_order_by_targets` **names** the synthetic column when the expression is not reachable in the projection. Changing one alone trades one miss for another — a hidden column named by `Display` is invisible to a lookup by `header_name`.

Each half has a test only it satisfies:

| mutation | result |
|---|---|
| revert the lookup to `Display` | 3 of 4 tests fail |
| revert **only** the hidden-column naming | exactly the hidden-column test fails |

## The neighbouring paths, re-verified rather than trusted

The issue asked for this explicitly, since the hidden-column machinery needed repair twice in #2170. Measured against **bean-query** (beanquery 0.2.0), row for row:

| query | result |
|---|---|
| `ORDER BY 1`, `ORDER BY 2` (ordinals) | match |
| `ORDER BY account, number` (multi-key) | match |
| `ORDER BY number DESC` | match |
| `GROUP BY account ORDER BY sum(number)` | match |
| `SELECT account AS a ORDER BY number + 1` (hidden column) | match |
| `SELECT number > 0 ORDER BY number > 0` | match |

**Wildcard unchanged**: `SELECT * FROM #postings ORDER BY date` output is byte-identical to `main`. (It differs from bean-query — 31 columns to its 5 — but that predates this PR and is untouched by it.)

Numbers differ from bean-query only by its **right-alignment padding** in CSV (`, 10.00` against `,10.00`), which is pre-existing and independent of ordering.

## Corpus

`order-by-expression` joins `tests/compatibility/bql-queries.toml`, verified to be real coverage rather than decoration: run through the harness it reports `match: True`, and `match: False` when the lookup is reverted.

## Note for #2176 / #2180

Sorting needed no ordering work — `compare_values_for_sort` already handles booleans and is total. This was purely the name lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr