### PR TITLE
fix(query): PIVOT BY applies when the query names a table

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -592,6 +592,11 @@ impl Executor<'_> {
         // it here meant a query with a FROM clause parsed its PIVOT BY, built
         // the transformation's validated inputs, and then returned the
         // un-pivoted result with no error (#2216).
+        //
+        // PIVOT BY requires GROUP BY, and a query with GROUP BY is routed to
+        // `execute_aggregate_from_table`, so reaching `apply_pivot` from here
+        // always ends in `PivotWithoutGroupBy`. That is the point: the clause
+        // is refused out loud rather than dropped.
         if let Some(pivot_exprs) = &query.pivot_by {
             result = self.apply_pivot(&result, pivot_exprs, &query.group_by)?;
         }
@@ -728,11 +733,16 @@ impl Executor<'_> {
             self.sort_results(&mut result, order_by, visible_cols)?;
         }
 
-        // Apply PIVOT BY, in the same pipeline slot `execute_select` uses:
-        // after ORDER BY and the hidden-column strip, before LIMIT. Omitting
-        // it here meant a query with a FROM clause parsed its PIVOT BY, built
-        // the transformation's validated inputs, and then returned the
-        // un-pivoted result with no error (#2216).
+        // Apply PIVOT BY, in the pipeline slot `execute_select` uses: after
+        // ORDER BY, before LIMIT. Omitting it here meant a query with a FROM
+        // clause parsed its PIVOT BY, built the transformation's validated
+        // inputs, and then returned the un-pivoted result with no error
+        // (#2216).
+        //
+        // No hidden-column strip to sit after, unlike the other two paths:
+        // `find_hidden_order_by_targets` materializes nothing for an aggregate
+        // query, because an ORDER BY target there must already be in GROUP BY
+        // or be an aggregate, so it is projected already.
         if let Some(pivot_exprs) = &query.pivot_by {
             result = self.apply_pivot(&result, pivot_exprs, &query.group_by)?;
         }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -676,7 +676,13 @@ impl Executor<'_> {
             group_map.insert(empty_key.clone(), (vec![], vec![]));
             key_order.push(empty_key);
         } else if group_map.is_empty() {
-            return Ok(result);
+            // No groups, so no rows -- but do NOT return here. ORDER BY and
+            // LIMIT are no-ops on an empty result, PIVOT is not: it reshapes
+            // the COLUMNS, and skipping it left `WHERE <no match> ... PIVOT BY`
+            // reporting the un-pivoted header while the same query emptied by
+            // HAVING reported the pivoted one. bean-query gives the pivoted
+            // shape for both (#2216).
+            return self.finish_aggregate_result(result, query);
         }
 
         // Build alias map once (used by HAVING evaluation).
@@ -727,27 +733,36 @@ impl Executor<'_> {
             result.add_row(row);
         }
 
-        // Apply ORDER BY
+        self.finish_aggregate_result(result, query)
+    }
+
+    /// ORDER BY, then PIVOT BY, then LIMIT -- the tail every aggregate result
+    /// goes through, including an empty one.
+    ///
+    /// Shared so the no-groups case cannot skip it. It used to `return` early,
+    /// which was harmless for ORDER BY and LIMIT (no-ops on zero rows) and not
+    /// for PIVOT, which reshapes the COLUMNS: `WHERE <no match> ... PIVOT BY`
+    /// reported the un-pivoted header while the same query emptied by HAVING
+    /// reported the pivoted one. bean-query gives the pivoted shape for both.
+    ///
+    /// No hidden-column strip here, unlike the other two execution paths:
+    /// `find_hidden_order_by_targets` materializes nothing for an aggregate
+    /// query, because an ORDER BY target there must already be in GROUP BY or
+    /// be an aggregate, so it is projected already.
+    fn finish_aggregate_result(
+        &self,
+        mut result: QueryResult,
+        query: &SelectQuery,
+    ) -> Result<QueryResult, QueryError> {
         if let Some(order_by) = &query.order_by {
             let visible_cols = result.columns.len();
             self.sort_results(&mut result, order_by, visible_cols)?;
         }
 
-        // Apply PIVOT BY, in the pipeline slot `execute_select` uses: after
-        // ORDER BY, before LIMIT. Omitting it here meant a query with a FROM
-        // clause parsed its PIVOT BY, built the transformation's validated
-        // inputs, and then returned the un-pivoted result with no error
-        // (#2216).
-        //
-        // No hidden-column strip to sit after, unlike the other two paths:
-        // `find_hidden_order_by_targets` materializes nothing for an aggregate
-        // query, because an ORDER BY target there must already be in GROUP BY
-        // or be an aggregate, so it is projected already.
         if let Some(pivot_exprs) = &query.pivot_by {
             result = self.apply_pivot(&result, pivot_exprs, &query.group_by)?;
         }
 
-        // Apply LIMIT
         if let Some(limit) = query.limit {
             result.truncate(limit as usize);
         }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -587,6 +587,15 @@ impl Executor<'_> {
             }
         }
 
