### PR TITLE
feat(query): #balances exposes the checker's discrepancy

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -114,6 +114,30 @@ pub enum ProcessError {
     PluginConversion(String),
 }
 
+/// A balance assertion that FAILED, with the difference the checker computed.
+///
+/// One per failing assertion; a passing one produces no entry. That mirrors
+/// beancount, whose checker sets `diff_amount` only on a failing entry and
+/// leaves it `None` otherwise -- and it is why this cannot be derived from the
+/// directive: a small non-zero difference inside the tolerance is a pass.
+///
+/// Captured during the loader's validation pass for the same reason
+/// [`Ledger::capital_gains`] is: consumers read it rather than re-deriving the
+/// balance, so `rledger check` and `#balances.discrepancy` cannot disagree
+/// (#2180).
+///
+/// Empty when the loader ran without validation, in which case the column
+/// reports NULL rather than a wrong number.
+#[derive(Debug, Clone)]
+pub struct BalanceDiscrepancy {
+    /// The `balance` directive's date.
+    pub date: rustledger_core::NaiveDate,
+    /// The asserted account.
+    pub account: rustledger_core::Account,
+    /// `computed - asserted`, in the asserted currency.
+    pub amount: rustledger_core::Amount,
+}
+
 /// A fully processed ledger.
 ///
 /// This is the result of loading and processing a beancount file,
@@ -158,6 +182,11 @@ pub struct Ledger {
     /// capgains report — read these directly rather than re-booking the stream
     /// and re-deriving them, so they cannot drift from `rledger check`.
     pub capital_gains: Vec<rustledger_booking::CapitalGain>,
+    /// Failing balance assertions and the difference the checker computed,
+    /// one per failure. Empty when the loader ran without validation.
+    ///
+    /// Feeds `#balances.discrepancy` (#2180).
+    pub balance_discrepancies: Vec<BalanceDiscrepancy>,
 }
 
 impl Ledger {
@@ -447,10 +476,11 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     )?;
 
     #[cfg(feature = "validation")]
-    let late_validated =
+    let (late_validated, balance_discrepancies) =
         regular_applied.late_validate(validation_session, today, &raw.source_map, &mut errors);
     #[cfg(not(feature = "validation"))]
-    let late_validated = regular_applied.late_validate(&raw.source_map, &mut errors);
+    let (late_validated, balance_discrepancies) =
+        regular_applied.late_validate(&raw.source_map, &mut errors);
 
     let finalized = late_validated.finalize(failed);
 
@@ -462,6 +492,7 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
         errors,
         display_context: raw.display_context,
         capital_gains,
+        balance_discrepancies,
     })
 }
 
@@ -716,20 +747,40 @@ impl crate::Directives<crate::RegularPluginsApplied> {
         today: rustledger_core::NaiveDate,
         source_map: &SourceMap,
         errors: &mut Vec<LedgerError>,
-    ) -> crate::Directives<crate::LateValidated> {
+    ) -> (
+        crate::Directives<crate::LateValidated>,
+        Vec<BalanceDiscrepancy>,
+    ) {
         // Typestate move: consume `EarlyDone`, drive through `LateDone`
         // to `finalize()`. The compile-time enforcement here is that
         // we cannot call `late_validate` with a fresh `Pending` session
         // (no `From<Pending>` to `EarlyDone`), so the loader caller
         // must have routed the session through `early_validate` first
         // (#1236).
+        let mut discrepancies = Vec::new();
         if let Some(session) = validation_session {
             let (session, phase_errors) = session.run_late_spanned(self.as_slice(), today);
             ledger_errors_extend(errors, phase_errors, source_map);
+            // Harvested BEFORE `finalize()` consumes the session. Only the
+            // failing assertions: a passing one has no discrepancy to report,
+            // which is what beancount's `diff_amount` does too (#2180).
+            discrepancies = session
+                .balance_actuals()
+                .iter()
+                .filter(|a| a.exceeds_tolerance)
+                .map(|a| BalanceDiscrepancy {
+                    date: a.date,
+                    account: a.account.clone(),
+                    amount: rustledger_core::Amount::new(a.diff, a.currency.clone()),
+                })
+                .collect();
             let finalize_errors = session.finalize();
             ledger_errors_extend(errors, finalize_errors, source_map);
         }
-        crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut()))
+        (
+            crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut())),
+            discrepancies,
+        )
     }
 
     #[cfg(not(feature = "validation"))]
