### PR TITLE
fix(ffi): a balance diff belongs to its own assertion

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -1041,6 +1041,69 @@ fn load_reports_balance_assertion_failure() -> Result<()> {
     Ok(())
 }
 
+/// #2239: two `balance` assertions sharing a date, account and currency each
+/// carry their OWN diff.
+///
+/// `attach_balance_diffs` keyed the validator's results by
+/// `(date, account, currency)`. Those three do not identify an assertion --
+/// a ledger may assert the same account and currency twice on one date with
+/// different amounts -- so building a map collapsed them and one directive
+/// received the other's difference.
+///
+/// A WIT-level test on purpose: the collision is in the map the component
+/// builds, so a unit test on the validator would not see it. Verified against
+/// bean-query, which reports `10.00 USD` and `-20.00 USD` here (the query
+/// layer had the same bug, fixed in #2238).
+#[test]
+fn same_date_balance_assertions_carry_their_own_diffs() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    // Accumulates 100.00. Asserting 90 is +10 too much; asserting 120 is -20.
+    let src = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Equity:O USD
+2024-01-02 * \"fund\"
+  Assets:Cash   100.00 USD
+  Equity:O
+2024-03-01 balance Assets:Cash    90.00 USD
+2024-03-01 balance Assets:Cash   120.00 USD
+";
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, src, "<stdin>", false)?;
+
+    let diffs: Vec<(String, Option<String>)> = loaded
+        .entries
+        .iter()
+        .filter_map(|d| match d {
+            rustledger::ledger::types::Directive::Balance(b) => Some((
+                b.amount.number.clone(),
+                b.diff.as_ref().map(|a| a.number.clone()),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(diffs.len(), 2, "both assertions must be present: {diffs:?}");
+    for (asserted, diff) in &diffs {
+        let diff = diff.as_deref().expect("each assertion carries a diff");
+        let expected = if asserted.starts_with("90") {
+            "10"
+        } else {
+            "-20"
+        };
+        assert!(
+            diff.starts_with(expected),
+            "the assertion of {asserted} should carry a diff of {expected}, \
+             got {diff}; all: {diffs:?}",
+        );
+    }
+    Ok(())
+}
+
 /// #1668: an oversell reports the "Not enough units" error exactly ONCE via
 /// `load`. Booking (run inside `load_source`) already reports it with
 /// transaction context; the validation session's context-free reduce-check

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -376,9 +376,26 @@ fn semantic_validation_errors(
     (errors, actuals)
 }
 
-/// Attach the computed `diff` (`computed − asserted`) to each `balance` directive
-/// entry from the validator's recorded results (#1663), keyed by
-/// `(date, account, currency)`.
+/// Attach the computed `diff` (`computed − asserted`) to each `balance`
+/// directive entry from the validator's recorded results (#1663), keyed by
+/// `(date, account, currency, asserted)`.
+///
+/// The asserted amount is part of the key because the other three do not
+/// identify an assertion: a ledger may assert the same account and currency
+/// twice on one date, with different amounts and so different differences.
+/// Keying without it collapsed them, and one directive received the other's
+/// diff (#2239; the query layer had the same bug, fixed in #2238).
+///
+/// The asserted number is compared as the STRING the WIT directive carries.
+/// Both sides come from `Decimal::to_string()` on the same value --
+/// `amount_from_core` for the directive, `BalanceActual::asserted` for the
+/// validator's record -- so they agree by construction. Two assertions
+/// matching on all four are the same assertion and share a difference, so
+/// collapsing those is harmless.
+///
+/// Unlike `#balances.discrepancy`, this attaches a diff for EVERY assertion
+/// including passing ones, where it is zero. That is this surface's contract
+/// (#1663): a consumer renders per-assertion pass/fail from it.
 fn attach_balance_diffs(
     entries: &mut [wit::Directive],
     actuals: &[rustledger_validate::BalanceActual],
@@ -386,7 +403,7 @@ fn attach_balance_diffs(
     if actuals.is_empty() {
         return;
     }
-    let map: std::collections::HashMap<(String, String, String), rustledger_core::Decimal> =
+    let map: std::collections::HashMap<(String, String, String, String), rustledger_core::Decimal> =
         actuals
             .iter()
             .map(|a| {
@@ -395,6 +412,7 @@ fn attach_balance_diffs(
                         a.date.to_string(),
                         a.account.to_string(),
                         a.currency.to_string(),
+                        a.asserted.to_string(),
                     ),
                     a.diff,
                 )
@@ -402,7 +420,12 @@ fn attach_balance_diffs(
             .collect();
     for entry in entries.iter_mut() {
         if let wit::Directive::Balance(b) = entry {
-            let key = (b.date.clone(), b.account.clone(), b.amount.currency.clone());
+            let key = (
+                b.date.clone(),
+                b.account.clone(),
+                b.amount.currency.clone(),
+                b.amount.number.clone(),
+            );
             if let Some(diff) = map.get(&key) {
                 b.diff = Some(wit::Amount {
                     number: diff.to_string(),

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -393,9 +393,14 @@ fn semantic_validation_errors(
 /// matching on all four are the same assertion and share a difference, so
 /// collapsing those is harmless.
 ///
-/// Unlike `#balances.discrepancy`, this attaches a diff for EVERY assertion
-/// including passing ones, where it is zero. That is this surface's contract
-/// (#1663): a consumer renders per-assertion pass/fail from it.
+/// Unlike `#balances.discrepancy`, this attaches a diff for EVERY assertion,
+/// passing ones included, and the value is the RAW signed difference rather
+/// than a pass/fail verdict. It is zero only on an exact match: an assertion
+/// that passes *within tolerance* carries its real difference, e.g. `-0.01`
+/// for `100.01` asserted against an accumulated `100.00` under a `0.05`
+/// tolerance. That is this surface's contract (#1663) -- a consumer renders
+/// per-assertion detail from it -- and it is why the query column, which
+/// reports only failures, could not simply reuse this.
 fn attach_balance_diffs(
     entries: &mut [wit::Directive],
     actuals: &[rustledger_validate::BalanceActual],


### PR DESCRIPTION
`attach_balance_diffs` keyed the validator's results by `(date, account, currency)`. Those three do not identify a balance assertion — a ledger may assert the same account and currency twice on one date with different amounts, and so different differences. Building a map collapsed them, and one directive received the other's diff. Closes #2239.

```
2024-03-01 balance Assets:Cash    90.00 USD
2024-03-01 balance Assets:Cash   120.00 USD

before  both carry -20.00
after   90.00 carries 10.00, 120.00 carries -20.00
```

bean-query reports `10.00` and `-20.00` here. The query layer had the same collision, fixed in #2238 — which is also what added `BalanceActual::asserted`, so the fix here is the **key**, not the semantics.

This surface deliberately attaches a diff for *every* assertion including passing ones, where it is zero. That is its contract (#1663) and is unchanged, which is why this wasn't folded into #2238.

The asserted number is compared as the string the WIT directive carries. Both sides come from `Decimal::to_string()` on the same value — `amount_from_core` for the directive, the validator's record for the map — so they agree by construction rather than by luck. I checked that rather than assuming, since a string key that silently never matched would drop the diff entirely, which is worse than attaching the wrong one.

## Tested at the WIT level

The collision is in the map the component builds, so a validator unit test cannot see it. When I filed #2239 I noted I'd read the code but not built a component-level test; this is that test.

**The component wasm was rebuilt for both runs.** The checked-in one was three days stale, and testing against it would have measured old code whichever way it came out. Against a freshly built *unfixed* component the test fails with both diffs at `-20.00`; against a freshly built *fixed* one it passes.

Full `parity` suite: 27 passed, including the existing `load_reports_balance_assertion_failure` that pins the #1663 contract.

No WIT change — the wire contract is untouched, only which record attaches to which directive.

4725 workspace tests green, clippy clean on 1.97.0, typos clean.