### PR TITLE
fix(plugin): metadata reaches the wire sorted by key

### DIFF
--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -12,6 +12,30 @@ use crate::types::{
     PriceData, QueryData, SourceSpan, TransactionData,
 };
 
+/// A directive's metadata as the wire's ordered `Vec`, sorted by key.
+///
+/// [`Metadata`](rustledger_core::Metadata) is an `FxHashMap`, so iterating it
+/// yields no particular order -- while the wire type is a `Vec`, whose
+/// equality and encoding ARE ordered. Collecting the map directly therefore
+/// made the wire representation depend on the order keys happened to be
+/// inserted in: two directives with identical metadata could serialize to
+/// different bytes and compare unequal.
+///
+/// Sorting by key costs nothing that could be preserved -- a hash map holds no
+/// authored ordering to begin with -- and buys a deterministic encoding, so
+/// equal metadata is equal on the wire.
+///
+/// Keys are unique (map keys), so `sort_by` on the key alone is a total order
+/// and the sort is not merely stable-by-luck.
+fn meta_to_data(meta: &rustledger_core::Metadata) -> Vec<(String, MetaValueData)> {
+    let mut pairs: Vec<(String, MetaValueData)> = meta
+        .iter()
+        .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
+        .collect();
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    pairs
+}
+
 pub(super) fn transaction_to_data(txn: &Transaction) -> TransactionData {
     TransactionData {
         flag: txn.flag.to_string(),
@@ -19,11 +43,7 @@ pub(super) fn transaction_to_data(txn: &Transaction) -> TransactionData {
         narration: txn.narration.to_string(),
         tags: txn.tags.iter().map(ToString::to_string).collect(),
         links: txn.links.iter().map(ToString::to_string).collect(),
-        metadata: txn
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&txn.meta),
         postings: txn.postings.iter().map(spanned_posting_to_data).collect(),
     }
 }
@@ -53,11 +73,7 @@ pub(super) fn posting_to_data(posting: &Posting) -> PostingData {
         cost: posting.cost.as_deref().map(cost_to_data),
         price: posting.price.as_deref().map(price_annotation_to_data),
         flag: posting.flag.map(|c| c.to_string()),
-        metadata: posting
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&posting.meta),
         span: None,
     }
 }
@@ -161,11 +177,7 @@ pub(super) fn balance_to_data(bal: &Balance) -> BalanceData {
         account: bal.account.to_string(),
         amount: amount_to_data(&bal.amount),
         tolerance: bal.tolerance.map(|t| t.to_string()),
-        metadata: bal
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&bal.meta),
     }
 }
 
@@ -174,33 +186,21 @@ pub(super) fn open_to_data(open: &Open) -> OpenData {
         account: open.account.to_string(),
         currencies: open.currencies.iter().map(ToString::to_string).collect(),
         booking: open.booking.clone(),
-        metadata: open
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&open.meta),
     }
 }
 
 pub(super) fn close_to_data(close: &Close) -> CloseData {
     CloseData {
         account: close.account.to_string(),
-        metadata: close
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&close.meta),
     }
 }
 
 pub(super) fn commodity_to_data(comm: &Commodity) -> CommodityData {
     CommodityData {
         currency: comm.currency.to_string(),
-        metadata: comm
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&comm.meta),
     }
 }
 
@@ -208,11 +208,7 @@ pub(super) fn pad_to_data(pad: &Pad) -> PadData {
     PadData {
         account: pad.account.to_string(),
         source_account: pad.source_account.to_string(),
-        metadata: pad
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&pad.meta),
     }
 }
 
@@ -220,11 +216,7 @@ pub(super) fn event_to_data(event: &Event) -> EventData {
     EventData {
         event_type: event.event_type.clone(),
         value: event.value.clone(),
-        metadata: event
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&event.meta),
     }
 }
 
@@ -232,11 +224,7 @@ pub(super) fn note_to_data(note: &Note) -> NoteData {
     NoteData {
         account: note.account.to_string(),
         comment: note.comment.clone(),
-        metadata: note
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&note.meta),
     }
 }
 
@@ -246,11 +234,7 @@ pub(super) fn document_to_data(doc: &Document) -> DocumentData {
         path: doc.path.clone(),
         tags: doc.tags.iter().map(ToString::to_string).collect(),
         links: doc.links.iter().map(ToString::to_string).collect(),
-        metadata: doc
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&doc.meta),
     }
 }
 
@@ -258,11 +242,7 @@ pub(super) fn price_to_data(price: &Price) -> PriceData {
     PriceData {
         currency: price.currency.to_string(),
         amount: amount_to_data(&price.amount),
-        metadata: price
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&price.meta),
     }
 }
 
@@ -270,11 +250,7 @@ pub(super) fn query_to_data(query: &Query) -> QueryData {
     QueryData {
         name: query.name.clone(),
         query: query.query.clone(),
-        metadata: query
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&query.meta),
     }
 }
 
@@ -282,10 +258,6 @@ pub(super) fn custom_to_data(custom: &Custom) -> CustomData {
     CustomData {
         custom_type: custom.custom_type.clone(),
         values: custom.values.iter().map(meta_value_to_data).collect(),
-        metadata: custom
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), meta_value_to_data(v)))
-            .collect(),
+        metadata: meta_to_data(&custom.meta),
     }
 }

