### PR TITLE
fix(query): PIVOT BY names its columns the way bean-query does

### DIFF
--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -254,23 +254,47 @@ impl Executor<'_> {
 
         // Build new column names. Layout: [key_col, <value_col × pivot_value>...].
         //
-        // Single-value-column case (the typical SUM(number) shape) gets
-        // just the pivot value as the header — matches bean-query
-        // exactly. Multi-value-column case qualifies with the value
-        // column name (`<value_col> / <pivot_value>`) so the headers
-        // stay unambiguous when there's more than one aggregate. The
-        // asymmetry is deliberate: a single-aggregate header like
-        // `USD` is what users expect from the typical pivot.
+        // Naming follows bean-query's `EvalPivot` (`query_compile.py`), which
+        // sets these names in the EVALUATOR and exposes them through its API —
+        // they are part of the result's structure, not something its renderer
+        // decorates. That is why this one is matched where the `BALANCES` /
+        // `JOURNAL` names (#2221) and the inventory slot layout (#2222) are
+        // deliberately not: those are a name-less query template and a column
+        // renderer respectively, so reproducing them would mean reproducing an
+        // artifact.
+        //
+        // Each of the three parts is also the better answer on its own terms
+        // (#2217):
+        //
+        // * The key column is `<key>/<spread>`, e.g. `account/year`. The
+        //   pivot key genuinely spans two source columns; naming it after
+        //   only the first drops the spread column's name.
+        // * A value column is `<pivot_value>/<value_col>`, e.g.
+        //   `2024/sum(number)`. Columns are emitted grouped by pivot value
+        //   (the loop below is pivot-value-outer, matching bean-query's
+        //   `product(keys, other(columns))`), so leading with the pivot value
+        //   is what the column ORDER already does. Naming it the other way
+        //   round described the layout backwards.
+        // * No spaces around the separator.
+        //
+        // Single-value-column case (the typical SUM(number) shape) keeps just
+        // the pivot value as the header, which bean-query also does — its
+        // `nother > 1` branch is the only one that qualifies with a column
+        // name. A single-aggregate header like `USD` is what users expect
+        // from the typical pivot, and both tools agree on it.
         let mut new_columns: Vec<String> =
             Vec::with_capacity(1 + value_col_idxs.len() * pivot_values.len());
-        new_columns.push(result.columns[key_col_idx].clone());
+        new_columns.push(format!(
+            "{}/{}",
+            result.columns[key_col_idx], result.columns[pivot_value_col_idx]
+        ));
         for pv in &pivot_values {
             let pv_str = Self::value_to_string(pv);
             if value_col_idxs.len() == 1 {
                 new_columns.push(pv_str);
             } else {
                 for &vci in &value_col_idxs {
-                    new_columns.push(format!("{} / {pv_str}", result.columns[vci]));
+                    new_columns.push(format!("{pv_str}/{}", result.columns[vci]));
                 }
             }
         }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -2128,7 +2128,10 @@ fn test_pivot_by_multi_value_column_qualifies_headers() {
         &directives,
     );
 