+        // Apply PIVOT BY, in the same pipeline slot `execute_select` uses:
+        // after ORDER BY and the hidden-column strip, before LIMIT. Omitting
+        // it here meant a query with a FROM clause parsed its PIVOT BY, built
+        // the transformation's validated inputs, and then returned the
+        // un-pivoted result with no error (#2216).
+        if let Some(pivot_exprs) = &query.pivot_by {
+            result = self.apply_pivot(&result, pivot_exprs, &query.group_by)?;
+        }
+
         // Apply LIMIT
         if let Some(limit) = query.limit {
             result.truncate(limit as usize);
@@ -717,6 +726,15 @@ impl Executor<'_> {
         if let Some(order_by) = &query.order_by {
             let visible_cols = result.columns.len();
             self.sort_results(&mut result, order_by, visible_cols)?;
+        }
+
+        // Apply PIVOT BY, in the same pipeline slot `execute_select` uses:
+        // after ORDER BY and the hidden-column strip, before LIMIT. Omitting
+        // it here meant a query with a FROM clause parsed its PIVOT BY, built
+        // the transformation's validated inputs, and then returned the
+        // un-pivoted result with no error (#2216).
+        if let Some(pivot_exprs) = &query.pivot_by {
+            result = self.apply_pivot(&result, pivot_exprs, &query.group_by)?;
         }
 
         // Apply LIMIT

--- a/crates/rustledger-query/tests/aggregate_count_null_test.rs
+++ b/crates/rustledger-query/tests/aggregate_count_null_test.rs
@@ -56,3 +56,59 @@ fn count_column_excludes_nulls() {
         "COUNT(payee) counts only non-NULL payees"
     );
 }
+
+/// A pure aggregate over ZERO matching rows still produces one row:
+/// `COUNT(*)` is 0, `SUM` is NULL. A `GROUP BY` query over zero rows produces
+/// none, because there are no groups to produce them for.
+///
+/// `execute_aggregate_from_table` states this contract in a comment and
+/// nothing pinned it: every other `count(*)` test here runs on data that
+/// matches. It is worth pinning because the branch is one arm of an if/else
+/// whose other arm was rewritten for #2216, and only a hand comparison against
+/// `main` caught that it still held.
+///
+/// This is also a deliberate divergence: bean-query returns NO row for
+/// `SELECT count(*)` over an empty filter, where we return 0. Recorded here so
+/// a future reader meets the choice rather than assuming it is a bug.
+#[test]
+fn a_pure_aggregate_over_no_rows_still_returns_a_row() {
+    let dirs = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "only")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-5), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(5), "USD"),
+                )),
+        ),
+    ];
+
+    let rows = |q: &str| {
+        let query = parse(q).expect("query should parse");
+        let mut executor = Executor::new(&dirs);
+        executor.execute(&query).expect("query should execute").rows
+    };
+
+    // `FROM #postings` on purpose: without it these route through
+    // `execute_select`, and the branch under test lives in
+    // `execute_aggregate_from_table`. Written without it first, the test
+    // passed against both mutations of that branch -- protection that was not
+    // there.
+    let counted = rows("SELECT count(*) FROM #postings WHERE account = 'Nope:Nope'");
+    assert_eq!(counted.len(), 1, "a pure aggregate always yields one row");
+    assert_eq!(counted[0][0], Value::Integer(0), "COUNT(*) of nothing is 0");
+
+    let summed = rows("SELECT sum(number) FROM #postings WHERE account = 'Nope:Nope'");
+    assert_eq!(summed.len(), 1);
+    assert_eq!(summed[0][0], Value::Null, "SUM of nothing is NULL, not 0");
+
+    let grouped = rows(
+        "SELECT account, count(*) FROM #postings WHERE account = 'Nope:Nope' GROUP BY account",
+    );
+    assert!(
+        grouped.is_empty(),
+        "GROUP BY over no rows has no groups, so no rows: {grouped:?}",
+    );
+}

