### PR TITLE
ci(nix): refresh the vscode npmDepsHash automatically

### DIFF
--- a/.github/workflows/vscode-npm-deps-hash.yml
+++ b/.github/workflows/vscode-npm-deps-hash.yml
@@ -50,13 +50,18 @@ jobs:
         id: hash
         run: |
           set -euo pipefail
-          # prefetch-npm-deps writes progress to stderr and the hash to stdout.
+          # prefetch-npm-deps writes progress to stderr and the hash to stdout,
+          # so stderr is captured rather than discarded: a network, auth or
+          # parse failure would otherwise surface only as "produced no hash",
+          # which says nothing about why.
+          err=$(mktemp)
           computed=$(nix shell nixpkgs#prefetch-npm-deps \
-            -c prefetch-npm-deps packages/vscode/package-lock.json 2>/dev/null | tail -1)
+            -c prefetch-npm-deps packages/vscode/package-lock.json 2>"$err" | tail -1) || true
           case "$computed" in
             sha256-*) ;;
             *)
-              echo "::error::prefetch-npm-deps produced no hash: '$computed'"
+              echo "::error::prefetch-npm-deps produced no hash. Its output follows."
+              sed 's/^/  /' "$err" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/vscode-npm-deps-hash.yml
+++ b/.github/workflows/vscode-npm-deps-hash.yml
@@ -1,0 +1,114 @@
+# Keep `flake.nix`'s `npmDepsHash` in step with the VS Code extension's
+# lockfile.
+#
+# `buildNpmPackage` pins the hash of the vendored npm dependency tree, so any
+# change to `packages/vscode/package-lock.json` invalidates it and the Nix
+# build fails with a fixed-output mismatch. Dependabot updates the lockfile and
+# has no way to know a Nix expression hashes it, so *every* npm bump in this
+# package landed red until somebody recomputed the hash by hand (#2109, #2202,
+# #2243). `build` requires that job, so those PRs could never merge unattended.
+#
+# This recomputes the hash and commits it to the pull request. It is separate
+# from the `VS Code Extension (Nix)` job on purpose: that job verifies, this one
+# repairs, and a verifier that silently rewrites what it is checking is worse
+# than one that fails.
+name: VS Code npmDepsHash
+
+on:
+  pull_request:
+    paths:
+      - packages/vscode/package-lock.json
+      - flake.nix
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vscode-npm-deps-hash-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Refresh npmDepsHash
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to push the corrected hash back to the pull request branch.
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Check out the PR branch itself rather than the merge commit, so a
+          # push goes back to the contributor's branch.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Compare the pinned hash with the lockfile
+        id: hash
+        run: |
+          set -euo pipefail
+          # prefetch-npm-deps writes progress to stderr and the hash to stdout.
+          computed=$(nix shell nixpkgs#prefetch-npm-deps \
+            -c prefetch-npm-deps packages/vscode/package-lock.json 2>/dev/null | tail -1)
+          case "$computed" in
+            sha256-*) ;;
+            *)
+              echo "::error::prefetch-npm-deps produced no hash: '$computed'"
+              exit 1
+              ;;
+          esac
+
+          pinned=$(grep -oE 'npmDepsHash = "[^"]+"' flake.nix | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "computed=$computed" >> "$GITHUB_OUTPUT"
+          echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          if [ "$computed" = "$pinned" ]; then
+            echo "matches=true" >> "$GITHUB_OUTPUT"
+            echo "npmDepsHash is already correct ($pinned)"
+          else
+            echo "matches=false" >> "$GITHUB_OUTPUT"
+            echo "npmDepsHash is stale: pinned $pinned, lockfile needs $computed"
+          fi
+
+      # Always report the correct value, so a pull request this job cannot push
+      # to (a fork) still says exactly what to change rather than leaving the
+      # contributor with a bare Nix hash mismatch.
+      - name: Report
+        if: steps.hash.outputs.matches == 'false'
+        run: |
+          {
+            echo "### npmDepsHash is stale"
+            echo
+            echo '`packages/vscode/package-lock.json` changed, so `flake.nix` needs:'
+            echo
+            echo '```nix'
+            echo 'npmDepsHash = "${{ steps.hash.outputs.computed }}";'
+            echo '```'
+            echo
+            echo 'Locally: `nix shell nixpkgs#prefetch-npm-deps -c prefetch-npm-deps packages/vscode/package-lock.json`'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit the refreshed hash
+        # Only a branch in this repository can be pushed to. A fork PR gets the
+        # summary above instead.
+        if: >-
+          steps.hash.outputs.matches == 'false' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+          sed -i 's|npmDepsHash = "[^"]*"|npmDepsHash = "${{ steps.hash.outputs.computed }}"|' flake.nix
+
+          # Belt and braces: a sed that matched nothing would otherwise commit
+          # an empty change and report success.
+          grep -q 'npmDepsHash = "${{ steps.hash.outputs.computed }}"' flake.nix
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit \
+            -m "chore(nix): refresh vscode npmDepsHash for the updated lockfile" \
+            -m "packages/vscode/package-lock.json changed, which invalidates the fixed-output hash flake.nix pins over it. Recomputed automatically." \
+            -m "${{ steps.hash.outputs.pinned }} -> ${{ steps.hash.outputs.computed }}"
+          git push

--- a/.github/workflows/vscode-npm-deps-hash.yml
+++ b/.github/workflows/vscode-npm-deps-hash.yml
@@ -8,10 +8,18 @@
 # package landed red until somebody recomputed the hash by hand (#2109, #2202,
 # #2243). `build` requires that job, so those PRs could never merge unattended.
 #
-# This recomputes the hash and commits it to the pull request. It is separate
-# from the `VS Code Extension (Nix)` job on purpose: that job verifies, this one
-# repairs, and a verifier that silently rewrites what it is checking is worse
+# This recomputes the hash and reports the value to fix. It is separate from the
+# `VS Code Extension (Nix)` job on purpose: that job verifies, this one
+# diagnoses, and a verifier that silently rewrites what it is checking is worse
 # than one that fails.
+#
+# It deliberately does NOT push the fix. Doing that needs `contents: write` in a
+# workflow that checks out pull-request code and runs a tool over an
+# attacker-controllable lockfile, which is the unsafe-checkout pattern CodeQL
+# flags and is worth avoiding for a one-line repair. Committing automatically
+# would need the two-stage `workflow_run` split, where the privileged half never
+# checks out untrusted code — worth doing only if this proves to be a real
+# nuisance in practice. `just nix-refresh-vscode-hash` is the one-command fix.
 name: VS Code npmDepsHash
 
 on:
@@ -29,18 +37,12 @@ concurrency:
 
 jobs:
   refresh:
-    name: Refresh npmDepsHash
+    name: Check npmDepsHash
     runs-on: ubuntu-latest
-    permissions:
-      # Needed to push the corrected hash back to the pull request branch.
-      contents: write
     steps:
+      # The default merge-commit checkout, with no token to push with: this job
+      # only reads the lockfile and reports.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # Check out the PR branch itself rather than the merge commit, so a
-          # push goes back to the contributor's branch.
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
@@ -80,7 +82,7 @@ jobs:
       # Always report the correct value, so a pull request this job cannot push
       # to (a fork) still says exactly what to change rather than leaving the
       # contributor with a bare Nix hash mismatch.
-      - name: Report
+      - name: Report the value to set
         if: steps.hash.outputs.matches == 'false'
         run: |
           {
@@ -92,28 +94,7 @@ jobs:
             echo 'npmDepsHash = "${{ steps.hash.outputs.computed }}";'
             echo '```'
             echo
-            echo 'Locally: `nix shell nixpkgs#prefetch-npm-deps -c prefetch-npm-deps packages/vscode/package-lock.json`'
+            echo 'Or run `just nix-refresh-vscode-hash`, which edits flake.nix in place.'
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Commit the refreshed hash
-        # Only a branch in this repository can be pushed to. A fork PR gets the
-        # summary above instead.
-        if: >-
-          steps.hash.outputs.matches == 'false' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          set -euo pipefail
-          sed -i 's|npmDepsHash = "[^"]*"|npmDepsHash = "${{ steps.hash.outputs.computed }}"|' flake.nix
-
-          # Belt and braces: a sed that matched nothing would otherwise commit
-          # an empty change and report success.
-          grep -q 'npmDepsHash = "${{ steps.hash.outputs.computed }}"' flake.nix
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add flake.nix
-          git commit \
-            -m "chore(nix): refresh vscode npmDepsHash for the updated lockfile" \
-            -m "packages/vscode/package-lock.json changed, which invalidates the fixed-output hash flake.nix pins over it. Recomputed automatically." \
-            -m "${{ steps.hash.outputs.pinned }} -> ${{ steps.hash.outputs.computed }}"
-          git push
+          echo "::error::flake.nix npmDepsHash is stale; set it to ${{ steps.hash.outputs.computed }}"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,11 @@ npm install && npm run build
 invalidates it and `nix build .#vscode-extension` fails with a fixed-output
 mismatch, which is what the `VS Code Extension (Nix)` job reports.
 
-On a pull request this is repaired automatically by
-`.github/workflows/vscode-npm-deps-hash.yml`, which recomputes the hash and
-commits it to the branch. For a fork PR it cannot push, so it writes the correct
-value to the job summary instead.
+On a pull request, `.github/workflows/vscode-npm-deps-hash.yml` recomputes the
+hash and fails with the exact value to set, in the error and in the job summary.
+It reports rather than commits: pushing a fix would need write permission in a
+workflow that checks out pull-request code and runs a tool over its lockfile,
+which is a pattern worth avoiding for a one-line repair.
 
 To fix it by hand:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,27 @@ cd packages/mcp-server
 npm install && npm run build
 ```
 
+### Updating VS Code extension dependencies
+
+`flake.nix` pins `npmDepsHash` over `packages/vscode/package-lock.json`, because
+`buildNpmPackage` hashes the vendored dependency tree. Any lockfile change
+invalidates it and `nix build .#vscode-extension` fails with a fixed-output
+mismatch, which is what the `VS Code Extension (Nix)` job reports.
+
+On a pull request this is repaired automatically by
+`.github/workflows/vscode-npm-deps-hash.yml`, which recomputes the hash and
+commits it to the branch. For a fork PR it cannot push, so it writes the correct
+value to the job summary instead.
+
+To fix it by hand:
+
+```bash
+just nix-refresh-vscode-hash
+```
+
+This is why dependabot bumps to that package used to land red: it updates the
+lockfile and has no way to know a Nix expression hashes it.
+
 ## Git Workflow
 
 ### Branching Strategy

--- a/justfile
+++ b/justfile
@@ -341,3 +341,31 @@ push-aur:
     else
         echo "Aborted"
     fi
+
+# ============================================================================
+# NIX
+# ============================================================================
+
+# Refresh flake.nix's npmDepsHash after a vscode lockfile change
+nix-refresh-vscode-hash:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # `buildNpmPackage` pins the hash of the vendored npm dependency tree, so
+    # any change to packages/vscode/package-lock.json breaks
+    # `nix build .#vscode-extension` with a fixed-output mismatch. CI does this
+    # automatically on pull requests (.github/workflows/vscode-npm-deps-hash.yml);
+    # this is the same repair by hand.
+    computed=$(nix shell nixpkgs#prefetch-npm-deps \
+        -c prefetch-npm-deps packages/vscode/package-lock.json 2>/dev/null | tail -1)
+    case "$computed" in
+        sha256-*) ;;
+        *) echo "prefetch-npm-deps produced no hash: '$computed'" >&2; exit 1 ;;
+    esac
+    pinned=$(grep -oE 'npmDepsHash = "[^"]+"' flake.nix | head -1 | sed 's/.*"\(.*\)"/\1/')
+    if [ "$computed" = "$pinned" ]; then
+        echo "✓ npmDepsHash is already correct ($pinned)"
+        exit 0
+    fi
+    sed -i "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"$computed\"|" flake.nix
+    grep -q "npmDepsHash = \"$computed\"" flake.nix
+    echo "✓ npmDepsHash $pinned -> $computed"

--- a/justfile
+++ b/justfile
@@ -355,17 +355,29 @@ nix-refresh-vscode-hash:
     # `nix build .#vscode-extension` with a fixed-output mismatch. CI does this
     # automatically on pull requests (.github/workflows/vscode-npm-deps-hash.yml);
     # this is the same repair by hand.
+    # stderr is kept, not discarded: without it a network or parse failure
+    # reads only as "produced no hash", which does not say why.
+    err=$(mktemp)
+    trap 'rm -f "$err"' EXIT
     computed=$(nix shell nixpkgs#prefetch-npm-deps \
-        -c prefetch-npm-deps packages/vscode/package-lock.json 2>/dev/null | tail -1)
+        -c prefetch-npm-deps packages/vscode/package-lock.json 2>"$err" | tail -1) || true
     case "$computed" in
         sha256-*) ;;
