### PR TITLE
fix(query): a string-literal header echoes the quote the query wrote

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -215,11 +215,99 @@ pub enum Expr {
     },
 }
 
+/// Which quote character a string literal was written with.
+///
+/// bean-query echoes the quote the query wrote -- `"dq"` heads `"dq"` and
+/// `'dq'` heads `'dq'` -- so reproducing its headers means carrying the style
+/// from the source (#2176).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QuoteStyle {
+    /// `'single'`.
+    Single,
+    /// `"double"`.
+    Double,
+}
+
+impl QuoteStyle {
+    /// The character itself.
+    #[must_use]
+    pub const fn char(self) -> char {
+        match self {
+            Self::Single => '\'',
+            Self::Double => '"',
+        }
+    }
+}
+
+/// A string literal, and the quote character its source used if it came from
+/// one.
+///
+/// # Provenance is not part of the value
+///
+/// `PartialEq` and `Hash` consider only [`Self::value`]. `'x'` and `"x"` are
+/// the same string, and an AST comparison that said otherwise would make
+/// query equality depend on typing style. The quote is carried solely so
+/// headers and [`Display`](std::fmt::Display) can echo what was written --
+/// the same reason [`Spanned`](rustledger_core::Spanned) keeps equality on
+/// its value rather than its span.
+///
+/// `quote` is `None` for a literal built programmatically rather than parsed
+/// (see [`Expr::string`]), which has no source style to echo. Those render by
+/// the fallback rule in `header_fragment`.
+#[derive(Debug, Clone, Eq)]
+pub struct QuotedString {
+    value: String,
+    quote: Option<QuoteStyle>,
+}
+
+impl QuotedString {
+    /// A literal read from source, carrying the quote it was written with.
+    #[must_use]
+    pub const fn parsed(value: String, quote: QuoteStyle) -> Self {
+        Self {
+            value,
+            quote: Some(quote),
+        }
+    }
+
+    /// A literal with no source style, built programmatically.
+    pub fn synthetic(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            quote: None,
+        }
+    }
+
+    /// The string itself, without quotes.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// The quote the source used, if this literal was parsed.
+    #[must_use]
+    pub const fn quote(&self) -> Option<QuoteStyle> {
+        self.quote
+    }
+}
+
+impl PartialEq for QuotedString {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl std::hash::Hash for QuotedString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
 /// A literal value.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Literal {
     /// String literal.
-    String(String),
+    String(QuotedString),
     /// Numeric literal.
     Number(Decimal),
     /// Integer literal.
@@ -506,9 +594,13 @@ impl Expr {
         Self::Column(name.into())
     }
 
-    /// Create a string literal.
+    /// Create a string literal with no source quote style.
+    ///
+    /// For literals built in code rather than parsed. A header for one falls
+    /// back to the heuristic in `header_fragment` rather than echoing a quote
+    /// it never had.
     pub fn string(s: impl Into<String>) -> Self {
-        Self::Literal(Literal::String(s.into()))
+        Self::Literal(Literal::String(QuotedString::synthetic(s)))
     }
 
     /// Create a number literal.
@@ -672,21 +764,26 @@ fn header_fragment(expr: &Expr) -> String {
     match expr {
         Expr::Column(name) => name.clone(),
         Expr::Wildcard => "*".to_string(),
-        // Single quotes, as bean-query writes them; `Display` uses double.
-        // Switch to double when the value contains a single quote and no
-        // double, so the header stays a well-formed literal instead of the
-        // ambiguous `'o'clock'`.
-        //
-        // Exact parity is out of reach here: bean-query echoes the quote
-        // character the query WROTE (`"dq"` heads `"dq"`, `'dq'` heads
-        // `'dq'`), and `Literal::String` does not record which was used.
-        // Reproducing that needs the parser to keep the original style
-        // (#2176).
+        // Echo the quote the query wrote, which is what bean-query does:
+        // `"dq"` heads `"dq"` and `'dq'` heads `'dq'` (#2176). The body is
+        // reproduced verbatim, again matching bean-query -- `'it''s'` heads
+        // `'it''s'`, with the doubled quote left as written rather than
+        // re-escaped.
         Expr::Literal(Literal::String(s)) => {
-            if s.contains('\'') && !s.contains('"') {
-                format!("\"{s}\"")
+            if let Some(q) = s.quote() {
+                format!("{}{}{}", q.char(), s.value(), q.char())
             } else {
-                format!("'{s}'")
+                // No source style: this literal was built in code. Single
+                // quotes, as bean-query writes them, switching to double when
+                // the value contains a single quote and no double so the
+                // header stays a well-formed literal rather than the
+                // ambiguous `'o'clock'` (#2175).
+                let v = s.value();
+                if v.contains('\'') && !v.contains('"') {
+                    format!("\"{v}\"")
+                } else {
+                    format!("'{v}'")
+                }
             }
         }
         Expr::Literal(lit) => lit.to_string(),
@@ -739,7 +836,12 @@ fn header_fragment(expr: &Expr) -> String {
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::String(s) => write!(f, "\"{s}\""),
+            // Echoes the source quote so a parsed literal round-trips as
+            // written; falls back to double quotes when there was none.
+            Self::String(s) => {
+                let q = s.quote().unwrap_or(QuoteStyle::Double).char();
+                write!(f, "{q}{}{q}", s.value())
+            }
             Self::Number(n) => write!(f, "{n}"),
             Self::Integer(n) => write!(f, "{n}"),
             Self::Date(d) => write!(f, "{d}"),
@@ -948,9 +1050,46 @@ mod tests {
         assert_eq!(UnaryOperator::IsNotNull.to_string(), " IS NOT NULL");
     }
 
+    /// A literal built in code has no source quote to echo, so the header
+    /// keeps the #2175 fallback: single quotes, switching to double only when
+    /// the value contains a single quote and no double, so the header stays a
+    /// well-formed literal rather than the ambiguous `'o'clock'`.
+    ///
+    /// A unit test because `header_name` is `pub(crate)` and a synthetic
+    /// literal cannot be reached through `parse` -- everything parsed carries
+    /// a style. The parsed cases live in
+    /// `tests/literal_quote_style_test.rs`.
+    #[test]
+    fn a_synthetic_literal_header_uses_the_fallback_rule() {
+        let name = |s: &str| header_name(&Expr::string(s));
+        assert_eq!(name("plain"), "'plain'");
+        assert_eq!(name("o'clock"), "\"o'clock\"");
+        // Both kinds present: single quotes, as before #2176.
+        assert_eq!(name("both'and\""), "'both'and\"'");
+    }
+
+    /// The parsed counterpart, so the two rules are visible side by side.
+    #[test]
+    fn a_parsed_literal_header_echoes_its_quote() {
+        let single = Expr::Literal(Literal::String(QuotedString::parsed(
+            "x".to_string(),
+            QuoteStyle::Single,
+        )));
+        let double = Expr::Literal(Literal::String(QuotedString::parsed(
+            "x".to_string(),
+            QuoteStyle::Double,
+        )));
+        assert_eq!(header_name(&single), "'x'");
+        assert_eq!(header_name(&double), "\"x\"");
+    }
+
     #[test]
     fn test_literal_display() {
-        assert_eq!(Literal::String("test".to_string()).to_string(), "\"test\"");
+        assert_eq!(
+            Literal::String(QuotedString::synthetic("test")).to_string(),
+            "\"test\"",
+            "a literal with no source style falls back to double quotes"
+        );
         assert_eq!(Literal::Number(dec!(1.5)).to_string(), "1.5");
         assert_eq!(Literal::Integer(42).to_string(), "42");
         assert_eq!(Literal::Boolean(false).to_string(), "false");

--- a/crates/rustledger-query/src/executor/dual_eval_parity.rs
+++ b/crates/rustledger-query/src/executor/dual_eval_parity.rs
@@ -17,7 +17,7 @@
 
 use super::Executor;
 use super::types::{PostingContext, Value};
-use crate::ast::{Expr, FunctionCall, Literal};
+use crate::ast::{Expr, FunctionCall, Literal, QuotedString};
 use crate::error::QueryError;
 use rust_decimal_macros::dec;
 use rustledger_core::{Amount, Directive, Posting, Transaction, naive_date};
@@ -40,7 +40,7 @@ fn scratch_txn() -> Transaction {
 /// …) — those functions are out of scope for this literal-driven harness.
 fn value_as_literal(v: &Value) -> Option<Expr> {
     Some(match v {
-        Value::String(s) => Expr::Literal(Literal::String(s.clone())),
+        Value::String(s) => Expr::Literal(Literal::String(QuotedString::synthetic(s.clone()))),
         Value::Number(n) => Expr::Literal(Literal::Number(*n)),
         Value::Integer(i) => Expr::Literal(Literal::Integer(*i)),
         Value::Date(d) => Expr::Literal(Literal::Date(*d)),

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -28,7 +28,7 @@ impl Executor<'_> {
                         ));
                     }
                     let pattern = match &func.args[0] {
-                        Expr::Literal(Literal::String(s)) => s.clone(),
+                        Expr::Literal(Literal::String(s)) => s.value().to_string(),
                         Expr::Column(s) => s.clone(),
                         _ => {
                             return Err(QueryError::Type(
@@ -525,7 +525,7 @@ impl Executor<'_> {
     /// Evaluate a literal.
     pub(super) fn evaluate_literal(&self, lit: &Literal) -> Result<Value, QueryError> {
         Ok(match lit {
-            Literal::String(s) => Value::String(s.clone()),
+            Literal::String(s) => Value::String(s.value().to_string()),
             Literal::Number(n) => Value::Number(*n),
             Literal::Integer(i) => Value::Integer(*i),
             Literal::Date(d) => Value::Date(*d),

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 
 use crate::ast::{
     BalancesQuery, BinaryOperator, ColumnDef, CreateTableStmt, Expr, FromClause, FunctionCall,
-    InsertSource, InsertStmt, JournalQuery, Literal, OrderSpec, PrintQuery, Query, SelectQuery,
-    SortDirection, Target, UnaryOperator, WindowFunction, WindowSpec,
+    InsertSource, InsertStmt, JournalQuery, Literal, OrderSpec, PrintQuery, Query, QuoteStyle,
+    QuotedString, SelectQuery, SortDirection, Target, UnaryOperator, WindowFunction, WindowSpec,
 };
 use crate::error::{ParseError, ParseErrorKind};
 use rustledger_core::NaiveDate;
@@ -1067,7 +1067,7 @@ fn literal<'a>() -> impl Parser<'a, ParserInput<'a>, Literal, ParserExtra<'a>> +
         // Number — Integer if no decimal point, Number otherwise
         number_literal(),
         // String
-        string_literal().map(Literal::String),
+        quoted_string_literal().map(Literal::String),
     ))
 }
 
@@ -1104,9 +1104,12 @@ fn table_identifier<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtr
 /// string continue past a quote but is kept VERBATIM — upstream's own
 /// `parser_test.py` pins `'rainy''day'` -> `rainy''day`. Double-quoted
 /// strings have no escapes at all and end at the first `"`.
-fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>> + Clone {
-    // Double-quoted string: body is everything up to the first `"`,
-    // captured as one input slice like the single-quoted arm.
+/// [`string_literal`] keeping the quote character the source used.
+///
+/// Only the literal-expression site needs the style -- headers echo it
+/// (#2176) -- so the other callers stay on the plain-`String` wrapper below.
+fn quoted_string_literal<'a>()
+-> impl Parser<'a, ParserInput<'a>, QuotedString, ParserExtra<'a>> + Clone {
     let double_quoted = just('"')
         .ignore_then(
             none_of("\"")
@@ -1115,12 +1118,9 @@ fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<
                 .to_slice()
                 .map(ToString::to_string),
         )
-        .then_ignore(just('"'));
+        .then_ignore(just('"'))
+        .map(|v| QuotedString::parsed(v, QuoteStyle::Double));
 
-    // Single-quoted string (SQL-style): `''` continues the string (and
-    // stays as-is in the value); anything else ends at the first `'`.
-    // The body is captured as one input slice (`to_slice`) — the value
-    // is verbatim anyway, so no per-piece assembly is needed.
     let single_quoted = just('\'')
         .ignore_then(
             just("''")
@@ -1130,9 +1130,22 @@ fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<
                 .to_slice()
                 .map(ToString::to_string),
         )
-        .then_ignore(just('\''));
+        .then_ignore(just('\''))
+        .map(|v| QuotedString::parsed(v, QuoteStyle::Single));
 
     choice((double_quoted, single_quoted))
+}
+
+fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>> + Clone {
+    // Delegates so there is ONE grammar for a string literal. The two arms
+    // were duplicated here and in `quoted_string_literal`; a fix applied to
+    // one and not the other would make a literal parse differently depending
+    // on which caller reached it.
+    //
+    // Double-quoted: body is everything up to the first `"`. Single-quoted
+    // (SQL-style): `''` continues the string and stays as-is in the value;
+    // anything else ends at the first `'`.
+    quoted_string_literal().map(|q| q.value().to_string())
 }
 
 /// Parse a date literal (YYYY-MM-DD).
@@ -1895,7 +1908,9 @@ mod tests {
             Query::Select(sel) => match &sel.targets[0].expr {
                 Expr::Function(f) => {
                     assert_eq!(f.name, "foo");
-                    assert!(matches!(&f.args[0], Expr::Literal(Literal::String(s)) if s == "bar"));
+                    assert!(
+                        matches!(&f.args[0], Expr::Literal(Literal::String(s)) if s.value() == "bar")
+                    );
                 }
                 _ => panic!("Expected function"),
             },
@@ -1912,7 +1927,7 @@ mod tests {
                     assert_eq!(f.name.to_uppercase(), "META");
                     assert_eq!(f.args.len(), 1);
                     assert!(
-                        matches!(&f.args[0], Expr::Literal(Literal::String(s)) if s == "category")
+                        matches!(&f.args[0], Expr::Literal(Literal::String(s)) if s.value() == "category")
                     );
                 }
                 _ => panic!("Expected function"),

--- a/crates/rustledger-query/tests/literal_quote_style_test.rs
+++ b/crates/rustledger-query/tests/literal_quote_style_test.rs
@@ -1,0 +1,166 @@
+//! Regression: a string-literal header echoes the quote the query wrote
+//! (#2176).
+//!
+//! bean-query names such a column by reproducing the literal as typed, quote
+//! character included. Measured against beanquery 0.2.0:
+//!
+//! ```text
+//! SELECT 'plain'    ->  'plain'
+//! SELECT "dq"       ->  "dq"
+//! SELECT "o'clock"  ->  "o'clock"
+//! SELECT 'it''s'    ->  'it''s'
+//! ```
+//!
+//! We rendered every literal single-quoted unless it contained a single
+//! quote, so `"dq"` headed `'dq'`. `Literal::String` now carries the source
+//! quote (`QuotedString`) instead of the header guessing one.
+//!
+//! The body is reproduced VERBATIM, matching bean-query: `'it''s'` heads
+//! `'it''s'`, the doubled quote left as written rather than re-escaped or
+//! collapsed. That is consistent with the value semantics pinned in
+//! `string_literal_escapes_test.rs`, where `''` stays in the value.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::ast::{Expr, Literal, QuoteStyle, QuotedString};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn ledger() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2026, 7, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2026, 7, 1), "Expenses:X")),
+        Directive::Transaction(
+            Transaction::new(date(2026, 7, 1), "t")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+                .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD"))),
+        ),
+    ]
+}
+
+/// The column NAME the executor reports for `SELECT <expr>`.
+fn header(expr: &str) -> String {
+    let dirs = ledger();
+    let q = parse(&format!("SELECT {expr} LIMIT 1")).expect("parse");
+    let mut ex = Executor::new(&dirs);
+    ex.execute(&q).expect("execute").columns[0].clone()
+}
+
+fn value(expr: &str) -> Value {
+    let dirs = ledger();
+    let q = parse(&format!("SELECT {expr} LIMIT 1")).expect("parse");
+    let mut ex = Executor::new(&dirs);
+    ex.execute(&q).expect("execute").rows[0][0].clone()
+}
+
+/// Both quote characters, each echoed. The double-quoted case is the one that
+/// was wrong; the single-quoted case is included so a fix that simply flipped
+/// the default cannot pass.
+#[test]
+fn a_header_echoes_the_source_quote() {
+    assert_eq!(header("'plain'"), "'plain'");
+    assert_eq!(header("\"dq\""), "\"dq\"");
+}
+
+/// A quote of the OTHER kind inside the body does not change the choice: the
+/// source style still wins, and the body is copied through.
+#[test]
+fn the_body_is_reproduced_verbatim() {
+    assert_eq!(header("\"o'clock\""), "\"o'clock\"");
+    assert_eq!(header("'say \"hi\"'"), "'say \"hi\"'");
+    // `''` continues a single-quoted string and stays in the value, so it
+    // stays in the header too -- bean-query prints `'it''s'`.
+    assert_eq!(header("'it''s'"), "'it''s'");
+    assert_eq!(value("'it''s'"), Value::String("it''s".into()));
+}
+
+/// Nested literals are named the same way, since `header_fragment` recurses.
+#[test]
+fn a_literal_inside_a_call_keeps_its_quote() {
+    assert_eq!(header("length('abc')"), "length('abc')");
+    assert_eq!(header("length(\"abc\")"), "length(\"abc\")");
+}
+
+/// Quote style is source provenance, NOT part of the value. Two literals
+/// spelling the same text must compare and hash alike, or query equality
+/// would depend on typing style.
+#[test]
+fn quote_style_does_not_affect_equality() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let single = QuotedString::parsed("x".to_string(), QuoteStyle::Single);
+    let double = QuotedString::parsed("x".to_string(), QuoteStyle::Double);
+    let none = QuotedString::synthetic("x");
+
+    assert_eq!(single, double, "'x' and \"x\" are the same string");
+    assert_eq!(single, none, "and so is one built in code");
+    assert_eq!(
+        Literal::String(single.clone()),
+        Literal::String(double.clone()),
+        "the enum around them agrees",
+    );
+
+    let hash = |q: &QuotedString| {
+        let mut h = DefaultHasher::new();
+        q.hash(&mut h);
+        h.finish()
+    };
+    assert_eq!(
+        hash(&single),
+        hash(&double),
+        "Hash must agree with Eq, or a HashMap keyed on literals splits",
+    );
+
+    // The styles are still distinguishable where it matters.
+    assert_eq!(single.quote(), Some(QuoteStyle::Single));
+    assert_eq!(double.quote(), Some(QuoteStyle::Double));
+    assert_eq!(
+        none.quote(),
+        None,
+        "a synthetic literal has no source style"
+    );
+}
+
+/// `Display` round-trips a parsed literal as written, so re-parsing its output
+/// yields the same value. Double quotes remain the fallback when there is no
+/// source style.
+#[test]
+fn display_round_trips_a_parsed_literal() {
+    for src in [
+        "'plain'",
+        "\"dq\"",
+        "\"o'clock\"",
+        "'say \"hi\"'",
+        "'it''s'",
+    ] {
+        let q = parse(&format!("SELECT {src} LIMIT 1")).expect("parse");
+        let rendered = format!("{}", first_target(&q));
+        assert_eq!(
+            rendered, src,
+            "Display must reproduce the literal as written",
+        );
+        assert_eq!(
+            value(&rendered),
+            value(src),
+            "and re-parsing it must yield the same value",
+        );
+    }
+
+    assert_eq!(
+        Literal::String(QuotedString::synthetic("test")).to_string(),
+        "\"test\"",
+        "no source style falls back to double quotes",
+    );
+}
+
+/// The first target expression of a parsed `SELECT`.
+fn first_target(q: &rustledger_query::ast::Query) -> &Expr {
+    match q {
+        rustledger_query::ast::Query::Select(s) => &s.targets[0].expr,
+        _ => panic!("expected a SELECT"),
+    }
+}


### PR DESCRIPTION
`SELECT "dq"` headed `'dq'`. bean-query names such a column by reproducing the literal as typed, quote character included. Closes #2176.

`Literal::String` did not record which quote the source used, so the header had to guess — single quotes unless the value contained one. It now carries a `QuotedString`, and the header echoes what was written. Verified against beanquery 0.2.0:

| query | bean-query | before | after |
|---|---|---|---|
| `SELECT 'plain'` | `'plain'` | `'plain'` | `'plain'` |
| `SELECT "dq"` | `"dq"` | `'dq'` | `"dq"` |
| `SELECT "o'clock"` | `"o'clock"` | `"o'clock"` | `"o'clock"` |
| `SELECT 'it''s'` | `'it''s'` | `"it''s"` | `'it''s'` |
| `SELECT 'say "hi"'` | `'say "hi"'` | `'say "hi"'` | `'say "hi"'` |
| `SELECT length('abc')` | `length('abc')` | `length('abc')` | `length('abc')` |

The body is reproduced **verbatim**, as bean-query does: `'it''s'` heads `'it''s'`, the doubled quote left as written rather than re-escaped or collapsed. That is consistent with the value semantics already pinned in `string_literal_escapes_test.rs`, where `''` stays in the value.

## Provenance is not part of the value

`QuotedString` implements `PartialEq` and `Hash` on the text alone. `'x'` and `"x"` are the same string, and AST equality must not depend on typing style — same reasoning as `Spanned`, which keeps equality on its value rather than its span. The test pins the Hash/Eq agreement too, since a `HashMap` keyed on literals would split otherwise.

`quote` is `None` for a literal built in code rather than parsed, which has no style to echo. Those keep the #2175 fallback (single quotes, switching to double when the value contains a single quote and no double), so that fix is untouched and still covered.

`Display` echoes the source quote as well, which makes a parsed literal round-trip as written — the issue notes this may matter more than the header does — and still falls back to double quotes when there is no style.

## Parser

`string_literal` now delegates to the new `quoted_string_literal` rather than restating the grammar. Writing the style-carrying version alongside the old one would have duplicated both quote arms, and a fix applied to one and not the other would make a literal parse differently depending on which caller reached it. Two callers want only the text and stay on the plain wrapper.

## Verification

Header and `Display` are separately controlled: making either ignore the recorded style fails tests (3 integration + 1 unit for the header, 1 for `Display`), and the equality test fails if `PartialEq` starts comparing the style. The fallback rule has its own unit test, placed there because `header_name` is `pub(crate)` and a synthetic literal cannot be reached through `parse` — everything parsed carries a style.

4703 workspace tests green, clippy clean on 1.97.0, typos clean. BQL compat harness over 71 files / 1349 runs: no regression against baseline. The corpus does not exercise string-literal targets, so the oracle comparisons above are what carries this.