### PR TITLE
fix(ci): move the flake vscode-extension check into the job that has nix

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -142,20 +142,6 @@ jobs:
             echo "Version mismatch!"
             exit 1
           fi
-      - name: Test the flake's VS Code extension package
-        run: |
-          # `nix run` above builds the DEFAULT package only, so the tag's other
-          # flake outputs went unevaluated. v0.22.0 shipped a
-          # `vscode-extension` derivation that could not build at all — a
-          # stale `npmDepsHash` — and this job passed, because nothing here
-          # ever asked for that output (#2109).
-          #
-          # Per-PR CI covers this on main now, and the tag is cut from main, so
-          # this is belt-and-braces rather than the primary guard. It costs one
-          # build and closes the gap between "main is green" and "the thing
-          # users actually pin builds".
-          nix build "github:rustledger/rustledger/v${VERSION}#vscode-extension" \
-            --no-link --print-build-logs
       - name: Create test file
         run: echo '${{ env.TEST_BEANCOUNT }}' > /tmp/test.beancount
       - name: Test rledger check
@@ -439,6 +425,20 @@ jobs:
             echo "Version mismatch!"
             exit 1
           fi
+      - name: Test the flake's VS Code extension package
+        run: |
+          # `nix run` above builds the DEFAULT package only, so the tag's other
+          # flake outputs went unevaluated. v0.22.0 shipped a
+          # `vscode-extension` derivation that could not build at all — a
+          # stale `npmDepsHash` — and this job passed, because nothing here
+          # ever asked for that output (#2109).
+          #
+          # Per-PR CI covers this on main now, and the tag is cut from main, so
+          # this is belt-and-braces rather than the primary guard. It costs one
+          # build and closes the gap between "main is green" and "the thing
+          # users actually pin builds".
+          nix build "github:rustledger/rustledger/v${VERSION}#vscode-extension" \
+            --no-link --print-build-logs
       - name: Create test file
         run: echo '${{ env.TEST_BEANCOUNT }}' > /tmp/test.beancount
       - name: Test rledger check


### PR DESCRIPTION
`Test the flake's VS Code extension package` was added to the `test-cargo` job, which runs in `container: rust:latest`. That container has no nix, so the step has always failed:

```
/__w/_temp/….sh: 11: nix: not found
##[error]Process completed with exit code 127
```

v0.23.0 was the first release to run it, and it failed the whole Release Channel Testing workflow with **19 of 20 jobs green** — including every distribution channel (Scoop, Nix, AUR, Homebrew, Docker, npm, all release binaries).

## The release itself was fine

Worth stating, since the red run looks alarming. Inside the failing job the steps that verify the release all passed:

```
✓ Wait for crates.io propagation
✓ Install rustledger        ← installed from crates.io
✓ Verify version
✗ Test the flake's VS Code extension package
```

crates.io serves `rustledger` 0.23.0, npm serves 0.23.0 for both `@rustledger/wasm` and `@rustledger/mcp-server`, and `rustledger-ffi-component-v0.23.0.wasm` is attached to the release.

## Where it belongs

`test-nix`, which installs nix via `cachix/install-nix-action`. The step's own comment gives it away:

> `nix run` above builds the DEFAULT package only, so the tag's other flake outputs went unevaluated.

There is no `nix run` above it in `test-cargo`. There is one in `test-nix` — its `Test nix run` step. Moved it to immediately after that step, so the comment reads correctly again.

## It was also costing coverage

The step failed mid-job, so everything after it was skipped:

```
– Create test file      (skipped)
– Test rledger check    (skipped)
– Test rledger query    (skipped)
```

Those are `test-cargo`'s functional smoke tests of the crates.io-installed binary, and they did not run for v0.23.0. The move restores them.

Introduced in 1d7bae15e6 (#2110) to guard the `vscode-extension` derivation that shipped broken in v0.22.0 (#2109). Right intent, wrong job.

## Verification

The workflow parses (`yaml.safe_load`, 17 jobs). Step ordering after the move:

```
test-cargo:  Wait for propagation → Install → Verify version →
             Create test file → Test rledger check → Test rledger query
test-nix:    Install Nix → Test nix run → Test the flake's VS Code extension
             package → Create test file → Test rledger check
```

This workflow only runs on `workflow_run` after Release Publish, so it cannot be exercised on this PR; the next release is the real test.