--- a/crates/rustledger-query/tests/pivot_with_from_test.rs
+++ b/crates/rustledger-query/tests/pivot_with_from_test.rs
@@ -1,0 +1,100 @@
+//! `PIVOT BY` applies when the query names a table (#2216).
+//!
+//! There are four execution paths that run ORDER BY and LIMIT, and only one of
+//! them ran PIVOT:
+//!
+//! | path | sort | pivot | limit |
+//! |---|---|---|---|
+//! | `execute_select` (no FROM) | yes | **yes** | yes |
+//! | `execute_select_from_table` | yes | no | yes |
+//! | `execute_aggregate_from_table` | yes | no | yes |
+//! | `execute_select_from_subquery` | yes | no | yes |
+//!
+//! So a query with a `FROM` clause parsed its `PIVOT BY`, validated it, and
+//! then returned the un-pivoted result with no error. Since `rledger query` is
+//! normally written with an explicit table, that was the form users hit.
+//!
+//! The subquery path is left alone: our parser rejects `FROM (SELECT ...)`
+//! outright, so nothing can reach it carrying a pivot, and an untestable branch
+//! is worse than a documented gap.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+fn fixture() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "x")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(10), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-10), "USD"),
+                )),
+        ),
+    ]
+}
+
+fn columns_of(query_str: &str) -> Result<Vec<String>, String> {
+    let dirs = fixture();
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(&dirs);
+    executor
+        .execute(&query)
+        .map(|r| r.columns)
+        .map_err(|e| e.to_string())
+}
+
+/// The reported case: aggregate query, explicit table. `year` collapses into
+/// column headers, so the result is two columns rather than three.
+#[test]
+fn pivot_applies_with_a_from_clause() {
+    let with_from = columns_of(
+        "SELECT account, year, sum(number) FROM #postings \
+         GROUP BY account, year PIVOT BY account, year",
+    )
+    .expect("pivot with FROM must execute");
+    assert_eq!(
+        with_from,
+        vec!["account".to_string(), "2024".to_string()],
+        "the spread column's values must become the headers",
+    );
+}
+
+/// Same query without the table, which already worked. Pinned so the two
+/// cannot drift apart again -- the bug was precisely that they had.
+#[test]
+fn pivot_output_is_the_same_with_and_without_from() {
+    let without = columns_of(
+        "SELECT account, year, sum(number) GROUP BY account, year PIVOT BY account, year",
+    )
+    .expect("pivot without FROM");
+    let with = columns_of(
+        "SELECT account, year, sum(number) FROM #postings \
+         GROUP BY account, year PIVOT BY account, year",
+    )
+    .expect("pivot with FROM");
+    assert_eq!(with, without, "a FROM clause must not change the shape");
+}
+
+/// The non-aggregate table path. `PIVOT BY` requires `GROUP BY`, so this
+/// cannot pivot -- but it must SAY so rather than ignore the clause, which is
+/// what it did. The no-FROM form already errored; now both agree.
+#[test]
+fn pivot_without_group_by_errors_with_a_from_clause_too() {
+    let err = columns_of("SELECT account, number FROM #postings PIVOT BY account, number")
+        .expect_err("PIVOT BY without GROUP BY must be refused, not dropped");
+    assert!(
+        err.contains("PIVOT BY requires an explicit GROUP BY"),
+        "expected the same message the no-FROM path gives, got {err}",
+    );
+    let without = columns_of("SELECT account, number PIVOT BY account, number")
+        .expect_err("the no-FROM form errors too");
+    assert_eq!(err, without, "both paths must give the same diagnostic");
+}

--- a/crates/rustledger-query/tests/pivot_with_from_test.rs
+++ b/crates/rustledger-query/tests/pivot_with_from_test.rs
@@ -98,3 +98,51 @@ fn pivot_without_group_by_errors_with_a_from_clause_too() {
         .expect_err("the no-FROM form errors too");
     assert_eq!(err, without, "both paths must give the same diagnostic");
 }
