### PR TITLE
feat(lsp): amountColors turns the sign swatch off from any editor

### DIFF
--- a/crates/rustledger-lsp/src/ledger_state.rs
+++ b/crates/rustledger-lsp/src/ledger_state.rs
@@ -40,12 +40,36 @@ fn extract_price_currency(price: &PriceAnnotation) -> Option<String> {
 }
 
 /// Configuration for the LSP server, parsed from initialization options.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct LspConfig {
     /// Path to the root journal file (e.g., "main.bean").
     /// When set, the LSP loads this file and all its includes for
     /// complete diagnostics and completions across the entire ledger.
     pub journal_file: Option<PathBuf>,
+    /// Whether to advertise `textDocument/documentColor` for amount signs.
+    ///
+    /// On by default. Turning it off suppresses the color swatch an editor
+    /// draws beside each amount, which occupies a character cell and so shifts
+    /// colored lines relative to uncolored ones -- perturbing the alignment
+    /// `rledger format` establishes (#2230, #2245).
+    ///
+    /// This is the SERVER-side switch, and it exists because the client-side
+    /// one is not portable: VS Code offers `editor.colorDecorators`, but an
+    /// editor without that setting has no way to decline the decoration. Sign
+    /// is still conveyed by the `negative` semantic-token modifier, which
+    /// costs no layout, so turning this off loses nothing but the swatch.
+    pub amount_colors: bool,
+}
+
+impl Default for LspConfig {
+    fn default() -> Self {
+        Self {
+            journal_file: None,
+            // On by default: this preserves the behavior every existing
+            // client already sees, so the setting is an opt-OUT.
+            amount_colors: true,
+        }
+    }
 }
 
 impl LspConfig {
@@ -62,9 +86,67 @@ impl LspConfig {
             {
                 config.journal_file = Some(PathBuf::from(path));
             }
+
+            // Only an explicit `false` turns it off. A missing key, or a
+            // non-boolean, leaves the default alone rather than silently
+            // disabling a feature the client did not ask to disable.
+            if let Some(on) = opts
+                .get("amountColors")
+                .or_else(|| opts.get("amount_colors"))
+                .and_then(serde_json::Value::as_bool)
+            {
+                config.amount_colors = on;
+            }
         }
 
         config
+    }
+}
+
+#[cfg(test)]
+mod amount_colors_config {
+    use super::LspConfig;
+
+    fn cfg(json: &str) -> LspConfig {
+        let v: serde_json::Value = serde_json::from_str(json).expect("valid json");
+        LspConfig::from_init_options(Some(&v))
+    }
+
+    /// The swatch stays on unless a client explicitly declines it, so every
+    /// existing client keeps the behavior it has today (#2245).
+    #[test]
+    fn amount_colors_default_on_and_opt_out_only() {
+        assert!(LspConfig::default().amount_colors, "default is on");
+        assert!(cfg("{}").amount_colors, "absent key leaves it on");
+        assert!(
+            cfg(r#"{"journalFile": "main.beancount"}"#).amount_colors,
+            "an unrelated option does not disturb it",
+        );
+        assert!(
+            !cfg(r#"{"amountColors": false}"#).amount_colors,
+            "false turns it off"
+        );
+        assert!(
+            cfg(r#"{"amountColors": true}"#).amount_colors,
+            "true keeps it on"
+        );
+        assert!(
+            !cfg(r#"{"amount_colors": false}"#).amount_colors,
+            "snake_case is accepted too, matching journalFile",
+        );
+    }
+
+    /// A non-boolean must not be read as "off". Silently disabling a feature
+    /// because a client sent the wrong type is worse than ignoring the value.
+    #[test]
+    fn a_non_boolean_leaves_the_default_alone() {
+        for bad in [
+            r#"{"amountColors": "false"}"#,
+            r#"{"amountColors": 0}"#,
+            r#"{"amountColors": null}"#,
+        ] {
+            assert!(cfg(bad).amount_colors, "{bad} must not disable the feature",);
+        }
     }
 }
 

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -26,14 +26,16 @@ pub struct Server {
 
 impl Server {
     /// Create a new LSP server from a connection.
+    /// `config` is parsed by the caller rather than here, because
+    /// `start_stdio` already needs it to decide which capabilities to
+    /// advertise. Parsing twice invited the two copies to disagree the moment
+    /// an option gained validation or a default.
     pub fn new(
         connection: Connection,
         init_params: InitializeParams,
         position_encoding: crate::handlers::utils::PositionEncoding,
+        config: LspConfig,
     ) -> Self {
-        // Parse configuration from initialization options
-        let config = LspConfig::from_init_options(init_params.initialization_options.as_ref());
-
         if let Some(ref journal) = config.journal_file {
             tracing::info!("Journal file configured: {}", journal.display());
         }
@@ -230,12 +232,13 @@ pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     let handler_encoding =
         crate::handlers::utils::PositionEncoding::from_negotiated(position_encoding.as_ref());
 
-    // Honor the amount-color opt-out before advertising the capability: a
-    // client that declines the swatch should not be told the server offers
-    // one. Sign still reaches it through the `negative` semantic-token
-    // modifier, which costs no layout (#2245).
-    let amount_colors =
-        LspConfig::from_init_options(init_params.initialization_options.as_ref()).amount_colors;
+    // Parsed ONCE, here, and handed to `Server::new` below. Capability
+    // advertisement needs it (a client that declines the amount swatch should
+    // not be told the server offers one -- sign still reaches it through the
+    // `negative` semantic-token modifier, which costs no layout, #2245) and so
+    // does the running server, and two parses could drift.
+    let config = LspConfig::from_init_options(init_params.initialization_options.as_ref());
+    let amount_colors = config.amount_colors;
 
     // Build server capabilities
     let capabilities = lsp_types::ServerCapabilities {
@@ -353,7 +356,7 @@ pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
 
     // Create and run server with the handler-facing position encoding
     // (derived above at the negotiation site).
-    let server = Server::new(connection, init_params, handler_encoding);
+    let server = Server::new(connection, init_params, handler_encoding, config);
     let exit_code = server.run();
 
     // Drain the writer thread BEFORE returning. The main loop has

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -230,6 +230,13 @@ pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     let handler_encoding =
         crate::handlers::utils::PositionEncoding::from_negotiated(position_encoding.as_ref());
 
+    // Honor the amount-color opt-out before advertising the capability: a
+    // client that declines the swatch should not be told the server offers
+    // one. Sign still reaches it through the `negative` semantic-token
+    // modifier, which costs no layout (#2245).
+    let amount_colors =
+        LspConfig::from_init_options(init_params.initialization_options.as_ref()).amount_colors;
+
     // Build server capabilities
     let capabilities = lsp_types::ServerCapabilities {
         position_encoding,
@@ -297,7 +304,7 @@ pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
         code_lens_provider: Some(lsp_types::CodeLensOptions {
             resolve_provider: Some(true), // Enable resolve for lazy-loading balance verification
         }),
-        color_provider: Some(lsp_types::ColorProviderCapability::Simple(true)),
+        color_provider: amount_colors.then_some(lsp_types::ColorProviderCapability::Simple(true)),
         declaration_provider: Some(lsp_types::DeclarationCapability::Simple(true)),
         call_hierarchy_provider: Some(lsp_types::CallHierarchyServerCapability::Simple(true)),
         signature_help_provider: Some(lsp_types::SignatureHelpOptions {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -84,6 +84,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically check for extension updates on startup"
+        },
+        "rustledger.amountColors": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a color swatch beside each amount indicating its sign. The swatch occupies a character cell, so it shifts colored lines relative to uncolored ones and can disturb the alignment `rledger format` produces. Turning this off keeps the sign indication, which is also carried by the `negative` semantic-token modifier."
         }
       }
     },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -88,6 +88,7 @@
         "rustledger.amountColors": {
           "type": "boolean",
           "default": true,
+          "scope": "resource",
           "description": "Show a color swatch beside each amount indicating its sign. The swatch occupies a character cell, so it shifts colored lines relative to uncolored ones and can disturb the alignment `rledger format` produces. Turning this off keeps the sign indication, which is also carried by the `negative` semantic-token modifier."
         }
       }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -266,6 +266,7 @@ async function startClientForRootUncontended(
   const command = config.get<string>("server.path", "rledger-lsp");
   const extraArgs = config.get<string[]>("server.extraArgs", []);
   const journalFile = config.get<string>("journalFile", "");
+  const amountColors = config.get<boolean>("amountColors", true);
 
   if (!(await ensureBinary(command))) {
     return;
@@ -273,7 +274,7 @@ async function startClientForRootUncontended(
 
   const serverOptions: ServerOptions = { command, args: extraArgs };
 
-  const initializationOptions: Record<string, string> = {};
+  const initializationOptions: Record<string, string | boolean> = {};
   if (journalFile) {
     // Left RELATIVE on purpose when the user wrote it that way. The server
     // resolves a relative journal against its workspace root
@@ -281,6 +282,18 @@ async function startClientForRootUncontended(
     // folders' settings resolves to two different files — which is the whole
     // point of the request.
     initializationOptions.journalFile = journalFile;
+  }
+
+  // Only sent when turned OFF. The server defaults it on, so staying silent
+  // keeps every existing client's behavior and makes this a pure opt-out.
+  //
+  // Turning it off stops the server advertising `documentColor`, which
+  // removes the swatch that occupies a character cell beside each amount and
+  // shifts colored lines out of the alignment `rledger format` produces.
+  // Sign is still conveyed, by the `negative` semantic-token modifier, so
+  // nothing is lost but the decoration (#2245).
+  if (!amountColors) {
+    initializationOptions.amountColors = false;
   }
 
   // Scope the selector to this root so exactly one client claims each file.


### PR DESCRIPTION
A client can decline `documentColor` for amounts by passing `amountColors: false` in its initialization options; the server then doesn't advertise the capability at all. Part of #2245.

## Why this and not removal

The decision on #2245 was **keep both**, since `documentColor` reaches clients without semantic-token support. That left one real problem unsolved: the swatch occupies a character cell, so a colored line sits a column right of an uncolored one and the alignment `rledger format` produces comes apart (#2230) — and the only escape was `editor.colorDecorators`, which is **VS Code's**. An editor without an equivalent had no way to decline the decoration.

Given the goal of reaching as many editors as possible, the fix is a server-side switch rather than relying on each client having its own.

## Turning it off is lossless

That's the part worth checking rather than assuming, so I drove the real server over stdio:

```
default              colorProvider=True   negative-modifier tokens=1
amountColors=false   colorProvider=None   negative-modifier tokens=1
amountColors=true    colorProvider=True   negative-modifier tokens=1
```

With the swatch off, the capability is gone **and** the negated amount still reports its `negative` semantic-token modifier (#2246). So a user who wants their alignment back keeps the sign signal they were previously trading away — which is exactly what the reporter of #2230 gave up with `editor.colorDecorators: false`.

## Opt-out, not opt-in

Default on; an absent key leaves it on; the VS Code client sends the option **only** when the setting is false. Every existing client sees exactly what it sees today.

A non-boolean leaves the default alone rather than being read as "off" — silently disabling a feature because a client sent the wrong type is worse than ignoring the value. Both halves are pinned: loosening the parse to `unwrap_or(false)` fails one test, flipping the default fails both.

## Scope

Server plus the VS Code client (`rustledger.amountColors`). Other clients get it by passing the initialization option, which is the point — it needs no per-editor feature.

4736 workspace tests green, clippy clean on 1.97.0, typos clean, `tsc --noEmit` clean, `package.json` valid.

#2245 stays open for the remaining question — whether `documentColor` should eventually be retired — which now has considerably less urgency, since its cost is opt-out-able in every editor rather than only in VS Code.