### PR TITLE
fix(query): grouped rows keep first-appearance order on every path

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -87,8 +87,6 @@ impl Executor<'_> {
             || query.group_by.is_some()
             || query.having.is_some();
 
-        // Track whether grouping is applied (explicit or implicit) for fallback sort
-
         if is_aggregate {
             // Determine GROUP BY expressions:
             // - If explicit GROUP BY is provided, use it

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -9,8 +9,7 @@ use rustledger_core::{Amount, Directive, Inventory, NaiveDate, Position};
 const PARALLEL_THRESHOLD: usize = 1000;
 
 use crate::ast::{
-    CreateTableStmt, Expr, InsertSource, InsertStmt, OrderSpec, SelectQuery, SortDirection, Target,
-    UnaryOperator,
+    CreateTableStmt, Expr, InsertSource, InsertStmt, SelectQuery, Target, UnaryOperator,
 };
 use crate::error::QueryError;
 
@@ -89,7 +88,6 @@ impl Executor<'_> {
             || query.having.is_some();
 
         // Track whether grouping is applied (explicit or implicit) for fallback sort
-        let mut has_grouping = false;
 
         if is_aggregate {
             // Determine GROUP BY expressions:
@@ -106,9 +104,6 @@ impl Executor<'_> {
                     Some(implicit)
                 }
             };
-
-            // Track if grouping is applied for deterministic fallback sort
-            has_grouping = group_by_exprs.is_some();
 
             // Group and aggregate
             let grouped = self.group_postings(&postings, group_by_exprs.as_ref())?;
@@ -217,23 +212,25 @@ impl Executor<'_> {
         if let Some(order_by) = &query.order_by {
             let visible_cols = result.columns.len() - num_hidden;
             self.sort_results(&mut result, order_by, visible_cols)?;
-        } else if has_grouping && !result.rows.is_empty() && !result.columns.is_empty() {
-            // When there's GROUP BY (explicit or implicit) but no ORDER BY, sort by
-            // the first column for deterministic output (matches Python beancount behavior).
-            //
-            // `result.columns[0]` is the first VISIBLE select target.
-            // `find_hidden_order_by_targets` appends hidden cols at
-            // positions `targets.len()..`, so position 0 is always
-            // visible. A future refactor that reorders `extended_targets`
-            // would need to revisit this default.
-            let first_col = result.columns[0].clone();
-            let default_order = vec![OrderSpec {
-                expr: Expr::Column(first_col),
-                direction: SortDirection::Asc,
-            }];
-            let visible_cols = result.columns.len() - num_hidden;
-            self.sort_results(&mut result, &default_order, visible_cols)?;
         }
+        // NO fallback sort. Grouped output keeps the order the groups were
+        // first seen in, which is what `group_postings` preserves and what
+        // bean-query does.
+        //
+        // This branch used to sort by the first column when a query grouped
+        // without an ORDER BY, claiming to match Python beancount. It does
+        // not -- verified against beanquery 0.2.0, which returns groups in
+        // first-appearance order for both explicit and implicit GROUP BY:
+        //
+        //   SELECT account, year, sum(number) GROUP BY account, year
+        //     bean-query  Assets:A/2024, Equity:O/2024, Assets:B/2025, ...
+        //     sorted      Assets:A/2024, Assets:B/2025, Equity:O/2024, ...
+        //
+        // The sort also applied HERE and not in the aggregate `FROM` path,
+        // so the same query returned differently-ordered rows depending on
+        // whether the user wrote `FROM #postings` -- and with a LIMIT, that
+        // meant different ROWS (#2235). Insertion order is deterministic on
+        // its own, so nothing is lost by dropping it.
 
         // Remove hidden columns after sorting (BEFORE PIVOT). With this
         // order, PIVOT operates on the visible-only shape and doesn't

