### PR TITLE
fix(wasm): give option warnings their code and phase fields

### DIFF
--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -145,6 +145,21 @@ impl OptionWarning {
     pub fn is_error(&self) -> bool {
         !matches!(self.code, "E7003" | "E7009")
     }
+
+    /// The processing phase these belong to.
+    ///
+    /// Here for the same reason as [`is_error`](Self::is_error): both surfaces
+    /// that report option warnings were choosing it independently, each with
+    /// its own `"parse"` literal, and a series of bugs in this family (#2291,
+    /// #2297) all came from one surface deciding something about a diagnostic
+    /// that the other decided differently.
+    ///
+    /// `parse` because options are read while the file is being loaded, before
+    /// anything is booked or validated.
+    #[must_use]
+    pub const fn phase(&self) -> &'static str {
+        "parse"
+    }
 }
 
 /// Beancount file options.
@@ -813,6 +828,22 @@ impl Options {
 
 #[cfg(test)]
 mod tests {
+
+    /// The phase both surfaces report for option warnings.
+    ///
+    /// Pinned because two consumers read it and the point of moving it here
+    /// was that neither should be choosing it. A change to the value should
+    /// have to be deliberate.
+    #[test]
+    fn option_warnings_are_reported_in_the_parse_phase() {
+        let warning = OptionWarning {
+            code: "E7009",
+            message: String::new(),
+            option: String::new(),
+            value: String::new(),
+        };
+        assert_eq!(warning.phase(), "parse");
+    }
 
     /// The one rule both `rledger check` and the LSP read (#2291).
     ///

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -525,10 +525,12 @@ pub struct Ledger {
 /// `code` and `phase` are set rather than left `None` (#2297). The code used
 /// to survive only as an `[E7009] ` prefix on the message, which meant a
 /// consumer wanting to branch on it had to parse it back out of the text that
-/// `Error::code` exists to save them from reading. `parse` is the phase
-/// `rledger check` reports for these, so the two surfaces now describe the
-/// same warning the same way, prefix included: it is gone from the message,
-/// which is what the CLI has always emitted.
+/// `Error::code` exists to save them from reading.
+///
+/// Two changes, then. The code moves into the `code` field, and `phase`
+/// becomes `"parse"`, which is what `rledger check` reports for these. The
+/// prefix is dropped from the message, so the text now matches the CLI's for
+/// the same warning exactly.
 fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
     warnings
         .iter()

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -527,10 +527,11 @@ pub struct Ledger {
 /// consumer wanting to branch on it had to parse it back out of the text that
 /// `Error::code` exists to save them from reading.
 ///
-/// Two changes, then. The code moves into the `code` field, and `phase`
-/// becomes `"parse"`, which is what `rledger check` reports for these. The
-/// prefix is dropped from the message, so the text now matches the CLI's for
-/// the same warning exactly.
+/// Two changes, then. The code moves into the `code` field, and `phase` is
+/// set from `OptionWarning::phase`, the same source `rledger check` reads, so
+/// the two cannot drift the way the severity rule did. The prefix is dropped
+/// from the message, so the text now matches the CLI's for the same warning
+/// exactly.
 fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
     warnings
         .iter()
@@ -540,7 +541,7 @@ fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> V
             } else {
                 Error::warning(w.message.clone())
             };
-            base.with_code(w.code).with_phase("parse")
+            base.with_code(w.code).with_phase(w.phase())
         })
         .collect()
 }

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -521,16 +521,24 @@ pub struct Ledger {
 /// E7003 and E7009 are warnings to `check`, which exits 0 on them. They used
 /// to go out here as errors, under a comment claiming parity with `check` and
 /// the LSP, so a ledger the CLI called clean arrived carrying errors (#2291).
+///
+/// `code` and `phase` are set rather than left `None` (#2297). The code used
+/// to survive only as an `[E7009] ` prefix on the message, which meant a
+/// consumer wanting to branch on it had to parse it back out of the text that
+/// `Error::code` exists to save them from reading. `parse` is the phase
+/// `rledger check` reports for these, so the two surfaces now describe the
+/// same warning the same way, prefix included: it is gone from the message,
+/// which is what the CLI has always emitted.
 fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
     warnings
         .iter()
         .map(|w| {
-            let text = format!("[{}] {}", w.code, w.message);
-            if w.is_error() {
-                Error::new(text)
+            let base = if w.is_error() {
+                Error::new(w.message.clone())
             } else {
-                Error::warning(text)
-            }
+                Error::warning(w.message.clone())
+            };
+            base.with_code(w.code).with_phase("parse")
         })
         .collect()
 }
