### PR TITLE
feat(lsp): find a ledger's root by its includes, not just by its name

### DIFF
--- a/crates/rustledger-loader/src/discover.rs
+++ b/crates/rustledger-loader/src/discover.rs
@@ -338,6 +338,41 @@ mod tests {
         }
     }
 
+    /// Candidates from one directory come out in a defined order.
+    ///
+    /// The caller takes the first candidate that reaches the file, so an
+    /// order that varied by filesystem would mean two machines adopting
+    /// different roots for the same tree. `read_dir` makes no ordering
+    /// promise and ext4 with `dir_index` really does return hash order.
+    ///
+    /// Honest about its reach: on a filesystem that happens to enumerate in
+    /// order this passes with the sort removed, which is exactly what
+    /// happened when the sort was mutated away here. It bites where it
+    /// matters and is worth having for that, but it is not proof on this
+    /// machine.
+    #[test]
+    fn candidates_from_one_directory_are_ordered() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+        // Created in reverse, so creation order is not the expected order.
+        for name in ["zulu", "mike", "alpha"] {
+            fs::write(
+                dir.path().join(format!("{name}.beancount")),
+                "include \"txns.beancount\"\n",
+            )
+            .expect("write root");
+        }
+
+        let found = discover_include_roots_upward(&target);
+        let mut expected = found.clone();
+        expected.sort();
+        assert_eq!(
+            found, expected,
+            "candidates from one directory must be sorted, whatever `read_dir` returns"
+        );
+    }
+
     /// The candidate cap is exact, so a caller can tell saturation from a
     /// directory that simply holds that many ledgers.
     ///
