### PR TITLE
fix(ci): restore the nightly compat budget and stop a false stale report

### DIFF
--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -1846,6 +1846,7 @@ def main() -> int:
     # DATA. Verified rather than assumed: if the sampled files disagree with
     # each other about a query's headers, the property the cap rests on is
     # false and the cap is hiding divergences on the files it skipped.
+    header_sampling_broken = False
     by_query: dict[str, set] = {}
     for r in results:
         if r.py_header is not None and r.rs_header is not None:
@@ -1860,6 +1861,7 @@ def main() -> int:
             f"{HEADER_SAMPLE_PER_QUERY} of them is not representative. Raise "
             "HEADER_SAMPLE_PER_QUERY or compare this query on every file."
         )
+        header_sampling_broken = True
 
     compared_headers = sum(1 for r in results if r.py_header is not None)
     print(
@@ -1877,6 +1879,7 @@ def main() -> int:
             f"::error::query {q!r} got NO header comparison -- every sampled "
             "file failed in one of the tools. Its column names are unchecked."
         )
+        header_sampling_broken = True
 
     skipped_headers = sum(1 for r in results if r.header_skipped)
     if skipped_headers:
@@ -2080,6 +2083,13 @@ def main() -> int:
             f"\nNo BQL regressions vs baseline "
             f"({len(baseline_passing)} baseline-passing pairs checked)."
         )
+
+    # An annotation alone does not fail a GitHub Actions step, so a guard that
+    # only printed would let a run whose header sampling is unsound report
+    # SUCCESS -- the check-that-cannot-fail this file exists to avoid.
+    # Deliberately last, so every other diagnostic is printed first.
+    if header_sampling_broken:
+        return 1
 
     return 0
 

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -1180,6 +1180,27 @@ def load_corpus(path: Path) -> list[Query]:
 # ends and data begins, instead of slicing a fixed-size header off — the
 # old approach broke whenever a tool emitted a deprecation banner ahead
 # of the table.
+# How many files per query get their column NAMES compared.
+#
+# A header is the rendered target expression, so it depends on the query and
+# not the ledger; the corpus confirms it, every query producing exactly one
+# distinct header pair across all files. Comparing it on all 735 is redundant
+# and cost the nightly its time budget (#2232), so a handful per query carries
+# the same signal.
+#
+# Raise this if a query is ever added whose header depends on DATA -- a
+# `PIVOT BY` names its columns after the pivot values, and the corpus excludes
+# pivots today for unrelated reasons. The run errors if the sampled files ever
+# disagree about a query's headers, so that change cannot pass unnoticed.
+#
+# Generous on purpose. The cost is `queries x N` REGARDLESS of corpus size --
+# 19 x 20 header passes against 735 files, not 735 x 19 -- so a bigger sample
+# is nearly free while a small one is fragile: about 28% of corpus runs end in
+# a tool failure and yield no header at all, so a sample of 4 left some queries
+# with only a handful of usable comparisons and risked zero. The run errors if
+# any query ends up with none.
+HEADER_SAMPLE_PER_QUERY = 20
+
 _SEPARATOR_RE = re.compile(r"^[-\s]+$")
 
 
@@ -1378,6 +1399,7 @@ def test_one(
     rledger_bin: list[str],
     bean_query_csv_bin: list[str] | None = None,
     rledger_csv_bin: list[str] | None = None,
+    compare_headers: bool = True,
 ) -> QueryRun:
     py_out = run_query(bean_query_bin, file_path, query.query)
     rs_out = run_query(rledger_bin, file_path, query.query)
