### PR TITLE
fix(query)!: -f json emits positional rows, not keyed objects

### DIFF
--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -223,19 +223,31 @@ fn write_csv<W: Write>(
     Ok(())
 }
 
+/// Rows are ARRAYS of values, positional against `columns` -- not objects
+/// keyed by column name.
+///
+/// A JSON object cannot hold duplicate keys, and BQL legitimately produces
+/// duplicate column names: `SELECT date AS a, account AS a`, two aliases
+/// differing only in case (since #2164 lowercases them), the same expression
+/// twice (#2171), or a column colliding with an alias. Keyed rows silently
+/// dropped all but the last of each collision while `columns` still listed
+/// them all, so a consumer that trusted `columns` read fewer fields than it
+/// was told to expect (#2178).
+///
+/// The names themselves are correct -- bean-query produces the same duplicate
+/// headers, verified in #2164 -- so the fix belongs in the shape, not the
+/// naming. Disambiguating (`a`, `a_2`) would invent names a consumer cannot
+/// predict AND make these keys disagree with the CSV/text headers.
+///
+/// This matches the other query surfaces, which were always positional: the
+/// component's `rows: list<list<query-value>>` and wasm's
+/// `rows: Vec<Vec<CellValue>>`. `-f csv` emits both fields positionally too.
+/// The CLI's JSON was the only shape that could not represent its own results.
 fn write_json<W: Write>(result: &rustledger_query::QueryResult, writer: &mut W) -> Result<()> {
     let rows: Vec<serde_json::Value> = result
         .rows
         .iter()
-        .map(|row| {
-            let obj: serde_json::Map<String, serde_json::Value> = result
-                .columns
-                .iter()
-                .zip(row.iter())
-                .map(|(col, val)| (col.clone(), value_to_json(val)))
-                .collect();
-            serde_json::Value::Object(obj)
-        })
+        .map(|row| serde_json::Value::Array(row.iter().map(value_to_json).collect()))
         .collect();
 
     let output = serde_json::json!({
@@ -1140,10 +1152,72 @@ mod tests {
         let json = String::from_utf8(buf).expect("utf8");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(
-            parsed["rows"][0]["b"],
+            parsed["rows"][0][0],
             serde_json::Value::Bool(true),
             "the JSON boolean must stay a real boolean, not a TRUE/FALSE string"
         );
+    }
+
+    /// Rows are positional, so duplicate column names keep every value.
+    ///
+    /// Keyed rows could not represent this: a JSON object cannot hold two
+    /// `"a"` keys, so the first value was dropped while `columns` still
+    /// listed both (#2178). BQL produces such names legitimately -- and
+    /// bean-query produces the same duplicate headers -- so the shape had to
+    /// give, not the naming.
+    #[test]
+    fn duplicate_column_names_keep_every_value() {
+        use rustledger_query::QueryResult;
+
+        let mut result = QueryResult::new(vec!["a".into(), "a".into()]);
+        result.add_row(vec![
+            Value::String("first".into()),
+            Value::String("second".into()),
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_json(&result, &mut buf).expect("json ok");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf).expect("utf8")).expect("valid JSON");
+
+        assert_eq!(
+            parsed["columns"],
+            serde_json::json!(["a", "a"]),
+            "both column names are reported",
+        );
+        assert_eq!(
+            parsed["rows"][0],
+            serde_json::json!(["first", "second"]),
+            "and both values survive, in column order",
+        );
+    }
+
+    /// A row has exactly as many entries as `columns` says, so a consumer can
+    /// zip the two. The keyed shape broke this invariant precisely when it
+    /// mattered.
+    #[test]
+    fn each_row_has_one_entry_per_column() {
+        use rustledger_query::QueryResult;
+
+        for columns in [
+            vec!["a".to_string(), "b".to_string()],
+            vec!["a".to_string(), "a".to_string()],
+        ] {
+            let n = columns.len();
+            let mut result = QueryResult::new(columns.clone());
+            result.add_row(vec![Value::Integer(1), Value::Integer(2)]);
+
+            let mut buf: Vec<u8> = Vec::new();
+            write_json(&result, &mut buf).expect("json ok");
+            let parsed: serde_json::Value =
+                serde_json::from_str(&String::from_utf8(buf).expect("utf8")).expect("valid JSON");
+
+            assert_eq!(
+                parsed["rows"][0].as_array().expect("row is an array").len(),
+                n,
+                "row width must equal column count for {columns:?}",
+            );
+        }
     }
 
     #[test]

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -109,8 +109,11 @@ rledger query ledger.beancount "
 # Filter output with grep
 rledger query ledger.beancount "BALANCES" | grep Expenses
 
-# Process JSON with jq
-rledger query ledger.beancount "BALANCES" -f json | jq '.rows[] | select(.balance > 100)'
+# Process JSON with jq. `rows` are arrays, positional against `columns`,
+# so zip them for access by name:
+rledger query ledger.beancount "BALANCES" -f json \
+  | jq -c '.columns as $c | .rows[] | [$c, .] | transpose
+           | map({key: .[0], value: .[1]}) | from_entries'
 
 # Export to file
 rledger query ledger.beancount "SELECT *" -f csv > transactions.csv

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -109,8 +109,12 @@ rledger query ledger.beancount "
 # Filter output with grep
 rledger query ledger.beancount "BALANCES" | grep Expenses
 
-# Process JSON with jq. `rows` are arrays, positional against `columns`,
-# so zip them for access by name:
+# Process JSON with jq. `rows` are arrays, positional against `columns`.
+# Index by position when you want one field:
+rledger query ledger.beancount "BALANCES" -f json | jq -r '.rows[][0]'
+
+# Or pair them up for access by name. `from_entries` collapses duplicate
+# column names, so use this only when the query's names are unique:
 rledger query ledger.beancount "BALANCES" -f json \
   | jq -c '.columns as $c | .rows[] | [$c, .] | transpose
            | map({key: .[0], value: .[1]}) | from_entries'

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -57,13 +57,17 @@ def get_balances(ledger_path):
 
 balances = get_balances("ledger.beancount")
 
-# `rows` are ARRAYS of values, positional against `columns`. Zip the two to
-# read by name:
+# `rows` are ARRAYS of values, positional against `columns`. Pair them up:
 columns = balances["columns"]
 for row in balances["rows"]:
-    r = dict(zip(columns, row))
-    print(f"{r['account']}: {r['balance']}")
+    for name, value in zip(columns, row):
+        print(f"{name}: {value}")
 ```
+
+Building a dict per row (`dict(zip(columns, row))`) reads more naturally and is
+fine **when the column names are unique** — but it collapses duplicates exactly
+as the old object shape did, so reach for it only when you control the query.
+Positional access, or `zip`, is always safe.
 
 The JSON shape is:
 
@@ -79,8 +83,7 @@ Rows are positional rather than objects keyed by column name because a query
 may return **duplicate column names** — `SELECT date AS a, account AS a`, the
 same expression twice, or a column colliding with an alias — and a JSON object
 cannot hold duplicate keys. Keyed rows silently dropped all but the last of
-each collision. The `zip` above is safe under duplicates too, if you index by
-position rather than building a dict.
+each collision.
 
 This matches the other query surfaces: the WASM API and the WIT component both
 return `rows` as lists of value lists.

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -56,9 +56,34 @@ def get_balances(ledger_path):
     return json.loads(result.stdout)
 
 balances = get_balances("ledger.beancount")
+
+# `rows` are ARRAYS of values, positional against `columns`. Zip the two to
+# read by name:
+columns = balances["columns"]
 for row in balances["rows"]:
-    print(f"{row['account']}: {row['balance']}")
+    r = dict(zip(columns, row))
+    print(f"{r['account']}: {r['balance']}")
 ```
+
+The JSON shape is:
+
+```json
+{
+  "columns": ["account", "balance"],
+  "rows": [["Assets:Cash", "100.00 USD"]],
+  "row_count": 1
+}
+```
+
+Rows are positional rather than objects keyed by column name because a query
+may return **duplicate column names** — `SELECT date AS a, account AS a`, the
+same expression twice, or a column colliding with an alias — and a JSON object
+cannot hold duplicate keys. Keyed rows silently dropped all but the last of
+each collision. The `zip` above is safe under duplicates too, if you index by
+position rather than building a dict.
+
+This matches the other query surfaces: the WASM API and the WIT component both
+return `rows` as lists of value lists.
 
 ## Rust Crates
 

--- a/scripts/compat-booking-fuzz.py
+++ b/scripts/compat-booking-fuzz.py
@@ -247,6 +247,19 @@ Booked = dict[tuple[str, str, str, str, str, str], Decimal]
 ERROR = "ERROR"
 
 
+def _keyed_rows(payload):
+    """`rows` as dicts, zipped against `columns`.
+
+    `query --format json` emits rows POSITIONALLY -- arrays of values indexed
+    by `columns` -- because a JSON object cannot hold the duplicate column
+    names BQL can produce (#2178). These queries name every column distinctly,
+    so re-keying is lossless here; do not copy this into a context where the
+    column names may collide.
+    """
+    columns = payload.get("columns") or []
+    return [dict(zip(columns, row)) for row in payload.get("rows", [])]
+
+
 def booked_rledger(rledger: str, path: str) -> Booked | str:
     """Lots as rledger books them, or ERROR if it refuses the ledger."""
     check = subprocess.run(
@@ -276,7 +289,7 @@ def booked_rledger(rledger: str, path: str) -> Booked | str:
     if out.returncode != 0:
         return ERROR
     try:
-        rows = json.loads(out.stdout).get("rows", [])
+        rows = _keyed_rows(json.loads(out.stdout))
     except json.JSONDecodeError:
         # A banner or log line on stdout is a failure to read the booking, not
         # a reason to abort the campaign — the beancount side already treats

--- a/scripts/compat-values.py
+++ b/scripts/compat-values.py
@@ -386,6 +386,19 @@ KNOWN_POSTING_DIVERGENCES: dict[tuple[str, str], str] = {
 }
 
 
+def _keyed_rows(payload):
+    """`rows` as dicts, zipped against `columns`.
+
+    `query --format json` emits rows POSITIONALLY -- arrays of values indexed
+    by `columns` -- because a JSON object cannot hold the duplicate column
+    names BQL can produce (#2178). These queries name every column distinctly,
+    so re-keying is lossless here; do not copy this into a context where the
+    column names may collide.
+    """
+    columns = payload.get("columns") or []
+    return [dict(zip(columns, row)) for row in payload.get("rows", [])]
+
+
 def _dec(text):
     """Numeric field -> Decimal, or None if absent or unparsable.
 
@@ -484,7 +497,7 @@ def rledger_postings(binary: str, path: Path):
         return _dec(v.get("number")), v.get("currency") or None
 
     rows = []
-    for r in payload.get("rows", []):
+    for r in _keyed_rows(payload):
         price_n, price_c = amount(r.get("price"))
         rows.append((
             r.get("date") or "",
@@ -544,7 +557,7 @@ def rledger_prices(binary: str, path: Path):
         return None
 
     rows = []
-    for r in payload.get("rows", []):
+    for r in _keyed_rows(payload):
         amount = r.get("amount")
         if not isinstance(amount, dict):
             return None


### PR DESCRIPTION
A JSON object cannot hold duplicate keys, and BQL legitimately produces duplicate column names. Keyed rows silently dropped all but the last of each collision **while `columns` still listed them all**, so a consumer that trusted `columns` read fewer fields than it was told to expect. Closes #2178.

```
SELECT date AS a, account AS a

before  {"columns": ["a","a"], "rows": [{"a": "Assets:Cash"}]}          <- date gone
after   {"columns": ["a","a"], "rows": [["2024-01-02","Assets:Cash"]]}
```

## Why positional, not disambiguation

The names are not the problem. bean-query produces the same duplicate headers (verified in #2164), and `-f csv` already emitted both fields positionally. Only the JSON shape could not represent its own results.

Positional also makes the CLI agree with the surfaces that were **always** positional — the component's `rows: list<list<query-value>>` and wasm's `rows: Vec<Vec<CellValue>>`. The CLI's JSON was the odd one out, which is what made it the wrong shape rather than a matter of taste.

Disambiguating (`a`, `a_2`) was considered and rejected: it invents names a consumer cannot predict, and it would make the JSON keys disagree with the CSV/text headers, which are pinned to bean-query's.

## Breaking

Anything reading `rows[i].name` must zip `columns` with the row.

`docs/guides/integration.md` carried exactly that pattern — a Python example doing `row['account']` — and is updated with the zip, the shape documented explicitly, and the reason. The `jq` recipe in `docs/commands/query.md` used `select(.balance > 100)` and is updated too.

Both were run rather than written from memory, which is how I caught that jq's `from_entries` does **not** accept bare `[key, value]` pairs — the obvious idiom errors with `Cannot index array with string ("key")`. The documented recipe is the one that actually works:

```bash
rledger query ledger.beancount "BALANCES" -f json \
  | jq -c '.columns as $c | .rows[] | [$c, .] | transpose
           | map({key: .[0], value: .[1]}) | from_entries'
```

## Verification

Two tests: one that duplicate names keep every value, and one that row width equals column count for both unique and duplicate names — the invariant the keyed shape broke precisely when it mattered. Restoring keyed rows fails 3 tests.

Checked all four collision shapes the issue lists reach the fix: identical aliases, aliases differing only in case (#2164 lowercases them), the same expression twice (#2171), and a column colliding with an alias.

4724 workspace tests green, clippy clean on 1.97.0, typos clean.