### PR TITLE
fix(extract): let importers.toml configure the OFX importer

### DIFF
--- a/crates/rustledger-importer/src/toml_entry.rs
+++ b/crates/rustledger-importer/src/toml_entry.rs
@@ -19,11 +19,37 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// Which built-in parser an entry configures.
+///
+/// `importers.toml` was CSV-only by construction until #2260: every entry
+/// built a `CsvConfig`, and `--importer <name>` forced `CsvImporter`, so an
+/// OFX statement named through the config was parsed as CSV while one
+/// dispatched by extension ignored the entry entirely. Declaring the format
+/// makes an entry reachable by the parser it was written for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EntryFormat {
+    /// Delimited text. The default, and what every field below configures.
+    #[default]
+    Csv,
+    /// OFX/QFX. Only `account`, `currency` and `filename_pattern` apply; the
+    /// column-mapping fields have no meaning for a self-describing format.
+    Ofx,
+}
+
 /// A single importer entry in `importers.toml`.
+///
+/// Unknown keys are rejected. A silently-ignored key is indistinguishable
+/// from a working one, and `type = "ofx"` was accepted-and-ignored before
+/// this field existed (#2260).
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImporterEntry {
     /// Name used to select this importer via --importer flag.
     pub name: String,
+
+    /// Which built-in parser this entry configures: `csv` (default) or `ofx`.
+    #[serde(rename = "type")]
+    pub format: Option<String>,
     /// Optional glob pattern to auto-identify this importer by filename.
     pub filename_pattern: Option<String>,
     /// Target account for imported transactions.
@@ -179,6 +205,24 @@ fn require_column_value(field: &str, value: &toml::Value) -> Result<String> {
 /// Returns an error when `name` is not a recognized locale.
 pub fn parse_amount_locale(name: &str) -> Result<Locale> {
     Locale::from_str(name).map_err(|_| anyhow!("{name} is not a valid locale"))
+}
+
+impl ImporterEntry {
+    /// The declared format, defaulting to CSV.
+    ///
+    /// # Errors
+    /// Returns an error for an unrecognized `type`, rather than silently
+    /// treating it as CSV — the failure mode this field exists to end.
+    pub fn entry_format(&self) -> Result<EntryFormat> {
+        match self.format.as_deref() {
+            None | Some("csv") => Ok(EntryFormat::Csv),
+            Some("ofx" | "qfx") => Ok(EntryFormat::Ofx),
+            Some(other) => Err(anyhow::anyhow!(
+                "importer '{}': unknown type '{other}' (expected \"csv\" or \"ofx\")",
+                self.name
+            )),
+        }
+    }
 }
 
 /// Build an [`ImporterConfig`] from a named importer entry.
@@ -406,6 +450,41 @@ mod tests {
     /// Regression for #1133: `amount_locale` / `amount_format` set in
     /// `importers.toml` were silently ignored — only the matching CLI flags
     /// (`--amount-locale` / `--amount-format`) applied them.
+    #[test]
+    fn entry_format_defaults_to_csv_and_reads_ofx() {
+        let csv: ImporterEntry = toml::from_str("name = \"a\"").unwrap();
+        assert_eq!(csv.entry_format().unwrap(), EntryFormat::Csv);
+
+        let explicit: ImporterEntry = toml::from_str("name = \"a\"\ntype = \"csv\"").unwrap();
+        assert_eq!(explicit.entry_format().unwrap(), EntryFormat::Csv);
+
+        for t in ["ofx", "qfx"] {
+            let e: ImporterEntry =
+                toml::from_str(&format!("name = \"a\"\ntype = \"{t}\"")).unwrap();
+            assert_eq!(e.entry_format().unwrap(), EntryFormat::Ofx, "type = {t}");
+        }
+    }
+
+    /// An unrecognized `type` must not quietly mean CSV — that is the failure
+    /// this field exists to end (#2260).
+    #[test]
+    fn entry_format_rejects_an_unknown_type() {
+        let e: ImporterEntry = toml::from_str("name = \"a\"\ntype = \"nonsense\"").unwrap();
+        let err = e.entry_format().unwrap_err().to_string();
+        assert!(err.contains("unknown type 'nonsense'"), "got: {err}");
+        assert!(err.contains('a'), "the error should name the entry: {err}");
+    }
+
+    /// Before #2260 `type = "ofx"` parsed fine and did nothing, and so did any
+    /// typo. Unknown keys are now an error.
+    #[test]
+    fn unknown_keys_are_rejected() {
+        let err = toml::from_str::<ImporterEntry>("name = \"a\"\ntotally_bogus = 1")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("totally_bogus"), "got: {err}");
+    }
+
     #[test]
     fn build_config_from_entry_applies_amount_locale_and_format() {
         let src = r##"

--- a/crates/rustledger-importer/src/toml_entry.rs
+++ b/crates/rustledger-importer/src/toml_entry.rs
@@ -47,7 +47,9 @@ pub struct ImporterEntry {
     /// Name used to select this importer via --importer flag.
     pub name: String,
 
-    /// Which built-in parser this entry configures: `csv` (default) or `ofx`.
+    /// Which built-in parser this entry configures: `csv` (the default) or
+    /// `ofx`. `qfx` is accepted as a spelling of `ofx`, since Quicken exports
+    /// carry that extension and users reach for it.
     #[serde(rename = "type")]
     pub format: Option<String>,
     /// Optional glob pattern to auto-identify this importer by filename.
@@ -231,6 +233,17 @@ impl ImporterEntry {
 /// Returns an error when a field fails to validate (e.g. an unknown
 /// `amount_locale`) or the assembled config is incomplete.
 pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> {
+    // Validate `type` here as well as at dispatch. This is the other consumer
+    // of an entry — the WASI component's importer interface calls it without
+    // going through the CLI's dispatcher — so validating only at dispatch left
+    // `type = "nonsense"` accepted and ignored on this path, which is the
+    // silent-misconfiguration failure the field was added to end (#2260).
+    //
+    // An `ofx` entry is NOT rejected: `account` and `currency` are meaningful
+    // to it, and the column fields it does not use are simply absent from the
+    // built config. Only an unrecognized value is an error.
+    entry.entry_format()?;
+
     let mut builder = ImporterConfig::csv();
 
     if let Some(ref account) = entry.account {
@@ -463,6 +476,28 @@ mod tests {
                 toml::from_str(&format!("name = \"a\"\ntype = \"{t}\"")).unwrap();
             assert_eq!(e.entry_format().unwrap(), EntryFormat::Ofx, "type = {t}");
         }
+    }
+
+    /// Copilot review on #2261: validating only at dispatch left the other
+    /// consumer — the component's importer interface, which calls
+    /// `build_config_from_entry` directly — accepting and ignoring a bad type.
+    #[test]
+    fn build_config_from_entry_also_rejects_an_unknown_type() {
+        let entry: ImporterEntry = toml::from_str("name = \"a\"\ntype = \"nonsense\"").unwrap();
+        let err = build_config_from_entry(&entry).unwrap_err().to_string();
+        assert!(err.contains("unknown type 'nonsense'"), "got: {err}");
+    }
+
+    /// An `ofx` entry is not rejected there: account/currency still apply.
+    #[test]
+    fn build_config_from_entry_accepts_an_ofx_entry() {
+        let entry: ImporterEntry = toml::from_str(
+            "name = \"a\"\ntype = \"ofx\"\naccount = \"Liabilities:Card\"\ncurrency = \"EUR\"",
+        )
+        .unwrap();
+        let cfg = build_config_from_entry(&entry).expect("ofx entries build a config");
+        assert_eq!(cfg.account, "Liabilities:Card");
+        assert_eq!(cfg.currency.as_deref(), Some("EUR"));
     }
 
     /// An unrecognized `type` must not quietly mean CSV — that is the failure

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -72,7 +72,11 @@ use config::expand_tilde;
 use duplicate::load_existing_transactions;
 use rustledger_core::{Directive, FormatConfig};
 use rustledger_importer::config::CsvConfigBuilder;
-use rustledger_importer::{Importer, ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
+use rustledger_importer::toml_entry::EntryFormat;
+use rustledger_importer::{
+    Importer, ImporterConfig, ImporterRegistry, csv_importer::CsvImporter,
+    ofx_importer::OfxImporter,
+};
 use rustledger_parser::format::canonicalize_directives;
 use std::fs;
 use std::io::{self, Write};
@@ -593,6 +597,69 @@ fn maybe_preprocess(args: &Args, file: &Path) -> Result<Option<tempfile::NamedTe
     Ok(Some(tmp))
 }
 
+/// The fields a non-CSV dispatcher can take from an `importers.toml` entry.
+///
+/// Deliberately not the whole `ImporterEntry`: the column-mapping fields
+/// describe delimited text and mean nothing to a self-describing format, so
+/// carrying them here would invite using them.
+struct MinimalEntry {
+    format: Option<String>,
+    account: Option<String>,
+    currency: Option<String>,
+}
+
+/// Resolve the entry that applies to this file, if a config exists at all.
+///
+/// `Ok(None)` covers the ordinary "no config, or nothing in it applies" case.
+/// An `Err` means the config exists and is broken or ambiguous.
+fn load_minimal_entry(args: &Args, file: &Path) -> Result<Option<MinimalEntry>> {
+    let Some(config_path) = find_importers_config(args.config.as_deref())? else {
+        return Ok(None);
+    };
+    let importers_file = load_importers_config(&config_path)?;
+    let filename = file
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or_default();
+    let Some(entry) = resolve_config_entry(args, &importers_file, filename)? else {
+        return Ok(None);
+    };
+    // Surface an unrecognized `type` here rather than treating it as CSV.
+    entry.entry_format()?;
+    Ok(Some(MinimalEntry {
+        format: entry.format.clone(),
+        account: entry.account.clone(),
+        currency: entry.currency.clone(),
+    }))
+}
+
+/// Entry lookup for the dispatch decision. Silent on failure by design: this
+/// runs before we know whether the config will be used at all, and a path that
+/// would never read one must not be failed by it.
+fn resolve_entry_for_dispatch(args: &Args, file: &Path) -> Option<MinimalEntry> {
+    load_minimal_entry(args, file).ok().flatten()
+}
+
+/// Entry lookup for the non-CSV config branch.
+///
+/// Warns rather than fails. WASM importers share this branch, and erroring
+/// would fail a `--wasm-importer` run whose config simply has no entry
+/// matching the file — something that worked before #2260. Falling back to
+/// the CLI arguments keeps that working, and the warning means the fallback
+/// is visible instead of silent, which was the actual complaint.
+fn entry_for_minimal_config(args: &Args, file: &Path) -> Option<MinimalEntry> {
+    match load_minimal_entry(args, file) {
+        Ok(entry) => entry,
+        Err(e) => {
+            eprintln!(
+                "warning: could not apply importers.toml ({e}); \
+                 using --account/--currency instead"
+            );
+            None
+        }
+    }
+}
+
 /// Pick the importer for a given file + CLI args.
 ///
 /// - If the user explicitly chose a TOML entry (`--importer <name>`),
@@ -612,14 +679,25 @@ fn maybe_preprocess(args: &Args, file: &Path) -> Result<Option<tempfile::NamedTe
 /// - Fall back to [`CsvImporter`] for unknown extensions (e.g. `.qbo`
 ///   Quicken exports) so users with custom-extension TOML entries
 ///   keep working.
-fn select_importer(registry: &ImporterRegistry, file: &Path, args: &Args) -> Arc<dyn Importer> {
+fn select_importer(
+    registry: &ImporterRegistry,
+    file: &Path,
+    args: &Args,
+    entry_format: Option<EntryFormat>,
+) -> Arc<dyn Importer> {
     if args.importer.is_some() {
-        Arc::new(CsvImporter)
-    } else {
-        registry
-            .identify(file)
-            .unwrap_or_else(|| Arc::new(CsvImporter) as Arc<dyn Importer>)
+        // `--importer` used to force CSV unconditionally, so naming an OFX
+        // statement's entry parsed it as CSV (#2260). An entry that declares
+        // its format is dispatched to that parser; one that declares nothing
+        // keeps the old CSV default.
+        return match entry_format {
+            Some(EntryFormat::Ofx) => Arc::new(OfxImporter),
+            _ => Arc::new(CsvImporter),
+        };
     }
+    registry
+        .identify(file)
+        .unwrap_or_else(|| Arc::new(CsvImporter) as Arc<dyn Importer>)
 }
 
 fn importers_config_not_found_message() -> anyhow::Error {
@@ -882,7 +960,21 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     // CSV config eagerly would error on "No importers defined" when a
     // user runs e.g. `--config x.toml --wasm-importer my.wasm` with
     // an x.toml that only sets `wasm_importer_dir`.
-    let importer = select_importer(&registry, file, args);
+    // Resolve the config entry BEFORE dispatch so an entry can say which
+    // parser it configures. Tolerant on purpose: discovery must not fail a
+    // path that would never have read a config (`--auto`, raw arguments) —
+    // the same rule `maybe_preprocess` documents. Every branch that goes on
+    // to USE the config re-resolves it below and reports the error there.
+    let resolved_entry = resolve_entry_for_dispatch(args, source_file);
+    let entry_format = resolved_entry
+        .as_ref()
+        .and_then(|e| e.format.as_deref())
+        .and_then(|f| match f {
+            "ofx" | "qfx" => Some(EntryFormat::Ofx),
+            _ => None,
+        });
+
+    let importer = select_importer(&registry, file, args, entry_format);
 
     // Stringly-typed dispatcher check: `CsvImporter::name()` returns
     // the literal "CSV". Acceptable coupling for a CLI-internal
@@ -898,9 +990,24 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     // - CSV dispatcher: builds the full CsvConfig from
     //   --importer/--config/--auto/raw-args sources.
     let (config, fallback_accounts) = if dispatcher_needs_minimal_config {
+        // An entry's values are authoritative when one applies, matching
+        // `build_config_from_entry` on the CSV path — which builds purely
+        // from the entry and does not merge CLI arguments. Before #2260 this
+        // branch read CLI arguments only, so a configured OFX account was
+        // silently discarded and every posting landed on the `--account`
+        // default.
+        let entry = entry_for_minimal_config(args, source_file);
         let cfg = rustledger_importer::ImporterConfig {
-            account: args.account.clone(),
-            currency: Some(args.currency.clone()),
+            account: entry
+                .as_ref()
+                .and_then(|e| e.account.clone())
+                .unwrap_or_else(|| args.account.clone()),
+            currency: Some(
+                entry
+                    .as_ref()
+                    .and_then(|e| e.currency.clone())
+                    .unwrap_or_else(|| args.currency.clone()),
+            ),
             importer_type: rustledger_importer::config::ImporterType::Csv(
                 rustledger_importer::config::CsvConfig::default(),
             ),
@@ -1821,6 +1928,7 @@ preprocess = ["cat", "{input}"]
     #[test]
     fn test_build_config_from_entry_basic() {
         let entry = ImporterEntry {
+            format: None,
             name: "test".to_string(),
             account: Some("Assets:Bank:Test".to_string()),
             currency: Some("EUR".to_string()),
@@ -1861,6 +1969,7 @@ preprocess = ["cat", "{input}"]
         mappings.insert("WHOLE FOODS".to_string(), "Expenses:Groceries".to_string());
 
         let entry = ImporterEntry {
+            format: None,
             name: "test".to_string(),
             account: Some("Assets:Bank".to_string()),
             currency: None,
@@ -1900,6 +2009,7 @@ preprocess = ["cat", "{input}"]
     #[test]
     fn test_build_config_from_entry_with_default_expense() {
         let entry = ImporterEntry {
+            format: None,
             name: "test".to_string(),
             account: Some("Assets:Bank".to_string()),
             currency: None,
@@ -1940,6 +2050,7 @@ preprocess = ["cat", "{input}"]
     #[test]
     fn test_build_config_from_entry_all_options() {
         let entry = ImporterEntry {
+            format: None,
             name: "full".to_string(),
             account: Some("Assets:Bank".to_string()),
             currency: Some("GBP".to_string()),
@@ -2088,11 +2199,39 @@ default_expense = "Expenses:Uncategorized"
     // `.ofx`-named file would silently dispatch to `OfxImporter` and drop
     // the user's column mappings.
 
+    /// #2260: `--importer` forced `CsvImporter` unconditionally, so naming an
+    /// OFX statement's entry parsed it as CSV. An entry that declares its
+    /// format now reaches the parser it was written for.
+    #[test]
+    fn select_importer_honors_an_ofx_entry_type() {
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "--importer", "card", "s.qfx"]);
+        let imp = select_importer(&registry, Path::new("s.qfx"), &args, Some(EntryFormat::Ofx));
+        assert_eq!(imp.name(), "OFX/QFX");
+    }
+
+    /// The complement, and the older guard this must not undo: an entry that
+    /// declares nothing keeps forcing CSV even on an `.ofx`-named file, so a
+    /// CSV entry's column mappings are not silently dropped.
+    #[test]
+    fn select_importer_still_forces_csv_for_an_untyped_entry() {
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "--importer", "mapped", "s.ofx"]);
+        assert_eq!(
+            select_importer(&registry, Path::new("s.ofx"), &args, None).name(),
+            "CSV"
+        );
+        assert_eq!(
+            select_importer(&registry, Path::new("s.ofx"), &args, Some(EntryFormat::Csv)).name(),
+            "CSV"
+        );
+    }
+
     #[test]
     fn test_select_importer_csv_extension_picks_csv() {
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.csv"]);
-        let imp = select_importer(&registry, Path::new("foo.csv"), &args);
+        let imp = select_importer(&registry, Path::new("foo.csv"), &args, None);
         assert_eq!(imp.name(), "CSV");
     }
 
@@ -2100,7 +2239,7 @@ default_expense = "Expenses:Uncategorized"
     fn test_select_importer_ofx_extension_picks_ofx() {
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.ofx"]);
-        let imp = select_importer(&registry, Path::new("foo.ofx"), &args);
+        let imp = select_importer(&registry, Path::new("foo.ofx"), &args, None);
         assert_eq!(imp.name(), "OFX/QFX");
     }
 
@@ -2113,7 +2252,7 @@ default_expense = "Expenses:Uncategorized"
         // must override this case.
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.ofx", "--importer", "chase"]);
-        let imp = select_importer(&registry, Path::new("foo.ofx"), &args);
+        let imp = select_importer(&registry, Path::new("foo.ofx"), &args, None);
         assert_eq!(
             imp.name(),
             "CSV",
@@ -2128,7 +2267,7 @@ default_expense = "Expenses:Uncategorized"
         // path should choose CSV rather than erroring.
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.qbo"]);
-        let imp = select_importer(&registry, Path::new("foo.qbo"), &args);
+        let imp = select_importer(&registry, Path::new("foo.qbo"), &args, None);
         assert_eq!(imp.name(), "CSV");
     }
 
@@ -2162,7 +2301,7 @@ default_expense = "Expenses:Uncategorized"
             wasm_path.to_str().unwrap(),
         ]);
         let registry = build_registry(&args).expect("builds");
-        let imp = select_importer(&registry, Path::new("foo.mt940"), &args);
+        let imp = select_importer(&registry, Path::new("foo.mt940"), &args, None);
         assert_eq!(
             imp.name(),
             "mt9",


### PR DESCRIPTION
Closes #2260.

`importers.toml` could not reach the OFX importer at all. The two dispatch paths failed in opposite directions, so there was no invocation that worked:

| before | result |
|---|---|
| `rledger extract card.qfx` | OFX parsed correctly, entry's `account` silently discarded, postings on the `--account` default |
| `rledger extract card.qfx --importer card` | entry found, then **CSV** parsed the OFX file → "missing date column", zero transactions |

After, with `type = "ofx"` on the entry, both give `Liabilities:CreditCard`.

## Changes

**Entries declare their format.** `type = "csv"` (default) or `type = "ofx"`, and `select_importer` dispatches on it instead of forcing `CsvImporter` whenever `--importer` is present.

The old force-CSV behavior is kept for entries that declare nothing. That is deliberate: it is what stops a CSV entry's column mappings being dropped when its file happens to be named `.ofx`, which is the regression the existing `test_select_importer_explicit_importer_flag_forces_csv_even_on_ofx_file` guards. Both cases are now pinned by tests.

**The non-CSV branch reads the entry.** `account`/`currency` come from a resolved entry, falling back to CLI arguments. Entry values are authoritative when an entry applies — matching `build_config_from_entry` on the CSV path, which builds purely from the entry and does not merge CLI arguments.

**`deny_unknown_fields` on `ImporterEntry`.** Before this, `type = "ofx"` parsed fine and did nothing, and so did any typo. I hit this myself while investigating: my first test config had `type = "ofx"` and I assumed it worked. An unrecognized `type` *value* is likewise an error rather than a silent fallback to CSV.

## Behavior notes

**Entry resolution warns rather than fails** in the non-CSV branch:

```
warning: could not apply importers.toml (importer 'card': unknown type 'nonsense'
         (expected "csv" or "ofx")); using --account/--currency instead
```

WASM importers share that branch, and erroring would fail a `--wasm-importer` run whose config simply has no entry matching the file — something that worked before. Falling back keeps that working while making the fallback visible, which was the actual complaint.

**`deny_unknown_fields` is a breaking change for malformed configs.** A config carrying a stray key now fails to parse instead of silently ignoring it. That is the point, but it will surface in configs that were quietly wrong.

## Tests

676 pass across both crates. New:

- `select_importer_honors_an_ofx_entry_type`
- `select_importer_still_forces_csv_for_an_untyped_entry` (the older guard, both `None` and explicit `Csv`)
- `entry_format_defaults_to_csv_and_reads_ofx`
- `entry_format_rejects_an_unknown_type`
- `unknown_keys_are_rejected`

Verified not vacuous: removing `deny_unknown_fields` and making `entry_format` fall back to CSV fails `unknown_keys_are_rejected` and `entry_format_rejects_an_unknown_type`.

Worth flagging for reviewers: `cargo test -p rustledger-importer` **silently skips** the entire `toml_entry` module, which is behind the `toml-config` feature — 163 tests run and none of them are these. `--all-features` is required to see them.

## Interaction with #2259

That PR warns when a statement's account type contradicts the configured account. Until this fix, it warned against the CLI *default* rather than the user's configured account, so a correct `importers.toml` still produced a mismatch warning. With both, the warning is silent for a correctly configured OFX entry — confirmed by hand.