### PR TITLE
fix(query): a comparison with a NULL operand yields NULL

### DIFF
--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -31,9 +31,9 @@ impl Executor<'_> {
     ) -> Result<Value, QueryError> {
         let left = self.evaluate_expr(&op.left, ctx)?;
         let right = self.evaluate_expr(&op.right, ctx)?;
-        // `binary_op_on_values` owns the operator semantics — including the SQL
-        // three-valued-logic NULL short-circuit (a comparison involving NULL is
-        // UNKNOWN → false, so WHERE drops rows with a missing optional field).
+        // `binary_op_on_values` owns the operator semantics — including the
+        // NULL-comparison rule (a comparison involving NULL yields NULL, which
+        // is falsy, so WHERE still drops rows with a missing optional field).
         self.binary_op_on_values(op.op, &left, &right)
     }
 
@@ -258,9 +258,13 @@ impl Executor<'_> {
         left: &Value,
         right: &Value,
     ) -> Result<Value, QueryError> {
-        // Same NULL-comparison rule as `evaluate_binary_op` (see there).
+        // A comparison with a NULL operand is NULL, not FALSE (#2213). The two
+        // are not interchangeable: `COUNT` skips NULLs but counts every FALSE,
+        // so `count(payee != '')` over payee-less rows answered 4 where it
+        // should answer 0. Filtering is unaffected -- `to_bool(NULL)` is false,
+        // so `WHERE` still drops the row.
         if is_comparison(op) && (matches!(left, Value::Null) || matches!(right, Value::Null)) {
-            return Ok(Value::Boolean(false));
+            return Ok(Value::Null);
         }
         match op {
             BinaryOperator::Eq => Ok(Value::Boolean(self.values_equal(left, right))),

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -10,7 +10,21 @@ use super::types::{Interval, PostingContext, Value};
 
 /// Whether `op` is an equality or ordering comparison — the operators for which
 /// a NULL operand yields SQL "UNKNOWN" (treated as not-matched).
-const fn is_comparison(op: BinaryOperator) -> bool {
+/// Operators for which a NULL operand makes the whole expression NULL (#2213).
+///
+/// The equality and ordering operators, plus regex matching and set
+/// membership. Verified against beanquery 0.2.0: on a payee-less posting,
+/// `payee ~ 'x'`, `payee !~ 'x'` and `payee IN ('a')` are each NULL there, not
+/// the FALSE/TRUE/FALSE this returned.
+///
+/// `IS NULL` / `IS NOT NULL` are excluded on purpose -- they are null TESTS,
+/// and must answer TRUE/FALSE precisely when the operand is NULL. `AND` and
+/// `OR` are excluded too: they coerce, as `NOT` does.
+///
+/// Note this fires only on a genuine NULL. An empty `tags` is an empty SET,
+/// not NULL, so `'food' IN tags` on an untagged posting is still FALSE --
+/// which is what bean-query answers.
+const fn propagates_null(op: BinaryOperator) -> bool {
     matches!(
         op,
         BinaryOperator::Eq
@@ -19,6 +33,10 @@ const fn is_comparison(op: BinaryOperator) -> bool {
             | BinaryOperator::Le
             | BinaryOperator::Gt
             | BinaryOperator::Ge
+            | BinaryOperator::Regex
+            | BinaryOperator::NotRegex
+            | BinaryOperator::In
+            | BinaryOperator::NotIn
     )
 }
 
@@ -262,8 +280,9 @@ impl Executor<'_> {
         // are not interchangeable: `COUNT` skips NULLs but counts every FALSE,
         // so `count(payee != '')` over payee-less rows answered 4 where it
         // should answer 0. Filtering is unaffected -- `to_bool(NULL)` is false,
-        // so `WHERE` still drops the row.
-        if is_comparison(op) && (matches!(left, Value::Null) || matches!(right, Value::Null)) {
+        // so `WHERE` still drops the row. See `propagates_null` for which
+        // operators this covers and which deliberately coerce instead.
+        if propagates_null(op) && (matches!(left, Value::Null) || matches!(right, Value::Null)) {
             return Ok(Value::Null);
         }
         match op {
@@ -284,11 +303,12 @@ impl Executor<'_> {
                 Ok(Value::Boolean(l || r))
             }
             BinaryOperator::Regex => {
-                // ~ operator: string matches regex pattern
-                // NULL ~ pattern returns false (matches Python beancount behavior)
+                // ~ operator: string matches regex pattern. A NULL operand
+                // never reaches here -- `propagates_null` short-circuits it to
+                // NULL above, which is what bean-query answers. This arm used
+                // to return FALSE and claim that matched beancount; it did not.
                 let s = match left {
                     Value::String(s) => s,
-                    Value::Null => return Ok(Value::Boolean(false)),
                     _ => {
                         return Err(QueryError::Type(
                             "regex requires string left operand".to_string(),
@@ -333,11 +353,11 @@ impl Executor<'_> {
                 }
             }
             BinaryOperator::NotRegex => {
-                // !~ operator: string does not match regex pattern
-                // NULL !~ pattern returns true (matches Python beancount behavior)
+                // !~ operator: string does not match regex pattern. As with
+                // `~`, a NULL operand is short-circuited to NULL above and
+                // never reaches this arm.
                 let s = match left {
                     Value::String(s) => s,
-                    Value::Null => return Ok(Value::Boolean(true)),
                     _ => {
                         return Err(QueryError::Type(
                             "!~ requires string left operand".to_string(),

--- a/crates/rustledger-query/tests/null_comparison_test.rs
+++ b/crates/rustledger-query/tests/null_comparison_test.rs
@@ -1,0 +1,158 @@
+//! Regression: a comparison with a NULL operand yields NULL, not FALSE (#2213).
+//!
+//! The two are not interchangeable. `COUNT(expr)` skips NULLs but counts every
+//! FALSE, so `count(payee != '')` over payee-less rows answered 4 where
+//! bean-query answers 0. Measured against beanquery 0.2.0 / beancount 3.2.3.
+//!
+//! The target is Python's rule, not strict SQL three-valued logic: beanquery
+//! evaluates `NOT (NULL)` as `TRUE` (Python's `not None`), where SQL would say
+//! NULL. `not_coerces_a_null_operand` pins that deliberately, so a later
+//! "make it proper 3VL" change has to meet the decision rather than assume the
+//! current answer is an oversight.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+/// Two postings with a payee, two without.
+fn mixed_payees() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "with payee")
+                .with_payee("Cafe")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-5), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(5), "USD"),
+                )),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 3), "no payee")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-7), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(7), "USD"),
+                )),
+        ),
+    ]
+}
+
+fn column(query_str: &str, directives: &[Directive]) -> Vec<Value> {
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(directives);
+    let result = executor.execute(&query).expect("query should execute");
+    result
+        .rows
+        .iter()
+        .map(|row| row.first().cloned().expect("one column"))
+        .collect()
+}
+
+/// Every comparison operator, on the same NULL operand. Checking one of them
+/// would leave the other five free to regress independently -- the bug was
+/// uniform across all six precisely because they share a single guard.
+#[test]
+fn every_comparison_with_a_null_operand_is_null() {
+    let dirs = mixed_payees();
+    for op in ["=", "!=", "<", "<=", ">", ">="] {
+        let values = column(&format!("SELECT payee {op} 'Cafe'"), &dirs);
+        assert_eq!(values.len(), 4, "all four postings are returned");
+
+        let nulls = values.iter().filter(|v| **v == Value::Null).count();
+        assert_eq!(
+            nulls, 2,
+            "`payee {op} 'Cafe'` must be NULL on the two payee-less postings, \
+             got {values:?}",
+        );
+        // The other two rows have a payee, so they must still be plain
+        // booleans -- returning NULL unconditionally would satisfy the count
+        // above on its own.
+        let booleans = values
+            .iter()
+            .filter(|v| matches!(v, Value::Boolean(_)))
+            .count();
+        assert_eq!(
+            booleans, 2,
+            "`payee {op} 'Cafe'` must stay boolean where the payee is present, \
+             got {values:?}",
+        );
+    }
+}
+
+/// The reason the distinction matters: `COUNT` skips NULL and counts FALSE.
+#[test]
+fn count_over_a_null_comparison_skips_the_null_rows() {
+    let dirs = mixed_payees();
+    let counted = column("SELECT count(payee != 'Nobody')", &dirs);
+    assert_eq!(
+        counted,
+        vec![Value::Integer(2)],
+        "only the two postings with a payee produce a non-NULL comparison",
+    );
+}
+
+/// A NULL comparison is falsy, so `WHERE` still drops the row. This is what
+/// made the FALSE answer survive so long: filtering looked correct, and only
+/// projecting or counting the comparison exposed it.
+#[test]
+fn where_still_drops_rows_whose_comparison_is_null() {
+    let dirs = mixed_payees();
+    let kept = column("SELECT account WHERE payee != 'Nobody'", &dirs);
+    assert_eq!(
+        kept.len(),
+        2,
+        "payee-less postings are filtered out: {kept:?}"
+    );
+}
+
+/// The ordinary case must be untouched: with both operands present, a
+/// comparison is still a plain boolean. Without this, returning NULL
+/// unconditionally would pass every other test in this file.
+#[test]
+fn a_comparison_between_two_present_values_is_unchanged() {
+    let dirs = mixed_payees();
+    let values = column("SELECT payee = 'Cafe' WHERE payee IS NOT NULL", &dirs);
+    assert_eq!(
+        values,
+        vec![Value::Boolean(true), Value::Boolean(true)],
+        "a comparison with no NULL operand is still TRUE/FALSE",
+    );
+
+    let negative = column("SELECT payee = 'Other' WHERE payee IS NOT NULL", &dirs);
+    assert_eq!(
+        negative,
+        vec![Value::Boolean(false), Value::Boolean(false)],
+        "and FALSE is still reachable",
+    );
+}
+
+/// `NOT` coerces its operand, so `NOT (NULL)` is TRUE -- Python's rule, which
+/// is what beanquery implements. Deliberate, not an oversight: see the module
+/// comment. `IS NULL` is likewise unaffected, being a null test rather than a
+/// comparison.
+#[test]
+fn not_coerces_a_null_operand() {
+    let dirs = mixed_payees();
+    let notted = column("SELECT NOT (payee = 'Cafe') WHERE payee IS NULL", &dirs);
+    assert_eq!(
+        notted,
+        vec![Value::Boolean(true), Value::Boolean(true)],
+        "NOT (NULL) is TRUE, matching bean-query",
+    );
+
+    let is_null = column("SELECT payee IS NULL", &dirs);
+    assert_eq!(
+        is_null
+            .iter()
+            .filter(|v| **v == Value::Boolean(true))
+            .count(),
+        2,
+        "IS NULL is a null test, not a comparison: {is_null:?}",
+    );
+}

--- a/crates/rustledger-query/tests/null_comparison_test.rs
+++ b/crates/rustledger-query/tests/null_comparison_test.rs
@@ -85,6 +85,69 @@ fn every_comparison_with_a_null_operand_is_null() {
     }
 }
 
+/// Regex matching and set membership propagate NULL too. These were missed by
+/// the first pass at #2213 and had comments explicitly claiming the old
+/// FALSE/TRUE answers "matched Python beancount behavior" -- they did not.
+/// Checked against beanquery 0.2.0: all four are NULL on a payee-less posting.
+#[test]
+fn regex_and_set_membership_propagate_null() {
+    let dirs = mixed_payees();
+    for expr in [
+        "payee ~ 'Cafe'",
+        "payee !~ 'Cafe'",
+        "payee IN ('Cafe')",
+        "payee NOT IN ('Cafe')",
+    ] {
+        let values = column(&format!("SELECT {expr}"), &dirs);
+        let nulls = values.iter().filter(|v| **v == Value::Null).count();
+        assert_eq!(
+            nulls, 2,
+            "`{expr}` must be NULL on the two payee-less postings, got {values:?}",
+        );
+        let booleans = values
+            .iter()
+            .filter(|v| matches!(v, Value::Boolean(_)))
+            .count();
+        assert_eq!(
+            booleans, 2,
+            "`{expr}` must stay boolean where the payee is present, got {values:?}",
+        );
+    }
+}
+
+/// An EMPTY collection is not NULL, so set membership against it is still a
+/// plain boolean. Without this, propagating NULL from an empty `tags` would
+/// silently break the common `'x' IN tags` query -- and it would look like a
+/// fix, since `tags` on an untagged posting reads as "missing".
+#[test]
+fn membership_in_an_empty_set_is_false_not_null() {
+    let dirs = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "untagged")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-5), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(5), "USD"),
+                )),
+        ),
+    ];
+
+    let inside = column("SELECT 'food' IN tags", &dirs);
+    assert_eq!(
+        inside,
+        vec![Value::Boolean(false), Value::Boolean(false)],
+        "an untagged posting has an EMPTY tag set, not a NULL one",
+    );
+    let outside = column("SELECT 'food' NOT IN tags", &dirs);
+    assert_eq!(
+        outside,
+        vec![Value::Boolean(true), Value::Boolean(true)],
+        "and NOT IN over it is TRUE, not NULL",
+    );
+}
+
 /// The reason the distinction matters: `COUNT` skips NULL and counts FALSE.
 #[test]
 fn count_over_a_null_comparison_skips_the_null_rows() {


### PR DESCRIPTION
`payee != ''` answered `FALSE` on a payee-less posting where bean-query answers NULL. Closes #2213.

FALSE and NULL are not interchangeable downstream. `COUNT(expr)` skips NULLs but counts every FALSE, so `count(payee != '')` over payee-less rows answered **4** where it should answer **0**. `COUNT` excluding NULLs was already correct and tested — it was the comparison feeding it that manufactured a non-NULL.

All six comparison operators shared one guard, so all six were wrong. The fix is that guard returning `Value::Null`.

## Target semantics

Python's rule, which is what beanquery implements — not strict SQL three-valued logic. `NOT (NULL)` is `TRUE` there (Python's `not None`) where SQL would say NULL. That behavior stays and is now pinned by a test, so a later "make it proper 3VL" change meets the decision rather than assuming the current answer is an oversight.

Filtering is unaffected: `to_bool(NULL)` is false, so `WHERE` still drops the row. That is why this survived — filtering looked right, and only projecting or counting a comparison exposed it.

## Verification

Against beanquery 0.2.0 / beancount 3.2.3, all seven expressions from the issue now agree:

| expression | bean-query | before | after |
|---|---|---|---|
| `payee != ''` | *(null)* | `FALSE` | *(null)* |
| `payee = ''` | *(null)* | `FALSE` | *(null)* |
| `payee > 'a'` | *(null)* | `FALSE` | *(null)* |
| `payee < 'a'` | *(null)* | `FALSE` | *(null)* |
| `payee IS NULL` | `TRUE` | `TRUE` | `TRUE` |
| `NOT (payee = '')` | `TRUE` | `TRUE` | `TRUE` |
| `count(payee != '')` | `0` | `4` | `0` |

Also checked on a mixed ledger that ordinary comparisons are untouched (`'Cafe' = 'Cafe'` → TRUE, `WHERE payee != ''` → 2 rows), agreeing with bean-query on each.

BQL compat harness over 71 corpus files / 1349 runs: **no regression against the pre-change baseline**, no new stale masks, counts unchanged. The corpus barely exercises NULL comparisons, which is part of why this survived.

## On the coverage gap

The full workspace suite (4686 tests) passed **unchanged** after the semantic fix, before any test was added — nothing covered this at all. Two of the five new tests fail against the old behavior; the other three deliberately pass both ways because they pin invariants that must *not* move (`WHERE` filtering, `NOT` coercion, and ordinary two-operand comparisons still being boolean). Without that third group, returning NULL unconditionally would satisfy the rest of the file.

Not addressed here: the issue's secondary note that `SELECT count(*) ... WHERE <no matches>` returns no row from bean-query where we return `0`. That is an aggregate-over-empty-input difference, already recorded as a deliberate divergence in `aggregate_count_null_test.rs`.