### PR TITLE
fix: give option warnings one severity rule instead of three

### DIFF
--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -62,7 +62,7 @@ pub use cache::{
 };
 pub use dedup::{reintern_directives, reintern_plain_directives};
 pub use discover::{COMMON_ROOT_NAMES, discover_journal_file, discover_journal_upward};
-pub use options::Options;
+pub use options::{OptionWarning, Options};
 pub use source_map::{SourceFile, SourceMap};
 pub use vfs::{DiskFileSystem, FileSystem, VirtualFileSystem};
 

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -107,7 +107,7 @@ const READONLY_OPTIONS: &[&str] = &["filename"];
 /// Option validation warning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptionWarning {
-    /// Warning code (E7001 through E7008).
+    /// Warning code (E7001 through E7009).
     pub code: &'static str,
     /// Warning message.
     pub message: String,
@@ -115,6 +115,36 @@ pub struct OptionWarning {
     pub option: String,
     /// Option value.
     pub value: String,
+}
+
+impl OptionWarning {
+    /// Whether this is a hard error rather than a warning.
+    ///
+    /// Lives on the warning, not in each consumer, because the consumers had
+    /// already drifted: `rledger check` reported `E7009` as a warning while
+    /// the LSP published the same code as an error, so one surface said the
+    /// file was fine and the other put a red squiggle on it (#2291).
+    ///
+    /// `E7001` (unknown option) and `E7002` (invalid value) are errors, which
+    /// matches `bean-check` exiting non-zero on both.
+    ///
+    /// `E7003` (duplicate non-repeatable option) is a WARNING, matching
+    /// `bean-check` (last value wins, exit 0), the loader, and `validate`. A
+    /// master ledger that includes self-contained sub-ledgers, each declaring
+    /// its own `option "title"` for standalone use, is a legitimate beancount
+    /// layout; erroring on it rejected that pattern (#1546).
+    ///
+    /// `E7009` (option in an included file is ignored) is a warning for the
+    /// same reason and about the same ledger: #1546's repro declares a title
+    /// in the master and in each sub-ledger, so once #2151 stopped the
+    /// included values from governing, that layout began reporting E7009.
+    /// Treating it as an error made the exact file #1546 was about exit
+    /// non-zero again. The unit tests all passed; only running the repro end
+    /// to end caught it.
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        !matches!(self.code, "E7003" | "E7009")
+    }
 }
 
 /// Beancount file options.
@@ -783,6 +813,36 @@ impl Options {
 
 #[cfg(test)]
 mod tests {
+
+    /// The one rule both `rledger check` and the LSP read (#2291).
+    ///
+    /// Enumerated rather than spot-checked: the bug was a consumer holding a
+    /// second, shorter copy of this list, and a test that only checked the two
+    /// warnings would not notice a code quietly moving out of the error class.
+    #[test]
+    fn only_e7003_and_e7009_are_warnings() {
+        let warn = |code: &'static str| OptionWarning {
+            code,
+            message: String::new(),
+            option: String::new(),
+            value: String::new(),
+        };
+
+        for code in ["E7003", "E7009"] {
+            assert!(
+                !warn(code).is_error(),
+                "{code} must stay a warning; `rledger check` exits 0 on it"
+            );
+        }
+        for code in [
+            "E7001", "E7002", "E7004", "E7005", "E7006", "E7007", "E7008",
+        ] {
+            assert!(
+                warn(code).is_error(),
+                "{code} must stay an error; `rledger check` exits non-zero on it"
+            );
+        }
+    }
     use super::*;
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -915,7 +915,8 @@ pub fn all_diagnostics(
         );
     }
 
-    // Emit option warnings (E7001–E7006).
+    // Emit option warnings (E7001–E7009), at the severity
+    // `OptionWarning::is_error` gives them.
     // In multi-file mode, use warnings from the loaded ledger (shown only in
     // the main file to avoid duplication). In single-file mode (no ledger),
     // validate options from the parse result so diagnostics still appear
@@ -1128,7 +1129,7 @@ pub(crate) fn ledger_diagnostics_multi(
                     MAX_VALIDATION_FILE_SIZE
                 );
             }
-            // Option warnings (E7001–E7006) are shown only in the main file to
+            // Option warnings (E7001–E7009) are shown only in the main file to
             // avoid duplication across open documents.
             if t.file_id == 0 {
                 for warning in ledger.options.warnings.as_slice() {

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -149,6 +149,19 @@ fn parse_result_to_plugins(
         .collect()
 }
 
+/// LSP severity for an option warning, from the one rule both surfaces share.
+///
+/// `rledger check` and the LSP each had their own idea of which `E70xx` codes
+/// were fatal, and they disagreed (#2291). The rule now lives on
+/// `OptionWarning`; this only translates it into the LSP's vocabulary.
+fn option_warning_severity(warning: &rustledger_loader::OptionWarning) -> DiagnosticSeverity {
+    if warning.is_error() {
+        DiagnosticSeverity::ERROR
+    } else {
+        DiagnosticSeverity::WARNING
+    }
+}
+
 /// Run validation on parsed directives and convert errors to LSP diagnostics.
 ///
 /// The `rledger check` pipeline is:
@@ -941,7 +954,10 @@ pub fn all_diagnostics(
                     start: Position::new(0, 0),
                     end: Position::new(0, 0),
                 },
-                severity: Some(DiagnosticSeverity::ERROR),
+                // Not always an error: `rledger check` calls E7003 and E7009
+                // warnings, and publishing them as errors put a red squiggle
+                // on a file the CLI exits 0 on (#2291).
+                severity: Some(option_warning_severity(warning)),
                 code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
                 source: Some("rustledger".to_string()),
                 message: warning.message.clone(),
@@ -1121,7 +1137,11 @@ pub(crate) fn ledger_diagnostics_multi(
                             start: Position::new(0, 0),
                             end: Position::new(0, 0),
                         },
-                        severity: Some(DiagnosticSeverity::ERROR),
+                        // Same rule as the single-file path above. This is
+                        // the SECOND site publishing option warnings, and
+                        // fixing only one would have left the multi-file path
+                        // still reporting warnings as errors.
+                        severity: Some(option_warning_severity(warning)),
                         code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
                         source: Some("rustledger".to_string()),
                         message: warning.message.clone(),
@@ -2441,6 +2461,131 @@ plugin "auto_accounts"
         assert!(
             !codes.iter().any(|c| c == "E1001"),
             "auto_accounts should still auto-generate opens. Got: {codes:?}"
+        );
+    }
+
+    /// Companion to the multi-file case: the SINGLE-FILE site, reached when
+    /// no ledger is loaded, must classify option warnings the same way.
+    ///
+    /// This is the second of the two sites. They are ~200 lines apart and
+    /// each has its own copy of the `Diagnostic` literal, which is how they
+    /// came to disagree with `rledger check` independently.
+    #[test]
+    fn single_file_option_warnings_carry_the_same_severity() {
+        // E7001, an error: an option that does not exist.
+        let src = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash\n";
+        let parsed = parse(src);
+        let diags = all_diagnostics(&parsed, src, None, None, None, &[], PositionEncoding::Utf16);
+        let e7001 = diags
+            .iter()
+            .find(|d| matches!(&d.code, Some(lsp_types::NumberOrString::String(c)) if c == "E7001"))
+            .expect("fixture must produce E7001");
+        assert_eq!(
+            e7001.severity,
+            Some(DiagnosticSeverity::ERROR),
+            "E7001 is an error to `rledger check`"
+        );
+
+        // E7003, a warning: a non-repeatable option set twice. `bean-check`
+        // takes the last value and exits 0, and so does `rledger check`.
+        let src =
+            "option \"title\" \"one\"\noption \"title\" \"two\"\n2024-01-01 open Assets:Cash\n";
+        let parsed = parse(src);
+        let diags = all_diagnostics(&parsed, src, None, None, None, &[], PositionEncoding::Utf16);
+        let e7003 = diags
+            .iter()
+            .find(|d| matches!(&d.code, Some(lsp_types::NumberOrString::String(c)) if c == "E7003"))
+            .expect("fixture must produce E7003");
+        assert_eq!(
+            e7003.severity,
+            Some(DiagnosticSeverity::WARNING),
+            "E7003 is a warning to `rledger check`, which exits 0 on it (#1546)"
+        );
+    }
+
+    /// #2291: option warnings must carry the severity `rledger check` gives
+    /// them, not a hardcoded ERROR.
+    ///
+    /// Covers the MULTI-FILE site. There are two places that publish option
+    /// warnings and they are far apart in this file; fixing one and leaving
+    /// the other would have left every included-file ledger still painting
+    /// `E7009` red, which is the exact ledger the code is about.
+    #[test]
+    fn option_warnings_carry_the_severity_check_gives_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let main = dir.path().join("main.beancount");
+        // `title` in the include is ignored (E7009, a warning); the bogus
+        // option is E7001, an error.
+        std::fs::write(
+            dir.path().join("a.beancount"),
+            "option \"title\" \"sub\"\n2024-01-01 open Assets:A\n",
+        )
+        .expect("write a");
+        std::fs::write(
+            &main,
+            "option \"title\" \"root\"\noption \"nonsense_option\" \"x\"\ninclude \"a.beancount\"\n",
+        )
+        .expect("write main");
+
+        let mut ls = LedgerState::new();
+        ls.load(&main).expect("load multi-file ledger");
+        let files: Vec<(u16, Arc<str>)> = ls
+            .ledger()
+            .expect("ledger loaded")
+            .source_map
+            .files()
+            .iter()
+            .map(|f| (f.id as u16, f.source.clone()))
+            .collect();
+        let parses: Vec<ParseResult> = files.iter().map(|(_, s)| parse(s)).collect();
+        let targets: Vec<FileDiagTarget<'_>> = files
+            .iter()
+            .zip(&parses)
+            .map(|((fid, src), p)| FileDiagTarget {
+                file_id: *fid,
+                source: src,
+                parse: p,
+            })
+            .collect();
+
+        let per_file = ledger_diagnostics_multi(
+            &ls,
+            Some(0),
+            &parses[0],
+            &[],
+            &targets,
+            PositionEncoding::Utf16,
+        );
+
+        let severity_of = |code: &str| {
+            per_file
+                .iter()
+                .flatten()
+                .find(
+                    |d| matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == code),
+                )
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no {code} diagnostic; the fixture no longer produces it. got {:?}",
+                        per_file
+                            .iter()
+                            .flatten()
+                            .filter_map(|d| d.code.clone())
+                            .collect::<Vec<_>>()
+                    )
+                })
+                .severity
+        };
+
+        assert_eq!(
+            severity_of("E7009"),
+            Some(DiagnosticSeverity::WARNING),
+            "E7009 is a warning to `rledger check`, which exits 0 on it"
+        );
+        assert_eq!(
+            severity_of("E7001"),
+            Some(DiagnosticSeverity::ERROR),
+            "E7001 is an error to `rledger check`, which exits non-zero on it"
         );
     }
 

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -14,7 +14,7 @@ use rustledger_parser::ParseResult as ParserResult;
 use crate::cache;
 use crate::convert::directive_to_json;
 use crate::editor;
-use crate::helpers::{load_and_book, run_validation, to_js};
+use crate::helpers::{has_fatal, load_and_book, run_validation, to_js};
 #[cfg(feature = "plugins")]
 use crate::types::PluginResult;
 use crate::types::{Error, FormatResult, LedgerOptions, PadResult, QueryResult};
@@ -223,10 +223,15 @@ impl ParsedLedger {
         }
     }
 
-    /// Check if the ledger is valid (no parse or validation errors).
+    /// Check if the ledger is valid (no parse or validation ERRORS).
+    ///
+    /// Warnings do not make a ledger invalid, matching `rledger check`, which
+    /// exits 0 on a warning-only ledger. Both of these vectors can hold
+    /// warnings: `run_validation` assigns severity per code, so a
+    /// warning-severity validation entry used to read as invalid here (#2291).
     #[wasm_bindgen(js_name = "isValid")]
     pub fn is_valid(&self) -> bool {
-        self.parse_errors.is_empty() && self.validation_errors.is_empty()
+        !has_fatal(&self.parse_errors) && !has_fatal(&self.validation_errors)
     }
 
     /// Get all errors (parse + validation).
@@ -615,8 +620,13 @@ impl Ledger {
 
     /// Check if the ledger is valid (no errors).
     #[wasm_bindgen(js_name = "isValid")]
+    /// Warnings do not make a ledger invalid, matching `rledger check`, which
+    /// exits 0 on a warning-only ledger. `has_fatal` is what `api.rs` already
+    /// uses for its `valid` field; this method was still asking whether the
+    /// list was empty, so giving E7009 the right severity would not have been
+    /// enough on its own (#2291).
     pub fn is_valid(&self) -> bool {
-        self.errors.is_empty()
+        !has_fatal(&self.errors)
     }
 
     /// Get all errors.
@@ -800,6 +810,86 @@ mod option_warning_severity_tests {
             mapped[0].message.contains("E7009"),
             "got {:?}",
             mapped[0].message
+        );
+    }
+
+    /// A ledger whose only complaint is a warning is VALID, the same way
+    /// `rledger check` exits 0 on one.
+    ///
+    /// `Ledger::is_valid` was `errors.is_empty()`, which cannot tell a warning
+    /// from an error. `has_fatal` exists for exactly this and is what `api.rs`
+    /// uses for its `valid` field; this one method never got it. Giving E7009
+    /// the right severity was not enough on its own, because the predicate
+    /// consumers actually call never looked at severity.
+    #[test]
+    fn a_warning_only_ledger_is_valid() {
+        let ledger = Ledger {
+            directives: Vec::new(),
+            options: LedgerOptions::default(),
+            account_types: rustledger_core::AccountTypes::default(),
+            errors: option_warnings_to_errors(&[warn("E7009")]),
+            editor_cache: editor::EditorCache::from_directives(&[]),
+        };
+        assert_eq!(
+            ledger.errors.len(),
+            1,
+            "the warning must still be REPORTED, just not fatal"
+        );
+        assert!(
+            ledger.is_valid(),
+            "a ledger carrying only E7009 is valid; `rledger check` exits 0 on it"
+        );
+
+        let broken = Ledger {
+            directives: Vec::new(),
+            options: LedgerOptions::default(),
+            account_types: rustledger_core::AccountTypes::default(),
+            errors: option_warnings_to_errors(&[warn("E7001")]),
+            editor_cache: editor::EditorCache::from_directives(&[]),
+        };
+        assert!(
+            !broken.is_valid(),
+            "E7001 is an error; the ledger must not read as valid"
+        );
+    }
+
+    /// The same rule on the single-source surface, through the real
+    /// constructor rather than a hand-built struct.
+    ///
+    /// A one-posting transaction is `SinglePosting` (E3004), which
+    /// `ErrorCode::is_warning` classifies as a warning, so `run_validation`
+    /// hands it back at `Severity::Warning`. The posting is zero so the
+    /// transaction still balances and E3004 is the ONLY finding: `rledger
+    /// check` prints "1 warning" and exits 0 on this exact source. `ParsedLedger::is_valid` was
+    /// `parse_errors.is_empty() && validation_errors.is_empty()`, which called
+    /// that ledger invalid while `rledger check` exits 0 on it.
+    #[test]
+    fn a_warning_only_source_is_valid_but_still_reports() {
+        let src =
+            "2024-01-01 open Assets:Cash EUR\n\n2024-02-01 * \"zero\"\n  Assets:Cash   0 EUR\n";
+        let parsed = ParsedLedger::new(src);
+        assert!(
+            parsed
+                .validation_errors
+                .iter()
+                .any(|e| e.severity == Severity::Warning),
+            "fixture must produce a warning-severity validation entry; got {:?}",
+            parsed
+                .validation_errors
+                .iter()
+                .map(|e| (&e.code, e.severity))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !parsed
+                .validation_errors
+                .iter()
+                .any(|e| e.severity == Severity::Error),
+            "fixture must not produce any hard error"
+        );
+        assert!(
+            parsed.is_valid(),
+            "a warning-only ledger is valid; `rledger check` exits 0 on it"
         );
     }
 }

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -505,7 +505,33 @@ pub struct Ledger {
     editor_cache: editor::EditorCache,
 }
 