-    // Expected layout: key + (<ccy>/SUM, <ccy>/COUNT) per pivot value.
+    // `PIVOT BY currency, account`, so `currency` is the KEY and `account` is
+    // the spread -- the pivot values are account names, not currencies.
+    // Expected layout: a `currency/account` key column, then
+    // (<account>/SUM(number), <account>/COUNT(*)) per account.
     let columns_joined = result.columns.join(",");
     assert!(
         result.columns.iter().any(|c| c.contains('/')),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -2056,7 +2056,8 @@ fn test_pivot_by_with_order_by_works() {
     // the test would have passed even if PIVOT didn't run at all).
     //
     // Post-PIVOT shape proof:
-    //   1. The `account` key column survives.
+    //   1. The `account` key column survives, named `account/currency`
+    //      since #2217.
     //   2. At least one pivoted currency column appears (USD per
     //      the test fixture). If PIVOT didn't run, the column list
     //      would be `[account, currency, SUM(number)]` — no USD.
@@ -2065,9 +2066,10 @@ fn test_pivot_by_with_order_by_works() {
     //      column would still be there.
     //   4. The original `SUM(number)` value column is also gone —
     //      its values moved into the pivoted cells. (Same logic.)
-    assert!(
-        result.columns.iter().any(|c| c == "account"),
-        "account column should survive; got: {:?}",
+    assert_eq!(
+        result.columns.first().map(String::as_str),
+        Some("account/currency"),
+        "the account key column should survive as `<key>/<spread>`; got: {:?}",
         result.columns
     );
     assert!(
@@ -2112,9 +2114,13 @@ fn test_pivot_by_without_group_by_clause_rejected() {
 fn test_pivot_by_multi_value_column_qualifies_headers() {
     // When the SELECT has more than one non-pivot non-key column —
     // e.g. SUM and COUNT side-by-side — apply_pivot generalizes by
-    // qualifying the new column headers as `<value_col_name> / <pivot_value>`.
+    // qualifying the new column headers as `<pivot_value>/<value_col_name>`.
     // The single-value-column case (every other PIVOT test) just uses
     // the pivot value alone. This test pins the multi-value branch.
+    //
+    // The pivot value leads, matching both bean-query and our own column
+    // ORDER, which groups by pivot value (#2217). No spaces around the
+    // separator.
     let directives = make_test_directives();
     let result = execute_query(
         "SELECT account, currency, SUM(number), COUNT(*) GROUP BY 1, 2 \
@@ -2122,26 +2128,28 @@ fn test_pivot_by_multi_value_column_qualifies_headers() {
         &directives,
     );
 
-    // Expected layout: account-key + (SUM/<ccy>, COUNT/<ccy>) per pivot value.
+    // Expected layout: key + (<ccy>/SUM, <ccy>/COUNT) per pivot value.
     let columns_joined = result.columns.join(",");
     assert!(
-        result.columns.iter().any(|c| c.contains(" / ")),
+        result.columns.iter().any(|c| c.contains('/')),
         "expected qualified headers in multi-value-column case; got {columns_joined}"
     );
-    // The qualified format is "<value_col_name> / <pivot_value>".
+    // The qualified format is "<pivot_value>/<value_col_name>".
     // A function target is headed by its source text since #2164, so the
-    // qualified headers are `SUM(number) / USD`, not `SUM / USD`.
+    // qualified headers end `/SUM(number)`, not `/SUM`.
     // Both value columns must survive into the output.
     assert!(
-        result
-            .columns
-            .iter()
-            .any(|c| c.starts_with("SUM(number) /")),
+        result.columns.iter().any(|c| c.ends_with("/SUM(number)")),
         "missing SUM-qualified columns in multi-value case; got {columns_joined}"
     );
     assert!(
-        result.columns.iter().any(|c| c.starts_with("COUNT(*) /")),
+        result.columns.iter().any(|c| c.ends_with("/COUNT(*)")),
         "missing COUNT-qualified columns in multi-value case; got {columns_joined}"
+    );
+    // The separator carries no spaces, and the value column never leads.
+    assert!(
+        !columns_joined.contains(" / ") && !columns_joined.contains("SUM(number)/"),
+        "value column must not lead, and no spaces around `/`; got {columns_joined}"
     );
 }
 
@@ -2161,10 +2169,12 @@ fn test_pivot_by_empty_result_yields_key_column_no_rows() {
     );
     assert!(result.rows.is_empty(), "expected no data rows");
     // The key column is the only one preserved when pivot_values is
-    // empty (no rows → no distinct pivot values).
+    // empty (no rows → no distinct pivot values). It still carries the
+    // `<key>/<spread>` name (#2217): the spread column's name is known from
+    // the query even when no values were found to spread.
     assert_eq!(
         result.columns,
-        vec!["account".to_string()],
+        vec!["account/currency".to_string()],
         "empty PIVOT should yield only the key column header"
     );
 }
@@ -11236,7 +11246,9 @@ fn test_pivot_by_first_column_is_the_row_key() {
         &directives,
     );
     // First column is the `account` row key; currency values became columns.
-    assert_eq!(result.columns[0], "account");
+    // Named `<key>/<spread>` since #2217 -- the key spans both source columns
+    // and bean-query names it accordingly.
+    assert_eq!(result.columns[0], "account/currency");
     assert!(
         result.columns.iter().any(|c| c == "USD"),
         "currency value should be a column header; got {:?}",

--- a/crates/rustledger-query/tests/pivot_header_names_test.rs
+++ b/crates/rustledger-query/tests/pivot_header_names_test.rs
@@ -1,0 +1,127 @@
+//! Regression: PIVOT BY names its columns the way bean-query does (#2217).
+//!
+//! Unlike the `BALANCES`/`JOURNAL` names (#2221) and the inventory slot layout
+//! (#2222) -- which are a name-less query template and a column renderer, and
+//! so are deliberately NOT matched -- these names are set in bean-query's
+//! evaluator (`EvalPivot` in `query_compile.py`) and are visible through its
+//! API, not just its CLI:
+//!
+//! ```text
+//! [d[0] for d in conn.execute(q).description]
+//!   -> ['account/year', '2024/sum(number)', '2024/count(number)', ...]
+//! ```
+//!
+//! Each part is also the better answer on its own terms:
+//!
+//! * The key column spans two source columns, so naming it after only the
+//!   first drops the spread column's name.
+//! * Columns are emitted grouped by pivot value, so leading the name with the
+//!   pivot value describes the layout the right way round.
+//! * No spaces around the separator.
+//!
+//! Measured against beanquery 0.2.0.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+/// Two accounts, one posting each, in different years.
+fn ledger() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:A")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:B")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:O")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 6, 1), "a")
+                .with_synthesized_posting(Posting::new("Assets:A", Amount::new(dec!(10), "USD")))
+                .with_synthesized_posting(Posting::new("Equity:O", Amount::new(dec!(-10), "USD"))),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2025, 6, 1), "b")
+                .with_synthesized_posting(Posting::new("Assets:B", Amount::new(dec!(5), "USD")))
+                .with_synthesized_posting(Posting::new("Equity:O", Amount::new(dec!(-5), "USD"))),
+        ),
+    ]
+}
+
+fn columns(q: &str) -> Vec<String> {
+    let dirs = ledger();
+    let query = parse(q).expect("parse");
+    let mut ex = Executor::new(&dirs);
+    ex.execute(&query).expect("execute").columns
+}
+
+/// More than one non-pivot column: every value column is
+/// `<pivot_value>/<column>`, grouped by pivot value.
+///
+/// bean-query's API reports exactly this list for the same query.
+#[test]
+fn multiple_value_columns_lead_with_the_pivot_value() {
+    assert_eq!(
+        columns(
+            "SELECT account, year, sum(number), count(number) FROM #postings \
+             GROUP BY account, year PIVOT BY account, year"
+        ),
+        vec![
+            "account/year",
+            "2024/sum(number)",
+            "2024/count(number)",
+            "2025/sum(number)",
+            "2025/count(number)",
+        ],
+    );
+}
+
+/// Exactly one non-pivot column: bean-query drops the qualification entirely
+/// and heads each column with the bare pivot value. `EvalPivot` only composes
+/// a two-part name in its `nother > 1` branch. We already agreed here before
+/// #2217 -- pinned so the multi-column fix did not collapse the two branches
+/// into one.
+#[test]
+fn a_single_value_column_is_headed_by_the_bare_pivot_value() {
+    assert_eq!(
+        columns(
+            "SELECT account, year, sum(number) FROM #postings \
+             GROUP BY account, year PIVOT BY account, year"
+        ),
+        vec!["account/year", "2024", "2025"],
+    );
+}
+
+/// The key column names BOTH source columns. Asserted separately from the
+/// lists above because it is the one part that was wrong in both branches.
+#[test]
+fn the_key_column_names_the_key_and_the_spread() {
+    for q in [
+        "SELECT account, year, sum(number) FROM #postings \
+         GROUP BY account, year PIVOT BY account, year",
+        "SELECT account, year, sum(number), count(number) FROM #postings \
+         GROUP BY account, year PIVOT BY account, year",
+    ] {
+        assert_eq!(
+            columns(q).first().map(String::as_str),
+            Some("account/year"),
+            "the key column spans both source columns",
+        );
+    }
+}
+
+/// No spaces around the separator, in any branch. Pinned on its own because
+/// the old format differed from bean-query by spacing as well as by order,
+/// and a fix that only reversed the halves would still be wrong.
+#[test]
+fn the_separator_carries_no_spaces() {
+    let all = columns(
+        "SELECT account, year, sum(number), count(number) FROM #postings \
+         GROUP BY account, year PIVOT BY account, year",
+    )
+    .join(",");
+    assert!(
+        !all.contains(" / ") && !all.contains(" /") && !all.contains("/ "),
+        "the separator must be a bare `/`; got {all}",
+    );
+}

