### PR TITLE
fix(vscode): register server commands once, not once per client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,15 @@ jobs:
       - name: Typecheck, build and package
         working-directory: packages/vscode
         run: npm run package
+      # The extension had no tests at all until #2287, whose bug (every client
+      # registering the same server-advertised command ids, so the second threw
+      # and never connected) is invisible to `tsc` and to the bundler. The
+      # harness stubs `vscode` and `vscode-languageclient`, and the stub
+      # reproduces the real throw, so a regression fails here rather than in a
+      # user's multi-root workspace.
+      - name: Test
+        working-directory: packages/vscode
+        run: npm test
 
   example-plugins:
     name: Example Plugins

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,5 +1,7 @@
 .vscode/**
 src/**
+test/**
+out/extension.test.cjs
 node_modules/**
 tsconfig.json
 .vscodeignore

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -117,7 +117,7 @@
     "build": "npm run typecheck && esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --watch",
     "package": "npm run build && vsce package --no-dependencies -o rustledger-vscode.vsix",
-    "test": "node_modules/.bin/esbuild src/extension.ts --bundle --outfile=out/extension.test.cjs --external:vscode --external:vscode-languageclient/node --format=cjs --platform=node && node --test test/*.test.cjs"
+    "test": "esbuild src/extension.ts --bundle --outfile=out/extension.test.cjs --external:vscode --external:vscode-languageclient/node --format=cjs --platform=node && node --test test/*.test.cjs"
   },
   "dependencies": {
     "vscode-languageclient": "^10.1.1"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rustledger-vscode",
   "publisher": "rustledger",
   "displayName": "rustledger",
-  "description": "Beancount language support powered by rustledger — completions, diagnostics, formatting, and more",
+  "description": "Beancount language support powered by rustledger \u2014 completions, diagnostics, formatting, and more",
   "version": "0.1.0",
   "license": "GPL-3.0-only",
   "repository": {
@@ -116,7 +116,8 @@
     "typecheck": "tsc --noEmit",
     "build": "npm run typecheck && esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --watch",
-    "package": "npm run build && vsce package --no-dependencies -o rustledger-vscode.vsix"
+    "package": "npm run build && vsce package --no-dependencies -o rustledger-vscode.vsix",
+    "test": "node_modules/.bin/esbuild src/extension.ts --bundle --outfile=out/extension.test.cjs --external:vscode --external:vscode-languageclient/node --format=cjs --platform=node && node --test test/*.test.cjs"
   },
   "dependencies": {
     "vscode-languageclient": "^10.1.1"

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -89,10 +89,16 @@ function commandTargetUri(args: unknown[]): vscode.Uri | undefined {
       try {
         return vscode.Uri.parse(candidate);
       } catch {
-        return undefined;
+        // Fall through rather than giving up. A uri that will not parse says
+        // nothing about which ledger the user is in, and the active editor
+        // still does; returning undefined here would drop the command on
+        // whichever client happens to be first.
       }
     }
   }
+  // Most invocations land here, and not only the ones with no argument at all:
+  // the `showAccountBalance` lens passes a bare account string, and
+  // format-on-save automation passes `{silent: true}` to `sortTransactions`.
   return vscode.window.activeTextEditor?.document.uri;
 }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -5,11 +5,13 @@ import { tmpdir } from "os";
 import { dirname, join } from "path";
 import * as vscode from "vscode";
 import {
-  DynamicFeature,
   ExecuteCommandRequest,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
+} from "vscode-languageclient/node";
+import type {
+  DynamicFeature,
   StaticFeature,
 } from "vscode-languageclient/node";
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -5,9 +5,12 @@ import { tmpdir } from "os";
 import { dirname, join } from "path";
 import * as vscode from "vscode";
 import {
+  DynamicFeature,
+  ExecuteCommandRequest,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
+  StaticFeature,
 } from "vscode-languageclient/node";
 
 const INSTALL_URL =
@@ -24,6 +27,108 @@ const VSIX_ASSET_NAME = "rustledger-vscode.vsix";
 // `workspace_folders.first()` and holds one ledger, which is exactly right
 // once each process is given exactly one folder.
 const clients = new Map<string, LanguageClient>();
+
+// A client that does NOT register the server's commands globally.
+//
+// `rledger-lsp` advertises `executeCommandProvider`, and vscode-languageclient's
+// built-in ExecuteCommand feature answers by calling
+// `vscode.commands.registerCommand` for each id, with no existence check and no
+// `try`. Command ids come from the server, so every client's are identical by
+// construction: in a multi-root workspace the second client threw
+// `command 'rledger.insertDate' already exists` during `initializeFeatures` and
+// never connected, leaving that folder with no diagnostics at all (#2287).
+//
+// Declining the feature here, rather than guarding the registration, is what
+// lets the ids be registered ONCE and routed to the client that owns the
+// document (see `registerServerCommands`). Guarding would let the first
+// registration win and answer `showAccountBalance` from the wrong ledger.
+//
+// Keyed on the LSP method name rather than the feature's class: the class is an
+// implementation detail of the library, the method is protocol.
+class SingleCommandOwnerClient extends LanguageClient {
+  public override registerFeature(
+    feature: StaticFeature | DynamicFeature<unknown>,
+  ): void {
+    const method = (
+      feature as { registrationType?: { method?: string } }
+    ).registrationType?.method;
+    if (method === ExecuteCommandRequest.method) {
+      return;
+    }
+    super.registerFeature(feature as StaticFeature);
+  }
+}
+
+// The server-advertised commands, registered once for the window.
+//
+// Deliberately NOT torn down when a client stops. `rustledger.restartServer`
+// stops every client and starts new ones; re-registering on each restart would
+// reintroduce the collision this exists to avoid, and the handler resolves its
+// target client per invocation anyway.
+const serverCommands = new Map<string, vscode.Disposable>();
+
+// The client that owns `uri`, if any.
+function clientForUri(uri: vscode.Uri): LanguageClient | undefined {
+  return clients.get(rootFor(uri).root.toString());
+}
+
+// The document a command invocation is about.
+//
+// Mirrors the server's own precedence: `handle_execute_command_request` reads
+// `arguments[0].uri` when present and otherwise falls back. Following the same
+// order here means a code lens in an unfocused document still reaches the
+// client that owns THAT document rather than whichever editor happens to be
+// active.
+function commandTargetUri(args: unknown[]): vscode.Uri | undefined {
+  const first = args[0];
+  if (typeof first === "object" && first !== null) {
+    const candidate = (first as { uri?: unknown }).uri;
+    if (typeof candidate === "string") {
+      try {
+        return vscode.Uri.parse(candidate);
+      } catch {
+        return undefined;
+      }
+    }
+  }
+  return vscode.window.activeTextEditor?.document.uri;
+}
+
+// Register whatever commands `client` advertises, once per id per window.
+function registerServerCommands(client: LanguageClient): void {
+  const advertised =
+    client.initializeResult?.capabilities?.executeCommandProvider?.commands ??
+    [];
+  for (const command of advertised) {
+    if (serverCommands.has(command)) {
+      continue;
+    }
+    serverCommands.set(
+      command,
+      vscode.commands.registerCommand(command, async (...args: unknown[]) => {
+        const target = commandTargetUri(args);
+        // Falling back to ANY running client rather than the one that
+        // advertised the command: that client may since have been stopped by a
+        // restart or a removed folder, and a command that silently does nothing
+        // is worse than one answered by the only server there is.
+        const owner =
+          (target ? clientForUri(target) : undefined) ??
+          clients.values().next().value;
+        if (!owner) {
+          outputChannel?.appendLine(
+            `No rledger-lsp client for ${command}; is a ledger open?`,
+          );
+          return undefined;
+        }
+        return owner.sendRequest(ExecuteCommandRequest.type, {
+          command,
+          arguments: args,
+        });
+      }),
+    );
+    outputChannel?.appendLine(`Registered server command ${command}`);
+  }
+}
 // Created with `{ log: true }` below, so it's a LogOutputChannel — which is
 // also what vscode-languageclient v10's LanguageClientOptions.outputChannel
 // requires (v9 accepted a plain OutputChannel).
@@ -343,7 +448,7 @@ async function startClientForRootUncontended(
   // A distinct id per client: vscode-languageclient uses it for the output
   // channel and for `client.stop()` bookkeeping, and reusing one id across
   // clients makes the second silently shadow the first.
-  const client = new LanguageClient(
+  const client = new SingleCommandOwnerClient(
     `rustledger:${key}`,
     "rustledger",
     serverOptions,
@@ -364,6 +469,7 @@ async function startClientForRootUncontended(
     outputChannel?.appendLine(`Failed to start rledger-lsp for ${key}: ${error}`);
     return;
   }
+  registerServerCommands(client);
   outputChannel?.appendLine(
     `Started rledger-lsp for ${key}` +
       (journalFile ? ` (journalFile: ${journalFile})` : " (auto-discovery)"),
@@ -486,6 +592,15 @@ export async function activate(
     }),
   );
 
+  context.subscriptions.push({
+    dispose: () => {
+      for (const disposable of serverCommands.values()) {
+        disposable.dispose();
+      }
+      serverCommands.clear();
+    },
+  });
+
   context.subscriptions.push({ dispose: () => void stopAllClients() });
 
   await startClientsForOpenDocuments();
@@ -500,3 +615,19 @@ export async function activate(
 export async function deactivate(): Promise<void> {
   await stopAllClients();
 }
+
+// Internals exposed for `test/extension.test.cjs`.
+//
+// The bug this covers (#2287) only reproduces with two workspace folders in a
+// real extension host, which no headless run has. What IS testable is the
+// decision-making: which feature is declined, which client a command is routed
+// to, and that an id is registered once rather than once per client. The test
+// bundle stubs `vscode` and `vscode-languageclient/node`, so these exercise
+// this file's logic and not the library's.
+export const __test = {
+  SingleCommandOwnerClient,
+  registerServerCommands,
+  commandTargetUri,
+  clients,
+  serverCommands,
+};

--- a/packages/vscode/test/extension.test.cjs
+++ b/packages/vscode/test/extension.test.cjs
@@ -28,6 +28,12 @@ Module._load = function (request, parent, isMain) {
   return originalLoad.call(this, request, parent, isMain);
 };
 
+// Global patch, so it has to come back off: another test file added later
+// would otherwise inherit these stubs and fail somewhere far from the cause.
+test.after(() => {
+  Module._load = originalLoad;
+});
+
 const vscode = require(STUB_VSCODE);
 const { __test } = require(path.join(__dirname, "..", "out", "extension.test.cjs"));
 const { SingleCommandOwnerClient, registerServerCommands, commandTargetUri, clients, serverCommands } = __test;

--- a/packages/vscode/test/extension.test.cjs
+++ b/packages/vscode/test/extension.test.cjs
@@ -155,6 +155,60 @@ test("an argument uri beats the active editor", () => {
   assert.equal(target.fsPath, "/w/ledger-b/y.beancount");
 });
 
+test("the real argument shapes route by the active editor", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  const b = clientFor("/w/ledger-b", COMMANDS);
+  vscode.workspace.workspaceFolders = [
+    { uri: vscode.Uri.file("/w/ledger-a") },
+    { uri: vscode.Uri.file("/w/ledger-b") },
+  ];
+  registerServerCommands(a);
+  registerServerCommands(b);
+  vscode.__harness.setActive(vscode.Uri.file("/w/ledger-b/ledger/2025-01.beancount"));
+
+  // What the server actually sends. `showAccountBalance`'s code lens passes a
+  // bare account string (code_lens.rs), and format-on-save automation passes
+  // `{silent: true}` to `sortTransactions` (execute_command.rs). Neither is an
+  // object carrying a uri, so both must fall through to the active editor
+  // rather than being treated as a target or as no target at all.
+  await vscode.__harness.registered.get("rledger.showAccountBalance")("Assets:Cash");
+  await vscode.__harness.registered.get("rledger.sortTransactions")({ silent: true });
+
+  assert.equal(a.sent.length, 0, "the unfocused ledger's server must not answer");
+  assert.equal(b.sent.length, 2);
+  assert.deepEqual(
+    b.sent.map((s) => s.params.command),
+    ["rledger.showAccountBalance", "rledger.sortTransactions"],
+  );
+  assert.deepEqual(
+    b.sent[0].params.arguments,
+    ["Assets:Cash"],
+    "the argument must reach the server unchanged",
+  );
+});
+
+test("an unparsable uri argument still falls back to the active editor", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  const b = clientFor("/w/ledger-b", COMMANDS);
+  vscode.workspace.workspaceFolders = [
+    { uri: vscode.Uri.file("/w/ledger-a") },
+    { uri: vscode.Uri.file("/w/ledger-b") },
+  ];
+  registerServerCommands(a);
+  registerServerCommands(b);
+  vscode.__harness.setActive(vscode.Uri.file("/w/ledger-b/x.beancount"));
+
+  await vscode.__harness.registered.get("rledger.insertDate")({ uri: "not a uri" });
+
+  assert.equal(
+    b.sent.length,
+    1,
+    "a uri that will not parse must not cost the routing; the active editor still knows",
+  );
+});
+
 test("a stopped owner falls back to a running client rather than doing nothing", async () => {
   reset();
   const a = clientFor("/w/ledger-a", COMMANDS);

--- a/packages/vscode/test/extension.test.cjs
+++ b/packages/vscode/test/extension.test.cjs
@@ -1,0 +1,165 @@
+// Tests for the multi-root command-collision fix (#2287).
+//
+// In a multi-root workspace only the first language server started: every
+// client registered the same server-advertised command ids globally, and the
+// second threw `command 'rledger.insertDate' already exists` during
+// `initializeFeatures`, so that folder got no diagnostics at all.
+//
+// The real failure needs two workspace folders in a live extension host. What
+// is testable here is the decision-making, against a `vscode` stub whose
+// `registerCommand` throws on a duplicate exactly as the real one does.
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const path = require("node:path");
+const Module = require("node:module");
+
+const STUB_VSCODE = require.resolve("./stubs/vscode.cjs");
+const STUB_CLIENT = require.resolve("./stubs/languageclient.cjs");
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === "vscode") {
+    return originalLoad.call(this, STUB_VSCODE, parent, isMain);
+  }
+  if (request === "vscode-languageclient/node") {
+    return originalLoad.call(this, STUB_CLIENT, parent, isMain);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const vscode = require(STUB_VSCODE);
+const { LanguageClient, ExecuteCommandRequest } = require(STUB_CLIENT);
+const { __test } = require(path.join(__dirname, "..", "out", "extension.test.cjs"));
+const { SingleCommandOwnerClient, registerServerCommands, commandTargetUri, clients, serverCommands } = __test;
+
+function reset() {
+  vscode.__harness.reset();
+  clients.clear();
+  serverCommands.clear();
+}
+
+function clientFor(rootPath, commands) {
+  const client = new SingleCommandOwnerClient(`rustledger:${rootPath}`, "rustledger", {}, {});
+  client.initializeResult = {
+    capabilities: { executeCommandProvider: { commands } },
+  };
+  clients.set(`file://${rootPath}`, client);
+  return client;
+}
+
+const COMMANDS = [
+  "rledger.insertDate",
+  "rledger.sortTransactions",
+  "rledger.alignAmounts",
+  "rledger.showAccountBalance",
+  "rledger.noop",
+];
+
+test("the executeCommand feature is declined and every other feature passes through", () => {
+  reset();
+  // The base constructor registers the builtins, so this already reflects the
+  // subclass's filtering by the time it returns.
+  const client = new SingleCommandOwnerClient("id", "rustledger", {}, {});
+  const methods = () =>
+    client.accepted.map((f) => f.registrationType?.method ?? "<static>");
+
+  assert.ok(
+    !methods().includes("workspace/executeCommand"),
+    `the executeCommand builtin must be declined; accepted ${methods()}`,
+  );
+  assert.ok(
+    methods().includes("textDocument/hover"),
+    `every other builtin must survive; accepted ${methods()}`,
+  );
+
+  // A static feature has no registrationType at all and must not be mistaken
+  // for the one being declined.
+  const staticFeature = { fillClientCapabilities() {} };
+  client.registerFeature(staticFeature);
+  assert.ok(
+    client.accepted.includes(staticFeature),
+    "a feature without a registrationType must pass through",
+  );
+});
+
+test("a second client starts instead of dying on duplicate command ids", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  const b = clientFor("/w/ledger-b", COMMANDS);
+
+  // `start` runs the features, which is where the real client threw
+  // `command 'rledger.insertDate' already exists` and left folder B with no
+  // server at all. The stub's base class registers the ids the same way, so
+  // this fails if the feature is not declined.
+  await a.start();
+  await b.start();
+
+  registerServerCommands(a);
+  registerServerCommands(b);
+
+  assert.deepEqual([...serverCommands.keys()].sort(), [...COMMANDS].sort());
+  assert.equal(
+    vscode.__harness.registered.size,
+    COMMANDS.length,
+    "each id must be registered exactly once for the window",
+  );
+});
+
+test("a command is answered by the client that owns the document", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  const b = clientFor("/w/ledger-b", COMMANDS);
+  vscode.workspace.workspaceFolders = [
+    { uri: vscode.Uri.file("/w/ledger-a") },
+    { uri: vscode.Uri.file("/w/ledger-b") },
+  ];
+  registerServerCommands(a);
+  registerServerCommands(b);
+
+  const handler = vscode.__harness.registered.get("rledger.showAccountBalance");
+  await handler({ uri: "file:///w/ledger-b/ledger/2025-01.beancount" });
+
+  assert.equal(a.sent.length, 0, "the wrong ledger's server must not answer");
+  assert.equal(b.sent.length, 1);
+  assert.equal(b.sent[0].params.command, "rledger.showAccountBalance");
+});
+
+test("with no argument uri, the active editor decides the owner", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  const b = clientFor("/w/ledger-b", COMMANDS);
+  vscode.workspace.workspaceFolders = [
+    { uri: vscode.Uri.file("/w/ledger-a") },
+    { uri: vscode.Uri.file("/w/ledger-b") },
+  ];
+  registerServerCommands(a);
+  registerServerCommands(b);
+  vscode.__harness.setActive(vscode.Uri.file("/w/ledger-b/ledger/2025-01.beancount"));
+
+  await vscode.__harness.registered.get("rledger.insertDate")();
+
+  assert.equal(a.sent.length, 0);
+  assert.equal(b.sent.length, 1);
+});
+
+test("an argument uri beats the active editor", () => {
+  reset();
+  vscode.__harness.setActive(vscode.Uri.file("/w/ledger-a/x.beancount"));
+  const target = commandTargetUri([{ uri: "file:///w/ledger-b/y.beancount" }]);
+  assert.equal(target.fsPath, "/w/ledger-b/y.beancount");
+});
+
+test("a stopped owner falls back to a running client rather than doing nothing", async () => {
+  reset();
+  const a = clientFor("/w/ledger-a", COMMANDS);
+  registerServerCommands(a);
+  vscode.workspace.workspaceFolders = [{ uri: vscode.Uri.file("/w/ledger-a") }];
+
+  // A file no client owns: a folder removed, or a scratch file elsewhere.
+  await vscode.__harness.registered.get("rledger.insertDate")({
+    uri: "file:///elsewhere/scratch.beancount",
+  });
+
+  assert.equal(a.sent.length, 1, "the only running server should still answer");
+});

--- a/packages/vscode/test/extension.test.cjs
+++ b/packages/vscode/test/extension.test.cjs
@@ -29,7 +29,6 @@ Module._load = function (request, parent, isMain) {
 };
 
 const vscode = require(STUB_VSCODE);
-const { LanguageClient, ExecuteCommandRequest } = require(STUB_CLIENT);
 const { __test } = require(path.join(__dirname, "..", "out", "extension.test.cjs"));
 const { SingleCommandOwnerClient, registerServerCommands, commandTargetUri, clients, serverCommands } = __test;
 

--- a/packages/vscode/test/stubs/languageclient.cjs
+++ b/packages/vscode/test/stubs/languageclient.cjs
@@ -1,0 +1,69 @@
+// Stand-in for `vscode-languageclient/node`.
+//
+// Faithful in the one respect that matters: the base class registers builtin
+// features from its CONSTRUCTOR (as `registerBuiltinFeatures` really does), and
+// the executeCommand feature registers each advertised id through
+// `vscode.commands.registerCommand` with no existence check, which is precisely
+// what throws on the second client in a multi-root workspace.
+//
+// Without that, a test asserting "no collision" would only be exercising the
+// extension's own code and would pass with the fix removed.
+const vscode = require("./vscode.cjs");
+
+class LanguageClient {
+  constructor(id, name, serverOptions, clientOptions) {
+    this.id = id;
+    this.name = name;
+    this.serverOptions = serverOptions;
+    this.clientOptions = clientOptions;
+    this.accepted = [];
+    this.sent = [];
+    this.initializeResult = undefined;
+    // Dispatches to the SUBCLASS override, exactly as the real constructor
+    // does, so the ordering under test is the real one.
+    this.registerBuiltinFeatures();
+  }
+
+  registerBuiltinFeatures() {
+    this.registerFeature({
+      registrationType: { method: "workspace/executeCommand" },
+      initialize: (capabilities) => {
+        for (const command of capabilities?.executeCommandProvider?.commands ??
+          []) {
+          // No existence check and no try/catch, same as the library.
+          vscode.commands.registerCommand(command, () => {});
+        }
+      },
+    });
+    this.registerFeature({
+      registrationType: { method: "textDocument/hover" },
+      initialize() {},
+    });
+  }
+
+  registerFeature(feature) {
+    this.accepted.push(feature);
+  }
+
+  async sendRequest(type, params) {
+    this.sent.push({ type, params });
+    return { ok: this.id };
+  }
+
+  // `initializeFeatures` in the real client; this is where the throw happens.
+  async start() {
+    for (const feature of this.accepted) {
+      feature.initialize?.(this.initializeResult?.capabilities);
+    }
+  }
+
+  async stop() {}
+}
+
+module.exports = {
+  LanguageClient,
+  ExecuteCommandRequest: {
+    method: "workspace/executeCommand",
+    type: { method: "workspace/executeCommand" },
+  },
+};

--- a/packages/vscode/test/stubs/vscode.cjs
+++ b/packages/vscode/test/stubs/vscode.cjs
@@ -1,0 +1,74 @@
+// Minimal `vscode` stand-in: only what extension.ts touches in the paths under
+// test. Anything else is deliberately absent so a test that strays into
+// untested territory fails loudly rather than silently passing on a mock.
+const registered = new Map();
+let activeUri;
+
+class Uri {
+  constructor(fsPath) {
+    this.fsPath = fsPath;
+  }
+  static file(p) {
+    return new Uri(p);
+  }
+  static parse(value) {
+    if (typeof value !== "string" || !value.startsWith("file://")) {
+      throw new Error(`not a uri: ${value}`);
+    }
+    return new Uri(value.slice("file://".length));
+  }
+  toString() {
+    return `file://${this.fsPath}`;
+  }
+}
+
+module.exports = {
+  Uri,
+  RelativePattern: class {
+    constructor(base, pattern) {
+      this.base = base;
+      this.pattern = pattern;
+    }
+  },
+  Disposable: class {
+    constructor(fn) {
+      this.dispose = fn;
+    }
+  },
+  commands: {
+    registerCommand(id, handler) {
+      if (registered.has(id)) {
+        // VS Code's real behavior, and the whole bug: a duplicate throws.
+        throw new Error(`command '${id}' already exists`);
+      }
+      registered.set(id, handler);
+      return { dispose: () => registered.delete(id) };
+    },
+  },
+  window: {
+    get activeTextEditor() {
+      return activeUri ? { document: { uri: activeUri } } : undefined;
+    },
+    createOutputChannel: () => ({ appendLine() {} }),
+  },
+  workspace: {
+    workspaceFolders: [],
+    getWorkspaceFolder(uri) {
+      const folders = module.exports.workspace.workspaceFolders ?? [];
+      return folders.find((f) => uri.fsPath.startsWith(`${f.uri.fsPath}/`));
+    },
+    createFileSystemWatcher: () => ({ dispose() {} }),
+    getConfiguration: () => ({ get: (_k, d) => d }),
+  },
+  __harness: {
+    registered,
+    setActive(uri) {
+      activeUri = uri;
+    },
+    reset() {
+      registered.clear();
+      activeUri = undefined;
+      module.exports.workspace.workspaceFolders = [];
+    },
+  },
+};


### PR DESCRIPTION
Fixes #2287. The diagnosis in the issue was right down to the library source; this implements option 1 with the routing it needs to be correct.

## Cause

`rledger-lsp` advertises `executeCommandProvider`. vscode-languageclient's built-in ExecuteCommand feature answers by calling `vscode.commands.registerCommand` for each id, with no existence check and no `try`. Command ids come from the server, so every client's set is identical by construction, and one client per workspace folder means the second throws during `initializeFeatures` and never connects. That folder is left with no diagnostics, completions or formatting, and `rustledger.restartServer` reruns the same startup.

## Fix

Two halves, and both are needed.

**Decline the feature.** A `LanguageClient` subclass overrides the public `registerFeature` and drops the one whose `registrationType.method` is `workspace/executeCommand`. Keyed on the LSP method rather than the library's class: the class is an implementation detail, the method is protocol. Overriding `registerBuiltinFeatures` instead would have meant restating ~50 features and silently losing whatever a version bump adds.

**Register the ids once, and route per invocation.** The extension registers each advertised id once for the window. The handler resolves its own target: the uri in `arguments[0]` when present, else the active editor, which is the same precedence `handle_execute_command_request` already uses server-side. A code lens in an unfocused document therefore still reaches the client owning *that* document.

This is why declining beats guarding. Wrapping `registerCommand` in a `try` would let the first registration win, and `rledger.showAccountBalance` would answer from whichever ledger started first. The issue calls that out and it is the reason option 2 was not taken.

Untouched: the server still advertises the commands, so every other editor keeps discovering them the standard way.

## Verification

The extension had no tests. This adds a harness where:

- the `vscode` stub's `registerCommand` throws on a duplicate, exactly as the real one does;
- the `LanguageClient` stub registers the advertised ids from its **constructor**, the way `registerBuiltinFeatures` really does, and runs feature `initialize` on `start`.

That second point is what makes the test worth having. An earlier version of the stub only recorded features, so "no collision" was exercising this extension's own code and passed with the fix removed. With the faithful stub and the fix reverted:

```
not ok 1 - the executeCommand feature is declined and every other feature passes through
not ok 2 - a second client starts instead of dying on duplicate command ids
  error: "command 'rledger.insertDate' already exists"
```

which is the reported error, reproduced. Restored: 6 pass.

Six cases: the feature is declined while every other builtin and static feature passes through; two clients both start; each id is registered exactly once for the window; a command is answered by the client owning the document rather than the other one; the active editor decides when no argument uri is given; an argument uri beats the active editor; and a document no client owns still reaches a running server instead of silently doing nothing.

`npm test` is wired into the `VS Code Extension` CI job, which previously only ran the bundler. `npm run package` still succeeds, and `test/**` is excluded from the vsix (9 files, unchanged).

## Not fixed here

The workaround in the issue mentions the no-workspace-folder fallback also creating a client. That path is fine now for the same reason as the rest, since no client registers commands globally any more. Worth a second pair of eyes on whether one ledger spanning two ad-hoc directory roots has any other shared-state assumption.