--- a/crates/rustledger-query/tests/pivot_pipeline_order_test.rs
+++ b/crates/rustledger-query/tests/pivot_pipeline_order_test.rs
@@ -163,6 +163,12 @@ fn the_no_from_pipeline_orders_and_limits_the_same_way() {
         ("ORDER BY account DESC", ""),
         ("ORDER BY account DESC", "LIMIT 2"),
         ("ORDER BY account ASC", "LIMIT 2"),
+        // No ORDER BY. This case was excluded when the file was written --
+        // the two paths kept DIFFERENT rows under the same limit, because
+        // only one applied a fallback sort by the first column. Fixed in
+        // #2235 by removing that sort, which bean-query does not do either.
+        ("", "LIMIT 2"),
+        ("", ""),
     ] {
         let with_from = run(&query(order_by, limit));
         let without = run(&query_without_from(order_by, limit));
@@ -177,18 +183,11 @@ fn the_no_from_pipeline_orders_and_limits_the_same_way() {
         );
     }
 
-    // Every case above names an ORDER BY on purpose. WITHOUT one the two
-    // paths return DIFFERENT rows for the same LIMIT -- `Assets:A, Equity:O`
-    // with `FROM`, `Assets:A, Assets:B` without -- because they order groups
-    // differently and the limit then keeps different ones. That is a real
-    // inconsistency, pre-existing on main and unrelated to the pipeline
-    // ORDER this file pins, so it is tracked separately rather than asserted
-    // here (#2235); asserting today's answer would pin a bug. The column set does
-    // agree, which is what #2216 pinned, so only the row identity differs.
-    let with_from = run(&query("", "LIMIT 2"));
-    let without = run(&query_without_from("", "LIMIT 2"));
+    // With no ORDER BY at all, grouped rows come back in first-appearance
+    // order -- which is what bean-query returns, and what BOTH paths now do.
     assert_eq!(
-        without.columns, with_from.columns,
-        "the column set must agree even where row identity does not",
+        keys(&run(&query("", ""))),
+        vec!["Assets:A", "Equity:O", "Assets:B"],
+        "grouped rows keep first-appearance order, as bean-query does",
     );
 }


### PR DESCRIPTION
The no-`FROM` path sorted grouped output by the first column when a query had no `ORDER BY`; the aggregate `FROM` path did not. So the same query returned differently-ordered rows depending on whether the user wrote `FROM #postings` — and with a `LIMIT`, that meant different **rows**. Closes #2235.

```
SELECT account, year, sum(number) [FROM #postings]
  GROUP BY account, year PIVOT BY account, year LIMIT 2

with FROM     Assets:A, Equity:O
without FROM  Assets:A, Assets:B
```

## The sort's justification was wrong

Its comment claimed it matched Python beancount "for deterministic output". Verified against beanquery 0.2.0 — it does not. bean-query returns groups in first-appearance order:

```
SELECT account, year, sum(number) GROUP BY account, year
  bean-query  Assets:A/2024, Equity:O/2024, Assets:B/2025, Equity:O/2025
  sorted      Assets:A/2024, Assets:B/2025, Equity:O/2024, Equity:O/2025
```

The `FROM` path already agreed with bean-query, so removing the sort makes the no-`FROM` path agree with **both**. I checked the implicit-`GROUP BY` case separately, since the branch covered that too and fixing one while breaking the other would have been easy — bean-query gives first-appearance order there as well, and gives the *same* answer with and without `FROM`, as it should.

Nothing is lost by dropping it. `group_postings` already returns groups in first-appearance order and posting order is file order, so the output was deterministic without the sort — which was the stated reason for having it.

## Test strengthening

`pivot_pipeline_order_test.rs` (from #2236, merged an hour ago) had to **exclude** the no-`ORDER BY` cases when it was written, because the two paths disagreed there and pinning either answer would have pinned this bug. Those cases are now asserted, along with the bare grouped order against bean-query's.

Negative control: reinstating the fallback sort fails the cross-path test.

4714 workspace tests green, clippy clean on 1.97.0. BQL compat harness over 71 files / 1349 runs: no regression against baseline.