--- a/crates/rustledger-query/tests/pivot_with_from_test.rs
+++ b/crates/rustledger-query/tests/pivot_with_from_test.rs
@@ -62,8 +62,9 @@ fn pivot_applies_with_a_from_clause() {
     .expect("pivot with FROM must execute");
     assert_eq!(
         with_from,
-        vec!["account".to_string(), "2024".to_string()],
-        "the spread column's values must become the headers",
+        vec!["account/year".to_string(), "2024".to_string()],
+        "the spread column's values must become the headers, and the key \
+         column is named `<key>/<spread>` (#2217)",
     );
 }
 
@@ -126,8 +127,9 @@ fn an_empty_result_is_pivoted_the_same_way_however_it_emptied() {
     );
     assert_eq!(
         by_where,
-        vec!["account".to_string()],
-        "the pivoted shape: the row key, with no spread values to add",
+        vec!["account/year".to_string()],
+        "the pivoted shape: the row key named `<key>/<spread>` (#2217), with \
+         no spread values to add",
     );
 
     // Without a pivot the same empty query keeps its projected columns, so


### PR DESCRIPTION
Three differences, all in the headers — the rows already agreed. Closes #2217.

| | key column | value columns |
|---|---|---|
| bean-query | `account/year` | `2024/sum(number)`, `2024/count(number)` |
| before | `account` | `sum(number) / 2024`, `count(number) / 2024` |
| after | `account/year` | `2024/sum(number)`, `2024/count(number)` |

