### PR TITLE
fix(lsp): follow includes when no journal file is configured

### DIFF
--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1750,10 +1750,21 @@ impl MainLoopState {
         // that window unreachable.
         self.bump_revision();
 
-        self.adopt_as_journal_if_it_has_includes(&uri);
+        let adopted = self.adopt_as_journal_if_it_has_includes(&uri);
 
-        // Compute and publish diagnostics
-        self.publish_diagnostics(&uri, &text);
+        if adopted {
+            // Adoption changes the ledger EVERY open document is validated
+            // against, not just this one. A user who opened a transactions
+            // file first saw its accounts reported unopened, and without this
+            // those diagnostics sat there uncorrected until the file was
+            // touched: the ledger knew better and the editor still said
+            // otherwise. Covers this document too, since it is in the VFS by
+            // now, so there is no separate publish for it.
+            self.revalidate_open_documents();
+        } else {
+            // Compute and publish diagnostics
+            self.publish_diagnostics(&uri, &text);
+        }
     }
 
     /// Adopt a just-opened file as the root journal when it declares includes
@@ -1771,12 +1782,14 @@ impl MainLoopState {
     /// still half-typed would otherwise be adopted on the strength of an
     /// include that led nowhere, and would then lock the session out of the
     /// real root for good.
-    fn adopt_as_journal_if_it_has_includes(&mut self, uri: &Uri) {
+    /// Returns whether a root was adopted, since that invalidates the
+    /// diagnostics of every already-open document, not just this one.
+    fn adopt_as_journal_if_it_has_includes(&mut self, uri: &Uri) -> bool {
         if self.journal_file.is_some() {
-            return;
+            return false;
         }
         let Ok(path) = uri_to_path(uri) else {
-            return;
+            return false;
         };
         let path = path.into_path_buf();
 
@@ -1831,7 +1844,7 @@ impl MainLoopState {
                     );
                     *self.ledger_state.write() = probe;
                     self.journal_file = Some(root);
-                    return;
+                    return true;
                 }
                 Ok(_) => {
                     tracing::debug!(
@@ -1847,6 +1860,7 @@ impl MainLoopState {
                 }
             }
         }
+        false
     }
 
     /// Handle textDocument/didChange notification.

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1732,10 +1732,15 @@ impl MainLoopState {
         // `rustledger.journalFile` still wins. Deliberately `didOpen` only: the
         // same check on every `didChange` would reload the whole ledger while
         // an include path is still half-typed.
-        self.adopt_as_journal_if_it_has_includes(&uri);
-
-        // Bump revision (invalidates any in-flight requests)
+        // BEFORE the adoption below, not after. Adoption loads the whole
+        // ledger, which is much slower than the VFS write above, and a
+        // background request completing inside that window would compare an
+        // unchanged revision and be delivered as fresh while the world it was
+        // computed against had already been replaced. Invalidating first makes
+        // that window unreachable.
         self.bump_revision();
+
+        self.adopt_as_journal_if_it_has_includes(&uri);
 
         // Compute and publish diagnostics
         self.publish_diagnostics(&uri, &text);

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1768,32 +1768,64 @@ impl MainLoopState {
         let Ok(path) = uri_to_path(uri) else {
             return;
         };
-        let (_text, parsed) = self.get_document_data(uri);
-        if parsed.includes.is_empty() {
-            return;
-        }
         let path = path.into_path_buf();
-        let loaded = {
-            let mut state = self.ledger_state.write();
-            state.load(&path)
-        };
-        match loaded {
-            Ok(files) if files.len() > 1 => {
-                tracing::info!(
-                    "Adopted {} as the root journal ({} files); it declares includes and none was configured",
-                    path.display(),
-                    files.len()
-                );
-                self.journal_file = Some(path);
-            }
-            Ok(_) => {
-                tracing::warn!(
-                    "Not adopting {} as a root journal: its includes resolved to nothing",
+
+        // Two ways to reach a root, in order of confidence.
+        //
+        // 1. The open file declares includes, so it IS a root, whatever it is
+        //    called. This is the reported case (#2285).
+        // 2. Otherwise look upward for a conventionally named root that turns
+        //    out to include this file. A user editing `ledger/2025-01.beancount`
+        //    hits the same wrong `E1001` as the reporter did, and that file
+        //    declares no includes of its own, so (1) cannot help it.
+        let (_text, parsed) = self.get_document_data(uri);
+        let mut candidates: Vec<PathBuf> = Vec::new();
+        if !parsed.includes.is_empty() {
+            candidates.push(path.clone());
+        }
+        if let Some(dir) = path.parent()
+            && let Some(found) = rustledger_loader::discover_journal_upward(dir)
+            && !candidates.contains(&found)
+        {
+            candidates.push(found);
+        }
+
+        for root in candidates {
+            // Load into a SCRATCH state, never straight into the shared one.
+            // A candidate that turns out not to qualify would otherwise leave
+            // the server holding a ledger it just decided not to use, with
+            // `journal_file` still None to say so -- two sources of truth
+            // disagreeing about which ledger is live.
+            let mut probe = crate::ledger_state::LedgerState::new();
+            let loaded = probe.load(&root);
+            match loaded {
+                // `files.len() > 1` because adoption is STICKY:
+                // `journal_file.is_some()` is what stops a second one. An
+                // unresolved include is not an `Err` -- the loader returns Ok
+                // with the failure recorded in `ledger.errors` -- so a file
+                // whose include is missing or still half-typed would otherwise
+                // be adopted on the strength of an include that led nowhere,
+                // and would lock the session out of the real root for good.
+                //
+                // `contains_file` because a root discovered upward is only
+                // this file's root if it actually reaches this file. An
+                // unrelated `main.beancount` further up the tree is not.
+                Ok(files) if files.len() > 1 && probe.contains_file(&path) => {
+                    tracing::info!(
+                        "Adopted {} as the root journal ({} files); none was configured",
+                        root.display(),
+                        files.len()
+                    );
+                    *self.ledger_state.write() = probe;
+                    self.journal_file = Some(root);
+                    return;
+                }
+                Ok(_) => tracing::debug!(
+                    "Not adopting {}: it does not resolve to a ledger containing {}",
+                    root.display(),
                     path.display()
-                );
-            }
-            Err(e) => {
-                tracing::warn!("Not adopting {} as a root journal: {e}", path.display());
+                ),
+                Err(e) => tracing::warn!("Not adopting {} as a root journal: {e}", root.display()),
             }
         }
     }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -2665,7 +2665,9 @@ mod tests {
             let f = work.join(format!("f{n}.beancount"));
             let text = "2026-01-01 balance Assets:Cash 0.00 EUR\n".to_string();
             std::fs::write(&f, &text).expect("write file");
-            let uri: Uri = format!("file://{}", f.display()).parse().expect("uri");
+            // `format!("file://{}")` is not a URI on Windows: an absolute
+            // path there is `C:\...`, which does not parse.
+            let uri: Uri = crate::path_to_uri(&f).expect("file URI");
             state.on_did_open(lsp_types::DidOpenTextDocumentParams {
                 text_document: lsp_types::TextDocumentItem {
                     uri,
@@ -2699,7 +2701,7 @@ mod tests {
 
         // An edit is what could make a rejected root start including this
         // file, so the memo must not outlive one.
-        let changed: Uri = format!("file://{}", root.display()).parse().expect("uri");
+        let changed: Uri = crate::path_to_uri(&root).expect("file URI");
         state.on_did_change_watched_files(lsp_types::DidChangeWatchedFilesParams {
             changes: vec![lsp_types::FileEvent {
                 uri: changed,

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1719,11 +1719,78 @@ impl MainLoopState {
                 .open(path.into_path_buf(), text.clone(), version);
         }
 
+        // A file that includes other files IS a root journal, whatever it is
+        // called (#2285). Discovery only recognizes the names in
+        // `COMMON_ROOT_NAMES`, so a ledger rooted at `m1.beancount` fell
+        // through to single-file mode, where nothing follows an `include` and
+        // every account opened in an included file read as never opened. The
+        // editor then reported `E1001` on a file `rledger check` calls clean,
+        // which is the worst shape of wrong: the tool contradicts itself, and
+        // the surface the user is looking at is the one that is wrong.
+        //
+        // Only when no journal is configured or discovered, so an explicit
+        // `rustledger.journalFile` still wins. Deliberately `didOpen` only: the
+        // same check on every `didChange` would reload the whole ledger while
+        // an include path is still half-typed.
+        self.adopt_as_journal_if_it_has_includes(&uri);
+
         // Bump revision (invalidates any in-flight requests)
         self.bump_revision();
 
         // Compute and publish diagnostics
         self.publish_diagnostics(&uri, &text);
+    }
+
+    /// Adopt a just-opened file as the root journal when it declares includes
+    /// and we have no journal yet.
+    ///
+    /// Loading is what makes an `open` in an included file visible to
+    /// validation, so this is the difference between a correct diagnostic and
+    /// a false one.
+    ///
+    /// Adoption is STICKY -- `journal_file.is_some()` is what stops a second
+    /// one -- so it only happens when the includes actually resolved, measured
+    /// by the loader reaching more than the root file itself. An unresolved
+    /// include is not an `Err`: the loader returns `Ok` with the failure
+    /// recorded in `ledger.errors`, so a file whose include is missing or
+    /// still half-typed would otherwise be adopted on the strength of an
+    /// include that led nowhere, and would then lock the session out of the
+    /// real root for good.
+    fn adopt_as_journal_if_it_has_includes(&mut self, uri: &Uri) {
+        if self.journal_file.is_some() {
+            return;
+        }
+        let Ok(path) = uri_to_path(uri) else {
+            return;
+        };
+        let (_text, parsed) = self.get_document_data(uri);
+        if parsed.includes.is_empty() {
+            return;
+        }
+        let path = path.into_path_buf();
+        let loaded = {
+            let mut state = self.ledger_state.write();
+            state.load(&path)
+        };
+        match loaded {
+            Ok(files) if files.len() > 1 => {
+                tracing::info!(
+                    "Adopted {} as the root journal ({} files); it declares includes and none was configured",
+                    path.display(),
+                    files.len()
+                );
+                self.journal_file = Some(path);
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    "Not adopting {} as a root journal: its includes resolved to nothing",
+                    path.display()
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Not adopting {} as a root journal: {e}", path.display());
+            }
+        }
     }
 
     /// Handle textDocument/didChange notification.

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -228,6 +228,15 @@ pub struct MainLoopState {
     pub position_encoding: crate::handlers::utils::PositionEncoding,
     /// Full ledger state (loaded from journal file if configured).
     pub ledger_state: SharedLedgerState,
+    /// Roots already probed and found not to be this session's root.
+    ///
+    /// Probing costs a full ledger load, and the search runs on every
+    /// `didOpen` until a root is adopted, so without this a stray
+    /// `main.beancount` over an unrelated ledger is re-loaded and re-rejected
+    /// once per file the user opens. Cleared whenever a watched `.beancount`
+    /// file changes, since an edit is what could make a rejected root start
+    /// including this file.
+    rejected_roots: std::collections::HashSet<PathBuf>,
     /// Path to the journal file (if configured).
     pub journal_file: Option<PathBuf>,
     /// Channel for receiving results from background tasks.
@@ -307,6 +316,7 @@ impl MainLoopState {
             // initialize (e.g., in tests) gets the spec-safe value.
             position_encoding: crate::handlers::utils::PositionEncoding::Utf16,
             ledger_state,
+            rejected_roots: std::collections::HashSet::new(),
             journal_file,
             task_sender,
             task_receiver,
@@ -1791,6 +1801,9 @@ impl MainLoopState {
         }
 
         for root in candidates {
+            if self.rejected_roots.contains(&root) {
+                continue;
+            }
             // Load into a SCRATCH state, never straight into the shared one.
             // A candidate that turns out not to qualify would otherwise leave
             // the server holding a ledger it just decided not to use, with
@@ -1820,12 +1833,18 @@ impl MainLoopState {
                     self.journal_file = Some(root);
                     return;
                 }
-                Ok(_) => tracing::debug!(
-                    "Not adopting {}: it does not resolve to a ledger containing {}",
-                    root.display(),
-                    path.display()
-                ),
-                Err(e) => tracing::warn!("Not adopting {} as a root journal: {e}", root.display()),
+                Ok(_) => {
+                    tracing::debug!(
+                        "Not adopting {}: it does not resolve to a ledger containing {}",
+                        root.display(),
+                        path.display()
+                    );
+                    self.rejected_roots.insert(root);
+                }
+                Err(e) => {
+                    tracing::warn!("Not adopting {} as a root journal: {e}", root.display());
+                    self.rejected_roots.insert(root);
+                }
             }
         }
     }
@@ -1926,6 +1945,13 @@ impl MainLoopState {
         if should_reload_journal {
             tracing::info!("Reloading journal due to external file changes");
             self.reload_journal();
+        }
+
+        // A rejected root is rejected against the tree as it was. An edit is
+        // exactly what could add the `include` that makes it this file's root
+        // after all, so the memo does not outlive one.
+        if should_revalidate {
+            self.rejected_roots.clear();
         }
 
         // Re-validate open documents once after processing all changes
@@ -2602,6 +2628,91 @@ mod tests {
 
         let handler = DispatchError::Handler("custom failure".into()).to_string();
         assert_eq!(handler, "custom failure");
+    }
+
+    /// A root rejected once must not be probed again for every file opened.
+    ///
+    /// Probing costs a full ledger load, and the upward search runs on every
+    /// `didOpen` until something is adopted, so a stray `main.beancount` over
+    /// an unrelated ledger was re-loaded and re-rejected once per file. On a
+    /// 900KB ledger that measured as three loads for three opens; with the
+    /// memo it is one.
+    ///
+    /// This asserts the memo is populated once and cleared by an edit. The
+    /// SKIP itself is a `continue` on that set, and its effect was measured
+    /// (0.06s then 0.00s per open, and one "Loading journal file" line instead
+    /// of three) rather than asserted here.
+    #[test]
+    fn an_unrelated_root_is_probed_once_not_once_per_file() {
+        let (sender, _receiver) = crossbeam_channel::unbounded();
+        let mut state = MainLoopState::new(sender, None);
+
+        let dir = std::env::temp_dir().join(format!("rl-reject-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let work = dir.join("work");
+        std::fs::create_dir_all(&work).expect("mkdir");
+
+        // An unrelated ledger with the conventional name, above the files.
+        std::fs::write(
+            dir.join("leaf.beancount"),
+            "2025-01-01 open Assets:Other EUR\n",
+        )
+        .expect("write leaf");
+        let root = dir.join("main.beancount");
+        std::fs::write(&root, "include \"leaf.beancount\"\n").expect("write root");
+
+        let open = |state: &mut MainLoopState, n: u32| {
+            let f = work.join(format!("f{n}.beancount"));
+            let text = "2026-01-01 balance Assets:Cash 0.00 EUR\n".to_string();
+            std::fs::write(&f, &text).expect("write file");
+            let uri: Uri = format!("file://{}", f.display()).parse().expect("uri");
+            state.on_did_open(lsp_types::DidOpenTextDocumentParams {
+                text_document: lsp_types::TextDocumentItem {
+                    uri,
+                    language_id: "beancount".to_string(),
+                    version: 1,
+                    text,
+                },
+            });
+        };
+
+        open(&mut state, 1);
+        let after_first = state.rejected_roots.len();
+        open(&mut state, 2);
+        open(&mut state, 3);
+
+        assert_eq!(
+            after_first, 1,
+            "the unrelated root should have been probed and rejected once"
+        );
+        assert_eq!(
+            state.rejected_roots.len(),
+            1,
+            "later opens re-probed instead of consulting the memo: {:?}",
+            state.rejected_roots
+        );
+        assert!(
+            state.journal_file.is_none(),
+            "an unrelated root was adopted: {:?}",
+            state.journal_file
+        );
+
+        // An edit is what could make a rejected root start including this
+        // file, so the memo must not outlive one.
+        let changed: Uri = format!("file://{}", root.display()).parse().expect("uri");
+        state.on_did_change_watched_files(lsp_types::DidChangeWatchedFilesParams {
+            changes: vec![lsp_types::FileEvent {
+                uri: changed,
+                typ: lsp_types::FileChangeType::CHANGED,
+            }],
+        });
+        assert!(
+            state.rejected_roots.is_empty(),
+            "a watched-file change must retire the memo: {:?}",
+            state.rejected_roots
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Opening a cross-published file hands its diagnostics to the buffer.

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1197,6 +1197,98 @@ fn issue_2285_an_unrelated_root_upward_is_not_adopted() {
     );
 }
 
+/// Adopting a root must correct the files that are ALREADY open.
+///
+/// A user opens their transactions file first and sees its accounts reported
+/// unopened, then opens the root to find out why. Adoption fires on that
+/// second open and fixes the ledger, but only the second file was
+/// republished, so the first sat there contradicting the ledger until it was
+/// touched. The wrong diagnostic is exactly the one the user went looking at
+/// the root to explain.
+#[test]
+fn issue_2285_adoption_corrects_documents_already_open() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let accounts_path = tmp.path().join("accounts.beancount");
+    let sub_path = tmp.path().join("txns.beancount");
+    // Deliberately NOT a name `discover_journal_upward` knows, so nothing is
+    // adopted until this root is opened explicitly.
+    let root_path = tmp.path().join("m1.beancount");
+
+    std::fs::write(
+        &accounts_path,
+        "2025-01-01 open Assets:Cash EUR\n2025-01-01 open Expenses:Food EUR\n",
+    )
+    .expect("write accounts");
+    std::fs::write(
+        &sub_path,
+        "2026-01-01 * \"lunch\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
+    )
+    .expect("write sub");
+    std::fs::write(
+        &root_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            include_name(&accounts_path),
+            include_name(&sub_path)
+        ),
+    )
+    .expect("write root");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let sub_uri = uri_for(&sub_path);
+    let sub_src = std::fs::read_to_string(&sub_path).expect("read sub");
+    client.open_document(&sub_uri, &sub_src);
+
+    // Single-file mode: the accounts really do look unopened from here. If
+    // this is ever empty the test has stopped exercising the correction.
+    let before = drain_e1001_for(&mut client, &sub_uri);
+    assert!(
+        !before.is_empty(),
+        "expected the pre-adoption false E1001s; the fixture no longer sets up the case"
+    );
+
+    let root_uri = uri_for(&root_path);
+    let root_src = std::fs::read_to_string(&root_path).expect("read root");
+    client.open_document(&root_uri, &root_src);
+
+    // The LAST word on the sub-file, not any publish: the stale set is still
+    // in the stream ahead of the corrected one.
+    let hard_deadline = Instant::now() + Duration::from_secs(15);
+    let quiet = Duration::from_millis(500);
+    let mut latest: Option<Vec<lsp_types::Diagnostic>> = None;
+    while Instant::now() < hard_deadline {
+        let wait = if latest.is_none() {
+            hard_deadline.saturating_duration_since(Instant::now())
+        } else {
+            quiet
+        };
+        let Some(msg) = client.recv_with_timeout(wait) else {
+            break;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            if same_file(&p.uri, &sub_uri) {
+                latest = Some(p.diagnostics);
+            }
+        }
+    }
+
+    let latest = latest.expect("the already-open file was never republished after adoption");
+    let unopened: Vec<_> = latest
+        .iter()
+        .filter(|d| matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == "E1001"))
+        .collect();
+    assert!(
+        unopened.is_empty(),
+        "an already-open file kept its pre-adoption diagnostics; got: {unopened:?}"
+    );
+}
+
 /// A root that will not load must not be adopted, because adoption is sticky.
 ///
 /// `journal_file.is_some()` is what stops a second adoption, so pinning it to

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -999,6 +999,44 @@ fn included_file_validation_errors_are_published() {
     );
 }
 
+/// Drain every `publishDiagnostics` for `uri` and return its E1001s.
+///
+/// Waits up to a hard deadline for the FIRST publish, then only for a short
+/// quiet window, so a test costs the server's actual latency rather than a
+/// fixed timeout. Draining every publish rather than asserting on the first
+/// matters: the server may publish an empty set before the validated one, and
+/// stopping there satisfies "no E1001" without ever seeing the real answer.
+fn drain_e1001_for(client: &mut LspTestClient, uri: &str) -> Vec<lsp_types::Diagnostic> {
+    let hard_deadline = Instant::now() + Duration::from_secs(15);
+    let quiet = Duration::from_millis(500);
+    let mut publishes = 0usize;
+    let mut offenders: Vec<lsp_types::Diagnostic> = Vec::new();
+    while Instant::now() < hard_deadline {
+        let wait = if publishes == 0 {
+            hard_deadline.saturating_duration_since(Instant::now())
+        } else {
+            quiet
+        };
+        let Some(msg) = client.recv_with_timeout(wait) else {
+            break;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            if same_file(&p.uri, uri) {
+                publishes += 1;
+                offenders.extend(p.diagnostics.into_iter().filter(|d| {
+                    matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == "E1001")
+                }));
+            }
+        }
+    }
+    assert!(publishes > 0, "no publishDiagnostics for {uri}");
+    offenders
+}
+
 /// Regression for #2285: in SINGLE-FILE mode (no `rustledger.journalFile`),
 /// an `open` directive living in an `include`d file must still count.
 ///
@@ -1007,10 +1045,6 @@ fn included_file_validation_errors_are_published() {
 /// false error in the editor against a file the CLI calls clean is the worst
 /// shape of wrong: the tool contradicts itself, and the one the user is
 /// looking at is the one that is wrong.
-///
-/// Drains EVERY publish for the file rather than asserting on the first. The
-/// server may publish an empty set before the validated one, and breaking on
-/// that would satisfy "no E1001" without ever seeing the real answer.
 #[test]
 fn issue_2285_open_in_an_included_file_counts_without_a_journal_file() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -1036,40 +1070,130 @@ fn issue_2285_open_in_an_included_file_counts_without_a_journal_file() {
     let root_src = std::fs::read_to_string(&root_path).expect("read root");
     client.open_document(&root_uri, &root_src);
 
-    // Wait up to the hard deadline for the FIRST publish, then only for a
-    // short quiet window: draining to a fixed deadline would add that delay to
-    // every run of the suite.
-    let hard_deadline = Instant::now() + Duration::from_secs(15);
-    let quiet = Duration::from_millis(500);
-    let mut publishes = 0usize;
-    let mut offenders: Vec<lsp_types::Diagnostic> = Vec::new();
-    while Instant::now() < hard_deadline {
-        let wait = if publishes == 0 {
-            hard_deadline.saturating_duration_since(Instant::now())
-        } else {
-            quiet
-        };
-        let Some(msg) = client.recv_with_timeout(wait) else {
-            break;
-        };
-        if let lsp_server::Message::Notification(n) = msg
-            && n.method == "textDocument/publishDiagnostics"
-        {
-            let p: lsp_types::PublishDiagnosticsParams =
-                serde_json::from_value(n.params).expect("valid publishDiagnostics");
-            if same_file(&p.uri, &root_uri) {
-                publishes += 1;
-                offenders.extend(p.diagnostics.into_iter().filter(|d| {
-                    matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == "E1001")
-                }));
-            }
-        }
-    }
-
-    assert!(publishes > 0, "no publishDiagnostics for the opened file");
+    let offenders = drain_e1001_for(&mut client, &root_uri);
     assert!(
         offenders.is_empty(),
         "E1001 for an account opened in an included file; `rledger check` reports this file clean. got: {offenders:?}"
+    );
+}
+
+/// #2285 for the file a user is far more likely to have open: a sub-file that
+/// declares no includes of its own.
+///
+/// `ledger/2025-01.beancount` cannot be its own root, so the server looks
+/// upward for a conventionally named one and adopts it once it proves to
+/// reach this file. Without that, the reported `E1001` survives for everyone
+/// who opens a transactions file rather than the root.
+#[test]
+fn issue_2285_a_sub_file_finds_its_root_upward() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sub_dir = tmp.path().join("ledger");
+    std::fs::create_dir_all(&sub_dir).expect("mkdir");
+
+    let accounts_path = tmp.path().join("accounts.beancount");
+    let sub_path = sub_dir.join("2025-01.beancount");
+    let root_path = tmp.path().join("main.beancount");
+
+    std::fs::write(
+        &accounts_path,
+        "2025-01-01 open Assets:Cash EUR\n2025-01-01 open Expenses:Food EUR\n",
+    )
+    .expect("write accounts");
+    std::fs::write(
+        &sub_path,
+        "2026-01-01 * \"lunch\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
+    )
+    .expect("write sub");
+    std::fs::write(
+        &root_path,
+        format!(
+            "include \"{}\"\ninclude \"ledger/2025-01.beancount\"\n",
+            include_name(&accounts_path)
+        ),
+    )
+    .expect("write root");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let sub_uri = uri_for(&sub_path);
+    let sub_src = std::fs::read_to_string(&sub_path).expect("read sub");
+    client.open_document(&sub_uri, &sub_src);
+
+    let offenders = drain_e1001_for(&mut client, &sub_uri);
+    assert!(
+        offenders.is_empty(),
+        "E1001 in a sub-file whose accounts are opened in a sibling include; got: {offenders:?}"
+    );
+}
+
+/// The upward search must not adopt a root that has nothing to do with the
+/// file, which is what `contains_file` is for.
+///
+/// A stray `main.beancount` higher up the tree is common: one repo, several
+/// unrelated ledgers. Adopting it is not visible in the opened file's own
+/// diagnostics -- a file the ledger does not contain falls back to single-file
+/// validation and looks the same either way -- so this asserts the part that
+/// does show: adoption is STICKY, and a wrong one locks out the real root for
+/// the rest of the session.
+///
+/// The first draft asserted on the opened file's diagnostics and passed with
+/// `contains_file` removed.
+#[test]
+fn issue_2285_an_unrelated_root_upward_is_not_adopted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Ledger A, unrelated, with the conventional name the upward search finds.
+    let other_dir = tmp.path().join("other");
+    std::fs::create_dir_all(&other_dir).expect("mkdir other");
+    std::fs::write(
+        other_dir.join("leaf.beancount"),
+        "2025-01-01 open Assets:Other EUR\n",
+    )
+    .expect("write leaf");
+    std::fs::write(
+        tmp.path().join("main.beancount"),
+        "include \"other/leaf.beancount\"\n",
+    )
+    .expect("write unrelated root");
+
+    // Ledger B, the real one, rooted at a name discovery does not know.
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).expect("mkdir proj");
+    std::fs::write(
+        proj.join("accounts.beancount"),
+        "2025-01-01 open Assets:Cash EUR\n",
+    )
+    .expect("write accounts");
+    let real_root = proj.join("m1.beancount");
+    std::fs::write(
+        &real_root,
+        "include \"accounts.beancount\"\n2026-01-01 balance Assets:Cash 0.00 EUR\n",
+    )
+    .expect("write real root");
+    let sub_path = proj.join("txns.beancount");
+    std::fs::write(&sub_path, "2026-02-01 balance Assets:Cash 0.00 EUR\n").expect("write sub");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    // Opening the sub-file first is what triggers the upward search, and
+    // ledger A is what it finds. Without `contains_file` that gets adopted.
+    let sub_uri = uri_for(&sub_path);
+    let sub_src = std::fs::read_to_string(&sub_path).expect("read sub");
+    client.open_document(&sub_uri, &sub_src);
+    let _ = drain_e1001_for(&mut client, &sub_uri);
+
+    // Now the real root. It can only be adopted if the unrelated one did not
+    // already claim `journal_file`.
+    let root_uri = uri_for(&real_root);
+    let root_src = std::fs::read_to_string(&real_root).expect("read real root");
+    client.open_document(&root_uri, &root_src);
+
+    let offenders = drain_e1001_for(&mut client, &root_uri);
+    assert!(
+        offenders.is_empty(),
+        "an unrelated root upward was adopted and locked out the real one; got: {offenders:?}"
     );
 }
 

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1036,13 +1036,21 @@ fn issue_2285_open_in_an_included_file_counts_without_a_journal_file() {
     let root_src = std::fs::read_to_string(&root_path).expect("read root");
     client.open_document(&root_uri, &root_src);
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    // Wait up to the hard deadline for the FIRST publish, then only for a
+    // short quiet window: draining to a fixed deadline would add that delay to
+    // every run of the suite.
+    let hard_deadline = Instant::now() + Duration::from_secs(15);
+    let quiet = Duration::from_millis(500);
     let mut publishes = 0usize;
     let mut offenders: Vec<lsp_types::Diagnostic> = Vec::new();
-    while Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        let Some(msg) = client.recv_with_timeout(remaining) else {
-            continue;
+    while Instant::now() < hard_deadline {
+        let wait = if publishes == 0 {
+            hard_deadline.saturating_duration_since(Instant::now())
+        } else {
+            quiet
+        };
+        let Some(msg) = client.recv_with_timeout(wait) else {
+            break;
         };
         if let lsp_server::Message::Notification(n) = msg
             && n.method == "textDocument/publishDiagnostics"

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -999,6 +999,148 @@ fn included_file_validation_errors_are_published() {
     );
 }
 
+/// Regression for #2285: in SINGLE-FILE mode (no `rustledger.journalFile`),
+/// an `open` directive living in an `include`d file must still count.
+///
+/// The reporter's case exactly: `rledger check` on the same file reports no
+/// errors while the LSP reports "Account Assets:Cash was never opened". A
+/// false error in the editor against a file the CLI calls clean is the worst
+/// shape of wrong: the tool contradicts itself, and the one the user is
+/// looking at is the one that is wrong.
+///
+/// Drains EVERY publish for the file rather than asserting on the first. The
+/// server may publish an empty set before the validated one, and breaking on
+/// that would satisfy "no E1001" without ever seeing the real answer.
+#[test]
+fn issue_2285_open_in_an_included_file_counts_without_a_journal_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root_path = tmp.path().join("m1.beancount");
+    let accounts_path = tmp.path().join("m1-accounts.beancount");
+
+    std::fs::write(&accounts_path, "2025-01-01 open Assets:Cash\n").expect("write accounts");
+    std::fs::write(
+        &root_path,
+        format!(
+            "include \"{}\"\n2026-01-01 balance Assets:Cash               0.00 EUR\n",
+            include_name(&accounts_path)
+        ),
+    )
+    .expect("write root");
+
+    // No journal file: single-file mode, the path most users follow and the
+    // one the reporter was on.
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let root_uri = uri_for(&root_path);
+    let root_src = std::fs::read_to_string(&root_path).expect("read root");
+    client.open_document(&root_uri, &root_src);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut publishes = 0usize;
+    let mut offenders: Vec<lsp_types::Diagnostic> = Vec::new();
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let Some(msg) = client.recv_with_timeout(remaining) else {
+            continue;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            if same_file(&p.uri, &root_uri) {
+                publishes += 1;
+                offenders.extend(p.diagnostics.into_iter().filter(|d| {
+                    matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == "E1001")
+                }));
+            }
+        }
+    }
+
+    assert!(publishes > 0, "no publishDiagnostics for the opened file");
+    assert!(
+        offenders.is_empty(),
+        "E1001 for an account opened in an included file; `rledger check` reports this file clean. got: {offenders:?}"
+    );
+}
+
+/// A root that will not load must not be adopted, because adoption is sticky.
+///
+/// `journal_file.is_some()` is what stops a second adoption, so pinning it to
+/// a path that failed to load would lock the session out of the real root for
+/// good: every later file would keep falling through to single-file mode and
+/// keep reporting #2285's false `E1001`.
+///
+/// Asserts a POSITIVE consequence of adoption rather than the absence of a
+/// diagnostic: the error in the unopened included file is published under its
+/// own URI, which can only happen once the ledger is loaded. An
+/// absence-assertion is satisfied by an empty publish and so cannot tell
+/// "clean" from "never checked" -- the first draft of this test passed with
+/// the guard removed for exactly that reason.
+#[test]
+fn issue_2285_a_failed_adoption_does_not_block_the_real_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let broken_path = tmp.path().join("broken.beancount");
+    std::fs::write(&broken_path, "include \"does-not-exist.beancount\"\n").expect("write broken");
+
+    let good_path = tmp.path().join("m1.beancount");
+    let included_path = tmp.path().join("m1-included.beancount");
+    std::fs::write(
+        &included_path,
+        "2025-01-01 open Assets:Cash USD\n         2025-01-01 open Expenses:Food USD\n         2025-02-01 * \"unbalanced in the include\"\n  \
+           Assets:Cash   -5 USD\n  \
+           Expenses:Food   3 USD\n",
+    )
+    .expect("write included");
+    std::fs::write(
+        &good_path,
+        format!("include \"{}\"\n", include_name(&included_path)),
+    )
+    .expect("write good");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    // The unloadable one first, so it gets the chance to pin `journal_file`.
+    let broken_uri = uri_for(&broken_path);
+    let broken_src = std::fs::read_to_string(&broken_path).expect("read broken");
+    client.open_document(&broken_uri, &broken_src);
+
+    let good_uri = uri_for(&good_path);
+    let good_src = std::fs::read_to_string(&good_path).expect("read good");
+    client.open_document(&good_uri, &good_src);
+
+    // The include is never opened, so a diagnostic under its URI proves the
+    // ledger was loaded, which proves the real root was adopted.
+    let included_uri = uri_for(&included_path);
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut seen: Vec<String> = Vec::new();
+    let mut found = false;
+    while Instant::now() < deadline && !found {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let Some(msg) = client.recv_with_timeout(remaining) else {
+            break;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            seen.push(p.uri.as_str().to_string());
+            if same_file(&p.uri, &included_uri) && !p.diagnostics.is_empty() {
+                found = true;
+            }
+        }
+    }
+
+    assert!(
+        found,
+        "a failed adoption pinned `journal_file` and locked out the real root: \
+         no diagnostics for the unopened include {included_uri}; saw {seen:?}"
+    );
+}
+
 /// Companion to the above: once the error in the unopened included file is
 /// fixed, its diagnostics must be explicitly CLEARED (an empty publish), not
 /// left lingering in the client. Exercises `publish_cross_file_diagnostics`'s


### PR DESCRIPTION
Fixes #2285.

`rledger check m1.beancount` reports no errors. The LSP, on the same file, reports `Account Assets:Cash was never opened`. The tool contradicts itself and the surface the user is looking at is the one that is wrong.

## Cause

Journal discovery only recognizes the names in `COMMON_ROOT_NAMES` (`main.bean`, `ledger.beancount`, `index.bean`, and so on). A ledger rooted at `m1.beancount` matches none of them, so with no `rustledger.journalFile` set the server stayed in single-file mode, where `booked_directives` is just the open buffer's own parse. Nothing follows an `include`, so the `open` in `m1-accounts.beancount` was never seen.

## Fix

Two ways to reach a root, tried in order, only when no journal is configured or discovered, so an explicit `rustledger.journalFile` still wins.

1. The open file declares includes, so it IS a root whatever it is called. This is the reported case.
2. Otherwise search upward for a conventionally named root and accept it only if it proves to contain this file. A user editing `ledger/2025-01.beancount` hits the same wrong `E1001` and that file declares no includes of its own, so (1) cannot help it. On the reporter's shape that case goes from 2 false `E1001` to 0.

A candidate is loaded into a scratch `LedgerState` and committed only on acceptance, so a rejected candidate cannot leave the server holding a ledger it just declined with `journal_file` still None to say so.

`didOpen` only: the same check on every `didChange` would reload the whole ledger while an include path is still half-typed.

Adoption is sticky, since `journal_file.is_some()` is what stops a second one, so it only happens when the includes actually resolved, measured by the loader reaching more than the root file itself.

That last condition is not defensive padding. An unresolved include is **not** an `Err`: the loader returns `Ok` with the failure recorded in `ledger.errors`. Probed directly:

```
broken.beancount (include of a missing file) -> Ok: 1 files, 1 directives, 1 errors
m1.beancount     (include that resolves)     -> Ok: 2 files, 2 directives, 0 errors
```

So a first guard keyed on `Err` never fired, and opening a file with a missing or half-typed include pinned `journal_file` to it and locked the session out of the real root. The second test caught that; reading the code did not.

## Verification

End to end against the reporter's exact files, driving the real `rledger-lsp` over stdio rather than the test harness:

```
fix disabled:  1 diagnostic   [E1001] line 2: Account Assets:Cash was never opened (2026-01-01)
fix enabled:   0 diagnostics
```

A file whose include is missing still reports `E1001` rather than going silent, which matches what `rledger check` says about the same file.

Four tests, each checked against a mutation of the guard it covers:

| mutation | root opened | sub-file upward | unrelated root | sticky adoption |
|---|---|---|---|---|
| adoption removed | FAIL | FAIL | FAIL | FAIL |
| `files.len() > 1` removed | ok | ok | ok | FAIL |
| upward discovery removed | ok | FAIL | ok | ok |
| `contains_file` removed | ok | ok | FAIL | ok |

Three drafts were vacuous before this and were rewritten. All three asserted the ABSENCE of a diagnostic, which the single-file fallback supplies whether or not the guard works, so they could not tell "clean" from "never checked". Each now asserts a positive consequence instead: a diagnostic published under an unopened include's own URI, or the real root still being adoptable afterwards.

`cargo test -p rustledger-lsp` 337 pass. `cargo +1.97.0 clippy --workspace --all-targets --all-features -D warnings` clean.

## Known limitations

Root discovery upward only knows the conventional names in `COMMON_ROOT_NAMES`. A sub-file whose root is named something else, as the reporter's `m1.beancount` is, still falls back to single-file mode when opened directly. Finding that root means searching the include graph rather than a name list, which is a bigger change than this.

Adoption is per server and first-wins. Two unrelated ledgers open in one server means the second stays in single-file mode. In VS Code that case is one server per workspace folder, which is #2287.

Separately, the LSP does not surface the loader's `failed to read <path>` for a missing include, where the CLI does. Pre-existing and out of scope here.