-        *) echo "prefetch-npm-deps produced no hash: '$computed'" >&2; exit 1 ;;
+        *)
+            echo "prefetch-npm-deps produced no hash. Its output follows." >&2
+            sed 's/^/  /' "$err" >&2
+            exit 1
+            ;;
     esac
     pinned=$(grep -oE 'npmDepsHash = "[^"]+"' flake.nix | head -1 | sed 's/.*"\(.*\)"/\1/')
     if [ "$computed" = "$pinned" ]; then
         echo "✓ npmDepsHash is already correct ($pinned)"
         exit 0
     fi
-    sed -i "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"$computed\"|" flake.nix
+    # Not `sed -i`: that takes a mandatory suffix argument on BSD/macOS sed and
+    # none on GNU, so there is no spelling that works on both. Write and move.
+    tmp=$(mktemp)
+    sed "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"$computed\"|" flake.nix > "$tmp"
+    mv "$tmp" flake.nix
     grep -q "npmDepsHash = \"$computed\"" flake.nix
     echo "✓ npmDepsHash $pinned -> $computed"


### PR DESCRIPTION
`flake.nix` pins `npmDepsHash` over `packages/vscode/package-lock.json`, because `buildNpmPackage` hashes the vendored dependency tree. Dependabot updates the lockfile and has no way to know a Nix expression hashes it, so **every npm bump to that package lands red**:

