### PR TITLE
fix(ag-rledger): reject report flags the report does not read

### DIFF
--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -24,6 +24,7 @@ use rustledger::config::Config;
 use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::process::ExitCode as ProcessExitCode;
+use std::sync::OnceLock;
 
 const SCHEMA_VERSION: &str = "ag-rledger.v1";
 
@@ -334,16 +335,29 @@ fn flag_was_supplied(req: &agcli::CommandRequest<'_>, long: &str) -> bool {
     })
 }
 
-fn report_command(name: &'static str, description: &'static str) -> Command {
-    Command::new(name, description)
-        .usage(Box::leak(
+/// The usage string, built once.
+///
+/// `Command::usage` wants a `&'static str` and the report-specific part is
+/// computed from `REPORT_FLAGS`. Leaking a fresh `Box` per call would leak
+/// once for `report` and again for the `r` alias, in a binary that may be
+/// driven as a long-running agent process. A `OnceLock` gives the same
+/// `'static` lifetime with one allocation for the life of the process.
+fn report_usage() -> &'static str {
+    static USAGE: OnceLock<String> = OnceLock::new();
+    USAGE
+        .get_or_init(|| {
             format!(
                 "ag-rledger report [<file>] <report> [--file <file>] [--format <format>] \
-                 [--verbose] [-v]  |  report-specific flags — {}",
+             [--verbose] [-v]  |  report-specific flags \u{2014} {}",
                 report_flag_usage()
             )
-            .into_boxed_str(),
-        ))
+        })
+        .as_str()
+}
+
+fn report_command(name: &'static str, description: &'static str) -> Command {
+    Command::new(name, description)
+        .usage(report_usage())
         .allow_unknown_flags()
         .allow_extra_args()
         .default_next_action(NextAction::new(
@@ -1479,16 +1493,28 @@ mod tests {
                     "`{report}` reads no report-specific flags but appears in the usage string"
                 );
             } else {
-                assert!(
-                    usage.contains(&format!("{report}:")),
-                    "`{report}` reads flags but is missing from the usage string"
+                // Check the report's own segment, not the whole string. An
+                // earlier draft searched all of `usage`, so dropping
+                // `--account` from `balances` still passed on `journal`'s
+                // copy of it: the shared flags were unguarded, which is most
+                // of them.
+                let segment = usage
+                    .split("; ")
+                    .find(|seg| seg.starts_with(&format!("{report}: ")))
+                    .unwrap_or_else(|| {
+                        panic!("`{report}` reads flags but is missing from the usage string")
+                    });
+                let listed: Vec<&str> = segment
+                    .split_once(": ")
+                    .expect("segment is `report: flags`")
+                    .1
+                    .split(' ')
+                    .collect();
+                let expected: Vec<String> = flags.iter().map(|f| format!("--{f}")).collect();
+                assert_eq!(
+                    listed, expected,
+                    "`{report}`'s usage segment disagrees with REPORT_FLAGS"
                 );
-                for flag in *flags {
-                    assert!(
-                        usage.contains(&format!("--{flag}")),
-                        "`{report}` reads --{flag} but the usage string omits it"
-                    );
-                }
             }
         }
     }

--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -189,13 +189,122 @@ fn format_command(name: &'static str, description: &'static str) -> Command {
         })
 }
 