+
+/// An empty result must still be pivoted, and both ways of emptying it must
+/// agree.
+///
+/// The aggregate path returned early when GROUP BY produced no groups, which
+/// skipped ORDER BY, PIVOT and LIMIT. The first and last are no-ops on zero
+/// rows; PIVOT is not, because it reshapes the COLUMNS. So a query emptied by
+/// WHERE reported the un-pivoted header while the same query emptied by HAVING
+/// reported the pivoted one. bean-query gives the pivoted shape for both.
+#[test]
+fn an_empty_result_is_pivoted_the_same_way_however_it_emptied() {
+    let by_where = columns_of(
+        "SELECT account, year, sum(number) FROM #postings WHERE account = 'nope' \
+         GROUP BY account, year PIVOT BY account, year",
+    )
+    .expect("empty by WHERE");
+    let by_having = columns_of(
+        "SELECT account, year, sum(number) FROM #postings \
+         GROUP BY account, year HAVING sum(number) > 100 PIVOT BY account, year",
+    )
+    .expect("empty by HAVING");
+
+    assert_eq!(
+        by_where, by_having,
+        "how a result became empty must not change its shape",
+    );
+    assert_eq!(
+        by_where,
+        vec!["account".to_string()],
+        "the pivoted shape: the row key, with no spread values to add",
+    );
+
+    // Without a pivot the same empty query keeps its projected columns, so
+    // the change above did not simply drop columns from every empty result.
+    let no_pivot = columns_of(
+        "SELECT account, year, sum(number) FROM #postings WHERE account = 'nope' \
+         GROUP BY account, year",
+    )
+    .expect("empty, no pivot");
+    assert_eq!(
+        no_pivot,
+        vec![
+            "account".to_string(),
+            "year".to_string(),
+            "sum(number)".to_string()
+        ],
+    );
+}


### PR DESCRIPTION
Closes #2216.

`PIVOT BY` was **silently dropped** by any query with a `FROM` clause. It parsed, it validated, and the un-pivoted result came back with no error. Since `rledger query` is normally written with an explicit table, **the CLI could not pivot at all**:

```
$ rledger query f.bean "SELECT account, year, sum(number) FROM #postings GROUP BY account, year PIVOT BY account, year"
account,year,sum(number)          <- not pivoted
Assets:A,2024,7.00

$ bean-query -f csv f.bean "<same>"
account/year,2024
Assets:A, 7.00
```

## Four tails, one pivot

| path | sort | pivot | limit |
|---|---|---|---|
| `execute_select` (no FROM) | ✓ | **✓** | ✓ |
| `execute_select_from_table` | ✓ | — | ✓ |
| `execute_aggregate_from_table` | ✓ | — | ✓ |
| `execute_select_from_subquery` | ✓ | — | ✓ |

Neither the parser nor `apply_pivot` was at fault — the parser populates `pivot_by` for the `FROM` form, and `apply_pivot` produces the right shape when reached. The step was simply absent from three tails.

## Two fixed, one deliberately not

Both additions sit in the slot `execute_select` uses (after ORDER BY and the hidden-column strip, before LIMIT), and each is reachable and improves something different:

- **`execute_aggregate_from_table`** — the reported case. The pivot applies and the rows match bean-query.
- **`execute_select_from_table`** — cannot pivot, since `PIVOT BY` requires `GROUP BY`. But it now **says so**, with the same message the no-`FROM` path gives, instead of ignoring the clause. bean-query answers that input with a Python traceback, so an error beats both.

**The subquery path is left alone.** Our parser rejects `FROM (SELECT ...)` outright, so nothing can reach it carrying a pivot. A branch no test can exercise is worse than a documented gap — the table above lives in the test file for whoever adds the next pipeline step.

## Controls

| mutation | result |
|---|---|
| remove the `execute_select_from_table` insertion | the without-`GROUP BY` test fails |
| remove the `execute_aggregate_from_table` insertion | the other two fail |

Each insertion has a test only it satisfies. A third test pins that the `FROM` and no-`FROM` forms produce the same shape — the bug was precisely that they had drifted.

## Left for #2217

Headers still differ: `account` against bean-query's `account/year`, and value columns reversed (`sum(number) / 2024` against `2024/sum(number)`). That is labeling on an otherwise-correct result, it changes the currently-working no-`FROM` path too, and it deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr