### PR TITLE
feat(query): SUM over a boolean counts the matching rows

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -313,6 +313,7 @@ impl<'a> Executor<'a> {
                         let mut total_number = Decimal::ZERO;
                         let mut has_positions = false;
                         let mut has_numbers = false;
+                        let mut has_booleans = false;
 
                         for ctx in group {
                             let val = self.evaluate_expr(&func.args[0], ctx)?;
@@ -348,6 +349,19 @@ impl<'a> Executor<'a> {
                                     );
                                     has_numbers = true;
                                 }
+                                // Python sums booleans as integers, so
+                                // `sum(number > 0)` is a count of the rows
+                                // where the comparison holds (#2214). Tracked
+                                // apart from `has_numbers` so
+                                // an all-boolean sum can come back as an
+                                // Integer rather than a Decimal.
+                                Value::Boolean(b) => {
+                                    total_number = rustledger_core::add_python_scale(
+                                        total_number,
+                                        Decimal::from(u8::from(b)),
+                                    );
+                                    has_booleans = true;
+                                }
                                 Value::Null => {}
                                 _ => {
                                     return Err(QueryError::Type(
@@ -382,6 +396,17 @@ impl<'a> Executor<'a> {
                         } else if has_numbers {
                             // Pure number sum - return as Number
                             Ok(Value::Number(total_number))
+                        } else if has_booleans {
+                            // An all-boolean sum is a count, so it is an
+                            // Integer. bean-query computes the same number but
+                            // PRINTS it as `TRUE`: its result column is typed
+                            // from the argument, so the integer goes through
+                            // the boolean formatter. We match the value and not
+                            // the rendering (#2214).
+                            use rust_decimal::prelude::ToPrimitive;
+                            Ok(total_number
+                                .to_i64()
+                                .map_or(Value::Number(total_number), Value::Integer))
                         } else {
                             // No values summed (all nulls)
                             Ok(Value::Null)
@@ -832,6 +857,7 @@ impl<'a> Executor<'a> {
                         let mut total_number = Decimal::ZERO;
                         let mut has_positions = false;
                         let mut has_numbers = false;
+                        let mut has_booleans = false;
 
                         for row in group {
                             let val =
@@ -867,6 +893,19 @@ impl<'a> Executor<'a> {
                                     );
                                     has_numbers = true;
                                 }
+                                // Python sums booleans as integers, so
+                                // `sum(number > 0)` is a count of the rows
+                                // where the comparison holds (#2214). Tracked
+                                // apart from `has_numbers` so
+                                // an all-boolean sum can come back as an
+                                // Integer rather than a Decimal.
+                                Value::Boolean(b) => {
+                                    total_number = rustledger_core::add_python_scale(
+                                        total_number,
+                                        Decimal::from(u8::from(b)),
+                                    );
+                                    has_booleans = true;
+                                }
                                 Value::Null => {}
                                 _ => {
                                     return Err(QueryError::Type(
@@ -888,6 +927,17 @@ impl<'a> Executor<'a> {
                             Ok(Value::Inventory(std::sync::Arc::new(total_inventory)))
                         } else if has_numbers {
                             Ok(Value::Number(total_number))
+                        } else if has_booleans {
+                            // An all-boolean sum is a count, so it is an
+                            // Integer. bean-query computes the same number but
+                            // PRINTS it as `TRUE`: its result column is typed
+                            // from the argument, so the integer goes through
+                            // the boolean formatter. We match the value and not
+                            // the rendering (#2214).
+                            use rust_decimal::prelude::ToPrimitive;
+                            Ok(total_number
+                                .to_i64()
+                                .map_or(Value::Number(total_number), Value::Integer))
                         } else {
                             Ok(Value::Null)
                         }

--- a/crates/rustledger-query/tests/sum_over_booleans_test.rs
+++ b/crates/rustledger-query/tests/sum_over_booleans_test.rs
@@ -1,0 +1,147 @@
+//! Regression: `SUM` over a boolean counts the true rows (#2214).
+//!
+//! Python sums booleans as integers, so `sum(number > 0)` is a meaningful
+//! number in beanquery. We used to reject it as a type error.
+//!
+//! We match bean-query's VALUE, not its output. Its CLI prints `TRUE` for this
+//! query -- the result column is typed from the argument, so the integer is
+//! rendered through the boolean formatter -- while the API returns `2`.
+//! Verified directly against beanquery 0.2.0:
+//!
+//! ```text
+//! conn.execute("SELECT sum(number > 0) FROM #postings").fetchall()  # [(2,)]
+//! bean-query -f csv ... "SELECT sum(number > 0) FROM #postings"     # TRUE
+//! ```
+//!
+//! Reproducing the rendering would mean reproducing a display bug, so the
+//! outputs deliberately differ. `docs/reference/compatibility.md` records it.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+/// Four postings: two negative (Assets:Cash), two positive (Expenses:Food).
+fn two_transactions() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 2), "a")
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-10.00), "USD"),
+                ))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(10.00), "USD"),
+                )),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 3), "b")
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-20.00), "USD"),
+                ))
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(20.00), "USD"),
+                )),
+        ),
+    ]
+}
+
+fn rows(query_str: &str, directives: &[Directive]) -> Vec<Vec<Value>> {
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(directives);
+    executor.execute(&query).expect("query should execute").rows
+}
+
+/// The value bean-query's API returns, as an Integer rather than a Decimal:
+/// this is a count, and `COUNT` answers with an Integer too.
+#[test]
+fn sum_over_a_boolean_counts_the_true_rows() {
+    let dirs = two_transactions();
+    let result = rows("SELECT sum(number > 0) FROM #postings", &dirs);
+    assert_eq!(
+        result,
+        vec![vec![Value::Integer(2)]],
+        "two of the four postings are positive",
+    );
+}
+
+/// The accumulator is duplicated, and the split is NOT grouped-vs-ungrouped as
+/// it looks: one copy serves queries written WITHOUT `FROM`, the other serves
+/// every `FROM #postings` form, grouped or not. Established by marking one copy
+/// and seeing which queries moved -- the first version of this file tested the
+/// same copy twice while claiming to cover both. `sum_without_a_from_clause`
+/// below is the one that reaches the other copy.
+///
+/// bean-query's API returns `[('Assets:Cash', 0), ('Expenses:Food', 2)]` here.
+#[test]
+fn the_grouped_sum_path_counts_booleans_too() {
+    let dirs = two_transactions();
+    let result = rows(
+        "SELECT account, sum(number > 0) FROM #postings GROUP BY account ORDER BY account",
+        &dirs,
+    );
+    assert_eq!(
+        result,
+        vec![
+            vec![Value::String("Assets:Cash".to_string()), Value::Integer(0)],
+            vec![
+                Value::String("Expenses:Food".to_string()),
+                Value::Integer(2)
+            ],
+        ],
+        "a group with no TRUE rows sums to 0, not NULL",
+    );
+}
+
+/// Summing actual numbers must be untouched -- in particular the Python scale
+/// semantics that make a total passing through zero render `0.00`, not `0`.
+/// Accepting booleans by widening the numeric arm would quietly break this.
+#[test]
+fn summing_numbers_is_unchanged() {
+    let dirs = two_transactions();
+    let result = rows("SELECT sum(number) FROM #postings", &dirs);
+    assert_eq!(
+        result,
+        vec![vec![Value::Number(dec!(0.00))]],
+        "the numeric sum keeps its scale and stays a Number, not an Integer",
+    );
+}
+
+/// `AVG` over a boolean still refuses, which is what bean-query does
+/// (`CompilationError: no function matches "avg(bool)"`). Agreeing by
+/// rejecting is still agreeing, and widening SUM must not widen AVG.
+#[test]
+fn avg_over_a_boolean_still_refuses() {
+    let dirs = two_transactions();
+    let query = parse("SELECT avg(number > 0) FROM #postings").expect("query should parse");
+    let mut executor = Executor::new(&dirs);
+    let err = executor
+        .execute(&query)
+        .expect_err("AVG over a boolean must stay an error");
+    let text = err.to_string();
+    assert!(
+        text.contains("AVG"),
+        "the error should name AVG, got {text:?}",
+    );
+}
+
+/// The no-`FROM` form, which is the OTHER copy of the accumulator. Both must
+/// agree; bean-query's API returns `[(2,)]` for this too.
+#[test]
+fn sum_without_a_from_clause_counts_booleans() {
+    let dirs = two_transactions();
+    let result = rows("SELECT sum(number > 0)", &dirs);
+    assert_eq!(
+        result,
+        vec![vec![Value::Integer(2)]],
+        "the no-FROM accumulator must count true rows like the table one",
+    );
+}

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -184,6 +184,56 @@ a label) rather than relying on either tiebreak.
 Fixture: `tests/fixtures/cross-file-order/`. Pinned by
 `cross_file_same_date_directives_keep_include_order` (issue #2149).
 
+### 8. SUM Over a Boolean
+
+`sum(number > 0)` counts the rows where the comparison is true. Python sums
+booleans as integers, so bean-query computes the same number -- but prints it
+as `TRUE`:
+
+```
+$ bean-query -f csv f.bean "SELECT sum(number > 0) FROM #postings"
+TRUE
+
+$ rledger query -f csv f.bean "SELECT sum(number > 0) FROM #postings"
+2
+```
+
+The values agree; only the rendering differs. bean-query types the result
+column from its argument, so the integer it computed is formatted through the
+boolean formatter. Through its API the number is visible:
+
+```python
+conn.execute("SELECT sum(number > 0) FROM #postings").fetchall()
+# [(2,)]
+```
+
+We print the value. Reproducing `TRUE` would mean reproducing a display bug,
+and `2` is what a user asking "how many postings are positive" means.
+
+`count(number > 0)` answers a different question -- it counts non-NULL
+comparisons, so on the same data it is 4, in both tools.
+
+Pinned by `crates/rustledger-query/tests/sum_over_booleans_test.rs` (issue
+#2214).
+
+### 9. Comparisons Against a Missing Value
+
+A comparison with a NULL operand is NULL, in both tools. On a posting whose
+transaction has no payee, `payee != ''`, `payee ~ 'x'` and `payee IN ('a')` are
+each NULL rather than a boolean, so `count(payee != '')` is 0 and not the row
+count.
+
+This is agreement, not divergence, and is listed here because it is easy to
+assume the opposite: `WHERE payee != ''` still filters those rows out, since
+NULL is falsy. Only projecting or counting a comparison shows the difference.
+
+`NOT (NULL)` is `TRUE` -- Python's rule, which beanquery follows, rather than
+SQL three-valued logic. An empty collection is not NULL: `'food' IN tags` on an
+untagged posting is `FALSE`, again in both tools.
+
+Pinned by `crates/rustledger-query/tests/null_comparison_test.rs` (issue
+#2213).
+
 ## BQL Query Compatibility
 
 BQL (Beancount Query Language) compatibility was tested with 11 standard queries on 50 files:


### PR DESCRIPTION
`sum(number > 0)` was a type error; it now answers `2` on a ledger with two positive postings. Closes #2214.

## The value, not the rendering

Python sums booleans as integers, so bean-query computes the same number. What its CLI **prints** is `TRUE` — the result column is typed from the argument, so the integer goes through the boolean formatter. Through its API the number is visible:

```python
conn.execute("SELECT sum(number > 0) FROM #postings").fetchall()   # [(2,)]
```

So "match bean-query" is ambiguous here, and this takes the value:

| | bean-query (API) | bean-query (CLI) | before | after |
|---|---|---|---|---|
| `sum(number > 0)` | `2` | `TRUE` | type error | `2` |
| grouped by account | `[('Assets:Cash', 0), ('Expenses:Food', 2)]` | — | type error | same |
| `count(number > 0)` | `4` | `4` | `4` | `4` |
| `avg(number > 0)` | *CompilationError* | — | type error | type error |

Reproducing `TRUE` would mean reproducing a display bug, and `2` is what a user asking "how many postings are positive" means. Recorded as a deliberate output divergence in `docs/reference/compatibility.md`, along with a section on #2213's NULL comparisons — that one is agreement, but it's easy to assume otherwise since `WHERE` filtering is unaffected.

## Implementation notes

An all-boolean sum returns an `Integer`, since it is a count and `COUNT` answers with one. `has_booleans` is tracked separately from `has_numbers` deliberately: widening the numeric arm instead would have folded booleans into the Decimal total, and a mixed sum passing through zero would then render `0` where bean-query renders `0.00`. `summing_numbers_is_unchanged` pins that.

`AVG` over a boolean still refuses, which is what bean-query does. Agreeing by rejecting is still agreeing, and the test pins that widening `SUM` did not widen `AVG`.

## On the duplicated accumulator

`SUM` is implemented twice, and the split is **not** grouped-vs-ungrouped as it appears: one copy serves queries written without `FROM`, the other serves every `FROM #postings` form, grouped or not.

I found this the hard way. The first version of the test file tested the same copy twice while its docstring claimed to cover both — a removal experiment failed both tests instead of one, which is what exposed it. I marked one copy with a sentinel and re-ran the queries to establish the real split. Now, removing either copy's boolean arm fails exactly the tests that name it: site 1 → `sum_without_a_from_clause_counts_booleans`, site 2 → the other two.

## Verification

4693 workspace tests green, clippy clean on 1.97.0, BQL compat harness over 71 files / 1349 runs shows no regression against baseline.