+/// Which report-specific flags each report actually reads.
+///
+/// One table, used both to build the usage string and to reject a flag that
+/// does not apply. They disagreed before: the usage string advertised the
+/// UNION for every report, `allow_unknown_flags` removed the safety net, and
+/// `build_report` read only the flags its variant had a field for — so
+/// `report income --from 2015-01-01` returned the whole-history figure with
+/// `"ok": true` (#2280). Deriving both from one list is what stops that
+/// recurring.
+///
+/// Flags handled for every report — `--file`, `--format`, `--verbose`,
+/// `--select`, `--compact`, `--profile` — are deliberately absent here.
+const REPORT_FLAGS: &[(&str, &[&str])] = &[
+    ("balances", &["account"]),
+    ("balsheet", &[]),
+    ("income", &[]),
+    ("journal", &["account", "limit"]),
+    ("holdings", &["account"]),
+    ("networth", &["period", "currency", "account", "no-zero"]),
+    ("accounts", &[]),
+    ("commodities", &[]),
+    ("stats", &[]),
+    ("prices", &["commodity"]),
+    ("budget", &["account", "from", "to", "children"]),
+];
+
+/// The report-specific flags, grouped by report, for the usage string.
+///
+/// Built from [`REPORT_FLAGS`] so the usage text cannot promise a flag the
+/// handler ignores.
+fn report_flag_usage() -> String {
+    REPORT_FLAGS
+        .iter()
+        .filter(|(_, flags)| !flags.is_empty())
+        .map(|(report, flags)| {
+            let rendered: Vec<String> = flags.iter().map(|f| format!("--{f}")).collect();
+            format!("{report}: {}", rendered.join(" "))
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Reject a report-specific flag that the named report does not read.
+///
+/// Native `rledger` already rejects these (`error: unexpected argument
+/// '--from' found`). The agent surface accepted them and returned an
+/// unfiltered figure with a success envelope, which is the worse of the two
+/// failures: nothing downstream can notice (#2280).
+fn reject_inapplicable_flags(
+    report_name: &str,
+    req: &agcli::CommandRequest<'_>,
+) -> Result<(), CommandError> {
+    let Some(canonical) = parse_report_name(report_name) else {
+        // An unknown report name is reported by `build_report`, with the list
+        // of valid ones. Saying it twice, differently, would be worse.
+        return Ok(());
+    };
+    let Some((_, applicable)) = REPORT_FLAGS.iter().find(|(r, _)| *r == canonical) else {
+        return Ok(());
+    };
+
+    // Every report-specific flag known to any report; anything outside this set
+    // is a global flag or a genuine unknown, neither of which is ours to judge.
+    let supplied: Vec<&str> = REPORT_FLAGS
+        .iter()
+        .flat_map(|(_, flags)| flags.iter().copied())
+        .filter(|flag| !applicable.contains(flag))
+        .filter(|flag| flag_was_supplied(req, flag))
+        .collect();
+
+    if supplied.is_empty() {
+        return Ok(());
+    }
+
+    let named: Vec<String> = supplied.iter().map(|f| format!("--{f}")).collect();
+    let hint = if applicable.is_empty() {
+        format!("`{canonical}` takes no report-specific flags.")
+    } else {
+        let ok: Vec<String> = applicable.iter().map(|f| format!("--{f}")).collect();
+        format!("`{canonical}` accepts: {}.", ok.join(", "))
+    };
+    // A distinct code, not a generic usage error: an agent that asked for a
+    // date window needs to tell "the window was refused" apart from "the file
+    // was wrong", and act on it.
+    Err(CommandError::new(
+        format!("report `{canonical}` does not accept {}", named.join(", ")),
+        "INAPPLICABLE_FLAG",
+        hint,
+    )
+    .exit_code(agcli::ExitCode::USAGE))
+}
+
+/// Whether `--flag` (or `--flag=value`) appears in the raw invocation.
+///
+/// Read from the raw args rather than the parsed flags because a flag the
+/// handler never reads leaves no other trace — which is precisely how these
+/// went unnoticed.
+fn flag_was_supplied(req: &agcli::CommandRequest<'_>, long: &str) -> bool {
+    let exact = format!("--{long}");
+    let prefixed = format!("--{long}=");
+    req.invocation()
+        .raw_args()
+        .iter()
+        .any(|arg| arg == &exact || arg.starts_with(&prefixed))
+}
+
 fn report_command(name: &'static str, description: &'static str) -> Command {
     Command::new(name, description)
-        .usage(
-            "ag-rledger report [<file>] <report> [--file <file>] [--format <format>] [--verbose] \
-             [-v] [--account <account>] [--limit <n>] [--period <period>] [--currency <currency>] \
-             [--no-zero] [--from <YYYY-MM-DD>] [--to <YYYY-MM-DD>] [--children]",
-        )
+        .usage(Box::leak(
+            format!(
+                "ag-rledger report [<file>] <report> [--file <file>] [--format <format>] \
+                 [--verbose] [-v]  |  report-specific flags — {}",
+                report_flag_usage()
+            )
+            .into_boxed_str(),
+        ))
         .allow_unknown_flags()
         .allow_extra_args()
         .default_next_action(NextAction::new(
@@ -597,6 +706,9 @@ fn build_report(
     req: &agcli::CommandRequest<'_>,
 ) -> Result<rustledger::cmd::report_cmd::Report, CommandError> {
     use rustledger::cmd::report_cmd::Report;
+    // Before building: a flag this report cannot read must not be silently
+    // dropped, which is what returned an unfiltered figure as a success (#2280).
+    reject_inapplicable_flags(report_name, req)?;
     match parse_report_name(report_name).as_deref() {
         Some("balances") => Ok(Report::Balances {
             account: string_flag(req, "account", Some("a")),
@@ -628,22 +740,13 @@ fn build_report(
             to: string_flag(req, "to", None),
             children: bool_flag(req, "children", None),
         }),
+        // Valid names come from REPORT_FLAGS rather than a third hand-kept
+        // list. Two lists that must agree is how the usage string came to
+        // advertise flags the handler ignored (#2280); three would be worse.
         _ => Err(invalid_enum(
             "report",
             report_name,
-            &[
-                "balances",
-                "balsheet",
-                "income",
-                "journal",
-                "holdings",
-                "networth",
-                "accounts",
-                "commodities",
-                "stats",
-                "prices",
-                "budget",
-            ],
+            &REPORT_FLAGS.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
         )),
     }
 }
@@ -1302,4 +1405,88 @@ fn parse_alias_expansion(expansion: &str) -> Vec<String> {
         parts.push(current);
     }
     parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every report in the flag table must be a report `build_report` handles.
+    ///
+    /// The table drives the usage string, the rejection, and the list of valid
+    /// names, so an entry `build_report` does not know about would advertise a
+    /// report that cannot run.
+    #[test]
+    fn every_tabled_report_is_buildable() {
+        for (report, _) in REPORT_FLAGS {
+            assert!(
+                parse_report_name(report).is_some(),
+                "`{report}` is in REPORT_FLAGS but is not a recognized report name"
+            );
+        }
+    }
+
+    /// #2280: the usage string advertised the union of every report's flags,
+    /// so `report income` promised `--from`/`--to`/`--period`/`--children` and
+    /// then discarded them. It is now derived from the table, so a report that
+    /// reads nothing cannot appear as accepting something.
+    #[test]
+    fn the_usage_string_does_not_promise_flags_a_report_ignores() {
+        let usage = report_flag_usage();
+        for (report, flags) in REPORT_FLAGS {
+            if flags.is_empty() {
+                assert!(
+                    !usage.contains(&format!("{report}:")),
+                    "`{report}` reads no report-specific flags but appears in the usage string"
+                );
+            } else {
+                assert!(
+                    usage.contains(&format!("{report}:")),
+                    "`{report}` reads flags but is missing from the usage string"
+                );
+                for flag in *flags {
+                    assert!(
+                        usage.contains(&format!("--{flag}")),
+                        "`{report}` reads --{flag} but the usage string omits it"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The reports from #2280 read no report-specific flags at all.
+    ///
+    /// Pinned by name rather than derived, so adding a flag to one of these
+    /// table entries fails here unless `build_report` is wired to read it —
+    /// which is the drift that caused the bug. (An earlier draft of this test
+    /// asserted `flags.contains(flag)` while iterating `flags`, which cannot
+    /// fail and proved nothing.)
+    #[test]
+    fn the_reports_that_take_no_flags_still_take_none() {
+        for report in ["income", "balsheet", "accounts", "commodities", "stats"] {
+            let (_, flags) = REPORT_FLAGS
+                .iter()
+                .find(|(r, _)| *r == report)
+                .unwrap_or_else(|| panic!("`{report}` missing from REPORT_FLAGS"));
+            assert!(
+                flags.is_empty(),
+                "`{report}` now lists {flags:?}; wire them in build_report before adding them here"
+            );
+        }
+    }
+
+    /// `--from` and `--to` belong to `budget` alone. This is the specific
+    /// claim #2280 made and the one most likely to regress, since a date
+    /// window reads as globally applicable.
+    #[test]
+    fn date_window_flags_belong_to_budget_only() {
+        for (report, flags) in REPORT_FLAGS {
+            let has_dates = flags.contains(&"from") || flags.contains(&"to");
+            assert_eq!(
+                has_dates,
+                *report == "budget",
+                "`{report}` date-flag ownership changed: {flags:?}"
+            );
+        }
+    }
 }

--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -215,6 +215,27 @@ const REPORT_FLAGS: &[(&str, &[&str])] = &[
     ("budget", &["account", "from", "to", "children"]),
 ];
 
+/// The short form of each report-specific flag, where one exists.
+///
+/// Taken from the `string_flag(req, "x", Some("y"))` calls in `build_report`:
+/// a check that knows only the long spelling lets `-a` through, which is the
+/// same silent drop one keystroke away. `currency` and `commodity` share `-c`
+/// but belong to different reports, so they never compete.
+const FLAG_SHORTS: &[(&str, &str)] = &[
+    ("account", "a"),
+    ("limit", "l"),
+    ("period", "p"),
+    ("currency", "c"),
+    ("commodity", "c"),
+];
+
+fn short_for(long: &str) -> Option<&'static str> {
+    FLAG_SHORTS
+        .iter()
+        .find(|(l, _)| *l == long)
+        .map(|(_, short)| *short)
+}
+
 /// The report-specific flags, grouped by report, for the usage string.
 ///
 /// Built from [`REPORT_FLAGS`] so the usage text cannot promise a flag the
@@ -252,18 +273,28 @@ fn reject_inapplicable_flags(
 
     // Every report-specific flag known to any report; anything outside this set
     // is a global flag or a genuine unknown, neither of which is ours to judge.
-    let supplied: Vec<&str> = REPORT_FLAGS
+    // Deduplicated: `account` appears in five entries, and listing it five
+    // times in the error would be its own small confusion.
+    let mut supplied: Vec<&str> = REPORT_FLAGS
         .iter()
         .flat_map(|(_, flags)| flags.iter().copied())
         .filter(|flag| !applicable.contains(flag))
         .filter(|flag| flag_was_supplied(req, flag))
         .collect();
+    supplied.sort_unstable();
+    supplied.dedup();
 
     if supplied.is_empty() {
         return Ok(());
     }
 
-    let named: Vec<String> = supplied.iter().map(|f| format!("--{f}")).collect();
+    let named: Vec<String> = supplied
+        .iter()
+        .map(|f| match short_for(f) {
+            Some(short) => format!("--{f}/-{short}"),
+            None => format!("--{f}"),
+        })
+        .collect();
     let hint = if applicable.is_empty() {
         format!("`{canonical}` takes no report-specific flags.")
     } else {
@@ -287,12 +318,20 @@ fn reject_inapplicable_flags(
 /// handler never reads leaves no other trace — which is precisely how these
 /// went unnoticed.
 fn flag_was_supplied(req: &agcli::CommandRequest<'_>, long: &str) -> bool {
-    let exact = format!("--{long}");
-    let prefixed = format!("--{long}=");
-    req.invocation()
-        .raw_args()
-        .iter()
-        .any(|arg| arg == &exact || arg.starts_with(&prefixed))
+    let mut spellings = vec![format!("--{long}"), format!("--{long}=")];
+    if let Some(short) = short_for(long) {
+        spellings.push(format!("-{short}"));
+        spellings.push(format!("-{short}="));
+    }
+    req.invocation().raw_args().iter().any(|arg| {
+        spellings.iter().any(|s| {
+            if s.ends_with('=') {
+                arg.starts_with(s)
+            } else {
+                arg == s
+            }
+        })
+    })
 }
 
 fn report_command(name: &'static str, description: &'static str) -> Command {
@@ -1472,6 +1511,50 @@ mod tests {
                 flags.is_empty(),
                 "`{report}` now lists {flags:?}; wire them in build_report before adding them here"
             );
+        }
+    }
+
+    /// Deep-review finding on #2289: the check knew only long spellings, so
+    /// `report income -a Foo` was still silently accepted. Half a fix is the
+    /// failure this whole change is about.
+    #[test]
+    fn every_flag_with_a_short_form_declares_it() {
+        // Mirrors the `string_flag(req, "x", Some("y"))` calls in
+        // `build_report`. If one gains or loses a short form there, this list
+        // has to move with it, and the assertion below is what says so.
+        let expected: &[(&str, &str)] = &[
+            ("account", "a"),
+            ("limit", "l"),
+            ("period", "p"),
+            ("currency", "c"),
+            ("commodity", "c"),
+        ];
+        assert_eq!(
+            FLAG_SHORTS, expected,
+            "FLAG_SHORTS drifted from build_report's short flags"
+        );
+
+        for (long, short) in expected {
+            assert_eq!(short_for(long), Some(*short), "--{long}");
+        }
+
+        // The assertion above only catches an edit to FLAG_SHORTS that skips
+        // this test. This one is a real cross-check: a short form declared for
+        // a flag no report reads is dead, and would mean the two tables have
+        // parted company.
+        for (long, _) in FLAG_SHORTS {
+            assert!(
+                REPORT_FLAGS.iter().any(|(_, flags)| flags.contains(long)),
+                "--{long} has a short form but no report reads it"
+            );
+        }
+    }
+
+    /// A flag with no short form must not invent one.
+    #[test]
+    fn flags_without_a_short_form_have_none() {
+        for long in ["from", "to", "children", "no-zero"] {
+            assert_eq!(short_for(long), None, "--{long} gained a short form");
         }
     }
 


### PR DESCRIPTION
Closes #2280, reported by @ayalavalva with an unusually complete diagnosis — including a version table showing exactly when each flag entered the usage string.

`ag-rledger report` advertised `--period`/`--from`/`--to`/`--children` for **every** report, opted out of unknown-flag rejection, and then read only the flags its typed `Report` variant had a field for. For `income`, `balsheet`, `accounts`, `commodities` and `stats` that is none of them.

Reproduced on a ledger with 1000 in 2015 and 2000 in 2020:

```
report income                                    -3000.00 USD  Total Income
report income --from 2015-01-01 --to 2015-12-31  -3000.00 USD  Total Income
                                                 "ok": true, "exit_code": 0
```

An agent asking for one year gets the whole-history figure **reported as success**, and nothing downstream can tell. Native `rledger` rejects the same flag (`error: unexpected argument '--from' found`), so the two surfaces disagreed and the silent one was the agent's.

## The reporter found the cause, not just the symptom

The header comment justifies `allow_unknown_flags()` because handlers "forward arbitrary flags through to the rustledger `cmd::*` argument structs rather than re-declaring every flag in the usage string". For `report` **neither half holds**: `build_report` hand-builds a typed variant and reads named flags, and the usage string *does* re-declare them. The safety net was removed without the property that justified removing it.

## Fix

One table now drives three things that previously drifted independently — which flags each report reads, the usage string, and the list of valid report names (which was a third hand-kept copy).

```
$ ag-rledger report ledger.beancount income --from 2015-01-01 --to 2015-12-31
{"ok":false,"exit_code":2,
 "error":{"message":"report `income` does not accept --from, --to",
          "code":"INAPPLICABLE_FLAG","retryable":false},
 "fix":"`income` takes no report-specific flags."}
```

A distinct code rather than a generic usage error, because an agent needs to tell "the window was refused" from "the file was wrong" — which is the reporter's argument for option 1 over a warning.

The usage string is derived from the table, so `income` no longer advertises flags it ignores:

```
report-specific flags — balances: --account; journal: --account --limit; holdings: --account;
networth: --period --currency --account --no-zero; prices: --commodity;
budget: --account --from --to --children
```

`budget --from/--to` and `networth --period` still work; verified.

## Tests

Four, two verified to fail when the table drifts (simulated by giving `income` the date flags).

**One earlier draft was a tautology** — it asserted `flags.contains(flag)` while iterating `flags`, which cannot fail. Replaced with assertions that pin the five reports from the report as taking no flags, and that `--from`/`--to` belong to `budget` alone.

499 workspace tests pass; `cargo clippy --workspace --all-targets --all-features -- -D warnings` exits 0.