+/// Option warnings as WASM `Error`s, carrying the severity `rledger check`
+/// gives them.
+///
+/// A free function rather than an inline loop because its only caller is a
+/// `wasm_bindgen` entry point taking `JsValue`, which cannot be called from a
+/// native test. The mapping is the part that was wrong, so it lives where a
+/// test can reach it.
+///
+/// E7003 and E7009 are warnings to `check`, which exits 0 on them. They used
+/// to go out here as errors, under a comment claiming parity with `check` and
+/// the LSP, so a ledger the CLI called clean arrived carrying errors (#2291).
+fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
+    warnings
+        .iter()
+        .map(|w| {
+            let text = format!("[{}] {}", w.code, w.message);
+            if w.is_error() {
+                Error::new(text)
+            } else {
+                Error::warning(text)
+            }
+        })
+        .collect()
+}
+
 #[wasm_bindgen]
+
 impl Ledger {
     /// Create a `Ledger` from multiple files with include resolution.
     ///
@@ -566,11 +592,7 @@ impl Ledger {
                 let directives: Vec<Directive> =
                     ledger.directives.into_iter().map(|s| s.value).collect();
                 let mut errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
-                // Include option warnings (E7001–E7006) so WASM consumers
-                // see the same diagnostics as `rledger check` and the LSP.
-                for w in &ledger.options.warnings {
-                    errors.push(Error::new(format!("[{}] {}", w.code, w.message)));
-                }
+                errors.extend(option_warnings_to_errors(&ledger.options.warnings));
                 let editor_cache = editor::EditorCache::from_directives(&directives);
 
                 Ok(Self {
@@ -723,5 +745,61 @@ impl Ledger {
             errors: payload.errors,
             editor_cache,
         })
+    }
+}
+
+#[cfg(test)]
+mod option_warning_severity_tests {
+    use super::*;
+    use crate::types::Severity;
+    use rustledger_loader::OptionWarning;
+
+    fn warn(code: &'static str) -> OptionWarning {
+        OptionWarning {
+            code,
+            message: "msg".to_string(),
+            option: "title".to_string(),
+            value: "v".to_string(),
+        }
+    }
+
+    /// #2291, third surface. `rledger check` exits 0 on E7003 and E7009, so a
+    /// ledger it calls clean must not arrive here carrying errors.
+    ///
+    /// The loop this replaced sent every option warning out as an `Error`,
+    /// under a comment claiming parity with `check` and the LSP: the claim
+    /// outlived the agreement.
+    #[test]
+    fn warnings_stay_warnings_and_errors_stay_errors() {
+        let mapped = option_warnings_to_errors(&[
+            warn("E7009"),
+            warn("E7003"),
+            warn("E7001"),
+            warn("E7002"),
+        ]);
+        let sev: Vec<_> = mapped.iter().map(|e| e.severity).collect();
+        assert_eq!(
+            sev,
+            vec![
+                Severity::Warning,
+                Severity::Warning,
+                Severity::Error,
+                Severity::Error
+            ],
+            "severity must follow OptionWarning::is_error, the rule `rledger check` reads"
+        );
+    }
+
+    /// The code stays visible in the message, which is how consumers identify
+    /// these today: `Error::code` is `None` on this path. Pinned so the
+    /// severity fix cannot quietly take the code away with it.
+    #[test]
+    fn the_code_is_still_in_the_message() {
+        let mapped = option_warnings_to_errors(&[warn("E7009")]);
+        assert!(
+            mapped[0].message.contains("E7009"),
+            "got {:?}",
+            mapped[0].message
+        );
     }
 }

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -628,37 +628,19 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
         }
     }
 
-    // All option warnings collected by `Options::set` (E7001 unknown option,
-    // E7002 invalid value, E7003 duplicate non-repeatable, E7004/E7005/E7006
-    // read-only and related) are surfaced here. Everything except E7003 is a
-    // hard error; E7003 is a warning (see below).
+    // All option warnings collected by `Options::set` are surfaced here.
+    // Which of them are fatal is `OptionWarning::is_error`, which is where the
+    // reasoning now lives too: why E7003 and E7009 are warnings, the #1546
+    // ledger that made it so, and what #2151 changed. It moved out of this
+    // file because the LSP and the WASM surface had each guessed differently
+    // and disagreed with what is printed here (#2291).
     //
-    // E7001/E7002 match beancount: `bean-check` exits non-zero on an unknown
-    // option or an invalid option value.
-    //
-    // E7003 (duplicate non-repeatable option) is a WARNING, not an error —
-    // matching `bean-check` (last value wins, exit 0), the loader, and
-    // `validate`. A master ledger that `include`s self-contained sub-ledgers,
-    // each declaring its own `option "title"` / `booking_method` / ... for
-    // standalone use, is a legitimate beancount layout; erroring on it rejected
-    // that pattern and disagreed with our own loader/`validate` (issue #1546).
-    // The value is already last-wins (the loader applies the latest). Pinned by
-    // `cli_commands_test::test_check_duplicate_option_warns`.
-    //
-    // E7009 (option in an included file is ignored) is a warning for the same
-    // reason, and the reason is the same LEDGER: #1546's repro declares a
-    // title in the master and in each sub-ledger. Once #2151 stopped the
-    // included values from governing, that layout started reporting E7009 —
-    // so leaving this list at E7003 alone made the exact file #1546 was about
-    // exit non-zero again. The unit tests all passed; only running its repro
-    // end to end caught it.
+    // Pinned by `cli_commands_test::test_check_duplicate_option_warns` and by
+    // `options::tests::only_e7003_and_e7009_are_warnings`.
     let main_file_str = file.display().to_string();
     let mut option_error_count = 0;
     let mut option_warning_count = 0;
     for warning in &load_result.options.warnings {
-        // `OptionWarning::is_error` owns this rule now; it used to live here
-        // and the LSP had its own idea (#2291). The reasoning, including why
-        // E7003 and E7009 are warnings, moved with it.
         let is_error = warning.is_error();
         let severity = if is_error { "error" } else { "warning" };
         // Same treatment as the literal-code sites; this one's code is

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -656,7 +656,10 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     let mut option_error_count = 0;
     let mut option_warning_count = 0;
     for warning in &load_result.options.warnings {
-        let is_error = !matches!(warning.code, "E7003" | "E7009");
+        // `OptionWarning::is_error` owns this rule now; it used to live here
+        // and the LSP had its own idea (#2291). The reasoning, including why
+        // E7003 and E7009 are warnings, moved with it.
+        let is_error = warning.is_error();
         let severity = if is_error { "error" } else { "warning" };
         // Same treatment as the literal-code sites; this one's code is
         // dynamic, so it needs saying explicitly.


### PR DESCRIPTION
Fixes #2291.

`rledger check` reports `E7009` as a warning and exits 0. The LSP published the same code as an error, so the editor put a red squiggle on a file the CLI calls clean.

```
CLI:  warning[E7009]: Option "title" set in an included file is ignored     exit 0
LSP:  severity=ERROR code=E7009 :: Option "title" set in an included file is ignored
```

## Cause

The rule was a `matches!` living inside `check.rs`, and every other surface guessed:

```rust
let is_error = !matches!(warning.code, "E7003" | "E7009");
```

It now lives on `OptionWarning::is_error`, together with the reasoning that was in `check.rs`: `E7003` and `E7009` are warnings because a master ledger that includes self-contained sub-ledgers, each declaring its own `option "title"` for standalone use, is a legitimate beancount layout (#1546, #2151). That reasoning was worth moving rather than restating.

## Three consumers, not one

- `check.rs`, which owned the rule.
- The LSP, at **both** sites that publish option warnings. They sit ~200 lines apart, each with its own copy of the `Diagnostic` literal, which is how they came to disagree with `check` independently. Fixing only the single-file one would have left every included-file ledger still painting `E7009` red, which is the exact ledger `E7009` is about.
- `rustledger-wasm`, found while checking for other copies. It pushed every option warning in at `Severity::Error`, under a comment saying WASM consumers "see the same diagnostics as `rledger check` and the LSP". The claim outlived the agreement. Its mapping moved to a free function so a native test can reach it, since its only caller is a `wasm_bindgen` entry point taking `JsValue`.

Why this surfaced now: #2290 made it reachable for more users. Before it, a file with includes and no configured journal never became a ledger, so a ledger-level option warning like `E7009` could not arise at all.

## Verification

End to end, both surfaces, three ledgers:

| ledger | LSP | CLI | CLI exit |
|---|---|---|---|
| `E7009`, option in an include | WARNING | `warning[E7009]` | 0 |
| `E7009`, 900KB real ledger | WARNING | `warning[E7009]` | 0 |
| `E7001`, unknown option | ERROR | `error[E7001]` | 1 |

Five tests, each checked against a mutation of the site it covers:

| mutation | loader rule | LSP single-file | LSP multi-file | wasm |
|---|---|---|---|---|
| LSP single-file site hardcoded again | ok | FAIL | ok | ok |
| LSP multi-file site hardcoded again | ok | ok | FAIL | ok |
| wasm site always `Error` | ok | ok | ok | FAIL |
| `is_error` returns true for everything | FAIL | FAIL | FAIL | FAIL |

The loader test enumerates every code rather than spot-checking the two warnings, since the bug was a consumer holding a shorter copy of the list.

`cargo +1.97.0 clippy --workspace --all-targets --all-features -D warnings` clean, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` clean. The doc build is not incidental here: it caught a helper I had inserted between `validation_errors_to_diagnostics` and its doc comment, which `cargo build` did not.

## Not changed

`Error::code` is still `None` on the WASM path, with the code carried inside the message text as `[E7009] ...`. Populating it would be an improvement and is pinned by a test so the severity fix cannot quietly take the code away, but it is a separate change from the severity disagreement this fixes.
