### PR TITLE
feat(extract): importer profiles from `open` directive metadata

### DIFF
--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -797,6 +797,7 @@ fn build_extract_args(
         output: path_flag(req, "output", Some("o")),
         force: bool_flag(req, "force", None),
         existing: path_flag(req, "existing", None),
+        ledger: path_flag(req, "ledger", None),
         suggest_categories: bool_flag(req, "suggest-categories", None),
         balance: string_flag(req, "balance", None),
         balance_date: string_flag(req, "balance-date", None),

--- a/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
@@ -54,7 +54,7 @@ pub(super) struct LedgerProfile {
 /// is an error rather than a silent skip: it can never match a file, so it is
 /// a typo or an unfinished edit, and staying quiet about it is how a user ends
 /// up believing their profile works.
-pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>> {
+pub(super) fn load_profiles(path: &Path) -> Result<Vec<(glob::Pattern, LedgerProfile)>> {
     let options = rustledger_loader::LoadOptions {
         run_plugins: false,
         validate: false,
@@ -62,6 +62,29 @@ pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>>
     };
     let ledger = rustledger_loader::load(path, &options)
         .map_err(|e| anyhow!("failed to load ledger {}: {e}", path.display()))?;
+
+    // `load` reports parse failures through `Ledger::errors` rather than an
+    // `Err`, so a ledger that does not parse arrives here looking like a
+    // ledger with no `open` directives. Ignoring that meant
+    // `--ledger broken.beancount` silently applied no profile and imported to
+    // the `--account` default: the user pointed at a file and was told
+    // nothing. `--ledger` is an explicit request to read it, so a file that
+    // cannot be read is an error here.
+    let fatal: Vec<&rustledger_loader::LedgerError> = ledger
+        .errors
+        .iter()
+        .filter(|e| e.severity == rustledger_loader::ErrorSeverity::Error)
+        .collect();
+    if let Some(first) = fatal.first() {
+        return Err(anyhow!(
+            "ledger {} has {} error(s) and cannot be read for importer \
+             profiles; first: [{}] {}",
+            path.display(),
+            fatal.len(),
+            first.code,
+            first.message
+        ));
+    }
 
     let mut out = Vec::new();
     for spanned in &ledger.directives {
@@ -81,14 +104,26 @@ pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>>
         match (importer, pattern) {
             // Neither key: an ordinary account, not a profile.
             (None, None) => {}
-            (Some(importer), Some(pattern)) => out.push((
-                pattern,
-                LedgerProfile {
-                    account,
-                    importer,
-                    currency: sole_currency(open),
-                },
-            )),
+            (Some(importer), Some(pattern)) => {
+                // Compile here, not at match time. `Pattern::new(..).is_ok_and(..)`
+                // turns an invalid glob into "did not match", so a typo like
+                // `[unclosed` silently disabled the profile and the import
+                // landed on the `--account` default.
+                let compiled = glob::Pattern::new(&pattern).map_err(|e| {
+                    anyhow!(
+                        "account {account}: `{KEY_PATTERN}: \"{pattern}\"` is not a \
+                         valid glob: {e}"
+                    )
+                })?;
+                out.push((
+                    compiled,
+                    LedgerProfile {
+                        account,
+                        importer,
+                        currency: sole_currency(open),
+                    },
+                ));
+            }
             (Some(importer), None) => {
                 return Err(anyhow!(
                     "account {account} declares `{KEY_IMPORTER}: \"{importer}\"` but no \
@@ -112,12 +147,12 @@ pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>>
 /// several entries claim: picking one silently would make which profile you
 /// got depend on directive order in the ledger.
 pub(super) fn match_profile(
-    profiles: &[(String, LedgerProfile)],
+    profiles: &[(glob::Pattern, LedgerProfile)],
     filename: &str,
 ) -> Result<Option<LedgerProfile>> {
     let matches: Vec<&LedgerProfile> = profiles
         .iter()
-        .filter(|(pattern, _)| glob::Pattern::new(pattern).is_ok_and(|p| p.matches(filename)))
+        .filter(|(pattern, _)| pattern.matches(filename))
         .map(|(_, profile)| profile)
         .collect();
 
@@ -192,7 +227,7 @@ mod tests {
         let profiles = load_profiles(f.path()).unwrap();
         assert_eq!(profiles.len(), 1);
         let (pattern, p) = &profiles[0];
-        assert_eq!(pattern, "*.qfx");
+        assert_eq!(pattern.as_str(), "*.qfx");
         assert_eq!(p.account, "Liabilities:CreditCard");
         assert_eq!(p.importer, "ofx");
         assert_eq!(p.currency.as_deref(), Some("USD"));
@@ -217,6 +252,42 @@ mod tests {
         let err = load_profiles(f.path()).unwrap_err().to_string();
         assert!(err.contains("Liabilities:Card"), "got: {err}");
         assert!(err.contains("importer-pattern"), "got: {err}");
+    }
+
+    /// Copilot review on #2262: an invalid glob was compiled at match time
+    /// with `is_ok_and`, so a typo became "did not match" and silently
+    /// disabled the profile.
+    #[test]
+    fn an_invalid_glob_is_an_error() {
+        let f = ledger(
+            "2024-01-01 open Liabilities:Card USD\n  importer: \"ofx\"\n  \
+             importer-pattern: \"[unclosed\"\n",
+        );
+        let err = load_profiles(f.path()).unwrap_err().to_string();
+        assert!(err.contains("not a"), "got: {err}");
+        assert!(err.contains("Liabilities:Card"), "got: {err}");
+    }
+
+    /// Third review pass on #2262: `load` reports parse failures through
+    /// `Ledger::errors`, not `Err`, so a ledger that does not parse arrived
+    /// looking like one with no `open` directives. `--ledger broken.beancount`
+    /// silently applied no profile and imported to the `--account` default.
+    #[test]
+    fn a_ledger_that_does_not_parse_is_an_error() {
+        let f = ledger("this is not valid beancount ~~~\n");
+        let err = load_profiles(f.path()).unwrap_err().to_string();
+        assert!(err.contains("cannot be read"), "got: {err}");
+    }
+
+    /// The complement: a ledger with no profiles at all is not an error, so
+    /// pointing `--ledger` at an ordinary file stays harmless.
+    #[test]
+    fn a_valid_ledger_without_profiles_is_not_an_error() {
+        let f = ledger(
+            "2024-01-01 open Assets:Bank USD\n\
+             2024-01-02 * \"Lunch\"\n  Assets:Bank  -5.00 USD\n  Expenses:Food\n",
+        );
+        assert!(load_profiles(f.path()).unwrap().is_empty());
     }
 
     /// Second review pass on #2262: the two halves of a profile were treated
@@ -269,7 +340,7 @@ mod tests {
     fn match_profile_selects_by_glob() {
         let profiles = vec![
             (
-                "*.qfx".to_string(),
+                glob::Pattern::new("*.qfx").unwrap(),
                 LedgerProfile {
                     account: "Liabilities:Card".into(),
                     importer: "ofx".into(),
@@ -277,7 +348,7 @@ mod tests {
                 },
             ),
             (
-                "acme-*.csv".to_string(),
+                glob::Pattern::new("acme-*.csv").unwrap(),
                 LedgerProfile {
                     account: "Assets:Acme".into(),
                     importer: "acme".into(),
@@ -300,7 +371,7 @@ mod tests {
     fn two_matching_profiles_are_an_error() {
         let profiles = vec![
             (
-                "*.qfx".to_string(),
+                glob::Pattern::new("*.qfx").unwrap(),
                 LedgerProfile {
                     account: "Liabilities:A".into(),
                     importer: "ofx".into(),
@@ -308,7 +379,7 @@ mod tests {
                 },
             ),
             (
-                "card*".to_string(),
+                glob::Pattern::new("card*").unwrap(),
                 LedgerProfile {
                     account: "Liabilities:B".into(),
                     importer: "ofx".into(),

--- a/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
@@ -1,0 +1,265 @@
+//! Importer profiles declared on `open` directives (#2257).
+//!
+//! An account's `open` directive already states the account and its currency,
+//! which are two of the three things an importer needs. Repeating them in
+//! `importers.toml` is the duplication this closes:
+//!
+//! ```beancount
+//! 2024-01-01 open Liabilities:CreditCard USD
+//!   importer: "ofx"
+//!   importer-pattern: "*.qfx"
+//! ```
+//!
+//! Deliberately a *selector*, not a second config format. `importer` names
+//! either a built-in parser (`csv`, `ofx`) or an `importers.toml` entry whose
+//! column mappings should be used; the ledger never carries column mappings
+//! itself. Two reasons: a ledger is a record of what happened rather than a
+//! configuration file, and a full second schema would need keeping in sync
+//! with the TOML one forever.
+//!
+//! Opt-in via `--ledger`. Without it nothing here runs, so no existing
+//! invocation changes behavior.
+
+use anyhow::{Result, anyhow};
+use rustledger_core::{Directive, MetaValue, Metadata};
+use std::path::Path;
+
+/// Metadata key naming the importer: a built-in (`csv`/`ofx`) or a TOML entry.
+const KEY_IMPORTER: &str = "importer";
+/// Metadata key holding the filename glob that selects this profile.
+const KEY_PATTERN: &str = "importer-pattern";
+
+/// A profile read off one `open` directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LedgerProfile {
+    /// The account the directive opens. This is the whole point: it is stated
+    /// once, where it is declared, rather than repeated in a config file.
+    pub account: String,
+    /// The `importer` value, verbatim. Resolved by the caller, which knows
+    /// whether a name matches a built-in or a TOML entry.
+    pub importer: String,
+    /// The single currency the directive declares, if it declares exactly one.
+    ///
+    /// `open Assets:X USD` is unambiguous. `open Assets:X USD,EUR` is not, and
+    /// guessing which one a statement is denominated in would be exactly the
+    /// kind of silent wrong answer this codebase avoids, so it yields `None`
+    /// and the caller falls back.
+    pub currency: Option<String>,
+}
+
+/// Read every importer profile from a ledger.
+///
+/// Directives without an `importer` key are ignored, so this is safe to run
+/// over any ledger. A directive that has `importer` but no `importer-pattern`
+/// is an error rather than a silent skip: it can never match a file, so it is
+/// a typo or an unfinished edit, and staying quiet about it is how a user ends
+/// up believing their profile works.
+pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>> {
+    let options = rustledger_loader::LoadOptions {
+        run_plugins: false,
+        validate: false,
+        ..Default::default()
+    };
+    let ledger = rustledger_loader::load(path, &options)
+        .map_err(|e| anyhow!("failed to load ledger {}: {e}", path.display()))?;
+
+    let mut out = Vec::new();
+    for spanned in &ledger.directives {
+        let Directive::Open(open) = &spanned.value else {
+            continue;
+        };
+        let Some(importer) = meta_string(&open.meta, KEY_IMPORTER) else {
+            continue;
+        };
+        let account = open.account.to_string();
+        let Some(pattern) = meta_string(&open.meta, KEY_PATTERN) else {
+            return Err(anyhow!(
+                "account {account} declares `{KEY_IMPORTER}: \"{importer}\"` but no \
+                 `{KEY_PATTERN}`, so it can never match a file"
+            ));
+        };
+        out.push((
+            pattern,
+            LedgerProfile {
+                account,
+                importer,
+                currency: sole_currency(open),
+            },
+        ));
+    }
+    Ok(out)
+}
+
+/// The profile whose pattern matches `filename`.
+///
+/// Ambiguity is an error, matching how `importers.toml` resolves a file that
+/// several entries claim: picking one silently would make which profile you
+/// got depend on directive order in the ledger.
+pub(super) fn match_profile(
+    profiles: &[(String, LedgerProfile)],
+    filename: &str,
+) -> Result<Option<LedgerProfile>> {
+    let matches: Vec<&LedgerProfile> = profiles
+        .iter()
+        .filter(|(pattern, _)| glob::Pattern::new(pattern).is_ok_and(|p| p.matches(filename)))
+        .map(|(_, profile)| profile)
+        .collect();
+
+    match matches.as_slice() {
+        [] => Ok(None),
+        [only] => Ok(Some((*only).clone())),
+        many => {
+            let accounts: Vec<&str> = many.iter().map(|p| p.account.as_str()).collect();
+            Err(anyhow!(
+                "{} accounts declare an importer matching '{filename}': {}. \
+                 Narrow one of their `{KEY_PATTERN}` globs.",
+                many.len(),
+                accounts.join(", ")
+            ))
+        }
+    }
+}
+
+fn meta_string(meta: &Metadata, key: &str) -> Option<String> {
+    match meta.get(key) {
+        Some(MetaValue::String(s)) => Some(s.clone()),
+        // A bare `ofx` parses as a currency, and `importer: USD` is not a
+        // thing anyone means, so accept it as the string it looks like.
+        Some(MetaValue::Currency(c)) => Some(c.to_string()),
+        _ => None,
+    }
+}
+
+/// The declared currency, only when there is exactly one.
+fn sole_currency(open: &rustledger_core::Open) -> Option<String> {
+    match open.currencies.as_slice() {
+        [one] => Some(one.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn ledger(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(".beancount")
+            .tempfile()
+            .unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn reads_account_and_currency_from_the_open_directive() {
+        let f = ledger(
+            "2024-01-01 open Liabilities:CreditCard USD\n  \
+             importer: \"ofx\"\n  importer-pattern: \"*.qfx\"\n",
+        );
+        let profiles = load_profiles(f.path()).unwrap();
+        assert_eq!(profiles.len(), 1);
+        let (pattern, p) = &profiles[0];
+        assert_eq!(pattern, "*.qfx");
+        assert_eq!(p.account, "Liabilities:CreditCard");
+        assert_eq!(p.importer, "ofx");
+        assert_eq!(p.currency.as_deref(), Some("USD"));
+    }
+
+    /// Running over an ordinary ledger must find nothing and complain about
+    /// nothing — the feature is opt-in per account, not per file.
+    #[test]
+    fn accounts_without_importer_metadata_are_ignored() {
+        let f = ledger(
+            "2024-01-01 open Assets:Bank:Checking USD\n\
+             2024-01-01 open Expenses:Food\n\
+             2024-01-02 * \"Lunch\"\n  Expenses:Food  5.00 USD\n  Assets:Bank:Checking\n",
+        );
+        assert!(load_profiles(f.path()).unwrap().is_empty());
+    }
+
+    /// A profile that can never match a file is a typo, not a preference.
+    #[test]
+    fn importer_without_a_pattern_is_an_error() {
+        let f = ledger("2024-01-01 open Liabilities:Card USD\n  importer: \"ofx\"\n");
+        let err = load_profiles(f.path()).unwrap_err().to_string();
+        assert!(err.contains("Liabilities:Card"), "got: {err}");
+        assert!(err.contains("importer-pattern"), "got: {err}");
+    }
+
+    /// Two currencies cannot be narrowed to one, and guessing which a
+    /// statement uses would be a silent wrong answer.
+    #[test]
+    fn currency_is_only_taken_when_the_account_declares_exactly_one() {
+        let multi = ledger(
+            "2024-01-01 open Assets:X USD,EUR\n  \
+             importer: \"csv\"\n  importer-pattern: \"*.csv\"\n",
+        );
+        assert_eq!(load_profiles(multi.path()).unwrap()[0].1.currency, None);
+
+        let none = ledger(
+            "2024-01-01 open Assets:X\n  importer: \"csv\"\n  importer-pattern: \"*.csv\"\n",
+        );
+        assert_eq!(load_profiles(none.path()).unwrap()[0].1.currency, None);
+    }
+
+    #[test]
+    fn match_profile_selects_by_glob() {
+        let profiles = vec![
+            (
+                "*.qfx".to_string(),
+                LedgerProfile {
+                    account: "Liabilities:Card".into(),
+                    importer: "ofx".into(),
+                    currency: Some("USD".into()),
+                },
+            ),
+            (
+                "acme-*.csv".to_string(),
+                LedgerProfile {
+                    account: "Assets:Acme".into(),
+                    importer: "acme".into(),
+                    currency: None,
+                },
+            ),
+        ];
+
+        let hit = match_profile(&profiles, "statement.qfx").unwrap().unwrap();
+        assert_eq!(hit.account, "Liabilities:Card");
+
+        let hit = match_profile(&profiles, "acme-jan.csv").unwrap().unwrap();
+        assert_eq!(hit.account, "Assets:Acme");
+
+        assert!(match_profile(&profiles, "unrelated.ofx").unwrap().is_none());
+    }
+
+    /// Picking one silently would make the result depend on directive order.
+    #[test]
+    fn two_matching_profiles_are_an_error() {
+        let profiles = vec![
+            (
+                "*.qfx".to_string(),
+                LedgerProfile {
+                    account: "Liabilities:A".into(),
+                    importer: "ofx".into(),
+                    currency: None,
+                },
+            ),
+            (
+                "card*".to_string(),
+                LedgerProfile {
+                    account: "Liabilities:B".into(),
+                    importer: "ofx".into(),
+                    currency: None,
+                },
+            ),
+        ];
+        let err = match_profile(&profiles, "card.qfx")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Liabilities:A"), "got: {err}");
+        assert!(err.contains("Liabilities:B"), "got: {err}");
+    }
+}

--- a/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/ledger_profile.rs
@@ -68,24 +68,40 @@ pub(super) fn load_profiles(path: &Path) -> Result<Vec<(String, LedgerProfile)>>
         let Directive::Open(open) = &spanned.value else {
             continue;
         };
-        let Some(importer) = meta_string(&open.meta, KEY_IMPORTER) else {
-            continue;
-        };
         let account = open.account.to_string();
-        let Some(pattern) = meta_string(&open.meta, KEY_PATTERN) else {
-            return Err(anyhow!(
-                "account {account} declares `{KEY_IMPORTER}: \"{importer}\"` but no \
-                 `{KEY_PATTERN}`, so it can never match a file"
-            ));
-        };
-        out.push((
-            pattern,
-            LedgerProfile {
-                account,
-                importer,
-                currency: sole_currency(open),
-            },
-        ));
+        let importer = meta_string(&open.meta, KEY_IMPORTER, &account)?;
+        let pattern = meta_string(&open.meta, KEY_PATTERN, &account)?;
+
+        // Both keys or neither. Half a profile is always a mistake, and the
+        // two halves are equally wrong: an `importer` with no pattern can
+        // never match a file, and a pattern with no `importer` says which
+        // files an account claims without saying how to read them. Skipping
+        // either silently is how someone ends up believing their profile
+        // works.
+        match (importer, pattern) {
+            // Neither key: an ordinary account, not a profile.
+            (None, None) => {}
+            (Some(importer), Some(pattern)) => out.push((
+                pattern,
+                LedgerProfile {
+                    account,
+                    importer,
+                    currency: sole_currency(open),
+                },
+            )),
+            (Some(importer), None) => {
+                return Err(anyhow!(
+                    "account {account} declares `{KEY_IMPORTER}: \"{importer}\"` but no \
+                     `{KEY_PATTERN}`, so it can never match a file"
+                ));
+            }
+            (None, Some(pattern)) => {
+                return Err(anyhow!(
+                    "account {account} declares `{KEY_PATTERN}: \"{pattern}\"` but no \
+                     `{KEY_IMPORTER}`, so nothing says how to read the files it claims"
+                ));
+            }
+        }
     }
     Ok(out)
 }
@@ -120,13 +136,27 @@ pub(super) fn match_profile(
     }
 }
 
-fn meta_string(meta: &Metadata, key: &str) -> Option<String> {
+/// Read a profile key as a string.
+///
+/// A key present with a non-string value is an error, not an absence. Both of
+/// these are things a user wrote on purpose, and treating them as "no profile
+/// here" is the silent-misconfiguration failure this whole feature keeps
+/// running into:
+///
+/// ```beancount
+/// importer: 42          ; not a string
+/// importer: Assets:Foo  ; an account, not a name
+/// ```
+fn meta_string(meta: &Metadata, key: &str, account: &str) -> Result<Option<String>> {
     match meta.get(key) {
-        Some(MetaValue::String(s)) => Some(s.clone()),
-        // A bare `ofx` parses as a currency, and `importer: USD` is not a
-        // thing anyone means, so accept it as the string it looks like.
-        Some(MetaValue::Currency(c)) => Some(c.to_string()),
-        _ => None,
+        None => Ok(None),
+        Some(MetaValue::String(s)) => Ok(Some(s.clone())),
+        // A bare `ofx` lexes as a currency, and `importer: USD` is not a thing
+        // anyone means, so accept it as the word it looks like.
+        Some(MetaValue::Currency(c)) => Ok(Some(c.to_string())),
+        Some(other) => Err(anyhow!(
+            "account {account}: `{key}` must be a quoted string, got {other:?}"
+        )),
     }
 }
 
@@ -187,6 +217,36 @@ mod tests {
         let err = load_profiles(f.path()).unwrap_err().to_string();
         assert!(err.contains("Liabilities:Card"), "got: {err}");
         assert!(err.contains("importer-pattern"), "got: {err}");
+    }
+
+    /// Second review pass on #2262: the two halves of a profile were treated
+    /// asymmetrically — `importer` without a pattern errored, but a pattern
+    /// without `importer` was skipped in silence.
+    #[test]
+    fn a_pattern_without_an_importer_is_an_error() {
+        let f = ledger("2024-01-01 open Liabilities:Card USD\n  importer-pattern: \"*.qfx\"\n");
+        let err = load_profiles(f.path()).unwrap_err().to_string();
+        assert!(err.contains("Liabilities:Card"), "got: {err}");
+        assert!(err.contains("importer"), "got: {err}");
+    }
+
+    /// Second review pass on #2262: a key present with a non-string value was
+    /// read as absent, so `importer: 42` silently meant "no profile here".
+    #[test]
+    fn a_non_string_key_is_an_error_not_an_absence() {
+        for src in [
+            "2024-01-01 open Liabilities:Card USD\n  importer: 42\n  \
+             importer-pattern: \"*.qfx\"\n",
+            "2024-01-01 open Liabilities:Card USD\n  importer: \"ofx\"\n  \
+             importer-pattern: 42\n",
+        ] {
+            let f = ledger(src);
+            let err = load_profiles(f.path()).unwrap_err().to_string();
+            assert!(
+                err.contains("must be a quoted string"),
+                "expected a type error, got: {err}"
+            );
+        }
     }
 
     /// Two currencies cannot be narrowed to one, and guessing which a

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -57,6 +57,7 @@
 
 mod config;
 mod duplicate;
+mod ledger_profile;
 mod suggest;
 
 use crate::cmd::completions::ShellType;
@@ -209,6 +210,15 @@ pub struct Args {
     #[arg(long, value_name = "FILE")]
     pub existing: Option<PathBuf>,
 
+    /// Read importer profiles from a ledger's `open` directives (#2257).
+    ///
+    /// An account that declares `importer:` and `importer-pattern:` supplies
+    /// the target account — and its currency, when it opens with exactly one —
+    /// so they need not be repeated in `importers.toml`. Separate from
+    /// `--existing`, which is only about duplicate detection.
+    #[arg(long, value_name = "FILE")]
+    pub ledger: Option<PathBuf>,
+
     /// Use ML to suggest accounts for transactions the rules engine didn't
     /// categorize. Trains a Naive Bayes model on the `--existing` ledger and
     /// replaces the configured fallback contra-accounts (the importer's
@@ -329,8 +339,18 @@ fn resolve_config_entry<'a>(
     importers_file: &'a ImportersFile,
     filename: &str,
 ) -> Result<Option<&'a rustledger_importer::toml_entry::ImporterEntry>> {
-    if let Some(ref name) = args.importer {
-        return Ok(importers_file.importers.iter().find(|e| e.name == *name));
+    resolve_config_entry_named(args.importer.as_deref(), importers_file, filename)
+}
+
+/// As [`resolve_config_entry`], but with the entry name supplied explicitly so
+/// a `--ledger` profile can name one (#2257) without forging an `Args`.
+fn resolve_config_entry_named<'a>(
+    importer_name: Option<&str>,
+    importers_file: &'a ImportersFile,
+    filename: &str,
+) -> Result<Option<&'a rustledger_importer::toml_entry::ImporterEntry>> {
+    if let Some(name) = importer_name {
+        return Ok(importers_file.importers.iter().find(|e| e.name == name));
     }
     if importers_file.importers.is_empty() {
         return Ok(None);
@@ -612,7 +632,11 @@ struct MinimalEntry {
 ///
 /// `Ok(None)` covers the ordinary "no config, or nothing in it applies" case.
 /// An `Err` means the config exists and is broken or ambiguous.
-fn load_minimal_entry(args: &Args, file: &Path) -> Result<Option<MinimalEntry>> {
+fn load_minimal_entry(
+    args: &Args,
+    file: &Path,
+    importer_name: Option<&str>,
+) -> Result<Option<MinimalEntry>> {
     let Some(config_path) = find_importers_config(args.config.as_deref())? else {
         return Ok(None);
     };
@@ -621,7 +645,12 @@ fn load_minimal_entry(args: &Args, file: &Path) -> Result<Option<MinimalEntry>> 
         .file_name()
         .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default();
-    let Some(entry) = resolve_config_entry(args, &importers_file, filename)? else {
+    let Some(entry) = resolve_config_entry_named(
+        importer_name.or(args.importer.as_deref()),
+        &importers_file,
+        filename,
+    )?
+    else {
         return Ok(None);
     };
     // Surface an unrecognized `type` here rather than treating it as CSV.
@@ -637,7 +666,7 @@ fn load_minimal_entry(args: &Args, file: &Path) -> Result<Option<MinimalEntry>> 
 /// runs before we know whether the config will be used at all, and a path that
 /// would never read one must not be failed by it.
 fn resolve_entry_for_dispatch(args: &Args, file: &Path) -> Option<MinimalEntry> {
-    load_minimal_entry(args, file).ok().flatten()
+    load_minimal_entry(args, file, None).ok().flatten()
 }
 
 /// Entry lookup for the non-CSV config branch.
@@ -647,8 +676,12 @@ fn resolve_entry_for_dispatch(args: &Args, file: &Path) -> Option<MinimalEntry> 
 /// matching the file — something that worked before #2260. Falling back to
 /// the CLI arguments keeps that working, and the warning means the fallback
 /// is visible instead of silent, which was the actual complaint.
-fn entry_for_minimal_config(args: &Args, file: &Path) -> Option<MinimalEntry> {
-    match load_minimal_entry(args, file) {
+fn entry_for_minimal_config(
+    args: &Args,
+    file: &Path,
+    importer_name: Option<&str>,
+) -> Option<MinimalEntry> {
+    match load_minimal_entry(args, file, importer_name) {
         Ok(entry) => entry,
         Err(e) => {
             eprintln!(
@@ -682,10 +715,10 @@ fn entry_for_minimal_config(args: &Args, file: &Path) -> Option<MinimalEntry> {
 fn select_importer(
     registry: &ImporterRegistry,
     file: &Path,
-    args: &Args,
+    entry_named: bool,
     entry_format: Option<EntryFormat>,
 ) -> Arc<dyn Importer> {
-    if args.importer.is_some() {
+    if entry_named {
         // `--importer` used to force CSV unconditionally, so naming an OFX
         // statement's entry parsed it as CSV (#2260). An entry that declares
         // its format is dispatched to that parser; one that declares nothing
@@ -960,6 +993,40 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     // CSV config eagerly would error on "No importers defined" when a
     // user runs e.g. `--config x.toml --wasm-importer my.wasm` with
     // an x.toml that only sets `wasm_importer_dir`.
+    // A `--ledger` profile, if one applies. Read before dispatch because it
+    // can name the parser as well as supply the account (#2257). Errors here
+    // are reported, not swallowed: `--ledger` is explicit opt-in, so a ledger
+    // that cannot be read or whose profiles are ambiguous is a real problem
+    // the user asked us to look at.
+    let profile = match args.ledger.as_deref() {
+        Some(ledger_path) => {
+            let profiles = ledger_profile::load_profiles(ledger_path)?;
+            let filename = source_file
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or_default();
+            ledger_profile::match_profile(&profiles, filename)?
+        }
+        None => None,
+    };
+
+    // `importer:` names either a built-in parser or an `importers.toml` entry.
+    // Splitting them here keeps the rest of the flow unaware of the source.
+    let profile_builtin = profile.as_ref().and_then(|p| match p.importer.as_str() {
+        "ofx" | "qfx" => Some(EntryFormat::Ofx),
+        "csv" => Some(EntryFormat::Csv),
+        _ => None,
+    });
+    let profile_entry_name = profile
+        .as_ref()
+        .filter(|_| profile_builtin.is_none())
+        .map(|p| p.importer.clone());
+
+    // An explicit `--importer` outranks a profile: the flag is this
+    // invocation, the ledger is standing configuration.
+    let effective_entry_name: Option<String> =
+        args.importer.clone().or_else(|| profile_entry_name.clone());
+
     // Resolve the config entry BEFORE dispatch so an entry can say which
     // parser it configures. Tolerant on purpose: discovery must not fail a
     // path that would never have read a config (`--auto`, raw arguments) —
@@ -974,7 +1041,13 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             _ => None,
         });
 
-    let importer = select_importer(&registry, file, args, entry_format);
+    let entry_format = entry_format.or(profile_builtin);
+    let importer = select_importer(
+        &registry,
+        file,
+        effective_entry_name.is_some(),
+        entry_format,
+    );
 
     // Stringly-typed dispatcher check: `CsvImporter::name()` returns
     // the literal "CSV". Acceptable coupling for a CLI-internal
@@ -996,16 +1069,21 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
         // branch read CLI arguments only, so a configured OFX account was
         // silently discarded and every posting landed on the `--account`
         // default.
-        let entry = entry_for_minimal_config(args, source_file);
+        let entry = entry_for_minimal_config(args, source_file, effective_entry_name.as_deref());
         let cfg = rustledger_importer::ImporterConfig {
-            account: entry
+            // A `--ledger` profile wins over a TOML entry for these two:
+            // the `open` directive IS the account's declaration, so repeating
+            // it in config and disagreeing would be the bug, not the config.
+            account: profile
                 .as_ref()
-                .and_then(|e| e.account.clone())
+                .map(|p| p.account.clone())
+                .or_else(|| entry.as_ref().and_then(|e| e.account.clone()))
                 .unwrap_or_else(|| args.account.clone()),
             currency: Some(
-                entry
+                profile
                     .as_ref()
-                    .and_then(|e| e.currency.clone())
+                    .and_then(|p| p.currency.clone())
+                    .or_else(|| entry.as_ref().and_then(|e| e.currency.clone()))
                     .unwrap_or_else(|| args.currency.clone()),
             ),
             importer_type: rustledger_importer::config::ImporterType::Csv(
@@ -1025,8 +1103,9 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     } else {
         // CSV branch: determine import config from --importer flag,
         // explicit --config, --auto, or raw CLI args.
-        let config = if let Some(ref importer_name) = args.importer {
-            // Explicit --importer: require config file, find named entry
+        let config = if let Some(ref importer_name) = effective_entry_name {
+            // A named entry, from `--importer` or from a `--ledger` profile's
+            // `importer:` key: require a config file and find that entry.
             let config_path = find_importers_config(args.config.as_deref())?
                 .ok_or_else(importers_config_not_found_message)?;
 
@@ -2206,7 +2285,12 @@ default_expense = "Expenses:Uncategorized"
     fn select_importer_honors_an_ofx_entry_type() {
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "--importer", "card", "s.qfx"]);
-        let imp = select_importer(&registry, Path::new("s.qfx"), &args, Some(EntryFormat::Ofx));
+        let imp = select_importer(
+            &registry,
+            Path::new("s.qfx"),
+            args.importer.is_some(),
+            Some(EntryFormat::Ofx),
+        );
         assert_eq!(imp.name(), "OFX/QFX");
     }
 
@@ -2218,11 +2302,17 @@ default_expense = "Expenses:Uncategorized"
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "--importer", "mapped", "s.ofx"]);
         assert_eq!(
-            select_importer(&registry, Path::new("s.ofx"), &args, None).name(),
+            select_importer(&registry, Path::new("s.ofx"), args.importer.is_some(), None).name(),
             "CSV"
         );
         assert_eq!(
-            select_importer(&registry, Path::new("s.ofx"), &args, Some(EntryFormat::Csv)).name(),
+            select_importer(
+                &registry,
+                Path::new("s.ofx"),
+                args.importer.is_some(),
+                Some(EntryFormat::Csv)
+            )
+            .name(),
             "CSV"
         );
     }
@@ -2231,7 +2321,12 @@ default_expense = "Expenses:Uncategorized"
     fn test_select_importer_csv_extension_picks_csv() {
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.csv"]);
-        let imp = select_importer(&registry, Path::new("foo.csv"), &args, None);
+        let imp = select_importer(
+            &registry,
+            Path::new("foo.csv"),
+            args.importer.is_some(),
+            None,
+        );
         assert_eq!(imp.name(), "CSV");
     }
 
@@ -2239,7 +2334,12 @@ default_expense = "Expenses:Uncategorized"
     fn test_select_importer_ofx_extension_picks_ofx() {
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.ofx"]);
-        let imp = select_importer(&registry, Path::new("foo.ofx"), &args, None);
+        let imp = select_importer(
+            &registry,
+            Path::new("foo.ofx"),
+            args.importer.is_some(),
+            None,
+        );
         assert_eq!(imp.name(), "OFX/QFX");
     }
 
@@ -2252,7 +2352,12 @@ default_expense = "Expenses:Uncategorized"
         // must override this case.
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.ofx", "--importer", "chase"]);
-        let imp = select_importer(&registry, Path::new("foo.ofx"), &args, None);
+        let imp = select_importer(
+            &registry,
+            Path::new("foo.ofx"),
+            args.importer.is_some(),
+            None,
+        );
         assert_eq!(
             imp.name(),
             "CSV",
@@ -2267,7 +2372,12 @@ default_expense = "Expenses:Uncategorized"
         // path should choose CSV rather than erroring.
         let registry = ImporterRegistry::with_builtins();
         let args = Args::parse_from(["extract", "ignored.qbo"]);
-        let imp = select_importer(&registry, Path::new("foo.qbo"), &args, None);
+        let imp = select_importer(
+            &registry,
+            Path::new("foo.qbo"),
+            args.importer.is_some(),
+            None,
+        );
         assert_eq!(imp.name(), "CSV");
     }
 
@@ -2301,7 +2411,12 @@ default_expense = "Expenses:Uncategorized"
             wasm_path.to_str().unwrap(),
         ]);
         let registry = build_registry(&args).expect("builds");
-        let imp = select_importer(&registry, Path::new("foo.mt940"), &args, None);
+        let imp = select_importer(
+            &registry,
+            Path::new("foo.mt940"),
+            args.importer.is_some(),
+            None,
+        );
         assert_eq!(
             imp.name(),
             "mt9",

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -1011,12 +1011,32 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     // the user asked us to look at.
     let profile = match args.ledger.as_deref() {
         Some(ledger_path) => {
+            // Loaded even when it will not be applied, so a broken ledger is
+            // still reported: `--ledger` is an explicit request to read it.
             let profiles = ledger_profile::load_profiles(ledger_path)?;
             let filename = source_file
                 .file_name()
                 .and_then(std::ffi::OsStr::to_str)
                 .unwrap_or_default();
-            ledger_profile::match_profile(&profiles, filename)?
+            let matched = ledger_profile::match_profile(&profiles, filename)?;
+
+            // An explicit `--importer` names the entry to use, which settles
+            // both the parser and the account; a profile matched by filename
+            // is then a second opinion nobody asked for. Dropped rather than
+            // merged — merging is how the account came from one source and
+            // the column mappings from another. Said out loud, because a
+            // silently ignored `--ledger` is the failure this feature keeps
+            // reproducing.
+            if matched.is_some() && args.importer.is_some() {
+                eprintln!(
+                    "warning: --importer was given, so the --ledger profile for \
+                     {} is not applied",
+                    matched.as_ref().map_or("", |p| p.account.as_str())
+                );
+                None
+            } else {
+                matched
+            }
         }
         None => None,
     };
@@ -2864,6 +2884,53 @@ default_expense = "Expenses:Uncategorized"
         assert!(
             text.contains("Liabilities:FromLedger"),
             "the ledger account must win; got:\n{text}"
+        );
+    }
+
+    /// Third review pass on #2262: the fix that made a profile outrank
+    /// `importers.toml` applied unconditionally, so it also overrode an
+    /// explicit `--importer` — contradicting the documented precedence, and
+    /// introduced by the previous fix.
+    #[test]
+    fn an_explicit_importer_flag_outranks_a_ledger_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let csv = dir.path().join("bank.csv");
+        std::fs::write(&csv, "Date,Description,Amount\n2024-01-15,COFFEE,-4.50\n").unwrap();
+        std::fs::write(
+            dir.path().join("importers.toml"),
+            "[[importers]]\nname = \"flagentry\"\naccount = \"Assets:FromFlag\"\n\
+             currency = \"USD\"\ndate_column = \"Date\"\n\
+             narration_column = \"Description\"\namount_column = \"Amount\"\n\
+             filename_pattern = \"*.NOMATCH\"\n\n\
+             [[importers]]\nname = \"b\"\nfilename_pattern = \"*.NOMATCH2\"\n",
+        )
+        .unwrap();
+        let ledger = dir.path().join("main.beancount");
+        std::fs::write(
+            &ledger,
+            "2024-01-01 open Assets:FromLedger USD\n  \
+             importer: \"flagentry\"\n  importer-pattern: \"*.csv\"\n",
+        )
+        .unwrap();
+
+        let args = Args::parse_from([
+            "extract",
+            csv.to_str().unwrap(),
+            "--ledger",
+            ledger.to_str().unwrap(),
+            "--importer",
+            "flagentry",
+        ]);
+        let mut out = Vec::new();
+        with_cwd(dir.path(), || run_with_writer(&args, &csv, &mut out)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("Assets:FromFlag"),
+            "the explicit flag must win; got:\n{text}"
+        );
+        assert!(
+            !text.contains("Assets:FromLedger"),
+            "the profile must not override an explicit --importer; got:\n{text}"
         );
     }
 

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -665,8 +665,14 @@ fn load_minimal_entry(
 /// Entry lookup for the dispatch decision. Silent on failure by design: this
 /// runs before we know whether the config will be used at all, and a path that
 /// would never read one must not be failed by it.
-fn resolve_entry_for_dispatch(args: &Args, file: &Path) -> Option<MinimalEntry> {
-    load_minimal_entry(args, file, None).ok().flatten()
+fn resolve_entry_for_dispatch(
+    args: &Args,
+    file: &Path,
+    profile_entry_name: Option<&str>,
+) -> Option<MinimalEntry> {
+    load_minimal_entry(args, file, profile_entry_name)
+        .ok()
+        .flatten()
 }
 
 /// Entry lookup for the non-CSV config branch.
@@ -680,14 +686,19 @@ fn entry_for_minimal_config(
     args: &Args,
     file: &Path,
     importer_name: Option<&str>,
+    warn_on_failure: bool,
 ) -> Option<MinimalEntry> {
     match load_minimal_entry(args, file, importer_name) {
         Ok(entry) => entry,
         Err(e) => {
-            eprintln!(
-                "warning: could not apply importers.toml ({e}); \
-                 using --account/--currency instead"
-            );
+            // Silent when a `--ledger` profile already supplied the account:
+            // saying we fell back to `--account` would simply be untrue.
+            if warn_on_failure {
+                eprintln!(
+                    "warning: could not apply importers.toml ({e}); \
+                     using --account/--currency instead"
+                );
+            }
             None
         }
     }
@@ -1032,7 +1043,8 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     // path that would never have read a config (`--auto`, raw arguments) —
     // the same rule `maybe_preprocess` documents. Every branch that goes on
     // to USE the config re-resolves it below and reports the error there.
-    let resolved_entry = resolve_entry_for_dispatch(args, source_file);
+    let resolved_entry =
+        resolve_entry_for_dispatch(args, source_file, profile_entry_name.as_deref());
     let entry_format = resolved_entry
         .as_ref()
         .and_then(|e| e.format.as_deref())
@@ -1069,7 +1081,14 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
         // branch read CLI arguments only, so a configured OFX account was
         // silently discarded and every posting landed on the `--account`
         // default.
-        let entry = entry_for_minimal_config(args, source_file, effective_entry_name.as_deref());
+        // Suppressed when a profile applies: it already supplied the account,
+        // so warning that we fell back to `--account` would be false.
+        let entry = entry_for_minimal_config(
+            args,
+            source_file,
+            effective_entry_name.as_deref(),
+            profile.is_none(),
+        );
         let cfg = rustledger_importer::ImporterConfig {
             // A `--ledger` profile wins over a TOML entry for these two:
             // the `open` directive IS the account's declaration, so repeating
@@ -1301,6 +1320,19 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
                 .clone()
                 .unwrap_or_else(|| "Income:Unknown".to_string()),
         ];
+        // A `--ledger` profile outranks whatever the entry said, on this path
+        // as much as the minimal one: the `open` directive IS the account's
+        // declaration. Applied after the chain so every arm above is covered,
+        // including `--auto` and raw CLI arguments.
+        let config = match profile.as_ref() {
+            Some(p) => ImporterConfig {
+                account: p.account.clone(),
+                currency: p.currency.clone().or(config.currency),
+                ..config
+            },
+            None => config,
+        };
+
         (config, fallbacks)
     };
 
@@ -2781,6 +2813,101 @@ default_expense = "Expenses:Uncategorized"
             std::fs::read_to_string(&output).unwrap(),
             after_first,
             "an all-duplicates run must not truncate the target"
+        );
+    }
+
+    /// Deep-review finding on #2262: a profile naming a TOML entry did not
+    /// reach the dispatcher, so an entry declaring `type = "ofx"` was parsed
+    /// as CSV — the #2260 failure, reintroduced through the profile path. It
+    /// passed a first test only because a single-entry config falls back to
+    /// "the only entry"; three entries remove that accident.
+    #[test]
+    fn a_profile_naming_an_ofx_entry_dispatches_to_ofx() {
+        let dir = tempfile::tempdir().unwrap();
+        let qfx = dir.path().join("card.qfx");
+        std::fs::write(
+            &qfx,
+            "OFXHEADER:100\n<OFX><CREDITCARDMSGSRSV1><CCSTMTTRNRS><CCSTMTRS><CURDEF>USD\n\
+             <BANKTRANLIST><STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20240115<TRNAMT>-50.00\
+             <FITID>t1<NAME>COFFEE</STMTTRN></BANKTRANLIST>\n\
+             </CCSTMTRS></CCSTMTTRNRS></CREDITCARDMSGSRSV1></OFX>",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("importers.toml"),
+            "[[importers]]\nname = \"card\"\ntype = \"ofx\"\n\
+             account = \"Liabilities:FromToml\"\ncurrency = \"USD\"\n\
+             filename_pattern = \"*.NOMATCH\"\n\n\
+             [[importers]]\nname = \"b\"\nfilename_pattern = \"*.NOMATCH2\"\n\n\
+             [[importers]]\nname = \"c\"\nfilename_pattern = \"*.NOMATCH3\"\n",
+        )
+        .unwrap();
+        let ledger = dir.path().join("main.beancount");
+        std::fs::write(
+            &ledger,
+            "2024-01-01 open Liabilities:FromLedger USD\n  \
+             importer: \"card\"\n  importer-pattern: \"*.qfx\"\n",
+        )
+        .unwrap();
+
+        let args = Args::parse_from([
+            "extract",
+            qfx.to_str().unwrap(),
+            "--ledger",
+            ledger.to_str().unwrap(),
+        ]);
+        let mut out = Vec::new();
+        with_cwd(dir.path(), || run_with_writer(&args, &qfx, &mut out))
+            .expect("the ofx entry must be parsed as OFX, not CSV");
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("COFFEE"), "OFX did not parse; got:\n{text}");
+        assert!(
+            text.contains("Liabilities:FromLedger"),
+            "the ledger account must win; got:\n{text}"
+        );
+    }
+
+    /// Deep-review finding on #2262: the docs said a profile outranks
+    /// `importers.toml` for the account, and it did on the minimal-config path
+    /// but not the CSV one, where the entry's account still won.
+    #[test]
+    fn a_profile_account_outranks_the_toml_entry_on_the_csv_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let csv = dir.path().join("bank.csv");
+        std::fs::write(&csv, "Date,Description,Amount\n2024-01-15,COFFEE,-4.50\n").unwrap();
+        std::fs::write(
+            dir.path().join("importers.toml"),
+            "[[importers]]\nname = \"bank\"\naccount = \"Assets:FromToml\"\n\
+             currency = \"USD\"\ndate_column = \"Date\"\n\
+             narration_column = \"Description\"\namount_column = \"Amount\"\n\
+             filename_pattern = \"*.NOMATCH\"\n\n\
+             [[importers]]\nname = \"b\"\nfilename_pattern = \"*.NOMATCH2\"\n",
+        )
+        .unwrap();
+        let ledger = dir.path().join("main.beancount");
+        std::fs::write(
+            &ledger,
+            "2024-01-01 open Assets:FromLedger USD\n  \
+             importer: \"bank\"\n  importer-pattern: \"*.csv\"\n",
+        )
+        .unwrap();
+
+        let args = Args::parse_from([
+            "extract",
+            csv.to_str().unwrap(),
+            "--ledger",
+            ledger.to_str().unwrap(),
+        ]);
+        let mut out = Vec::new();
+        with_cwd(dir.path(), || run_with_writer(&args, &csv, &mut out)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("Assets:FromLedger"),
+            "the open directive is the account's declaration; got:\n{text}"
+        );
+        assert!(
+            !text.contains("Assets:FromToml"),
+            "the TOML account must not win; got:\n{text}"
         );
     }
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -178,8 +178,12 @@ Rules worth knowing:
 - **The currency is only taken when the account opens with exactly one.**
   `open Assets:X USD,EUR` cannot be narrowed to one, and guessing which a
   statement uses would be a silent wrong answer, so the CLI value applies.
-- **`importer` without `importer-pattern` is an error.** Such a profile can
-  never match a file, so it is a typo rather than a preference.
+- **Both keys or neither.** `importer` without `importer-pattern` can never
+  match a file; `importer-pattern` without `importer` says which files an
+  account claims without saying how to read them. Either half alone is an
+  error, not a preference.
+- **A key with a non-string value is an error**, not an absence. `importer: 42`
+  is something you wrote on purpose, so it is not read as "no profile here".
 - **Two accounts claiming one file is an error.** Picking one would make the
   result depend on directive order.
 - **`--importer` outranks a profile.** The flag is this invocation; the ledger

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -186,8 +186,16 @@ Rules worth knowing:
   is something you wrote on purpose, so it is not read as "no profile here".
 - **Two accounts claiming one file is an error.** Picking one would make the
   result depend on directive order.
-- **`--importer` outranks a profile.** The flag is this invocation; the ledger
-  is standing configuration.
+- **`--importer` outranks a profile.** The flag names the entry to use, which
+  settles both the parser and the account, so a profile matched by filename is
+  dropped rather than merged — and a warning says so, since a silently ignored
+  `--ledger` would be worse than a noisy one.
+- **A ledger that does not parse is an error.** `--ledger` is an explicit
+  request to read a file, so being unable to read it is not a reason to carry
+  on with defaults.
+- **Patterns match the filename, not the path.** `importer-pattern:
+  "statements/*.qfx"` never matches, the same as `filename_pattern` in
+  `importers.toml`.
 - **A profile outranks `importers.toml` for the account and currency.** The
   `open` directive *is* the account's declaration; a config file disagreeing
   with it is the bug.

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -61,6 +61,7 @@ rledger extract [OPTIONS] [FILE]
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-o, --output <FILE>`   | Write output to file instead of stdout. Refuses to overwrite a file that already has content (use `--force`, or append with `>>`)               |
 | `--force`               | Allow `--output` to overwrite a non-empty file, replacing its contents                                                                         |
+| `--ledger <FILE>`       | Read importer profiles from a ledger's `open` directives (see below)                                                                           |
 | `--existing <FILE>`     | Existing ledger file for duplicate detection                                                                                                    |
 | `--suggest-categories`  | Use ML (Naive Bayes on the `--existing` ledger) to suggest accounts for transactions the rules engine didn't categorize. Requires `--existing`. |
 | `--balance <AMOUNT>`    | Append a balance assertion directive with the given amount (e.g., `1234.56`)                                                                    |
@@ -144,6 +145,50 @@ error: refusing to overwrite ledger.beancount (163 bytes)
 `--existing` is for duplicate detection only and does not protect a file from
 being overwritten, so naming the same file for both `--existing` and `--output`
 is refused outright.
+
+### Importer Profiles in the Ledger
+
+An account's `open` directive already declares the account and its currency,
+which are two of the three things an importer needs. `--ledger` lets it declare
+the third, so they need not be repeated in `importers.toml`:
+
+```beancount
+2024-01-01 open Liabilities:CreditCard USD
+  importer: "ofx"
+  importer-pattern: "*.qfx"
+```
+
+```bash
+rledger extract card.qfx --ledger main.beancount
+```
+
+The transactions post to `Liabilities:CreditCard` in `USD`, both taken from the
+directive. No `importers.toml` is needed for a format like OFX that describes
+its own columns.
+
+| key | meaning |
+|-----|---------|
+| `importer` | A built-in parser (`csv`, `ofx`; `qfx` is accepted for `ofx`) **or** the `name` of an `importers.toml` entry whose column mappings to use |
+| `importer-pattern` | Filename glob selecting which files this account claims |
+
+Rules worth knowing:
+
+- **Opt-in.** Without `--ledger` nothing changes. Accounts with no `importer`
+  key are ignored, so pointing it at an ordinary ledger is harmless.
+- **The currency is only taken when the account opens with exactly one.**
+  `open Assets:X USD,EUR` cannot be narrowed to one, and guessing which a
+  statement uses would be a silent wrong answer, so the CLI value applies.
+- **`importer` without `importer-pattern` is an error.** Such a profile can
+  never match a file, so it is a typo rather than a preference.
+- **Two accounts claiming one file is an error.** Picking one would make the
+  result depend on directive order.
+- **`--importer` outranks a profile.** The flag is this invocation; the ledger
+  is standing configuration.
+- **A profile outranks `importers.toml` for the account and currency.** The
+  `open` directive *is* the account's declaration; a config file disagreeing
+  with it is the bug.
+- **`--ledger` is separate from `--existing`.** The latter is only about
+  duplicate detection. Passing both is fine, and they may name the same file.
 
 ### Duplicate Detection
 


### PR DESCRIPTION
Addresses #2257, proposed by @petemounce in [#2126](https://github.com/rustledger/rustledger/discussions/2126).

An account's `open` directive already declares the account and its currency — two of the three things an importer needs. `--ledger` lets it declare the third:

```beancount
2024-01-01 open Liabilities:CreditCard USD
  importer: "ofx"
  importer-pattern: "*.qfx"
```

```console
$ rledger extract card.qfx --ledger main.beancount
2024-01-15 * "COFFEE SHOP"
  Liabilities:CreditCard  -50.00 USD
  Expenses:Unknown
```

Account and currency both come from the directive. No `importers.toml` is needed at all for a self-describing format like OFX.

## Scope: a selector, not a second config format

`importer` names a built-in parser (`csv`, `ofx`) **or** an `importers.toml` entry whose column mappings to use. The ledger never carries column mappings itself.

Two reasons. A ledger is a record of what happened, not a configuration file — putting `date-column` in it means your ledger changes when your bank changes its CSV export. And a full second schema would need keeping in sync with the TOML one forever, which is the two-sources-of-truth problem #2257 flagged as the actual work.

## Rules, each with a test

- **Opt-in.** Without `--ledger` nothing here runs, so no existing invocation changes behavior. Accounts without an `importer` key are ignored, so pointing it at an ordinary ledger is harmless.
- **Currency only when the account opens with exactly one.** `open Assets:X USD,EUR` cannot be narrowed, and guessing which a statement uses would be a silent wrong answer.
- **`importer` without `importer-pattern` is an error, not a skip.** Such a profile can never match a file, so it is a typo, and staying quiet is how someone ends up believing their profile works.
- **Two accounts claiming one file is an error**, matching how `importers.toml` resolves an ambiguous match. Picking one would make the result depend on directive order in the ledger.
- **`--importer` outranks a profile** — the flag is this invocation, the ledger is standing configuration.
- **A profile outranks `importers.toml`** for account and currency: the `open` directive *is* the account's declaration, so a config file disagreeing with it is the bug.

## Why `--ledger` and not `--existing`

`--existing` is documented as "existing ledger file for duplicate detection". Reusing it would give one flag two unrelated jobs, and would mean you could not read profiles without also enabling dedup. They may name the same file.

## Verification

471 tests pass; 6 new unit tests plus end-to-end checks against the built binary:

```
--ledger with a matching profile   -> Liabilities:CreditCard, USD
no --ledger                        -> unchanged (Assets:Bank:Checking default)
importer: without importer-pattern -> error naming the account
two accounts matching one file     -> error naming both
open with USD,EUR                  -> currency falls back, account still applies
nonexistent ledger                 -> error
```

It also composes with #2259: with a correct profile, the statement-vs-account warning stays silent, because the account now matches what the statement says it is.

## Note

`--ledger` also had to be threaded through `ag-rledger`'s arg builder, which constructs `Args` as a struct literal. That is the third time this session a new `Args` field has needed it and `cargo build --bin rledger` has not caught it.