@@ -737,9 +788,17 @@ impl crate::Directives<crate::RegularPluginsApplied> {
         mut self,
         source_map: &SourceMap,
         errors: &mut Vec<LedgerError>,
-    ) -> crate::Directives<crate::LateValidated> {
+    ) -> (
+        crate::Directives<crate::LateValidated>,
+        Vec<BalanceDiscrepancy>,
+    ) {
         let _ = (source_map, errors);
-        crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut()))
+        // No validator, so nothing computed the differences. Empty rather
+        // than wrong: `#balances.discrepancy` reports NULL.
+        (
+            crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut())),
+            Vec::new(),
+        )
     }
 }
 

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -136,6 +136,12 @@ pub struct BalanceDiscrepancy {
     pub account: rustledger_core::Account,
     /// `computed - asserted`, in the asserted currency.
     pub amount: rustledger_core::Amount,
+    /// The asserted number, i.e. the directive's own amount.
+    ///
+    /// Part of the identity, not payload: `(date, account, currency)` does not
+    /// distinguish two assertions on the same account and currency on one
+    /// date, and those can assert different amounts and so fail differently.
+    pub asserted: rustledger_core::Decimal,
 }
 
 /// A fully processed ledger.
@@ -772,6 +778,7 @@ impl crate::Directives<crate::RegularPluginsApplied> {
                     date: a.date,
                     account: a.account.clone(),
                     amount: rustledger_core::Amount::new(a.diff, a.currency.clone()),
+                    asserted: a.asserted,
                 })
                 .collect();
             let finalize_errors = session.finalize();

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -140,7 +140,13 @@ pub struct Executor<'a> {
     /// In-memory tables created by CREATE TABLE.
     tables: FxHashMap<String, Table>,
     /// The difference the balance checker computed for each FAILING assertion,
-    /// keyed by `(date, account, currency)`. Backs `#balances.discrepancy`.
+    /// keyed by `(date, account, currency, asserted)`. Backs
+    /// `#balances.discrepancy`.
+    ///
+    /// The asserted amount is part of the key because the other three do not
+    /// identify an assertion: a ledger may assert the same account and
+    /// currency twice on one date, and those rows can fail differently.
+    /// Keying without it made both rows report the second one's difference.
     ///
     /// Supplied by the host rather than computed here: the value belongs to
     /// the checker, and re-deriving it in the query layer would be a second
@@ -148,7 +154,15 @@ pub struct Executor<'a> {
     /// decides whether an assertion failed at all. A host that did not
     /// validate supplies nothing, and the column reports NULL rather than a
     /// wrong number (#2180).
-    balance_discrepancies: FxHashMap<(rustledger_core::NaiveDate, String, String), Amount>,
+    balance_discrepancies: FxHashMap<
+        (
+            rustledger_core::NaiveDate,
+            String,
+            String,
+            rustledger_core::Decimal,
+        ),
+        Amount,
+    >,
 }
 
 // Sub-modules for focused functionality
@@ -233,7 +247,7 @@ impl<'a> Executor<'a> {
     }
 
     /// Supply the balance checker's computed differences, one per FAILING
-    /// assertion, keyed by `(date, account, currency)`.
+    /// assertion, keyed by `(date, account, currency, asserted_number)`.
     ///
     /// Backs `#balances.discrepancy`. Pass only failures: a passing assertion
     /// has no discrepancy, and beancount likewise leaves `diff_amount` unset
@@ -242,11 +256,21 @@ impl<'a> Executor<'a> {
     /// schema matching bean-query's rather than a missing column (#2180).
     pub fn set_balance_discrepancies(
         &mut self,
-        discrepancies: impl IntoIterator<Item = (rustledger_core::NaiveDate, String, String, Amount)>,
+        discrepancies: impl IntoIterator<
+            Item = (
+                rustledger_core::NaiveDate,
+                String,
+                String,
+                rustledger_core::Decimal,
+                Amount,
+            ),
+        >,
     ) {
         self.balance_discrepancies = discrepancies
             .into_iter()
-            .map(|(date, account, currency, amount)| ((date, account, currency), amount))
+            .map(|(date, account, currency, asserted, amount)| {
+                ((date, account, currency, asserted), amount)
+            })
             .collect();
     }
 

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -139,6 +139,16 @@ pub struct Executor<'a> {
     source_map: Option<&'a SourceMap>,
     /// In-memory tables created by CREATE TABLE.
     tables: FxHashMap<String, Table>,
+    /// The difference the balance checker computed for each FAILING assertion,
+    /// keyed by `(date, account, currency)`. Backs `#balances.discrepancy`.
+    ///
+    /// Supplied by the host rather than computed here: the value belongs to
+    /// the checker, and re-deriving it in the query layer would be a second
+    /// implementation of balance accumulation AND of the tolerance rule that
+    /// decides whether an assertion failed at all. A host that did not
+    /// validate supplies nothing, and the column reports NULL rather than a
+    /// wrong number (#2180).
+    balance_discrepancies: FxHashMap<(rustledger_core::NaiveDate, String, String), Amount>,
 }
 
 // Sub-modules for focused functionality