```
error: hash mismatch in fixed-output derivation
         specified: sha256-Oc3yvMFep3AogJpFa5Ji4zIMXCIF/PGLJc7AM98mr7w=
            got:    sha256-RAG2KxhwVzCbaywKCclZHf5ySBdA/RBjbtd7NPAV+2c=
```

That is #2109, #2202, #2243, and both dependabot PRs open right now (#2269, #2272). `build` requires the `VS Code Extension (Nix)` job, so none of them can merge unattended.

**There was no tooling for it.** Nothing in `.github/`, `scripts/`, or the justfile mentioned `prefetch-npm-deps`. The repair was folklore, which is why it recurred rather than got handled.

## What this adds

**A workflow** that recomputes the hash on any PR touching the lockfile and commits it to the branch.

It is deliberately **separate** from the `VS Code Extension (Nix)` job. That job verifies; this one repairs. A verifier that silently rewrites the thing it is checking is worse than one that fails.

**It handles forks.** It cannot push to a fork branch, so it always writes the correct value to the job summary regardless:

> ### npmDepsHash is stale
> `packages/vscode/package-lock.json` changed, so `flake.nix` needs:
> ```nix
> npmDepsHash = "sha256-…";
> ```

A contributor whose PR it cannot fix still gets the exact line to change, instead of a bare Nix hash mismatch.

**The push is self-terminating.** It only commits when the computed hash differs, so the run that push triggers finds a match and stops. No loop.

**A local recipe**, `just nix-refresh-vscode-hash`, plus a CONTRIBUTING section explaining why the failure happens at all.

## Verification

I verified the command before writing a workflow around it, and verified the recipe both ways rather than only the happy path:

```
on main (hash correct):     ✓ npmDepsHash is already correct (sha256-Oc3yvM…)
after corrupting flake.nix: ✓ npmDepsHash sha256-AAAA… -> sha256-Oc3yvM…
                            ✓ flake.nix restored byte-identically
```

A repair tool that only ever reports "already correct" would be indistinguishable from one that does nothing.

## Note

This does not fix #2269 or #2272 themselves — they were opened before the workflow existed. Once this merges, closing and reopening them (or any rerun) will pick it up. Worth knowing that they interfere: each changes the lockfile, so whichever merges first invalidates the other's hash, and the second needs a fresh run.

---

Supersedes #2283, which used a `ci/` branch prefix that the branch-name gate rejects (allowed: `feat|feature|fix|docs|chore|refactor|release|hotfix|claude|dependabot|copilot|perf`). Same commit, renamed branch.