@@ -385,6 +420,12 @@ mod tests {
 
     /// The walk is bounded. Without a cap, opening a scratch file would read
     /// every beancount file between it and the filesystem root.
+    ///
+    /// Tests that a bound EXISTS, not that it is eight: the fixture is built
+    /// from `MAX_LEVELS`, so it moves with the constant and passes at any
+    /// value. Removing the bound altogether does fail it. Nothing depends on
+    /// the exact number, unlike `MAX_CANDIDATES`, which a caller compares
+    /// against and which is pinned separately.
     #[test]
     fn stops_walking_up_after_max_levels() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/rustledger-loader/src/discover.rs
+++ b/crates/rustledger-loader/src/discover.rs
@@ -96,10 +96,12 @@ pub fn discover_include_roots_upward(target: &Path) -> Vec<PathBuf> {
         let Some(current) = dir else {
             break;
         };
+        // An unreadable directory holds no candidates, which is not the same
+        // as there being none above it. Stopping here would let one directory
+        // the user cannot read hide their actual root, so carry on upward.
         let Ok(entries) = std::fs::read_dir(current) else {
-            // An unreadable directory is not an error worth failing an editor
-            // over; it just holds no candidates.
-            break;
+            dir = current.parent();
+            continue;
         };
 
         // Sorted so the answer does not depend on directory order, which
@@ -135,8 +137,65 @@ pub fn discover_include_roots_upward(target: &Path) -> Vec<PathBuf> {
 /// which ones are worth loading properly, and being wrong in the permissive
 /// direction only costs one load that the caller then rejects. Being wrong in
 /// the other direction would hide the real root.
+///
+/// Chunked, because the answer is usually NO and a no costs a full read
+/// however it is spelled. Reading the file into a `String` allocates the whole
+/// of the ledger next door, and reading it a line at a time was measurably
+/// worse again: one buffer reused across chunks beats both. The overlap is
+/// what keeps a match split across a chunk boundary from being missed.
 fn declares_an_include(path: &Path) -> bool {
-    std::fs::read_to_string(path).is_ok_and(|text| text.contains("include"))
+    use std::io::Read;
+
+    const NEEDLE: &[u8] = b"include";
+    const CHUNK: usize = 256 * 1024;
+
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut buf = vec![0u8; CHUNK + NEEDLE.len()];
+    let mut carry = 0usize;
+    loop {
+        let read = match file.read(&mut buf[carry..]) {
+            Ok(0) => return false,
+            Ok(n) => n,
+            // A read error is not an opinion about the file's contents.
+            Err(_) => return false,
+        };
+        let end = carry + read;
+        if contains_needle(&buf[..end], NEEDLE) {
+            return true;
+        }
+        // Keep the tail so `inclu|de` across a boundary still matches.
+        let keep = NEEDLE.len() - 1;
+        if end > keep {
+            buf.copy_within(end - keep..end, 0);
+            carry = keep;
+        } else {
+            carry = end;
+        }
+    }
+}
+
+/// `haystack.windows(n).any(..)` for a fixed needle, without building a slice
+/// per position.
+///
+/// Anchoring on the first byte and only then comparing is what closes the gap
+/// with `str::contains`, whose optimized search this is standing in for. The
+/// naive form measured at four times the cost over a megabyte of ledger, which
+/// is a file this reads in full every time the answer is no.
+fn contains_needle(haystack: &[u8], needle: &[u8]) -> bool {
+    let Some((&first, _)) = needle.split_first() else {
+        return true;
+    };
+    let mut at = 0;
+    while let Some(offset) = haystack[at..].iter().position(|&b| b == first) {
+        let start = at + offset;
+        if haystack[start..].starts_with(needle) {
+            return true;
+        }
+        at = start + 1;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -216,6 +275,49 @@ mod tests {
             "the nearer root must come first; got {found:?}"
         );
         assert!(found.contains(&outer));
+    }
+
+    /// The line-at-a-time scan must not stop before it reaches the include.
+    ///
+    /// Short-circuiting is the point of reading this way, and a scan that
+    /// gave up early would silently drop roots whose includes sit below a
+    /// header comment or a block of options, which is where they usually are.
+    #[test]
+    fn finds_an_include_that_is_not_on_the_first_line() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+
+        let mut body = String::new();
+        body.push_str(";; a long header comment\n".repeat(500).as_str());
+        body.push_str("option \"title\" \"Ledger\"\n");
+        body.push_str("include \"txns.beancount\"\n");
+        let root = dir.path().join("late.beancount");
+        fs::write(&root, body).expect("write root");
+
+        assert!(
+            discover_include_roots_upward(&target).contains(&root),
+            "an include below a header must still be found"
+        );
+    }
+
+    /// Bytes that are not UTF-8 must not panic or be reported as a root.
+    #[test]
+    fn a_non_utf8_file_is_not_a_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+        fs::write(
+            dir.path().join("binary.beancount"),
+            [0xff, 0xfe, 0x00, 0x01],
+        )
+        .expect("write binary");
+
+        assert_eq!(
+            discover_include_roots_upward(&target),
+            Vec::<PathBuf>::new(),
+            "unreadable bytes are not an include"
+        );
     }
 
     /// The walk is bounded. Without a cap, opening a scratch file would read

--- a/crates/rustledger-loader/src/discover.rs
+++ b/crates/rustledger-loader/src/discover.rs
@@ -70,7 +70,12 @@ const MAX_LEVELS: usize = 8;
 /// Each one costs the caller a full ledger load to test, so the cap is what
 /// keeps a directory holding many ledgers from turning one file-open into a
 /// long stall. Nearest first, so the cap drops the least likely candidates.
-const MAX_CANDIDATES: usize = 16;
+///
+/// Public because a truncated search can only end in a wrong answer that
+/// looks like an ordinary one: the file's real root was dropped and it is
+/// validated alone, reporting accounts as never opened with nothing to say
+/// why. A caller that gets exactly this many candidates should say so.
+pub const MAX_CANDIDATES: usize = 16;
 
 /// Files that might be the root of the ledger containing `target`, nearest
 /// first.
@@ -298,6 +303,64 @@ mod tests {
         assert!(
             discover_include_roots_upward(&target).contains(&root),
             "an include below a header must still be found"
+        );
+    }
+
+    /// An `include` straddling a chunk boundary must still be found.
+    ///
+    /// The scan reads a fixed chunk at a time and carries the last few bytes
+    /// forward for exactly this. Nothing else exercises that carry, and an
+    /// off-by-one in it fails silently: the root is simply never offered, and
+    /// the user gets #2285's wrong diagnostic back with no clue why.
+    ///
+    /// Sweeps a window of offsets rather than computing where the boundary
+    /// falls. The first draft placed the word at `CHUNK - n`, which is not the
+    /// boundary at all (the buffer is a chunk plus the needle), so the word
+    /// landed inside the first read every time and the case passed with the
+    /// carry removed entirely. A sweep cannot be wrong about the arithmetic
+    /// because it does not do any.
+    #[test]
+    fn finds_an_include_split_across_a_chunk_boundary() {
+        const CHUNK: usize = 256 * 1024;
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        for offset in (CHUNK - 8)..(CHUNK + 32) {
+            let root = dir.path().join("root.beancount");
+            let mut body = ";".repeat(offset);
+            body.push_str("include \"txns.beancount\"\n");
+            fs::write(&root, &body).expect("write root");
+
+            assert!(
+                declares_an_include(&root),
+                "`include` starting at byte {offset} was missed; \
+                 the chunk carry does not cover this alignment"
+            );
+        }
+    }
+
+    /// The candidate cap is exact, so a caller can tell saturation from a
+    /// directory that simply holds that many ledgers.
+    ///
+    /// Nothing else pins the number, and a cap that quietly returned one more
+    /// or one fewer would make the caller's "did we truncate" check wrong in
+    /// the direction that stays silent.
+    #[test]
+    fn returns_at_most_max_candidates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+        for i in 0..(MAX_CANDIDATES + 5) {
+            fs::write(
+                dir.path().join(format!("root{i:03}.beancount")),
+                "include \"txns.beancount\"\n",
+            )
+            .expect("write root");
+        }
+
+        assert_eq!(
+            discover_include_roots_upward(&target).len(),
+            MAX_CANDIDATES,
+            "the cap must be exact for the caller's saturation check to mean anything"
         );
     }
 

--- a/crates/rustledger-loader/src/discover.rs
+++ b/crates/rustledger-loader/src/discover.rs
@@ -57,8 +57,193 @@ pub fn discover_journal_upward(start: &Path) -> Option<PathBuf> {
     None
 }
 
+/// How far up the tree [`discover_include_roots_upward`] looks.
+///
+/// A ledger's root sits a directory or two above its statements in every
+/// layout seen in the wild. Walking to the filesystem root would mean reading
+/// every `.beancount` file in the user's home directory the first time a
+/// scratch file is opened.
+const MAX_LEVELS: usize = 8;
+
+/// How many candidate roots [`discover_include_roots_upward`] returns.
+///
+/// Each one costs the caller a full ledger load to test, so the cap is what
+/// keeps a directory holding many ledgers from turning one file-open into a
+/// long stall. Nearest first, so the cap drops the least likely candidates.
+const MAX_CANDIDATES: usize = 16;
+
+/// Files that might be the root of the ledger containing `target`, nearest
+/// first.
+///
+/// [`discover_journal_upward`] only recognizes the names in
+/// [`COMMON_ROOT_NAMES`], so a ledger rooted at `m1.beancount` is invisible to
+/// it and its sub-files fall back to being validated alone, reporting accounts
+/// as unopened that an `include`d file opens (#2285).
+///
+/// This is the fallback for that: any file near `target` that declares an
+/// `include` is a candidate, whatever it is called. Deliberately returns
+/// candidates rather than an answer, because "does this root actually reach
+/// that file" can only be settled by resolving the includes, which is the
+/// caller's business and expensive enough to be worth caching there.
+///
+/// Cheap on purpose. Directory listings plus a substring check, no parsing: a
+/// file with no `include` anywhere in it cannot be the root of anything.
+#[must_use]
+pub fn discover_include_roots_upward(target: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut dir = target.parent();
+    for _ in 0..MAX_LEVELS {
+        let Some(current) = dir else {
+            break;
+        };
+        let Ok(entries) = std::fs::read_dir(current) else {
+            // An unreadable directory is not an error worth failing an editor
+            // over; it just holds no candidates.
+            break;
+        };
+
+        // Sorted so the answer does not depend on directory order, which
+        // varies by filesystem. Two candidate roots in one directory is
+        // already unusual; picking a different one run to run would be worse.
+        let mut here: Vec<PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p != target
+                    && p.extension()
+                        .is_some_and(|e| e == "beancount" || e == "bean")
+            })
+            .collect();
+        here.sort();
+
+        for candidate in here {
+            if declares_an_include(&candidate) {
+                out.push(candidate);
+                if out.len() >= MAX_CANDIDATES {
+                    return out;
+                }
+            }
+        }
+        dir = current.parent();
+    }
+    out
+}
+
+/// Whether `path` contains an `include` directive.
+///
+/// Substring rather than a parse: this runs over every nearby file to decide
+/// which ones are worth loading properly, and being wrong in the permissive
+/// direction only costs one load that the caller then rejects. Being wrong in
+/// the other direction would hide the real root.
+fn declares_an_include(path: &Path) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|text| text.contains("include"))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    /// The #2285 shape: a root whose name discovery does not know, above a
+    /// sub-file that declares no includes of its own.
+    #[test]
+    fn finds_a_root_that_is_not_conventionally_named() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sub_dir = dir.path().join("ledger");
+        fs::create_dir_all(&sub_dir).expect("mkdir");
+        let target = sub_dir.join("2025-01.beancount");
+        fs::write(&target, "2026-01-01 balance Assets:Cash 0.00 EUR\n").expect("write target");
+        fs::write(
+            dir.path().join("accounts.beancount"),
+            "2025-01-01 open Assets:Cash\n",
+        )
+        .expect("write accounts");
+        let root = dir.path().join("m1.beancount");
+        fs::write(
+            &root,
+            "include \"accounts.beancount\"\ninclude \"ledger/2025-01.beancount\"\n",
+        )
+        .expect("write root");
+
+        let found = discover_include_roots_upward(&target);
+        assert!(
+            found.contains(&root),
+            "the include-declaring root must be a candidate; got {found:?}"
+        );
+        assert!(
+            !found.contains(&target),
+            "the file itself must never be its own candidate: {found:?}"
+        );
+    }
+
+    /// A file with no `include` anywhere cannot be a root, and testing it would
+    /// cost the caller a full ledger load for nothing.
+    #[test]
+    fn skips_files_that_declare_no_include() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("txns.beancount");
+        fs::write(&target, "2026-01-01 balance Assets:Cash 0.00 EUR\n").expect("write target");
+        fs::write(
+            dir.path().join("plain.beancount"),
+            "2025-01-01 open Assets:Cash\n",
+        )
+        .expect("write plain");
+
+        assert_eq!(
+            discover_include_roots_upward(&target),
+            Vec::<PathBuf>::new(),
+            "a file with no include must not be offered as a root"
+        );
+    }
+
+    /// Nearest first, because the caller takes the first that reaches the file
+    /// and a sub-ledger's own root should beat an outer one.
+    #[test]
+    fn orders_candidates_nearest_first() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inner_dir = dir.path().join("sub");
+        fs::create_dir_all(&inner_dir).expect("mkdir");
+        let target = inner_dir.join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+        let inner = inner_dir.join("inner.beancount");
+        fs::write(&inner, "include \"txns.beancount\"\n").expect("write inner");
+        let outer = dir.path().join("outer.beancount");
+        fs::write(&outer, "include \"sub/txns.beancount\"\n").expect("write outer");
+
+        let found = discover_include_roots_upward(&target);
+        assert_eq!(
+            found.first(),
+            Some(&inner),
+            "the nearer root must come first; got {found:?}"
+        );
+        assert!(found.contains(&outer));
+    }
+
+    /// The walk is bounded. Without a cap, opening a scratch file would read
+    /// every beancount file between it and the filesystem root.
+    #[test]
+    fn stops_walking_up_after_max_levels() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut deep = dir.path().to_path_buf();
+        for i in 0..(MAX_LEVELS + 3) {
+            deep = deep.join(format!("d{i}"));
+        }
+        fs::create_dir_all(&deep).expect("mkdir");
+        let target = deep.join("txns.beancount");
+        fs::write(&target, "\n").expect("write target");
+        // A root far enough up to be outside the walk.
+        fs::write(
+            dir.path().join("root.beancount"),
+            "include \"x.beancount\"\n",
+        )
+        .expect("write root");
+
+        assert_eq!(
+            discover_include_roots_upward(&target),
+            Vec::<PathBuf>::new(),
+            "a root beyond MAX_LEVELS must not be reached"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -62,7 +62,7 @@ pub use cache::{
 };
 pub use dedup::{reintern_directives, reintern_plain_directives};
 pub use discover::{
-    COMMON_ROOT_NAMES, discover_include_roots_upward, discover_journal_file,
+    COMMON_ROOT_NAMES, MAX_CANDIDATES, discover_include_roots_upward, discover_journal_file,
     discover_journal_upward,
 };
 pub use options::{OptionWarning, Options};

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -61,7 +61,10 @@ pub use cache::{
     save_cache_entry,
 };
 pub use dedup::{reintern_directives, reintern_plain_directives};
-pub use discover::{COMMON_ROOT_NAMES, discover_journal_file, discover_journal_upward};
+pub use discover::{
+    COMMON_ROOT_NAMES, discover_include_roots_upward, discover_journal_file,
+    discover_journal_upward,
+};
 pub use options::{OptionWarning, Options};
 pub use source_map::{SourceFile, SourceMap};
 pub use vfs::{DiskFileSystem, FileSystem, VirtualFileSystem};

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1829,7 +1829,19 @@ impl MainLoopState {
         {
             candidates.push(found);
         }
-        for found in rustledger_loader::discover_include_roots_upward(&path) {
+        let by_include = rustledger_loader::discover_include_roots_upward(&path);
+        if by_include.len() == rustledger_loader::MAX_CANDIDATES {
+            // Saying so, because the alternative is a wrong diagnostic that
+            // looks ordinary: if the real root was the one dropped, this file
+            // is validated alone and reports its accounts as never opened.
+            tracing::warn!(
+                "root search for {} hit the {}-candidate cap; if its root is missing, \
+                 set `rustledger.journalFile`",
+                path.display(),
+                rustledger_loader::MAX_CANDIDATES
+            );
+        }
+        for found in by_include {
             if !candidates.contains(&found) {
                 candidates.push(found);
             }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1818,6 +1818,16 @@ impl MainLoopState {
         // Ordered by confidence and by cost, and every candidate still has to
         // prove it reaches this file, so a wider net does not mean a wronger
         // answer.
+        //
+        // By SOURCE rather than by distance, which matters when more than one
+        // root reaches the file. A master ledger including self-contained
+        // sub-ledgers is a legitimate layout (#1546), and there the master is
+        // the better answer even though the sub-ledger's own root is nearer:
+        // the master gives complete cross-file validation, while the inner one
+        // reports accounts the master opens as never opened. So this
+        // deliberately does not extend `discover_journal_upward`'s
+        // "nearest wins" across sources; nearest and most-complete point in
+        // opposite directions here.
         let (_text, parsed) = self.get_document_data(uri);
         let mut candidates: Vec<PathBuf> = Vec::new();
         if !parsed.includes.is_empty() {

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1835,9 +1835,9 @@ impl MainLoopState {
             }
         }
 
-        // `contains_file` canonicalizes; the loader canonicalizes what it
-        // records, so comparing canonical-to-canonical is what makes a cached
-        // answer agree with a freshly probed one.
+        // Canonical on both sides. `LedgerState::load` canonicalizes every
+        // path it records, so the target has to be canonicalized too or a uri
+        // carrying `..` or a symlink would miss a set that does contain it.
         let canonical_target = path.canonicalize().unwrap_or_else(|_| path.clone());
 
         for root in candidates {

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -228,15 +228,23 @@ pub struct MainLoopState {
     pub position_encoding: crate::handlers::utils::PositionEncoding,
     /// Full ledger state (loaded from journal file if configured).
     pub ledger_state: SharedLedgerState,
-    /// Roots already probed and found not to be this session's root.
+    /// What each candidate root was found to reach, once probed.
     ///
-    /// Probing costs a full ledger load, and the search runs on every
-    /// `didOpen` until a root is adopted, so without this a stray
-    /// `main.beancount` over an unrelated ledger is re-loaded and re-rejected
-    /// once per file the user opens. Cleared whenever a watched `.beancount`
-    /// file changes, since an edit is what could make a rejected root start
-    /// including this file.
-    rejected_roots: std::collections::HashSet<PathBuf>,
+    /// Probing costs a full ledger load and the search runs on every `didOpen`
+    /// until a root is adopted, so a stray `main.beancount` over an unrelated
+    /// ledger would otherwise be re-loaded once per file the user opens.
+    ///
+    /// The value is what makes this correct rather than merely fast. A flat
+    /// "rejected" set was wrong: whether a root qualifies depends on the file
+    /// being opened, so a root rejected while looking for one file could never
+    /// be adopted for another, including for ITSELF. Caching the file set
+    /// instead answers per target from one load. `None` records the answers
+    /// that are target-independent: it would not load, or its includes
+    /// resolved to nothing.
+    ///
+    /// Cleared whenever a watched `.beancount` file changes, since an edit is
+    /// what could make a root start including a file it did not before.
+    probed_roots: HashMap<PathBuf, Option<std::collections::HashSet<PathBuf>>>,
     /// Path to the journal file (if configured).
     pub journal_file: Option<PathBuf>,
     /// Channel for receiving results from background tasks.
@@ -316,7 +324,7 @@ impl MainLoopState {
             // initialize (e.g., in tests) gets the spec-safe value.
             position_encoding: crate::handlers::utils::PositionEncoding::Utf16,
             ledger_state,
-            rejected_roots: std::collections::HashSet::new(),
+            probed_roots: HashMap::new(),
             journal_file,
             task_sender,
             task_receiver,
@@ -1801,6 +1809,15 @@ impl MainLoopState {
         //    out to include this file. A user editing `ledger/2025-01.beancount`
         //    hits the same wrong `E1001` as the reporter did, and that file
         //    declares no includes of its own, so (1) cannot help it.
+        // 3. Failing that, any nearby file that declares an `include` at all.
+        //    Discovery by name cannot see a root called `m1.beancount`, which
+        //    is the reporter's own root, so without this the sub-files of any
+        //    unconventionally named ledger keep reporting accounts as never
+        //    opened.
+        //
+        // Ordered by confidence and by cost, and every candidate still has to
+        // prove it reaches this file, so a wider net does not mean a wronger
+        // answer.
         let (_text, parsed) = self.get_document_data(uri);
         let mut candidates: Vec<PathBuf> = Vec::new();
         if !parsed.includes.is_empty() {
@@ -1812,52 +1829,80 @@ impl MainLoopState {
         {
             candidates.push(found);
         }
+        for found in rustledger_loader::discover_include_roots_upward(&path) {
+            if !candidates.contains(&found) {
+                candidates.push(found);
+            }
+        }
+
+        // `contains_file` canonicalizes; the loader canonicalizes what it
+        // records, so comparing canonical-to-canonical is what makes a cached
+        // answer agree with a freshly probed one.
+        let canonical_target = path.canonicalize().unwrap_or_else(|_| path.clone());
 
         for root in candidates {
-            if self.rejected_roots.contains(&root) {
-                continue;
-            }
-            // Load into a SCRATCH state, never straight into the shared one.
-            // A candidate that turns out not to qualify would otherwise leave
-            // the server holding a ledger it just decided not to use, with
-            // `journal_file` still None to say so -- two sources of truth
-            // disagreeing about which ledger is live.
-            let mut probe = crate::ledger_state::LedgerState::new();
-            let loaded = probe.load(&root);
-            match loaded {
+            let reach = if let Some(cached) = self.probed_roots.get(&root) {
+                cached.clone()
+            } else {
+                // Load into a SCRATCH state, never straight into the shared
+                // one. A candidate that turns out not to qualify would
+                // otherwise leave the server holding a ledger it just decided
+                // not to use, with `journal_file` still None to say so: two
+                // sources of truth disagreeing about which ledger is live.
+                let mut probe = crate::ledger_state::LedgerState::new();
                 // `files.len() > 1` because adoption is STICKY:
                 // `journal_file.is_some()` is what stops a second one. An
                 // unresolved include is not an `Err` -- the loader returns Ok
                 // with the failure recorded in `ledger.errors` -- so a file
                 // whose include is missing or still half-typed would otherwise
-                // be adopted on the strength of an include that led nowhere,
-                // and would lock the session out of the real root for good.
-                //
-                // `contains_file` because a root discovered upward is only
-                // this file's root if it actually reaches this file. An
-                // unrelated `main.beancount` further up the tree is not.
-                Ok(files) if files.len() > 1 && probe.contains_file(&path) => {
+                // be adopted on the strength of an include that led nowhere.
+                let reach = match probe.load(&root) {
+                    Ok(files) if files.len() > 1 => Some(files),
+                    Ok(_) => {
+                        tracing::debug!(
+                            "Not adopting {}: its includes resolved to nothing",
+                            root.display()
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        tracing::warn!("Not adopting {} as a root journal: {e}", root.display());
+                        None
+                    }
+                };
+                self.probed_roots.insert(root.clone(), reach.clone());
+                // Already loaded, so commit this one rather than loading again.
+                if reach
+                    .as_ref()
+                    .is_some_and(|files| files.contains(&canonical_target))
+                {
                     tracing::info!(
-                        "Adopted {} as the root journal ({} files); none was configured",
-                        root.display(),
-                        files.len()
+                        "Adopted {} as the root journal; none was configured",
+                        root.display()
                     );
                     *self.ledger_state.write() = probe;
                     self.journal_file = Some(root);
                     return true;
                 }
-                Ok(_) => {
-                    tracing::debug!(
-                        "Not adopting {}: it does not resolve to a ledger containing {}",
-                        root.display(),
-                        path.display()
+                continue;
+            };
+
+            // Cache hit. It reaches this file, so load it for real: the probe
+            // that produced the cached answer was dropped with its state.
+            if reach.is_some_and(|files| files.contains(&canonical_target)) {
+                let mut state = crate::ledger_state::LedgerState::new();
+                if state.load(&root).is_ok() {
+                    tracing::info!(
+                        "Adopted {} as the root journal (cached reach); none was configured",
+                        root.display()
                     );
-                    self.rejected_roots.insert(root);
+                    *self.ledger_state.write() = state;
+                    self.journal_file = Some(root);
+                    return true;
                 }
-                Err(e) => {
-                    tracing::warn!("Not adopting {} as a root journal: {e}", root.display());
-                    self.rejected_roots.insert(root);
-                }
+                // It loaded a moment ago and does not now. Treat the cache as
+                // stale rather than trusting it.
+                self.probed_roots.remove(&root);
             }
         }
         false
@@ -1965,7 +2010,7 @@ impl MainLoopState {
         // exactly what could add the `include` that makes it this file's root
         // after all, so the memo does not outlive one.
         if should_revalidate {
-            self.rejected_roots.clear();
+            self.probed_roots.clear();
         }
 
         // Re-validate open documents once after processing all changes
@@ -2644,7 +2689,7 @@ mod tests {
         assert_eq!(handler, "custom failure");
     }
 
-    /// A root rejected once must not be probed again for every file opened.
+    /// A root probed once must not be re-loaded for every file opened.
     ///
     /// Probing costs a full ledger load, and the upward search runs on every
     /// `didOpen` until something is adopted, so a stray `main.beancount` over
@@ -2693,19 +2738,29 @@ mod tests {
         };
 
         open(&mut state, 1);
-        let after_first = state.rejected_roots.len();
+        let after_first = state.probed_roots.len();
         open(&mut state, 2);
         open(&mut state, 3);
 
         assert_eq!(
             after_first, 1,
-            "the unrelated root should have been probed and rejected once"
+            "the unrelated root should have been probed exactly once"
         );
         assert_eq!(
-            state.rejected_roots.len(),
+            state.probed_roots.len(),
             1,
-            "later opens re-probed instead of consulting the memo: {:?}",
-            state.rejected_roots
+            "later opens re-probed instead of consulting the cache: {:?}",
+            state.probed_roots.keys().collect::<Vec<_>>()
+        );
+        // It loaded fine, it just does not reach these files. Recording that
+        // as a flat rejection is what made a root unadoptable for ITSELF.
+        assert!(
+            state
+                .probed_roots
+                .get(&root)
+                .expect("the root must be in the cache")
+                .is_some(),
+            "a root that loads must cache what it reaches, not a bare rejection"
         );
         assert!(
             state.journal_file.is_none(),
@@ -2713,8 +2768,8 @@ mod tests {
             state.journal_file
         );
 
-        // An edit is what could make a rejected root start including this
-        // file, so the memo must not outlive one.
+        // An edit is what could make a root start including a file it did
+        // not before, so the cache must not outlive one.
         let changed: Uri = crate::path_to_uri(&root).expect("file URI");
         state.on_did_change_watched_files(lsp_types::DidChangeWatchedFilesParams {
             changes: vec![lsp_types::FileEvent {
@@ -2723,9 +2778,9 @@ mod tests {
             }],
         });
         assert!(
-            state.rejected_roots.is_empty(),
-            "a watched-file change must retire the memo: {:?}",
-            state.rejected_roots
+            state.probed_roots.is_empty(),
+            "a watched-file change must retire the cache: {:?}",
+            state.probed_roots.keys().collect::<Vec<_>>()
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1205,32 +1205,36 @@ fn issue_2285_an_unrelated_root_upward_is_not_adopted() {
 /// republished, so the first sat there contradicting the ledger until it was
 /// touched. The wrong diagnostic is exactly the one the user went looking at
 /// the root to explain.
+///
+/// The root lives in a SIBLING directory, which is what keeps this reachable
+/// now that unconventionally named roots are discovered: the search walks
+/// ancestors, so a root beside the data directory rather than above it is
+/// still invisible until it is opened. An earlier fixture put the root one
+/// level up, and once discovery found it there was no "before" state left to
+/// correct; the test said so rather than passing vacuously.
 #[test]
 fn issue_2285_adoption_corrects_documents_already_open() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let accounts_path = tmp.path().join("accounts.beancount");
-    let sub_path = tmp.path().join("txns.beancount");
-    // Deliberately NOT a name `discover_journal_upward` knows, so nothing is
-    // adopted until this root is opened explicitly.
-    let root_path = tmp.path().join("m1.beancount");
+    let data = tmp.path().join("data");
+    let roots = tmp.path().join("roots");
+    std::fs::create_dir_all(&data).expect("mkdir data");
+    std::fs::create_dir_all(&roots).expect("mkdir roots");
 
     std::fs::write(
-        &accounts_path,
+        data.join("accounts.beancount"),
         "2025-01-01 open Assets:Cash EUR\n2025-01-01 open Expenses:Food EUR\n",
     )
     .expect("write accounts");
+    let sub_path = data.join("txns.beancount");
     std::fs::write(
         &sub_path,
         "2026-01-01 * \"lunch\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
     )
     .expect("write sub");
+    let root_path = roots.join("m1.beancount");
     std::fs::write(
         &root_path,
-        format!(
-            "include \"{}\"\ninclude \"{}\"\n",
-            include_name(&accounts_path),
-            include_name(&sub_path)
-        ),
+        "include \"../data/accounts.beancount\"\ninclude \"../data/txns.beancount\"\n",
     )
     .expect("write root");
 
@@ -1286,6 +1290,104 @@ fn issue_2285_adoption_corrects_documents_already_open() {
     assert!(
         unopened.is_empty(),
         "an already-open file kept its pre-adoption diagnostics; got: {unopened:?}"
+    );
+}
+
+/// A sub-file whose root is not conventionally named still finds it.
+///
+/// `discover_journal_upward` only knows `main.bean`, `ledger.beancount` and
+/// the rest, so the reporter's own root, `m1.beancount`, was invisible to it.
+/// Opening `ledger/2025-01.beancount` under such a ledger kept reporting
+/// accounts as never opened: the same #2285 error, for everyone whose root
+/// happens to be called something else.
+#[test]
+fn a_sub_file_finds_an_unconventionally_named_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sub_dir = tmp.path().join("ledger");
+    std::fs::create_dir_all(&sub_dir).expect("mkdir");
+
+    std::fs::write(
+        tmp.path().join("accounts.beancount"),
+        "2025-01-01 open Assets:Cash EUR\n2025-01-01 open Expenses:Food EUR\n",
+    )
+    .expect("write accounts");
+    let sub_path = sub_dir.join("2025-01.beancount");
+    std::fs::write(
+        &sub_path,
+        "2026-01-01 * \"lunch\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
+    )
+    .expect("write sub");
+    // Deliberately a name no discovery list contains.
+    std::fs::write(
+        tmp.path().join("m1.beancount"),
+        "include \"accounts.beancount\"\ninclude \"ledger/2025-01.beancount\"\n",
+    )
+    .expect("write root");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let sub_uri = uri_for(&sub_path);
+    let sub_src = std::fs::read_to_string(&sub_path).expect("read sub");
+    client.open_document(&sub_uri, &sub_src);
+
+    let offenders = drain_e1001_for(&mut client, &sub_uri);
+    assert!(
+        offenders.is_empty(),
+        "E1001 under a root named `m1.beancount`; got: {offenders:?}"
+    );
+}
+
+/// Probing a root against one file must not disqualify it for another.
+///
+/// Whether a root qualifies depends on the file being opened, so the answer
+/// cannot be cached as a flat "rejected". It was, and the result was that a
+/// root probed while looking for one file could never be adopted for any
+/// other, including for ITSELF: open a scratch file first and the real ledger
+/// stayed broken for the rest of the session.
+#[test]
+fn a_root_probed_for_one_file_is_still_adoptable_for_another() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("accounts.beancount"),
+        "2025-01-01 open Assets:Cash EUR\n2025-01-01 open Expenses:Food EUR\n",
+    )
+    .expect("write accounts");
+    let txns = tmp.path().join("txns.beancount");
+    std::fs::write(
+        &txns,
+        "2026-01-01 * \"lunch\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
+    )
+    .expect("write txns");
+    std::fs::write(
+        tmp.path().join("m1.beancount"),
+        "include \"accounts.beancount\"\ninclude \"txns.beancount\"\n",
+    )
+    .expect("write root");
+
+    // Not part of that ledger, and opened first, so the root is probed against
+    // it and found not to reach it.
+    let scratch = tmp.path().join("scratch.beancount");
+    std::fs::write(&scratch, "2026-03-01 balance Assets:Other 0.00 EUR\n").expect("write scratch");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let scratch_uri = uri_for(&scratch);
+    let scratch_src = std::fs::read_to_string(&scratch).expect("read scratch");
+    client.open_document(&scratch_uri, &scratch_src);
+    // Its account really is unopened, so this is correct and only here to make
+    // sure the probe has happened before the next open.
+    let _ = drain_e1001_for(&mut client, &scratch_uri);
+
+    let txns_uri = uri_for(&txns);
+    let txns_src = std::fs::read_to_string(&txns).expect("read txns");
+    client.open_document(&txns_uri, &txns_src);
+
+    let offenders = drain_e1001_for(&mut client, &txns_uri);
+    assert!(
+        offenders.is_empty(),
+        "a root probed against an unrelated file first was never adoptable again; got: {offenders:?}"
     );
 }
 

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1391,6 +1391,67 @@ fn a_root_probed_for_one_file_is_still_adoptable_for_another() {
     );
 }
 
+/// A master ledger beats a nested sub-ledger that also reaches the file.
+///
+/// A master that includes self-contained sub-ledgers, each usable on its own,
+/// is a legitimate beancount layout (#1546). Both roots reach the file, so the
+/// order candidates are tried in decides which one answers, and the master is
+/// the one that gives complete cross-file validation: adopting the inner
+/// ledger validates against a partial one and reports accounts the master
+/// opens as never opened, which is #2285 again by another route.
+///
+/// The ordering that produces this is by source, conventional names before
+/// include-declaring files, rather than by distance. `discover_journal_upward`
+/// documents "nearest wins" for its own search and this deliberately does not
+/// extend that across sources, because nearest and most-complete point in
+/// opposite directions here.
+#[test]
+fn a_master_ledger_beats_a_nested_sub_ledger() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sub = tmp.path().join("sub");
+    std::fs::create_dir_all(&sub).expect("mkdir");
+
+    std::fs::write(
+        tmp.path().join("accounts.beancount"),
+        "2025-01-01 open Assets:Cash EUR\n",
+    )
+    .expect("write accounts");
+    let txns = sub.join("txns.beancount");
+    std::fs::write(
+        &txns,
+        "2026-01-01 * \"x\"\n  Assets:Cash   -5 EUR\n  Expenses:Food  5 EUR\n",
+    )
+    .expect("write txns");
+
+    // The master opens BOTH accounts.
+    std::fs::write(
+        tmp.path().join("main.beancount"),
+        "2025-01-01 open Expenses:Food EUR\n         include \"accounts.beancount\"\ninclude \"sub/txns.beancount\"\n",
+    )
+    .expect("write master");
+    // The nested root opens only one, so adopting it leaves the other
+    // reported as never opened.
+    std::fs::write(
+        sub.join("m1.beancount"),
+        "include \"../accounts.beancount\"\ninclude \"txns.beancount\"\n",
+    )
+    .expect("write nested");
+
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let txns_uri = uri_for(&txns);
+    let txns_src = std::fs::read_to_string(&txns).expect("read txns");
+    client.open_document(&txns_uri, &txns_src);
+
+    let offenders = drain_e1001_for(&mut client, &txns_uri);
+    assert!(
+        offenders.is_empty(),
+        "the nested sub-ledger answered instead of the master, so an account \
+         the master opens reads as never opened; got: {offenders:?}"
+    );
+}
+
 /// A root that will not load must not be adopted, because adoption is sticky.
 ///
 /// `journal_file.is_some()` is what stops a second adoption, so pinning it to


### PR DESCRIPTION
Follow-up to #2290, which fixed half of #2285.

## What was still broken

Root discovery only recognizes the names in `COMMON_ROOT_NAMES` (`main.bean`, `ledger.beancount`, `index.bean`, …). So after #2290 two shapes worked and one did not:

| file opened | root | before |
|---|---|---|
| a file that declares includes | itself | fixed in #2290 |
| a sub-file under `main.beancount` | found by name | fixed in #2290 |
| a sub-file under `m1.beancount` | not found | still wrong |

That third row is the reporter's own layout. Opening `ledger/2025-01.beancount` under it kept reporting every account as never opened, which is #2285 again for anyone whose root happens to be called something else. Measured on that shape: 2 false `E1001` before, 0 after.

## How

`discover_include_roots_upward` offers any nearby file that declares an `include` as a candidate, nearest first. It sits beside the existing discovery in the loader, which is where `COMMON_ROOT_NAMES` already lives so that the LSP and `rledger format` cannot disagree about what a root is.

Cheap on purpose: directory listings plus a substring check, no parsing, because a file with no `include` in it cannot be the root of anything. Being permissive only costs the caller one load it then rejects; being strict would hide the real root.

Bounded at 8 levels and 16 candidates. Each candidate costs a full ledger load to test, so without a cap opening a scratch file would read every beancount file between it and `/`.

Every candidate still has to prove it reaches the file, so a wider net does not mean a wronger answer.

## The bug this exposed

The memo added in #2290 recorded roots as flatly "rejected". That was wrong, and widening the search made it reachable: whether a root qualifies depends on the file being opened, so a root probed while looking for one file could never be adopted for another, **including for itself**. Open a scratch file first and the real ledger stayed broken for the rest of the session.

The cache now stores what each root REACHES, so one load answers for every subsequent target, and `None` is kept only for the answers that really are target-independent: it would not load, or its includes resolved to nothing.

Three existing tests failed on this change and each was right to. One caught exactly that bug. Two had fixtures whose premise was that a root could not be found, which discovery had just made false; one is rebuilt around a root in a sibling directory, which the ancestor walk still cannot see, and it fails loudly rather than passing vacuously if that ever stops being true.

## Verification

Mutations, each failing only what covers it:

| mutation | new sub-file case | target-dependence | other #2285 cases |
|---|---|---|---|
| include-graph candidates removed | FAIL | FAIL | ok |
| cache a flat rejection again | ok | FAIL | 2 FAIL |

End to end against the release binary, driving `rledger-lsp` over stdio:

| case | result |
|---|---|
| reporter's original file | clean |
| sub-file, unconventional root | clean (was 2x `E1001`) |
| sub-file, conventional root | clean |
| missing include | still reports, matching the CLI |
| self-including file | no hang |

Cost. An open that finds its root stops at the first candidate. An open that finds none pays for what it tried: worst case measured at 0.45s for twelve unrelated 900KB ledgers in one directory, then 0.02s for every later file once cached. The earlier benchmark (six files under one unrelated 900KB root) is 0.09s then 0.02s.

Loader and LSP suites pass, `clippy --workspace --all-targets --all-features -D warnings` clean, `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

## Still not covered

Adoption remains one root per server, first wins. Two unrelated ledgers open in one window means the second stays in single-file mode. In VS Code that is one server per workspace folder, so it is mostly reachable through the no-folder fallback.