--- a/crates/rustledger-plugin/tests/metadata_wire_order_test.rs
+++ b/crates/rustledger-plugin/tests/metadata_wire_order_test.rs
@@ -1,0 +1,104 @@
+//! Metadata reaches the plugin wire sorted by key, so identical metadata has
+//! one representation.
+//!
+//! `Metadata` is an `FxHashMap`, but the wire type is a `Vec<(String,
+//! MetaValueData)>` whose equality and `MessagePack` encoding are ordered.
+//! Collecting the map directly made the wire depend on insertion order: two
+//! directives carrying the same metadata could encode to different bytes.
+//!
+//! Found reviewing #2226, which adds `PartialEq` to these types — that is what
+//! turned a latent nondeterminism into a visible one, since two equal
+//! directives could then compare unequal. `FxHash` is not randomized, so this
+//! was never run-to-run flakiness; it was silently reproducible, which reads
+//! as a real difference rather than an artifact.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, MetaValue, NaiveDate, Open, Posting, Transaction};
+use rustledger_plugin::convert::directive_to_wrapper;
+use rustledger_plugin::types::{DirectiveData, DirectiveWrapper};
+
+fn date() -> NaiveDate {
+    rustledger_core::naive_date(2024, 1, 1).unwrap()
+}
+
+const KEYS: [&str; 6] = ["epsilon", "zeta", "delta", "alpha", "gamma", "beta"];
+
+fn open_with(order: &[&str]) -> Directive {
+    let mut o = Open::new(date(), "Assets:Bank");
+    for k in order {
+        o.meta
+            .insert((*k).to_string(), MetaValue::String((*k).to_string()));
+    }
+    Directive::Open(o)
+}
+
+fn meta_keys(w: &DirectiveWrapper) -> Vec<String> {
+    match &w.data {
+        DirectiveData::Open(o) => o.metadata.iter().map(|(k, _)| k.clone()).collect(),
+        _ => panic!("expected an Open"),
+    }
+}
+
+/// Insertion order must not survive into the wire.
+#[test]
+fn metadata_reaches_the_wire_sorted_by_key() {
+    let forward = directive_to_wrapper(&open_with(&KEYS));
+    let mut reversed = KEYS;
+    reversed.reverse();
+    let backward = directive_to_wrapper(&open_with(&reversed));
+
+    let sorted = {
+        let mut k: Vec<String> = KEYS.iter().map(|s| (*s).to_string()).collect();
+        k.sort();
+        k
+    };
+    assert_eq!(meta_keys(&forward), sorted, "keys must arrive sorted");
+    assert_eq!(
+        meta_keys(&forward),
+        meta_keys(&backward),
+        "insertion order must not reach the wire",
+    );
+}
+
+/// The encoded bytes must match too — the `Vec` order is what `MessagePack`
+/// writes, so an unsorted wire made identical metadata encode differently.
+/// Asserting on the keys alone would not catch a change that reordered the
+/// values against them.
+#[test]
+fn identical_metadata_encodes_to_identical_bytes() {
+    let forward = directive_to_wrapper(&open_with(&KEYS));
+    let mut reversed = KEYS;
+    reversed.reverse();
+    let backward = directive_to_wrapper(&open_with(&reversed));
+
+    let a = rmp_serde::to_vec(&forward).expect("encode");
+    let b = rmp_serde::to_vec(&backward).expect("encode");
+    assert_eq!(a, b, "equal metadata must encode to equal bytes");
+}
+
+/// Posting metadata goes through the same helper. Postings are converted by a
+/// different function from directives, and the two once held separate copies
+/// of this expression.
+#[test]
+fn posting_metadata_is_sorted_too() {
+    let mut posting = Posting::new("Assets:Bank", Amount::new(dec!(1), "USD"));
+    for k in KEYS.iter().rev() {
+        posting
+            .meta
+            .insert((*k).to_string(), MetaValue::String((*k).to_string()));
+    }
+    let txn = Transaction::new(date(), "t").with_synthesized_posting(posting);
+    let wrapper = directive_to_wrapper(&Directive::Transaction(txn));
+
+    let DirectiveData::Transaction(t) = &wrapper.data else {
+        panic!("expected a Transaction");
+    };
+    let keys: Vec<String> = t.postings[0]
+        .metadata
+        .iter()
+        .map(|(k, _)| k.clone())
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "posting metadata must be sorted as well");
+}


### PR DESCRIPTION
`Metadata` is an `FxHashMap`, but the plugin wire type is a `Vec<(String, MetaValueData)>` whose equality and MessagePack encoding are ordered. All 13 conversion sites collected the map directly, so the wire representation depended on the order keys happened to be inserted in — two directives carrying identical metadata could encode to different bytes.

Found reviewing #2226, which adds `PartialEq` to these types. That is what turns this from latent to visible: with equality defined, two directives with the same metadata in a different insertion order compare unequal. Through the real `directive_to_wrapper` path, the same six keys inserted forwards and backwards:

```
order-a: ["epsilon", "zeta", "delta", "alpha", "gamma", "beta"]
order-b: ["beta", "alpha", "delta", "gamma", "zeta", "epsilon"]
equal:   false
```

`FxHash` is not randomized, so this was never run-to-run flakiness. It was silently reproducible, which is worse in one way — it reads as a real difference rather than an artifact.

## Why sorting is free here

A hash map holds no authored ordering, so there is no file order being lost: the previous order was an artifact of hashing, not information. Sorting replaces an arbitrary order with a deterministic one and buys a stable encoding. No plugin could have depended on the old order, because it was not predictable.

## One helper instead of thirteen

The same expression was written out 13 times. It is now a single `meta_to_data`. Postings convert through a different function from directives and held their own copy — exactly the drift this removes, and the same shape as the three copies of the pad placement rule in #2228.

## Tests

Three, each failing with the sort removed:

- keys arrive sorted, and insertion order does not reach the wire
- **the encoded bytes match** — the `Vec` order is what MessagePack writes, and asserting on keys alone would miss a change that reordered values against them
- the posting path separately, since it is the second conversion function

4706 workspace tests green, clippy clean on 1.97.0, typos clean.

Does not close #2226; it removes one of the three findings blocking it.