## Why this one is matched when #2221 and #2222 are not

Same test in each case: **did upstream choose the result, or is it an artifact?**

- **#2221** (`BALANCES`/`JOURNAL` names) — `transform_journal` parses a SQL string template with no `AS` aliases, so `MAXWIDTH(payee, 48)` falls through to the generic expression-as-name path. Never chosen as a column name.
- **#2222** (inventory slots) — the padded per-currency layout comes from `class InventoryRenderer(ColumnRenderer)`. The API returns a plain `Inventory`, no slots.
- **#2217** (this) — names are built in `EvalPivot.__call__` (`query_compile.py`), in the **evaluator**, and survive to the API:

```python
[d[0] for d in conn.execute(q).description]
# ['account/year', '2024/sum(number)', '2024/count(number)', '2025/sum(number)', '2025/count(number)']
```

Reproducing the first two would mean reproducing an artifact. This one is part of the result's structure.

It is also the better answer on its own terms, which is why it is a fix rather than a concession: the key column genuinely spans two source columns, and columns are emitted **grouped by pivot value** (`product(keys, other(columns))`, and our loop matches) — so leading the name with the pivot value describes the layout the right way round. The old form described it backwards. The spaces were gratuitous.

## A branch the issue did not record

beanquery composes a two-part name only in its `nother > 1` branch. With exactly one non-pivot column it emits the bare pivot value:

```
API: ['account/year', '2024', '2025']
```

We already agreed there — only the key column was wrong. That branch is untouched and now pinned, because a fix that collapsed the two branches would have broken the case that was already right.

## Verification

Both shapes now match bean-query exactly, character for character.

Four new tests, each with a distinct negative control — reverting the key-column name fails 3, reverting the value-column form fails 2, and collapsing the single-column branch fails 1. Separate tests for the key column and for the spacing, because a fix that only reversed the halves would still have been wrong.

Five existing tests pinned the old names; every one was a header assertion with no row change. All updated, and one is now stronger (`columns[0]` compared exactly rather than searched for).

4706 workspace tests green, clippy clean on 1.97.0, typos clean. BQL compat harness over 71 files / 1349 runs: no regression against baseline.