@@ -800,16 +808,28 @@ mod option_warning_severity_tests {
         );
     }
 
-    /// The code stays visible in the message, which is how consumers identify
-    /// these today: `Error::code` is `None` on this path. Pinned so the
-    /// severity fix cannot quietly take the code away with it.
+    /// The code reaches consumers as a FIELD, not as message text (#2297).
+    ///
+    /// This case used to pin the `[E7009] ` prefix, because that prefix was
+    /// the only place the code survived and #2292 could have dropped it by
+    /// accident. The code now has a field of its own, so the guard moves to
+    /// the field rather than being deleted: something still has to fail if a
+    /// future change stops carrying it.
+    ///
+    /// The message is asserted NOT to repeat it, which is what makes the
+    /// WASM text identical to the CLI's for the same warning.
     #[test]
-    fn the_code_is_still_in_the_message() {
+    fn the_code_travels_in_its_own_field() {
         let mapped = option_warnings_to_errors(&[warn("E7009")]);
-        assert!(
-            mapped[0].message.contains("E7009"),
-            "got {:?}",
-            mapped[0].message
+        assert_eq!(mapped[0].code.as_deref(), Some("E7009"));
+        assert_eq!(
+            mapped[0].phase.as_deref(),
+            Some("parse"),
+            "`rledger check` reports these under the parse phase"
+        );
+        assert_eq!(
+            mapped[0].message, "msg",
+            "the message must carry the text alone; the code has a field now"
         );
     }
 

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -654,7 +654,7 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
                 end_line: 1,
                 end_column: 1,
                 severity: severity.to_string(),
-                phase: "parse".to_string(),
+                phase: warning.phase().to_string(),
                 code: warning.code.to_string(),
                 message: warning.message.clone(),
                 hint: None,


### PR DESCRIPTION
Fixes #2297.

## Before and after

Same warning, both surfaces:

```
CLI  --format json   {"code": "E7009", "severity": "warning", "phase": "parse",
                      "message": "Option \"title\" set in an included file is ignored; ..."}

WASM before          {"code": null,    "severity": "warning", "phase": null,
                      "message": "[E7009] Option \"title\" set in an included file is ignored; ..."}

WASM after           {"code": "E7009", "severity": "warning", "phase": "parse",
                      "message": "Option \"title\" set in an included file is ignored; ..."}
```

A consumer wanting to branch on `E7009` had to parse it back out of the message, which is what `Error::code` exists to save them from. Parse and validation errors already set both fields via `with_code`; only this path did not. These are not codeless diagnostics either: `OptionWarning::code` is a `&'static str` that is always populated.

## Breaking

The `[E7009] ` prefix is gone from the message. Setting `code` and `phase` is additive, but removing the prefix is not, and it is deliberate rather than incidental: with the code carried in a field, the prefix is the only thing left making the WASM text differ from the CLI's for the same warning. Nothing in the repository reads it, which I checked rather than assumed.

`phase` is `"parse"`, matching what `check.rs` reports for these.

## The test moved rather than being deleted

A test pinned the `[E7009] ` prefix. It was added in #2292 so that the severity fix could not drop the code by accident, and that concern outlives the prefix, so it now guards the field instead: the code is `E7009`, the phase is `parse`, and the message does NOT repeat the code.

Each assertion fails under a mutation of exactly what it covers:

| mutation | result |
|---|---|
| `with_code` removed | FAIL |
| `with_phase` removed | FAIL |
| prefix put back in the message | FAIL |

Deleting the old test and calling the change covered would have left nothing failing if a later edit stopped carrying the code again, which is the situation #2292 wrote it to prevent.

`cargo test -p rustledger-wasm -p rustledger` passes, `clippy --workspace --all-targets --all-features -D warnings` clean, `RUSTDOCFLAGS="-D warnings" cargo doc` clean.