@@ -1394,7 +1416,7 @@ def test_one(
     # below, and skipping keeps the extra invocation off the failure paths.
     py_header = rs_header = None
     tools_ran = not py_out.failed and not rs_out.failed
-    if tools_ran and bean_query_csv_bin and rledger_csv_bin:
+    if tools_ran and compare_headers and bean_query_csv_bin and rledger_csv_bin:
         py_csv = run_query(bean_query_csv_bin, file_path, query.query)
         rs_csv = run_query(rledger_csv_bin, file_path, query.query)
         if not py_csv.failed and not rs_csv.failed:
@@ -1408,7 +1430,10 @@ def test_one(
     # both tools print one, so `None` here really is "we did not look".
     header_compared = py_header is not None and rs_header is not None
     header_match = (not header_compared) or py_header == rs_header
-    header_skipped = tools_ran and not header_compared
+    # A pair outside the header SAMPLE is not a blind spot -- it was not meant
+    # to be compared. Only a pair we tried and failed to compare counts, which
+    # is what the reported "header checks skipped" number is for.
+    header_skipped = tools_ran and compare_headers and not header_compared
     # A registered header divergence excuses the NAMES only. `header_match`
     # keeps the raw fact so the stale check still notices when the divergence
     # goes away; the row comparison below is untouched by the mask.
@@ -1652,11 +1677,34 @@ def main() -> int:
     rledger_csv_bin = [*rledger_bin, "-f", "csv"]
     bean_query_csv_bin = [*bean_query_bin, "-f", "csv"]
 
-    # Build (file, filename, query) cases
+    # Build (file, filename, query, compare_headers) cases.
+    #
+    # Headers are compared on only the first `HEADER_SAMPLE_PER_QUERY` files
+    # per query, because a header is a property of the QUERY and not of the
+    # ledger: it is the rendered target expression. Measured across the corpus,
+    # every query yields exactly ONE distinct header pair however many files it
+    # runs on -- which is also why the divergence registry keys these
+    # `("*", query)` rather than enumerating files.
+    #
+    # The full cross product cost real time. The header pass is a second
+    # subprocess per run, and comparing it on all 735 files took the nightly's
+    # BQL step from ~19 to ~35 minutes, past the job's 45-minute cap: the
+    # 2026-09-02 and 09-03 nightlies were killed after BQL and never reached
+    # "Commit results to compatibility branch", so the trend lost two days
+    # (#2232). Sampling restores the runtime and keeps the signal.
+    #
+    # `queries` and `selected_pairs` are both ordered, so the sample is the
+    # same set run to run -- a regression cannot hide by landing on a file that
+    # happened not to be sampled today.
     cases = []
+    header_budget: dict[str, int] = {}
     for filename, path in selected_pairs:
         for q in queries:
-            cases.append((path, filename, q))
+            used = header_budget.get(q.name, 0)
+            compare_headers = used < HEADER_SAMPLE_PER_QUERY
+            if compare_headers:
+                header_budget[q.name] = used + 1
+            cases.append((path, filename, q, compare_headers))
 
     if not cases:
         # An empty case list used to silently produce a 0-runs/0-mismatches
@@ -1684,8 +1732,9 @@ def main() -> int:
                 rledger_bin,
                 bean_query_csv_bin,
                 rledger_csv_bin,
+                ch,
             )
-            for (p, fn, q) in cases
+            for (p, fn, q, ch) in cases
         ]
         for fut in as_completed(futures):
             try:
@@ -1793,6 +1842,42 @@ def main() -> int:
     print(f"Real mismatches:     {real_mismatches}")
     # Report the header comparisons that did NOT happen. A skipped check scores
     # as a match, so leaving the count silent is how coverage quietly erodes.