@@ -211,6 +221,7 @@ impl<'a> Executor<'a> {
             source_locations: None,
             source_map: None,
             tables: FxHashMap::default(),
+            balance_discrepancies: FxHashMap::default(),
         }
     }
 
@@ -219,6 +230,24 @@ impl<'a> Executor<'a> {
     /// roots the way beanquery does.
     pub fn set_account_types(&mut self, account_types: rustledger_core::AccountTypes) {
         self.account_types = account_types;
+    }
+
+    /// Supply the balance checker's computed differences, one per FAILING
+    /// assertion, keyed by `(date, account, currency)`.
+    ///
+    /// Backs `#balances.discrepancy`. Pass only failures: a passing assertion
+    /// has no discrepancy, and beancount likewise leaves `diff_amount` unset
+    /// there rather than reporting zero. Without this the column is still
+    /// present and reports NULL, so a host that skips validation gets a
+    /// schema matching bean-query's rather than a missing column (#2180).
+    pub fn set_balance_discrepancies(
+        &mut self,
+        discrepancies: impl IntoIterator<Item = (rustledger_core::NaiveDate, String, String, Amount)>,
+    ) {
+        self.balance_discrepancies = discrepancies
+            .into_iter()
+            .map(|(date, account, currency, amount)| ((date, account, currency), amount))
+            .collect();
     }
 
     /// Create a new executor with source location support.
@@ -305,6 +334,7 @@ impl<'a> Executor<'a> {
             source_locations: Some(source_locations),
             source_map: Some(source_map),
             tables: FxHashMap::default(),
+            balance_discrepancies: FxHashMap::default(),
         }
     }
 

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -132,7 +132,12 @@ impl Executor<'_> {
         for (date, account, amount, tolerance, meta) in balances {
             let discrepancy = self
                 .balance_discrepancies
-                .get(&(date, account.to_string(), amount.currency.to_string()))
+                .get(&(
+                    date,
+                    account.to_string(),
+                    amount.currency.to_string(),
+                    amount.number,
+                ))
                 .cloned()
                 .map_or(Value::Null, Value::Amount);
             let row = vec![

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -63,22 +63,31 @@ impl Executor<'_> {
 
     /// Build the #balances table from balance assertion directives.
     ///
-    /// The table has columns: date, account, amount, tolerance, meta
+    /// The table has columns: date, account, amount, tolerance, discrepancy, meta
     /// - date: The date of the balance assertion
     /// - account: The account being balanced
     /// - amount: The expected balance amount
     /// - tolerance: The explicit `~` tolerance, or NULL if none was given
+    /// - discrepancy: `computed − asserted` for a FAILING assertion, else NULL
     /// - meta: The directive's metadata (hidden from `SELECT *`)
     ///
-    /// bean-query also exposes `discrepancy` here. It is not a field of the
-    /// directive — the balance checker computes it — so it is tracked
-    /// separately rather than faked from the data we have (#2180).
+    /// `discrepancy` is not a field of the directive — the balance checker
+    /// computes it — so it comes from the host via
+    /// [`Executor::set_balance_discrepancies`](super::Executor::set_balance_discrepancies)
+    /// rather than being re-derived here (#2180). A host that did not validate
+    /// supplies nothing and every row reports NULL, which keeps the SCHEMA
+    /// matching bean-query's even where the values are unavailable.
+    ///
+    /// NULL on a passing assertion, matching beancount: its checker sets
+    /// `diff_amount` only on a failing entry, so an assertion that is off by
+    /// less than its tolerance reports nothing rather than a small number.
     pub(super) fn build_balances_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
             "account".to_string(),
             "amount".to_string(),
             "tolerance".to_string(),
+            "discrepancy".to_string(),
             "meta".to_string(),
         ];
         let mut table = Table::new(columns).with_hidden(&["meta"]);
@@ -121,11 +130,17 @@ impl Executor<'_> {
         balances.sort_by_key(|(date, ..)| *date);
 
         for (date, account, amount, tolerance, meta) in balances {
+            let discrepancy = self
+                .balance_discrepancies
+                .get(&(date, account.to_string(), amount.currency.to_string()))
+                .cloned()
+                .map_or(Value::Null, Value::Amount);
             let row = vec![
                 Value::Date(date),
                 Value::String(account.to_string()),
                 Value::Amount(amount),
                 tolerance.map_or(Value::Null, Value::Number),
+                discrepancy,
                 Self::metadata_to_value(meta),
             ];
             table.add_row(row);

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6313,12 +6313,24 @@ fn test_balances_table_select_all() {
     let result = execute_query("SELECT * FROM #balances", &directives);
 
     assert_eq!(result.len(), 3);
-    // `tolerance` is in bean-query's wildcard here; `meta` is not. See
-    // select_star_matches_bean_query_per_table for the full per-table pinning.
+    // `tolerance` and `discrepancy` are in bean-query's wildcard here; `meta`
+    // is not. See select_star_matches_bean_query_per_table for the full
+    // per-table pinning.
+    //
+    // `discrepancy` is present even though this executor was built straight
+    // from directives with no checker attached -- it reports NULL. The SCHEMA
+    // does not depend on whether the host validated (#2180).
     assert_eq!(
         result.columns,
-        vec!["date", "account", "amount", "tolerance"]
+        vec!["date", "account", "amount", "tolerance", "discrepancy"]
     );
+    for row in &result.rows {
+        assert_eq!(
+            row[4],
+            rustledger_query::Value::Null,
+            "no checker attached, so every discrepancy is NULL",
+        );
+    }
 }
 
 #[test]
@@ -7271,48 +7283,37 @@ fn select_star_matches_bean_query_per_table() {
     // carry hand-written lists), so a name-based rule gets #commodities
     // silently wrong.
     //
-    // `gap` is the part of bean-query's set we do NOT produce yet. Where it
-    // is None the expectation IS bean-query's set, column for column. Where
-    // it is Some, closing that gap SHOULD fail this test -- the failure means
-    // the table moved toward bean-query, not away, so update the expectation
-    // rather than reverting the work (#2154).
+    // Every expectation here IS bean-query's set, column for column. The list
+    // used to carry a per-table `gap` -- the part of bean-query's set we did
+    // not produce yet -- because a census of all 55 columns across its ten
+    // tables (#2154) found three we could not register. All three are closed:
+    // `#notes.tags`/`.links` needed `Note` to keep them through parsing
+    // (#2160), and `#balances.discrepancy` needed the balance checker's
+    // computed difference plumbed through to the query layer (#2180). With no
+    // gaps left the mechanism is gone; a divergence now means drift, and a
+    // failure here is a regression rather than progress.
     let directives = make_all_directive_types_test_directives();
 
-    for (table, expected, gap) in [
+    for (table, expected) in [
         (
             "#balances",
-            vec!["date", "account", "amount", "tolerance"],
-            Some("discrepancy, which the balance checker computes rather than stores"),
+            vec!["date", "account", "amount", "tolerance", "discrepancy"],
         ),
-        // Full parity since #2160 gave `Note` its tags and links: this row
-        // carried a recorded gap, and closing it is what the gap message told
-        // the next reader to do.
         (
             "#notes",
             vec!["date", "account", "comment", "tags", "links"],
-            None,
         ),
-        ("#events", vec!["date", "type", "description"], None),
+        ("#events", vec!["date", "type", "description"]),
         (
             "#documents",
             vec!["date", "account", "filename", "tags", "links"],
-            None,
         ),
-        ("#commodities", vec!["meta", "date", "name"], None),
+        ("#commodities", vec!["meta", "date", "name"]),
     ] {
         let result = execute_query(&format!("SELECT * FROM {table}"), &directives);
         assert_eq!(
-            result.columns,
-            expected,
-            "{}",
-            gap.map_or_else(
-                || format!("SELECT * FROM {table} drifted from bean-query"),
-                |g| format!(
-                    "SELECT * FROM {table} changed. Note this is NOT full bean-query \
-                     parity: bean-query also returns {g}. If you just added it, update \
-                     this expectation."
-                ),
-            )
+            result.columns, expected,
+            "SELECT * FROM {table} drifted from bean-query"
         );
         assert!(
             !result.rows.is_empty(),

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -309,6 +309,13 @@ pub struct BalanceActual {
     pub account: Account,
     /// The asserted currency.
     pub currency: rustledger_core::Currency,
+    /// The asserted number, i.e. the `balance` directive's own amount.
+    ///
+    /// Recorded so a consumer can tell two assertions apart. `(date, account,
+    /// currency)` is NOT unique -- a ledger may assert the same account and
+    /// currency twice on one date, with different amounts and therefore
+    /// different differences (#2180).
+    pub asserted: rustledger_core::Decimal,
     /// `computed − asserted` in `currency` (zero = exact match).
     pub diff: rustledger_core::Decimal,
     /// Whether `diff` was outside the assertion's tolerance, i.e. whether

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -311,6 +311,16 @@ pub struct BalanceActual {
     pub currency: rustledger_core::Currency,
     /// `computed − asserted` in `currency` (zero = exact match).
     pub diff: rustledger_core::Decimal,
+    /// Whether `diff` was outside the assertion's tolerance, i.e. whether
+    /// this assertion FAILED.
+    ///
+    /// Not derivable from `diff`: a small non-zero difference is a pass when
+    /// it falls within the tolerance, explicit or inferred. Recorded from the
+    /// same comparison that raises the error, so a consumer never re-derives
+    /// the tolerance rule (#2180). `#balances.discrepancy` reports `diff`
+    /// only where this is true, matching beancount's `diff_amount`, which its
+    /// checker sets only on a failing entry.
+    pub exceeds_tolerance: bool,
 }
 
 /// Ledger state for validation.

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -286,23 +286,31 @@ pub fn validate_balance_late(
     let expected = bal.amount.number;
     let difference = (actual - expected).abs();
 
+    // Determine tolerance via the shared helper so out-of-pipeline
+    // consumers (LSP code lens) and the validator stay in lockstep.
+    let is_explicit = bal.tolerance.is_some();
+    let tolerance = balance_tolerance(expected, bal.tolerance, state.options.tolerance_multiplier);
+    let exceeds_tolerance = difference > tolerance;
+
     // Record the computed result so consumers can render per-assertion pass/fail
     // without re-deriving the balance (#1663). `diff` is signed (`computed −
     // asserted`); this is the validator's own `actual`, so the load/validate
     // surfaces can't diverge from the check.
+    //
+    // Recorded AFTER the tolerance is resolved so `exceeds_tolerance` comes
+    // from the same comparison that raises the error below. A consumer that
+    // re-derived "did this fail" from `diff` alone would be a second
+    // implementation of the tolerance rule, and would disagree the moment
+    // either changed (#2180).
     state.balance_actuals.push(crate::BalanceActual {
         date: bal.date,
         account: bal.account.clone(),
         currency: bal.amount.currency.clone(),
         diff: actual - expected,
+        exceeds_tolerance,
     });
 
-    // Determine tolerance via the shared helper so out-of-pipeline
-    // consumers (LSP code lens) and the validator stay in lockstep.
-    let is_explicit = bal.tolerance.is_some();
-    let tolerance = balance_tolerance(expected, bal.tolerance, state.options.tolerance_multiplier);
-
-    if difference > tolerance {
+    if exceeds_tolerance {
         // Use E2002 for explicit tolerance, E2001 for inferred
         let error_code = if is_explicit {
             ErrorCode::BalanceToleranceExceeded

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -306,6 +306,7 @@ pub fn validate_balance_late(
         date: bal.date,
         account: bal.account.clone(),
         currency: bal.amount.currency.clone(),
+        asserted: expected,
         diff: actual - expected,
         exceeds_tolerance,
     });

--- a/crates/rustledger/src/cmd/query/interactive.rs
+++ b/crates/rustledger/src/cmd/query/interactive.rs
@@ -60,6 +60,7 @@ pub(super) fn run_interactive(
         rustledger_core::NaiveDate,
         String,
         String,
+        rustledger_core::Decimal,
         rustledger_core::Amount,
     )],
     args: &Args,

--- a/crates/rustledger/src/cmd/query/interactive.rs
+++ b/crates/rustledger/src/cmd/query/interactive.rs
@@ -53,6 +53,15 @@ pub(super) fn run_interactive(
     source_map: &SourceMap,
     display_context: &DisplayContext,
     account_types: &rustledger_core::AccountTypes,
+    // The balance checker's difference per FAILING assertion, backing
+    // `#balances.discrepancy` (#2180). Computed once for the session, since
+    // the ledger does not change between prompts.
+    balance_discrepancies: &[(
+        rustledger_core::NaiveDate,
+        String,
+        String,
+        rustledger_core::Amount,
+    )],
     args: &Args,
 ) -> Result<()> {
     let mut rl: Editor<(), DefaultHistory> = DefaultEditor::new()?;
@@ -86,8 +95,12 @@ pub(super) fn run_interactive(
     );
     println!();
 
-    let mut settings =
-        ShellSettings::from_args(args, display_context.clone(), account_types.clone());
+    let mut settings = ShellSettings::from_args(
+        args,
+        display_context.clone(),
+        account_types.clone(),
+        balance_discrepancies.to_vec(),
+    );
 
     loop {
         let readline = rl.readline("beanquery> ");

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -243,6 +243,7 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
         rustledger_core::NaiveDate,
         String,
         String,
+        rustledger_core::Decimal,
         rustledger_core::Amount,
     )> = ledger
         .balance_discrepancies
@@ -252,6 +253,7 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
                 d.date,
                 d.account.to_string(),
                 d.amount.currency.to_string(),
+                d.asserted,
                 d.amount.clone(),
             )
         })
@@ -308,6 +310,7 @@ struct ShellSettings {
         rustledger_core::NaiveDate,
         String,
         String,
+        rustledger_core::Decimal,
         rustledger_core::Amount,
     )>,
 }
@@ -321,6 +324,7 @@ impl ShellSettings {
             rustledger_core::NaiveDate,
             String,
             String,
+            rustledger_core::Decimal,
             rustledger_core::Amount,
         )>,
     ) -> Self {

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -153,8 +153,14 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     }
 
     // Load and fully process the file (parse → book → plugins).
+    // Validation is ON. It is what computes `#balances.discrepancy` -- the
+    // balance checker's difference per failing assertion, which cannot be
+    // derived from the directive (#2180). Measured at load-dominated cost:
+    // on the largest corpus file a full query runs in the same ~0.1s either
+    // way. Diagnostics go to stderr, so stdout is byte-identical, and
+    // bean-query likewise reports a failing assertion before its results.
     let options = LoadOptions {
-        validate: false, // Query doesn't need validation
+        validate: true,
         ..Default::default()
     };
 
@@ -230,6 +236,27 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     }
 
     // Determine query source
+    // Flatten the loader's failing-assertion list into the executor's key
+    // shape once. Computed here rather than per query so the REPL, which
+    // reuses one ledger across prompts, does not redo it at every prompt.
+    let balance_discrepancies: Vec<(
+        rustledger_core::NaiveDate,
+        String,
+        String,
+        rustledger_core::Amount,
+    )> = ledger
+        .balance_discrepancies
+        .iter()
+        .map(|d| {
+            (
+                d.date,
+                d.account.to_string(),
+                d.amount.currency.to_string(),
+                d.amount.clone(),
+            )
+        })
+        .collect();
+
     let query_str = if !args.query.is_empty() {
         args.query.join(" ")
     } else if let Some(ref query_file) = args.query_file {
@@ -243,14 +270,19 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
             &source_map,
             &display_context,
             &ledger.options.to_account_types(),
+            &balance_discrepancies,
             args,
         );
     };
 
     // Batch query: no pager (matching Python bean-query behavior).
     // Pager is only used in interactive REPL mode.
-    let settings =
-        ShellSettings::from_args(args, display_context, ledger.options.to_account_types());
+    let settings = ShellSettings::from_args(
+        args,
+        display_context,
+        ledger.options.to_account_types(),
+        balance_discrepancies,
+    );
     if let Some(ref output_path) = settings.output_file {
         let mut file = fs::File::create(output_path)
             .with_context(|| format!("failed to create output file {}", output_path.display()))?;
@@ -270,6 +302,14 @@ struct ShellSettings {
     /// Config-aware account types from the loaded ledger (L5: `POSSIGN` /
     /// `ACCOUNT_SORTKEY` must honor `name_*` renames like beanquery).
     account_types: rustledger_core::AccountTypes,
+    /// The balance checker's computed difference per FAILING assertion,
+    /// keyed by `(date, account, currency)`. Backs `#balances.discrepancy`.
+    balance_discrepancies: Vec<(
+        rustledger_core::NaiveDate,
+        String,
+        String,
+        rustledger_core::Amount,
+    )>,
 }
 
 impl ShellSettings {
@@ -277,6 +317,12 @@ impl ShellSettings {
         args: &Args,
         display_context: DisplayContext,
         account_types: rustledger_core::AccountTypes,
+        balance_discrepancies: Vec<(
+            rustledger_core::NaiveDate,
+            String,
+            String,
+            rustledger_core::Amount,
+        )>,
     ) -> Self {
         Self {
             format: args.format.unwrap_or(OutputFormat::Text),
@@ -285,6 +331,7 @@ impl ShellSettings {
             output_file: args.output.clone(),
             display_context,
             account_types,
+            balance_discrepancies,
         }
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -33,6 +33,7 @@ pub(super) fn execute_query<W: Write>(
     // positions instead of NULL.
     let mut executor = Executor::new_with_sources(directives, source_map);
     executor.set_account_types(settings.account_types.clone());
+    executor.set_balance_discrepancies(settings.balance_discrepancies.iter().cloned());
     let result = executor
         .execute(&query)
         .with_context(|| "failed to execute query")?;

--- a/crates/rustledger/tests/query_balances_discrepancy_test.rs
+++ b/crates/rustledger/tests/query_balances_discrepancy_test.rs
@@ -1,0 +1,171 @@
+//! `#balances.discrepancy` reports the balance checker's computed difference
+//! for a FAILING assertion, and NULL otherwise (#2180).
+//!
+//! Measured against beanquery 0.2.0 / beancount 3.2.3 on the same ledger:
+//!
+//! ```text
+//! date,account,amount,tolerance,discrepancy
+//! 2024-02-01,Assets:Cash, 100.00 USD,,
+//! 2024-03-01,Assets:Cash,  90.00 USD,, 10.00 USD
+//! ```
+//!
+//! `discrepancy` is `computed - asserted`, so asserting 90 against an
+//! accumulated 100 gives `+10.00`, and asserting 120 gives `-20.00`.
+//!
+//! It is NULL when the assertion PASSES -- including when it is off by less
+//! than its tolerance, which is why the value cannot be derived from the
+//! directive or from the raw difference alone. beancount does the same: its
+//! checker sets `diff_amount` only on a failing entry.
+//!
+//! A CLI test because that is where the whole path is exercised: the loader
+//! runs the checker, the checker records the difference, and the query command
+//! hands it to the executor. A unit test on the executor would only prove the
+//! column renders.
+
+mod common;
+
+use std::process::Command;
+
+/// Accumulates 100.00 USD. The first assertion passes; the second is off by
+/// 10.00 and fails; the third is off by 0.01 with a 0.05 tolerance, so it
+/// passes despite a non-zero difference.
+const SRC: &str = r#"option "inferred_tolerance_default" "USD:0.05"
+
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:O
+
+2024-01-02 * "fund"
+  Assets:Cash    100.00 USD
+  Equity:O      -100.00 USD
+
+2024-02-01 balance Assets:Cash  100.00 USD
+2024-03-01 balance Assets:Cash   90.00 USD
+2024-04-01 balance Assets:Cash  100.01 USD
+"#;
+
+fn query(bin: &std::path::Path, file: &std::path::Path, q: &str) -> String {
+    let out = Command::new(bin)
+        .arg("query")
+        .arg("-f")
+        .arg("csv")
+        .arg(file)
+        .arg(q)
+        .output()
+        .expect("run rledger query");
+    String::from_utf8(out.stdout).expect("utf8")
+}
+
+#[test]
+fn discrepancy_is_the_checkers_difference_on_failure_and_null_otherwise() {
+    let bin = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let out = query(
+        &bin,
+        &file,
+        "SELECT date, discrepancy FROM #balances ORDER BY date",
+    );
+    let rows: Vec<&str> = out.lines().collect();
+
+    assert_eq!(rows[0], "date,discrepancy", "the column must exist");
+    assert_eq!(
+        rows[1], "2024-02-01,",
+        "a passing assertion has no discrepancy",
+    );
+    assert_eq!(
+        rows[2], "2024-03-01,10.00 USD",
+        "a failing assertion reports computed - asserted",
+    );
+    assert_eq!(
+        rows[3], "2024-04-01,",
+        "off by 0.01 within a 0.05 tolerance is a PASS, so still no \
+         discrepancy -- this is what makes the value underivable from the \
+         raw difference",
+    );
+}
+
+/// The sign is `computed - asserted`, not its absolute value and not the
+/// reverse. Asserted separately because the failing case above is positive,
+/// so a sign flip would not show there.
+#[test]
+fn discrepancy_is_signed_computed_minus_asserted() {
+    let bin = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(
+        &file,
+        r#"2024-01-01 open Assets:Cash
+2024-01-01 open Equity:O
+
+2024-01-02 * "fund"
+  Assets:Cash    100.00 USD
+  Equity:O      -100.00 USD
+
+2024-03-01 balance Assets:Cash  120.00 USD
+"#,
+    )
+    .expect("write ledger");
+
+    let out = query(&bin, &file, "SELECT discrepancy FROM #balances");
+    assert_eq!(
+        out.lines().nth(1),
+        Some("-20.00 USD"),
+        "asserting 120 against an accumulated 100 is -20.00, matching \
+         bean-query; got {out}",
+    );
+}
+
+/// `SELECT *` includes the column, in bean-query's position: after
+/// `tolerance`, and `meta` still excluded.
+#[test]
+fn the_wildcard_includes_discrepancy_last() {
+    let bin = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let out = query(&bin, &file, "SELECT * FROM #balances");
+    assert_eq!(
+        out.lines().next(),
+        Some("date,account,amount,tolerance,discrepancy"),
+        "wildcard must match bean-query's column set and order",
+    );
+}
+
+/// The failing assertion is still REPORTED, on stderr, and stdout is
+/// unaffected. Enabling validation on the query path is what computes the
+/// discrepancy; this pins that it did not also start polluting stdout, which
+/// every consumer parses.
+#[test]
+fn validation_diagnostics_do_not_reach_stdout() {
+    let bin = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let out = Command::new(&bin)
+        .arg("query")
+        .arg("-f")
+        .arg("csv")
+        .arg(&file)
+        .arg("SELECT date FROM #balances")
+        .output()
+        .expect("run rledger query");
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    let stderr = String::from_utf8(out.stderr).expect("utf8");
+    assert!(
+        !stdout.contains("Balance failed"),
+        "stdout must stay pure data; got {stdout}",
+    );
+    assert!(
+        stderr.contains("Balance failed"),
+        "the failing assertion must still be reported somewhere; stderr was {stderr}",
+    );
+    assert!(
+        out.status.success(),
+        "a failing assertion must not fail the query, matching bean-query",
+    );
+}

--- a/crates/rustledger/tests/query_balances_discrepancy_test.rs
+++ b/crates/rustledger/tests/query_balances_discrepancy_test.rs
@@ -169,3 +169,37 @@ fn validation_diagnostics_do_not_reach_stdout() {
         "a failing assertion must not fail the query, matching bean-query",
     );
 }
+
+/// Two assertions on the SAME date, account and currency get their own
+/// discrepancies. `(date, account, currency)` does not identify an assertion,
+/// and keying on it alone made both rows report the second one's difference.
+///
+/// bean-query returns `10.00 USD` and `-20.00 USD` here, one per row.
+#[test]
+fn same_date_assertions_do_not_share_a_discrepancy() {
+    let bin = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(
+        &file,
+        r#"2024-01-01 open Assets:Cash
+2024-01-01 open Equity:O
+
+2024-01-02 * "fund"
+  Assets:Cash    100.00 USD
+  Equity:O      -100.00 USD
+
+2024-03-01 balance Assets:Cash   90.00 USD
+2024-03-01 balance Assets:Cash  120.00 USD
+"#,
+    )
+    .expect("write ledger");
+
+    let out = query(&bin, &file, "SELECT amount, discrepancy FROM #balances");
+    let rows: Vec<&str> = out.lines().skip(1).collect();
+    assert_eq!(
+        rows,
+        vec!["90.00 USD,10.00 USD", "120.00 USD,-20.00 USD"],
+        "each assertion reports its OWN difference; got {out}",
+    );
+}


### PR DESCRIPTION
`SELECT * FROM #balances` now returns bean-query's fifth column. Closes #2180.

`discrepancy` is `computed − asserted` for a **failing** assertion and NULL otherwise. Verified against beanquery 0.2.0:

| asserted | accumulated | tolerance | discrepancy |
|---|---|---|---|
| 90.00 | 100.00 | — | `10.00 USD` |
| 120.00 | 100.00 | — | `-20.00 USD` |
| 100.01 | 100.00 | 0.05 | *(null)* |

That last row is the reason this couldn't be faked from the directive: a small non-zero difference **inside** the tolerance is a pass and reports nothing, so the value depends on the tolerance rule as much as on the arithmetic. beancount does the same — `ops/balance.py` sets `diff_amount` only when `abs(diff) > tolerance`, leaving it `None` otherwise.

## Plumbed, not recomputed

The issue's constraint was that re-deriving this in the query layer means a second implementation of balance accumulation. It's worse than that — it also means a second implementation of the *tolerance* rule.

So: the validator already recorded the signed difference per assertion (#1663). It now also records whether that difference exceeded the tolerance, taken from **the same comparison that raises the error**. The loader carries the failing ones onto `Ledger`, beside `capital_gains` and for the same stated reason — a consumer that re-derives either would drift from `rledger check`.

`rustledger-query` can't depend on `rustledger-validate` (checked: it's an optional dep of the loader only), so the executor receives the differences from its host via `set_balance_discrepancies` and reports NULL without them. **The column exists either way**, so a host that skips validation gets bean-query's schema rather than a missing column.

## The query command now validates

That's what computes them. Two things I measured rather than assumed:

- **Cost**: a query on the largest corpus file (18.6k lines) runs in ~0.09s with validation and ~0.12s without — load dominates, and the difference is noise.
- **Output**: diagnostics go to **stderr**, so stdout is byte-identical. bean-query likewise prints a failing assertion before returning its rows, so this moves us toward it in behavior as well as schema.

## Last gap in the census

This was the final item from #2154's census of all 55 columns bean-query exposes across its ten tables (`#notes.tags`/`.links` went with #2160). So `select_star_matches_bean_query_per_table` loses its per-table `gap` field — every expectation is now bean-query's set exactly, and a difference means drift rather than progress. That also fixes the type-inference break that removing the last `Some(...)` would otherwise have caused.

## Verification

Four CLI-level tests, because that's where the whole path runs — loader → checker → executor. Two negative controls, each failing a distinct set: reverting the query path to `validate: false` fails 3, and reporting the difference for passing assertions too fails the tolerance case.

One test pins that stdout stays free of diagnostics, since every consumer parses it.

4718 workspace tests green, clippy clean on 1.97.0, typos clean on all changed files. BQL compat harness over 71 files / 1349 runs: no regression against baseline.