### PR TITLE
chore: release v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-budget"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rust_decimal",
@@ -3444,11 +3444,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.22.0"
+version = "0.23.0"
 
 [[package]]
 name = "rustledger-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "criterion",
  "imbl",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rust_decimal",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component-tests"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "rustledger-booking",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.3",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "glob",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-channel",
  "glob",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-returns"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -200,21 +200,21 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.22.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.22.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.22.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.22.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.22.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.22.0", path = "crates/rustledger-query" }
-rustledger-returns = { version = "0.22.0", path = "crates/rustledger-returns" }
-rustledger-budget = { version = "0.22.0", path = "crates/rustledger-budget" }
-rustledger-completion = { version = "0.22.0", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.22.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.22.0", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.22.0", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.22.0", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.22.0", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.22.0", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.23.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.23.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.23.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.23.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.23.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.23.0", path = "crates/rustledger-query" }
+rustledger-returns = { version = "0.23.0", path = "crates/rustledger-returns" }
+rustledger-budget = { version = "0.23.0", path = "crates/rustledger-budget" }
+rustledger-completion = { version = "0.23.0", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.23.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.23.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.23.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.23.0", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.23.0", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.23.0", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-booking/fuzz/Cargo.lock
+++ b/crates/rustledger-booking/fuzz/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustledger-booking"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "rust_decimal",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "imbl",
  "jiff",

--- a/crates/rustledger-budget/Cargo.toml
+++ b/crates/rustledger-budget/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-budget"
 description = "Budget model for beancount ledgers — Fava-compatible `custom \"budget\"` directives, calendar intervals, and per-day accrual"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Slimmed FFI-support helpers reused by the rustledger WASI component FFI (loader orchestration + WIT-input construction + directive hashing; the wasip1 JSON-RPC surface and Directive-to-JSON DTO were removed in #1419)"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/fuzz/Cargo.lock
+++ b/crates/rustledger-ffi-wasi/fuzz/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustledger-booking"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "rust_decimal",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-budget"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rust_decimal",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "imbl",
  "jiff",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.3",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "glob",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "logos",
  "num_enum",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "jiff",
@@ -1324,14 +1324,14 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rustledger-query"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chumsky",
  "jiff",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-returns"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rust_decimal",
  "rustledger-core",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "jiff",

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-loader/fuzz/Cargo.lock
+++ b/crates/rustledger-loader/fuzz/Cargo.lock
@@ -1045,7 +1045,7 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustledger-booking"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "rust_decimal",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-budget"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jiff",
  "rust_decimal",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "imbl",
  "jiff",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "glob",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "logos",
  "num_enum",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "jiff",
@@ -1156,14 +1156,14 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rustledger-validate"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bigdecimal",
  "jiff",

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -2,15 +2,15 @@
 name = "rustledger-lsp"
 # Lockstep with the workspace, like every other crate.
 #
-# This release DOES carry a breaking change to this crate's public API —
-# `uri_to_path`/`path_to_uri` went from `Option<PathBuf>` to
-# `Result<AbsPathBuf, PathUriError>` — and an earlier version of this line said
-# 0.22.0 to signal it. That does not work here: the release cut runs
-# `cargo set-version` over the whole workspace, so a hand-written version is
-# overwritten with whatever the tag says. The only effect was to invite a
-# downstream `rustledger-lsp = "0.22"` pin that no published crate would ever
-# satisfy. The break belongs in the release notes, which is where this repo's
-# consumers actually learn about one.
+# Do not hand-set this to signal a breaking change. v0.22.0 carried one to this
+# crate's public API — `uri_to_path`/`path_to_uri` went from `Option<PathBuf>`
+# to `Result<AbsPathBuf, PathUriError>` — and an earlier version of this line
+# was edited by hand to advertise it. That does not work here: the release cut
+# runs `cargo set-version` over the whole workspace, so a hand-written version
+# is overwritten with whatever the tag says. The only effect was to invite a
+# downstream pin that no published crate would ever satisfy. A break belongs in
+# the release notes, which is where this repo's consumers actually learn about
+# one.
 version = "0.23.0"
 edition.workspace = true
 authors.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -11,7 +11,7 @@ name = "rustledger-lsp"
 # downstream `rustledger-lsp = "0.22"` pin that no published crate would ever
 # satisfy. The break belongs in the release notes, which is where this repo's
 # consumers actually learn about one.
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/fuzz/Cargo.lock
+++ b/crates/rustledger-parser/fuzz/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "imbl",
  "jiff",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "logos",
  "num_enum",

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-returns/Cargo.toml
+++ b/crates/rustledger-returns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-returns"
 description = "Investment returns math for beancount ledgers — XIRR (money-weighted return) and, later, time-weighted return"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/wasm-importer-csv-example/Cargo.lock
+++ b/examples/wasm-importer-csv-example/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/examples/wasm-plugin-template/Cargo.lock
+++ b/examples/wasm-plugin-template/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
 ]

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.22.0
+Version:        0.23.0
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.22.0.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.23.0.tar.gz
 
 # Must match `workspace.package.rust-version` in Cargo.toml.
 # Edition 2024 stabilized in 1.85, so older toolchains fail at parse
@@ -24,7 +24,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.22.0
+%setup -q -n rustledger-0.23.0
 
 %build
 cargo build --release


### PR DESCRIPTION
Bump to v0.23.0. 84 commits since v0.22.0.

Bumped with `cargo set-version 0.23.0` (workspace version, all 17 crates, and the `[workspace.dependencies]` sibling pins), plus the three surfaces it does not reach:

- **`packages/mcp-server/package.json`** version only. The `@rustledger/wasm` dependency stays at `^0.22.0` and `package-lock.json` is untouched, matching the v0.22.0 release commit: 0.23.0 does not exist on npm until the publish workflow's earlier job puts it there, so naming it here would fail `npm ci` and with it the `build` gate. `release-publish.yml` force-syncs both from the tag.
- **`packaging/rpm/rustledger.spec`** `Version`, `Source0`, `%setup`. `BuildRequires: rust >= 1.96` already matches `[workspace.package].rust-version`.
- **All eight standalone lockfiles**, regenerated by enumerating `git ls-files '*Cargo.lock'` rather than working from a hand-kept list, with `--workspace` so only path dependencies move.

## Pre-flight

```
check-publish-crates.py --check-registry   17/17 crates exist on crates.io, array matches workspace
cargo check --workspace --all-features --all-targets   ok
mcp-server: npm ci && npm run build (tsc)              ok
wasm-pack build --target web --release                 ok
```

The registry check is the one that matters most here: v0.22.0 broke because `rustledger-returns` and `rustledger-budget` were listed but never published, and trusted publishing cannot create a crate. No crate was added this cycle, so that path is clear.

## Breaking change

`rledger query -f json` now emits **positional row arrays** instead of objects keyed by column name. Consumers that indexed rows by name need to zip against the `columns` array. This wants calling out explicitly in the release notes, since `generate_release_notes: true` will only show the commit subject.

## After merge

Tag at the merge commit, then verify all three workflows rather than stopping at the build:

1. **Release Build** — must attach `rustledger-ffi-component-<tag>.wasm` (rustfava and the desktop build glob for it)
2. **Release Publish** — crates.io, irreversible
3. **Release Channel Testing** — Scoop/Nix/AUR/Homebrew commonly fail immediately after a release because those manifests need a separate bump; that is a channel-update follow-up, not a build regression