+    # The sample is only sound while a query's header does not depend on the
+    # DATA. Verified rather than assumed: if the sampled files disagree with
+    # each other about a query's headers, the property the cap rests on is
+    # false and the cap is hiding divergences on the files it skipped.
+    by_query: dict[str, set] = {}
+    for r in results:
+        if r.py_header is not None and r.rs_header is not None:
+            by_query.setdefault(r.query_name, set()).add(
+                (tuple(r.py_header), tuple(r.rs_header))
+            )
+    varying = sorted(q for q, seen in by_query.items() if len(seen) > 1)
+    for q in varying:
+        print(
+            f"::error::query {q!r} produced different headers on different "
+            "files, so comparing only "
+            f"{HEADER_SAMPLE_PER_QUERY} of them is not representative. Raise "
+            "HEADER_SAMPLE_PER_QUERY or compare this query on every file."
+        )
+
+    compared_headers = sum(1 for r in results if r.py_header is not None)
+    print(
+        f"Header checks:       {compared_headers} of {len(results)} runs "
+        f"(sampling {HEADER_SAMPLE_PER_QUERY} file(s) per query)"
+    )
+
+    # A query with NO usable comparison is not being header-checked at all --
+    # the sample landed entirely on files where a tool failed. Silent zero
+    # coverage is exactly what sampling must not buy, so it is an error.
+    all_queries = {r.query_name for r in results}
+    unchecked = sorted(all_queries - set(by_query))
+    for q in unchecked:
+        print(
+            f"::error::query {q!r} got NO header comparison -- every sampled "
+            "file failed in one of the tools. Its column names are unchecked."
+        )
+
     skipped_headers = sum(1 for r in results if r.header_skipped)
     if skipped_headers:
         print(

--- a/scripts/nightly-health.py
+++ b/scripts/nightly-health.py
@@ -103,10 +103,32 @@ def scheduled_workflows() -> dict[str, str]:
     return out
 
 
+# How many recent scheduled runs to fetch before picking the newest.
+#
+# More than one because the newest is chosen by comparing timestamps rather
+# than by trusting list order (see `latest_scheduled_run`).
+_RUN_PAGE = 10
+
+
 def latest_scheduled_run(workflow: str) -> dict | None:
+    """The most recent scheduled run of `workflow`, by `createdAt`.
+
+    Fetches a page and takes the MAXIMUM rather than the first element. On
+    2026-09-03 this reported `bench.yml` as ten days stale while it had in fact
+    run six hours earlier, and the run it linked was a real but old one -- so
+    the lookup returned a stale entry rather than failing. The cause was not
+    reproducible afterwards (the same `gh run list --limit 1` returned the
+    correct run by hand), so this does not claim to fix a diagnosed bug: it
+    removes the dependence on list ORDER, which is the only assumption that
+    could have produced that output.
+
+    That matters more here than the code size suggests. A health reporter
+    exists to be believed; one that cries wolf gets muted, which is the failure
+    it was written to prevent.
+    """
     raw = gh(
         "run", "list", "--repo", REPO, "--workflow", workflow,
-        "--event", "schedule", "--limit", "1",
+        "--event", "schedule", "--limit", str(_RUN_PAGE),
         "--json", "conclusion,status,createdAt,databaseId,url",
         tolerate_missing=True,
     )
@@ -114,7 +136,9 @@ def latest_scheduled_run(workflow: str) -> dict | None:
         runs = json.loads(raw)
     except json.JSONDecodeError:
         return None
-    return runs[0] if runs else None
+    if not runs:
+        return None
+    return max(runs, key=lambda r: r["createdAt"])
 
 
 def later_successful_manual_run(workflow: str, after: datetime) -> dict | None:
@@ -215,6 +239,29 @@ def self_test() -> int:
         ok = flag in argv and argv[argv.index(flag) + 1] == value
         failures += not ok
         print(f"  {'ok  ' if ok else 'FAIL'} query passes {flag} {value}")
+
+    # `latest_scheduled_run` must pick by TIMESTAMP, not by position. The
+    # 2026-09-03 report called `bench.yml` ten days stale while it had run six
+    # hours earlier, linking a real but older run -- consistent with taking
+    # element zero of a list that was not newest-first. Fed deliberately
+    # out-of-order here, since a correctly-ordered fixture cannot tell the two
+    # implementations apart.
+    out_of_order = (
+        '[{"conclusion":"success","status":"completed",'
+        '"createdAt":"2026-08-24T02:52:42Z","databaseId":1,"url":"old"},'
+        '{"conclusion":"success","status":"completed",'
+        '"createdAt":"2026-09-03T06:34:44Z","databaseId":2,"url":"new"}]'
+    )
+    gh = stub(out_of_order)
+    picked = latest_scheduled_run("bench.yml")
+    ok = picked is not None and picked["url"] == "new"
+    failures += not ok
+    print(f"  {'ok  ' if ok else 'FAIL'} newest scheduled run wins regardless of list order")
+
+    gh = stub("[]")
+    ok = latest_scheduled_run("bench.yml") is None
+    failures += not ok
+    print(f"  {'ok  ' if ok else 'FAIL'} no scheduled runs reports None")
 
     gh = real_gh
     if failures:


### PR DESCRIPTION
Two unrelated problems behind the same health issue (#2232).

## 1. compat.yml was timing out — my regression

#2223 added a second CSV invocation per run to compare column names. I measured ~1.7× on a 71-file sample, judged it acceptable, and **never checked it against the job's cap**. On the full corpus:

| | BQL step | job |
|---|---|---|
| Sep 1 (before #2223) | 18m37s | 29 min, success |
| Sep 2 / Sep 3 (after) | 34m36s | hit `timeout-minutes: 45`, cancelled |

Both nightlies were killed *after* BQL and never reached "Commit results to compatibility branch", so the trend lost two days — the exact failure the concurrency comment in that workflow warns about.

**Headers are now compared on a sample of files per query.** A header is the rendered target expression, so it depends on the query, not the ledger. Measured across the corpus: every query yields exactly **one** distinct header pair however many files it runs on — which is also why the divergence registry keys these `("*", query)` rather than enumerating files.

The cost is `queries × N` regardless of corpus size — 380 header passes against 735 files instead of ~14,000 — so the sample is generous rather than minimal. That property is what makes this a fix rather than a trade.

Two guards, because a cap that hides a divergence is worse than the runtime it saves:

- **Sampled files disagreeing** about a query's headers means the property the sample rests on is false → the run errors. That is what would happen if a `PIVOT BY` query were added, since a pivot names its columns after the data.
- **A query with no usable comparison** — every sampled file failing in one of the tools, which ~28% of runs do — errors rather than reporting a silent zero. My first attempt sampled 4 files and hit exactly this: 19 usable comparisons out of 76 budgeted.

Verified: verdicts unchanged (58/0/21 over 71 files), the same four queries still report header divergences, and **both guards fire when forced**. Runtime 1m44s → 1m10s against a 1m02s baseline. A pleasant accident: forcing zero coverage also trips the existing stale-mask check, so that registry independently notices a query losing header coverage.

## 2. nightly-health called a healthy workflow stale

Separately, the report claimed `bench.yml` had not run in 10 days, linking a real run from 2026-08-24. It had in fact run **six hours earlier**, successfully, as it had every day for weeks.

`latest_scheduled_run` took element zero of `gh run list`; it now takes the maximum by `createdAt`.

This does **not** claim to fix a diagnosed bug. The same command by hand returns the correct run, so I could not reproduce the cause and I am not going to invent one. What it removes is the dependence on list *order* — the only assumption that could produce that output. The self-test feeds a deliberately out-of-order page, since a correctly-ordered fixture cannot tell the two implementations apart; reverting to `runs[0]` fails it.

A false alarm matters more here than the diff size suggests: a health reporter exists to be believed, and one that cries wolf gets muted — which is the failure it was written to prevent.

## Note

The issue closes itself when everything is green, so it should clear on the next nightly if both fixes hold. Worth watching the next `compat.yml` scheduled run to confirm the job completes and publishes.