### PR TITLE
fix(wasm): validate options on the single-source entry points

### DIFF
--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -13,6 +13,7 @@ use rustledger_parser::parse as parse_beancount;
 use crate::convert::{directive_to_json, value_to_cell};
 use crate::helpers::{
     extract_options, has_fatal, load_and_book, parse_error_to_wasm, run_validation, to_js,
+    validate_option_tuples,
 };
 #[cfg(feature = "completions")]
 use crate::types::{CompletionJson, CompletionResultJson};
@@ -88,11 +89,17 @@ pub fn parse(source: &str) -> Result<JsValue, JsError> {
     let result = parse_beancount(source);
     let lookup = LineLookup::new(source);
 
-    let errors: Vec<Error> = result
+    let mut errors: Vec<Error> = result
         .errors
         .iter()
         .map(|e| parse_error_to_wasm(e, &lookup, None))
         .collect();
+
+    // This entry point never builds a loader `Options`, so nothing here used to
+    // raise E7001/E7002 and an invalid option was invisible (#2299). Validating
+    // the tuples is option-only work — no IO, no booking — so `parse` stays as
+    // cheap as its name promises.
+    errors.extend(validate_option_tuples(&result.options));
 
     // Extract options from parsed result
     let options = extract_options(&result.options);
@@ -117,9 +124,12 @@ pub fn parse(source: &str) -> Result<JsValue, JsError> {
 #[wasm_bindgen(js_name = "validateSource")]
 pub fn validate_source(source: &str) -> Result<JsValue, JsError> {
     let load = load_and_book(source);
+    // `run_validation` first: it gates on `load.errors`, and an invalid option
+    // must not stop a ledger's real validation errors from being found (#2299).
     let validation_errors = run_validation(&load);
     let mut errors = load.errors;
     errors.extend(validation_errors);
+    errors.extend(load.option_errors);
 
     let result = ValidationResult {
         // Warnings do not invalidate a ledger (matching `rledger check`, which

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -127,9 +127,8 @@ pub fn validate_source(source: &str) -> Result<JsValue, JsError> {
     // `run_validation` first: it gates on `load.errors`, and an invalid option
     // must not stop a ledger's real validation errors from being found (#2299).
     let validation_errors = run_validation(&load);
-    let mut errors = load.errors;
+    let mut errors = load.reported_errors();
     errors.extend(validation_errors);
-    errors.extend(load.option_errors);
 
     let result = ValidationResult {
         // Warnings do not invalidate a ledger (matching `rledger check`, which
@@ -157,14 +156,14 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
         let result = QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
-            errors: load.errors,
+            errors: load.reported_errors(),
         };
         return to_js(&result);
     }
 
     // Carry any non-fatal load warnings through every result path so callers
     // still see them alongside (or instead of) query output.
-    let warnings = load.errors;
+    let warnings = load.reported_errors();
 
     // Parse the query
     let query = match parse_query(query_str) {
@@ -279,13 +278,13 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
         let result = PadResult {
             directives: Vec::new(),
             padding_transactions: Vec::new(),
-            errors: load.errors,
+            errors: load.reported_errors(),
         };
         return to_js(&result);
     }
 
     // Carry non-fatal load warnings through to the result.
-    let mut errors = load.errors;
+    let mut errors = load.reported_errors();
 
     // Process pads
     let pad_result = process_pads(&load.directives);
@@ -354,13 +353,13 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
     if has_fatal(&load.errors) {
         let result = PluginResult {
             directives: Vec::new(),
-            errors: load.errors,
+            errors: load.reported_errors(),
         };
         return to_js(&result);
     }
 
     // Carry non-fatal load warnings through every result path.
-    let warnings = load.errors;
+    let warnings = load.reported_errors();
 
     // Find and run the plugin
     let registry = NativePluginRegistry::global();

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -115,6 +115,21 @@ use crate::types::{Error, LedgerOptions};
 /// Measured on a pre-fix blob at v20, which this build accepted: `isValid()`
 /// came back true with no codes where a fresh parse of the same source returns
 /// false with E7001 -- the fix silently did not apply to any cached ledger.
+///
+/// v21 carries a debt that is not its own, which is the more useful half of
+/// this entry. #2291/#2292 (option-warning SEVERITY), #2297/#2298 (its code
+/// and phase, and the `[E7009] ` prefix dropped from the message text) each
+/// changed the CONTENT of a cached error list and none of them touched this
+/// file. `Ledger::is_valid` is `!has_fatal(&self.errors)` over exactly that
+/// restored list, so a blob written before them decides validity by the rules
+/// those PRs replaced. Measured on the same input, a duplicated option:
+///
+///   this build     E7003 Warning  code Some("E7003")  isValid=true
+///   pre-#2291 blob E7003 Error    code None           isValid=false
+///
+/// which is the #2291 bug served back out of the cache -- a ledger `rledger
+/// check` exits 0 on, reported invalid. Those three bumps are owed and this
+/// one pays them, so the range v20 -> v21 covers more than #2299 alone.
 pub const CACHE_VERSION: u32 = 21;
 
 /// The `rustledger-loader` cache version this one was last reconciled with.

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -183,6 +183,10 @@ pub struct ParsedLedgerPayload {
     pub directives: Vec<Directive>,
     pub options: LedgerOptions,
     pub parse_errors: Vec<Error>,
+    /// Option diagnostics, archived apart from `parse_errors` because the
+    /// restored ledger gates its operations on that list and must not refuse
+    /// a query over an invalid option.
+    pub option_errors: Vec<Error>,
     pub validation_errors: Vec<Error>,
 }
 
@@ -535,6 +539,7 @@ option "operating_currency" "USD"
             directives: processed.directives.clone(),
             options: processed.options.clone(),
             parse_errors: Vec::new(),
+            option_errors: Vec::new(),
             validation_errors: Vec::new(),
         };
 
@@ -625,6 +630,7 @@ option "operating_currency" "USD"
             directives: Vec::new(),
             options: LedgerOptions::default(),
             parse_errors: Vec::new(),
+            option_errors: Vec::new(),
             validation_errors: Vec::new(),
         })
         .unwrap();

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -107,7 +107,15 @@ use crate::types::{Error, LedgerOptions};
 /// carrying a second juxtaposed number, is diagnosed rather than partly read
 /// and partly discarded (#2193). Loader v35. Same shape as v19: the archived
 /// directive is identical and the diagnostic is what a stale blob would hide.
-pub const CACHE_VERSION: u32 = 20;
+/// v21: an invalid option is diagnosed on the single-source entry points
+/// (#2299). Loader v35, unchanged -- this one is ours alone. Same shape as v19
+/// and v20 again: the archived directives are identical, and what a stale blob
+/// hides is the diagnostic. `from_cache` restores `parse_errors` verbatim and
+/// re-parses the source only for editor spans, so it never re-derives them.
+/// Measured on a pre-fix blob at v20, which this build accepted: `isValid()`
+/// came back true with no codes where a fresh parse of the same source returns
+/// false with E7001 -- the fix silently did not apply to any cached ledger.
+pub const CACHE_VERSION: u32 = 21;
 
 /// The `rustledger-loader` cache version this one was last reconciled with.
 ///

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -70,6 +70,17 @@ pub struct ProcessedLedger {
     pub directives: Vec<Directive>,
     pub options: LedgerOptions,
     pub errors: Vec<Error>,
+    /// Option diagnostics (E7001, E7002, E7003, E7009, ...), kept apart from
+    /// `errors` on purpose.
+    ///
+    /// `errors` is what [`has_fatal`] gates on, and that gate means "the
+    /// directive stream is unsound to work with" — a parse or booking failure.
+    /// An invalid option does not make directives unsound, so folding these in
+    /// here would make [`run_validation`] skip, and a ledger with a typo'd
+    /// option would silently stop reporting its real validation errors (the
+    /// exact drop #2292 fixed for plugin warnings). Surfaces that *report*
+    /// diagnostics merge this in; surfaces that gate on soundness do not.
+    pub option_errors: Vec<Error>,
     /// Raw parse result, needed by editor features and `ParsedLedger`.
     pub parse_result: ParserResult,
     pub lookup: LineLookup,
@@ -94,11 +105,13 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
             .collect();
 
         let options = extract_options(&parse_result.options);
+        let option_errors = validate_option_tuples(&parse_result.options);
 
         return ProcessedLedger {
             directives: Vec::new(),
             options,
             errors,
+            option_errors,
             parse_result,
             lookup,
         };
@@ -113,10 +126,12 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
         Ok(raw) => raw,
         Err(e) => {
             let options = extract_options(&parse_result.options);
+            let option_errors = validate_option_tuples(&parse_result.options);
             return ProcessedLedger {
                 directives: Vec::new(),
                 options,
                 errors: vec![Error::new(format!("Load error: {e}"))],
+                option_errors,
                 parse_result,
                 lookup,
             };
@@ -125,6 +140,11 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
 
     // Extract options before process() consumes raw
     let options = extract_loader_options(&raw.options);
+    // Same, for the warnings `Options::set` raised while building them. The
+    // loader ran, so these already exist — the single-source path used to drop
+    // them on the floor here, which is why E7001/E7002 were invisible on every
+    // entry point built on this function (#2299).
+    let option_errors = option_warnings_to_errors(&raw.options.warnings);
 
     // Run the shared processing pipeline:
     // sort → synth-plugins → book → regular-plugins → finalize
@@ -146,6 +166,7 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
                 directives,
                 options,
                 errors,
+                option_errors,
                 parse_result,
                 lookup,
             }
@@ -154,6 +175,7 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
             directives: Vec::new(),
             options,
             errors: vec![Error::new(format!("Processing error: {e}"))],
+            option_errors,
             parse_result,
             lookup,
         },
@@ -249,6 +271,63 @@ pub fn account_types_from_raw(
         }
     }
     at
+}
+
+/// Option warnings as WASM [`Error`]s, carrying the severity, code, and phase
+/// `rledger check` gives them.
+///
+/// Severity, code, and phase are all read off the warning rather than decided
+/// here — `is_error()`, `code`, `phase()` — because each one, when a surface
+/// decided it locally instead, drifted:
+///
+/// - E7003 and E7009 are warnings to `check`, which exits 0 on them. They used
+///   to go out from here as errors, under a comment claiming parity with
+///   `check` and the LSP, so a ledger the CLI called clean arrived carrying
+///   errors (#2291). `is_error` moved onto the warning in #2292.
+/// - The code used to survive only as an `[E7009] ` prefix on the message, so a
+///   consumer wanting to branch on it had to parse it back out of the text that
+///   [`Error::code`] exists to save them from reading (#2297). It moved into the
+///   `code` field, and the prefix was dropped, so the message text now matches
+///   the CLI's for the same warning exactly.
+/// - `phase` was then written as a `"parse"` literal on each surface, which is
+///   the same shape one field over; it moved onto `phase()` in #2298.
+///
+/// Shared, finally, rather than copied: this used to be a private function in
+/// `parsed_ledger.rs` serving only the multi-file path, which is why the
+/// single-source path had nothing to call and reported no option diagnostics at
+/// all (#2299).
+///
+/// [`OptionWarning`]: rustledger_loader::OptionWarning
+pub fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
+    warnings
+        .iter()
+        .map(|w| {
+            let base = if w.is_error() {
+                Error::new(w.message.clone())
+            } else {
+                Error::warning(w.message.clone())
+            };
+            base.with_code(w.code).with_phase(w.phase())
+        })
+        .collect()
+}
+
+/// Validate raw parsed `option` tuples and return the resulting diagnostics.
+///
+/// For entry points that never build a loader [`Options`] — `parse()`, and the
+/// early-return paths of [`load_and_book`] where loading did not get far enough
+/// to produce one. Running the keys and values through [`Options::set`] is what
+/// raises E7001/E7002, and it is cheap: no file IO, no booking, no plugins, so
+/// a syntax-only entry point stays syntax-only in cost.
+///
+/// [`Options`]: rustledger_loader::Options
+/// [`Options::set`]: rustledger_loader::Options::set
+pub fn validate_option_tuples(options: &[(String, String, rustledger_parser::Span)]) -> Vec<Error> {
+    let mut opts = rustledger_loader::Options::new();
+    for (key, value, _span) in options {
+        opts.set(key, value);
+    }
+    option_warnings_to_errors(&opts.warnings)
 }
 
 pub fn extract_options(options: &[(String, String, rustledger_parser::Span)]) -> LedgerOptions {
@@ -379,5 +458,94 @@ mod account_types_tests {
         assert_eq!(at.assets, "Assets"); // untouched types keep defaults
         assert!(at.is_credit_normal("Revenue:Sales"));
         assert!(!at.is_credit_normal("Income:Sales")); // renamed away
+    }
+}
+
+#[cfg(test)]
+mod option_diagnostic_tests {
+    use super::*;
+
+    /// An invalid option, plus a posting to an account that was never opened.
+    /// The second is a genuine validation error, and it is what proves the
+    /// first does not suppress it.
+    const BAD_OPTION_AND_BAD_ACCOUNT: &str = "option \"nonsense_option\" \"x\"\n\
+2024-01-01 open Assets:Cash USD\n\
+2024-01-02 * \"p\"\n  Assets:Cash 1 USD\n  Assets:NeverOpened -1 USD\n";
+
+    const BAD_OPTION: &str = "option \"nonsense_option\" \"x\"\n\
+2024-01-01 open Assets:Cash USD\n";
+
+    fn codes(errors: &[Error]) -> Vec<&str> {
+        errors.iter().filter_map(|e| e.code.as_deref()).collect()
+    }
+
+    /// The bug: the loader raised E7001 and `load_and_book` dropped it, so
+    /// every single-source entry point built on it reported a clean ledger
+    /// where `rledger check` errors and exits 1 (#2299).
+    #[test]
+    fn load_and_book_surfaces_the_option_error_the_loader_raised() {
+        let load = load_and_book(BAD_OPTION);
+        assert!(
+            codes(&load.option_errors).contains(&"E7001"),
+            "E7001 must reach the caller, got {:?}",
+            load.option_errors
+        );
+    }
+
+    /// The trap in the obvious fix. `run_validation` skips when
+    /// `has_fatal(&load.errors)`, so folding option errors into `errors` would
+    /// make a typo'd option silently swallow every real validation error —
+    /// the same drop #2292 fixed for plugin warnings.
+    #[test]
+    fn an_invalid_option_does_not_suppress_validation() {
+        let load = load_and_book(BAD_OPTION_AND_BAD_ACCOUNT);
+        assert!(
+            codes(&load.option_errors).contains(&"E7001"),
+            "precondition: the option error is reported"
+        );
+        assert!(
+            !run_validation(&load).is_empty(),
+            "the undefined-account error must still be found; an invalid \
+             option does not make the directive stream unsound"
+        );
+    }
+
+    /// `parse()` never builds a loader `Options`, so it needs its own call to
+    /// `Options::set` rather than warnings to read off a `LoadResult`.
+    #[test]
+    fn validate_option_tuples_raises_on_an_unknown_option() {
+        let parsed = parse_beancount(BAD_OPTION);
+        let errors = validate_option_tuples(&parsed.options);
+        assert!(codes(&errors).contains(&"E7001"), "got {errors:?}");
+    }
+
+    #[test]
+    fn validate_option_tuples_is_quiet_on_a_valid_option() {
+        let parsed = parse_beancount("option \"title\" \"My Ledger\"\n");
+        assert!(
+            validate_option_tuples(&parsed.options).is_empty(),
+            "a valid option must not produce a diagnostic"
+        );
+    }
+
+    /// The two paths reach the warnings differently — `parse()` recomputes
+    /// them, `load_and_book` reads what the loader already produced — so the
+    /// thing worth pinning is that they agree.
+    #[test]
+    fn both_paths_report_the_same_option_diagnostics() {
+        let recomputed = validate_option_tuples(&parse_beancount(BAD_OPTION).options);
+        let from_loader = load_and_book(BAD_OPTION).option_errors;
+
+        let seen = |errors: &[Error]| -> Vec<(Option<String>, String, Severity)> {
+            errors
+                .iter()
+                .map(|e| (e.code.clone(), e.message.clone(), e.severity))
+                .collect()
+        };
+        assert_eq!(
+            seen(&recomputed),
+            seen(&from_loader),
+            "recomputing the option warnings must match what the loader raised"
+        );
     }
 }

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -86,6 +86,29 @@ pub struct ProcessedLedger {
     pub lookup: LineLookup,
 }
 
+impl ProcessedLedger {
+    /// Everything a caller should be shown: load diagnostics plus option
+    /// diagnostics.
+    ///
+    /// Every surface that *reports* goes through here, and every surface that
+    /// *gates on soundness* reads [`ProcessedLedger::errors`] directly. Keeping
+    /// those two questions apart is the whole point of the split — see the
+    /// `option_errors` field docs for what folding them together breaks.
+    ///
+    /// It is a method rather than something each entry point assembles because
+    /// the alternative is what #2299 was: one surface deciding what a caller
+    /// sees while the next one decides differently. `query`, `expandPads`, and
+    /// `applyPlugin` each already carry non-fatal load warnings through every
+    /// result path; a second diagnostics channel they did not know to carry
+    /// would have left them silent on options while `validateSource` reported.
+    #[must_use]
+    pub fn reported_errors(&self) -> Vec<Error> {
+        let mut all = self.errors.clone();
+        all.extend(self.option_errors.iter().cloned());
+        all
+    }
+}
+
 /// Parse, book, and process a Beancount source string.
 ///
 /// This is the common entry point for all processing functions.
@@ -528,13 +551,20 @@ mod option_diagnostic_tests {
         );
     }
 
-    /// The two paths reach the warnings differently — `parse()` recomputes
-    /// them, `load_and_book` reads what the loader already produced — so the
-    /// thing worth pinning is that they agree.
+    /// The two paths reach the warnings differently — `parse()` recomputes them
+    /// through `Options::set`, `load_and_book` reads what the loader already
+    /// produced — so the thing worth pinning is that they agree, and for every
+    /// code rather than just the one in the bug report. E7002 in particular is
+    /// raised on a *value*, which is a different arm than E7001's unknown key.
     #[test]
-    fn both_paths_report_the_same_option_diagnostics() {
-        let recomputed = validate_option_tuples(&parse_beancount(BAD_OPTION).options);
-        let from_loader = load_and_book(BAD_OPTION).option_errors;
+    fn both_paths_agree_for_every_option_code() {
+        let cases: &[(&str, &str)] = &[
+            ("E7001", "option \"nonsense_option\" \"x\"\n"),
+            ("E7002", "option \"render_commas\" \"not_a_bool\"\n"),
+            ("E7003", "option \"title\" \"a\"\noption \"title\" \"b\"\n"),
+            ("E7004", "option \"allow_pipe_separator\" \"TRUE\"\n"),
+            ("none", "option \"title\" \"t\"\n"),
+        ];
 
         let seen = |errors: &[Error]| -> Vec<(Option<String>, String, Severity)> {
             errors
@@ -542,10 +572,51 @@ mod option_diagnostic_tests {
                 .map(|e| (e.code.clone(), e.message.clone(), e.severity))
                 .collect()
         };
-        assert_eq!(
-            seen(&recomputed),
-            seen(&from_loader),
-            "recomputing the option warnings must match what the loader raised"
+
+        for (expected, opt) in cases {
+            let src = format!("{opt}2024-01-01 open Assets:Cash USD\n");
+            let recomputed = validate_option_tuples(&parse_beancount(&src).options);
+            let from_loader = load_and_book(&src).option_errors;
+
+            assert_eq!(
+                seen(&recomputed),
+                seen(&from_loader),
+                "the recomputed option warnings must match what the loader \
+                 raised, for {expected}"
+            );
+            if *expected == "none" {
+                assert!(recomputed.is_empty(), "a valid option must be quiet");
+            } else {
+                assert!(
+                    codes(&recomputed).contains(expected),
+                    "fixture must actually raise {expected}; got {:?}",
+                    codes(&recomputed)
+                );
+            }
+        }
+    }
+
+    /// `reported_errors` is what every reporting surface reads and `errors` is
+    /// what every soundness gate reads. If option diagnostics ever leak into
+    /// the second, `run_validation` starts skipping; if they ever fall out of
+    /// the first, surfaces go silent again. Both directions, pinned.
+    #[test]
+    fn option_diagnostics_are_reported_but_do_not_gate() {
+        let load = load_and_book(BAD_OPTION);
+
+        assert!(
+            codes(&load.reported_errors()).contains(&"E7001"),
+            "reported_errors must carry the option error; got {:?}",
+            codes(&load.reported_errors())
+        );
+        assert!(
+            !codes(&load.errors).contains(&"E7001"),
+            "`errors` is the soundness gate's input and must NOT carry it; got {:?}",
+            codes(&load.errors)
+        );
+        assert!(
+            !has_fatal(&load.errors),
+            "an invalid option must not read as an unsound directive stream"
         );
     }
 }

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -846,6 +846,7 @@ option "operating_currency" "USD"
             directives: processed.directives.clone(),
             options: processed.options.clone(),
             parse_errors: Vec::new(),
+            option_errors: Vec::new(),
             validation_errors: Vec::new(),
         };
 

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -14,7 +14,7 @@ use rustledger_parser::ParseResult as ParserResult;
 use crate::cache;
 use crate::convert::directive_to_json;
 use crate::editor;
-use crate::helpers::{has_fatal, load_and_book, run_validation, to_js};
+use crate::helpers::{has_fatal, load_and_book, option_warnings_to_errors, run_validation, to_js};
 #[cfg(feature = "plugins")]
 use crate::types::PluginResult;
 use crate::types::{Error, FormatResult, LedgerOptions, PadResult, QueryResult};
@@ -209,15 +209,21 @@ impl ParsedLedger {
     #[wasm_bindgen(constructor)]
     pub fn new(source: &str) -> Self {
         let load = load_and_book(source);
+        // Before merging option diagnostics in: `run_validation` gates on
+        // `load.errors`, and an invalid option must not stop a ledger's real
+        // validation errors from being reported (#2299).
         let validation_errors = run_validation(&load);
         let editor_cache = editor::EditorCache::new(source, &load.parse_result);
+
+        let mut parse_errors = load.errors;
+        parse_errors.extend(load.option_errors);
 
         Self {
             source: source.to_string(),
             parse_result: load.parse_result,
             directives: load.directives,
             options: load.options,
-            parse_errors: load.errors,
+            parse_errors,
             validation_errors,
             editor_cache,
         }
@@ -508,42 +514,6 @@ pub struct Ledger {
     errors: Vec<Error>,
     /// Editor cache for cross-file completions.
     editor_cache: editor::EditorCache,
-}
-
-/// Option warnings as WASM `Error`s, carrying the severity `rledger check`
-/// gives them.
-///
-/// A free function rather than an inline loop because its only caller is a
-/// `wasm_bindgen` entry point taking `JsValue`, which cannot be called from a
-/// native test. The mapping is the part that was wrong, so it lives where a
-/// test can reach it.
-///
-/// E7003 and E7009 are warnings to `check`, which exits 0 on them. They used
-/// to go out here as errors, under a comment claiming parity with `check` and
-/// the LSP, so a ledger the CLI called clean arrived carrying errors (#2291).
-///
-/// `code` and `phase` are set rather than left `None` (#2297). The code used
-/// to survive only as an `[E7009] ` prefix on the message, which meant a
-/// consumer wanting to branch on it had to parse it back out of the text that
-/// `Error::code` exists to save them from reading.
-///
-/// Two changes, then. The code moves into the `code` field, and `phase` is
-/// set from `OptionWarning::phase`, the same source `rledger check` reads, so
-/// the two cannot drift the way the severity rule did. The prefix is dropped
-/// from the message, so the text now matches the CLI's for the same warning
-/// exactly.
-fn option_warnings_to_errors(warnings: &[rustledger_loader::OptionWarning]) -> Vec<Error> {
-    warnings
-        .iter()
-        .map(|w| {
-            let base = if w.is_error() {
-                Error::new(w.message.clone())
-            } else {
-                Error::warning(w.message.clone())
-            };
-            base.with_code(w.code).with_phase(w.phase())
-        })
-        .collect()
 }
 
 #[wasm_bindgen]
@@ -873,6 +843,57 @@ mod option_warning_severity_tests {
         assert!(
             !broken.is_valid(),
             "E7001 is an error; the ledger must not read as valid"
+        );
+    }
+
+    /// End-to-end on the surface JS actually calls. `rledger check` errors and
+    /// exits 1 on this source; `new ParsedLedger(src)` used to report a clean
+    /// ledger, because the loader's E7001 was dropped before anyone could read
+    /// it (#2299).
+    #[test]
+    fn an_invalid_option_is_visible_through_the_constructor() {
+        let src = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
+        let parsed = ParsedLedger::new(src);
+
+        assert!(
+            parsed
+                .parse_errors
+                .iter()
+                .any(|e| e.code.as_deref() == Some("E7001")),
+            "E7001 must be reported; got {:?}",
+            parsed
+                .parse_errors
+                .iter()
+                .map(|e| (&e.code, e.severity))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !parsed.is_valid(),
+            "E7001 is an error, so the ledger must not read as valid — \
+             `rledger check` exits 1 on this source"
+        );
+    }
+
+    /// And the option error must not cost the ledger its real diagnostics:
+    /// `run_validation` is gated on `load.errors`, so an option folded in
+    /// there would silently swallow the undefined-account error below.
+    #[test]
+    fn an_invalid_option_does_not_hide_a_real_validation_error() {
+        let src = "option \"nonsense_option\" \"x\"\n\
+2024-01-01 open Assets:Cash USD\n\
+2024-01-02 * \"p\"\n  Assets:Cash 1 USD\n  Assets:NeverOpened -1 USD\n";
+        let parsed = ParsedLedger::new(src);
+
+        assert!(
+            parsed
+                .parse_errors
+                .iter()
+                .any(|e| e.code.as_deref() == Some("E7001")),
+            "precondition: the option error is reported"
+        );
+        assert!(
+            !parsed.validation_errors.is_empty(),
+            "the undefined-account error must survive alongside E7001"
         );
     }
 

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -845,6 +845,55 @@ mod option_warning_severity_tests {
         );
     }
 
+    /// The multi-file class caches the same diagnostics and decides validity
+    /// off the restored list, so it needs the round-trip pinned too.
+    ///
+    /// `Ledger::is_valid` is `!has_fatal(&self.errors)`, reading exactly what
+    /// `from_cache` handed back. Severity is the field that decides it, and
+    /// severity is what #2291 changed without bumping `CACHE_VERSION` — so a
+    /// round-trip that silently altered it would reproduce that bug from cache.
+    #[test]
+    fn ledger_option_diagnostics_survive_the_cache_round_trip() {
+        let warning = Error::warning("Option \"title\" specified twice".to_string())
+            .with_code("E7003")
+            .with_phase("parse");
+        let fatal = Error::new("Invalid option \"nonsense_option\"".to_string())
+            .with_code("E7001")
+            .with_phase("parse");
+
+        for (label, errors, expect_valid) in [
+            ("warning only", vec![warning.clone()], true),
+            ("with an error", vec![warning, fatal], false),
+        ] {
+            let ledger = Ledger {
+                directives: Vec::new(),
+                options: LedgerOptions::default(),
+                account_types: rustledger_core::AccountTypes::default(),
+                errors,
+                editor_cache: editor::EditorCache::from_directives(&[]),
+            };
+            let restored =
+                Ledger::from_cache(&ledger.serialize().expect("serialize")).expect("restore");
+
+            let shape = |l: &Ledger| -> Vec<(Option<String>, Severity)> {
+                l.errors
+                    .iter()
+                    .map(|e| (e.code.clone(), e.severity))
+                    .collect()
+            };
+            assert_eq!(
+                shape(&restored),
+                shape(&ledger),
+                "{label}: code and severity must both survive the round trip"
+            );
+            assert_eq!(
+                restored.is_valid(),
+                expect_valid,
+                "{label}: validity is decided off the restored list"
+            );
+        }
+    }
+
     /// The cache must carry option diagnostics, or a cached ledger reports
     /// clean where a fresh one reports E7001.
     ///

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -845,6 +845,42 @@ mod option_warning_severity_tests {
         );
     }
 
+    /// The cache must carry option diagnostics, or a cached ledger reports
+    /// clean where a fresh one reports E7001.
+    ///
+    /// `from_cache` restores `parse_errors` verbatim and re-parses the source
+    /// only for editor spans, so nothing downstream would re-derive these. The
+    /// cross-version case is handled by the `CACHE_VERSION` 21 bump; this pins
+    /// the round-trip itself, which is what makes the bump sufficient.
+    #[test]
+    fn option_diagnostics_survive_the_cache_round_trip() {
+        let src = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
+        let fresh = ParsedLedger::new(src);
+        let restored =
+            ParsedLedger::from_cache(&fresh.serialize().expect("serialize"), src).expect("restore");
+
+        let codes = |p: &ParsedLedger| -> Vec<String> {
+            p.parse_errors
+                .iter()
+                .filter_map(|e| e.code.clone())
+                .collect()
+        };
+        assert!(
+            codes(&fresh).contains(&"E7001".to_string()),
+            "precondition: a fresh parse reports it"
+        );
+        assert_eq!(
+            codes(&restored),
+            codes(&fresh),
+            "a restored ledger must report what a fresh one does"
+        );
+        assert_eq!(
+            restored.is_valid(),
+            fresh.is_valid(),
+            "and must agree on validity"
+        );
+    }
+
     /// End-to-end on the surface JS actually calls. `rledger check` errors and
     /// exits 1 on this source; `new ParsedLedger(src)` used to report a clean
     /// ledger, because the loader's E7001 was dropped before anyone could read

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -215,8 +215,7 @@ impl ParsedLedger {
         let validation_errors = run_validation(&load);
         let editor_cache = editor::EditorCache::new(source, &load.parse_result);
 
-        let mut parse_errors = load.errors;
-        parse_errors.extend(load.option_errors);
+        let parse_errors = load.reported_errors();
 
         Self {
             source: source.to_string(),

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -194,7 +194,18 @@ pub struct ParsedLedger {
     /// Ledger options.
     options: LedgerOptions,
     /// Parse errors.
+    /// Parse and booking errors — the *soundness* list.
+    ///
+    /// Every operation gate below reads this and only this. An entry here means
+    /// the directive stream could not be built, so running a query over it
+    /// would be answering with data that does not exist.
     parse_errors: Vec<Error>,
+    /// Option diagnostics (E7001, E7003, ...), kept out of `parse_errors` for
+    /// the same reason they are kept out of `ProcessedLedger::errors`: an
+    /// invalid option does not make the directive stream unsound, so it must
+    /// not stop a query from running. Reported by `isValid`, `getErrors`, and
+    /// `getParseErrors`; invisible to the gates.
+    option_errors: Vec<Error>,
     /// Validation errors.
     validation_errors: Vec<Error>,
     /// Cached editor data (accounts, currencies, payees, line index).
@@ -215,14 +226,13 @@ impl ParsedLedger {
         let validation_errors = run_validation(&load);
         let editor_cache = editor::EditorCache::new(source, &load.parse_result);
 
-        let parse_errors = load.reported_errors();
-
         Self {
             source: source.to_string(),
             parse_result: load.parse_result,
             directives: load.directives,
             options: load.options,
-            parse_errors,
+            parse_errors: load.errors,
+            option_errors: load.option_errors,
             validation_errors,
             editor_cache,
         }
@@ -236,13 +246,16 @@ impl ParsedLedger {
     /// warning-severity validation entry used to read as invalid here (#2291).
     #[wasm_bindgen(js_name = "isValid")]
     pub fn is_valid(&self) -> bool {
-        !has_fatal(&self.parse_errors) && !has_fatal(&self.validation_errors)
+        !has_fatal(&self.parse_errors)
+            && !has_fatal(&self.option_errors)
+            && !has_fatal(&self.validation_errors)
     }
 
     /// Get all errors (parse + validation).
     #[wasm_bindgen(js_name = "getErrors")]
     pub fn get_errors(&self) -> Result<JsValue, JsError> {
         let mut all_errors = self.parse_errors.clone();
+        all_errors.extend(self.option_errors.clone());
         all_errors.extend(self.validation_errors.clone());
         to_js(&all_errors)
     }
@@ -250,7 +263,11 @@ impl ParsedLedger {
     /// Get parse errors only.
     #[wasm_bindgen(js_name = "getParseErrors")]
     pub fn get_parse_errors(&self) -> Result<JsValue, JsError> {
-        to_js(&self.parse_errors)
+        // Option diagnostics carry `phase: "parse"`, so they belong in the
+        // parse-phase view even though the gates must not see them.
+        let mut errors = self.parse_errors.clone();
+        errors.extend(self.option_errors.clone());
+        to_js(&errors)
     }
 
     /// Get validation errors only.
@@ -436,6 +453,7 @@ impl ParsedLedger {
             directives: self.directives.clone(),
             options: self.options.clone(),
             parse_errors: self.parse_errors.clone(),
+            option_errors: self.option_errors.clone(),
             validation_errors: self.validation_errors.clone(),
         };
         cache::serialize_parsed(&payload).map_err(|e| JsError::new(&e))
@@ -468,6 +486,7 @@ impl ParsedLedger {
             directives: payload.directives,
             options: payload.options,
             parse_errors: payload.parse_errors,
+            option_errors: payload.option_errors,
             validation_errors: payload.validation_errors,
             editor_cache,
         })
@@ -897,10 +916,13 @@ mod option_warning_severity_tests {
     /// The cache must carry option diagnostics, or a cached ledger reports
     /// clean where a fresh one reports E7001.
     ///
-    /// `from_cache` restores `parse_errors` verbatim and re-parses the source
-    /// only for editor spans, so nothing downstream would re-derive these. The
-    /// cross-version case is handled by the `CACHE_VERSION` 21 bump; this pins
-    /// the round-trip itself, which is what makes the bump sufficient.
+    /// `from_cache` restores the archived diagnostics verbatim and re-parses
+    /// the source only for editor spans, so nothing downstream re-derives
+    /// them. The cross-version case is handled by the `CACHE_VERSION` 21 bump;
+    /// this pins the round-trip itself, which is what makes the bump
+    /// sufficient. Both lists are checked: option diagnostics must come back,
+    /// and they must come back in `option_errors` rather than leaking into the
+    /// soundness list the operation gates read.
     #[test]
     fn option_diagnostics_survive_the_cache_round_trip() {
         let src = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
@@ -908,25 +930,72 @@ mod option_warning_severity_tests {
         let restored =
             ParsedLedger::from_cache(&fresh.serialize().expect("serialize"), src).expect("restore");
 
-        let codes = |p: &ParsedLedger| -> Vec<String> {
-            p.parse_errors
-                .iter()
-                .filter_map(|e| e.code.clone())
-                .collect()
+        let codes = |errors: &[Error]| -> Vec<String> {
+            errors.iter().filter_map(|e| e.code.clone()).collect()
         };
         assert!(
-            codes(&fresh).contains(&"E7001".to_string()),
+            codes(&fresh.option_errors).contains(&"E7001".to_string()),
             "precondition: a fresh parse reports it"
         );
         assert_eq!(
-            codes(&restored),
-            codes(&fresh),
+            codes(&restored.option_errors),
+            codes(&fresh.option_errors),
             "a restored ledger must report what a fresh one does"
+        );
+        assert!(
+            restored.parse_errors.is_empty(),
+            "and must not restore them into the list the operation gates read"
         );
         assert_eq!(
             restored.is_valid(),
             fresh.is_valid(),
             "and must agree on validity"
+        );
+    }
+
+    /// A warning-only ledger must still be operable.
+    ///
+    /// `rledger check` exits 0 on a duplicated option (E7003 is a warning), and
+    /// `isValid()` agrees. But `query`, `format`, `expandPads`, and `runPlugin`
+    /// gate on `!parse_errors.is_empty()` — an emptiness test, which is exactly
+    /// what #2291 replaced in `is_valid` and did not replace here. Routing
+    /// option diagnostics through that list made every one of those operations
+    /// refuse to run on a ledger reporting itself valid.
+    #[test]
+    fn a_warning_only_option_does_not_disable_operations() {
+        let src = "option \"title\" \"a\"\noption \"title\" \"b\"\n\
+2024-01-01 open Assets:Cash USD\n";
+        let parsed = ParsedLedger::new(src);
+
+        assert!(
+            parsed
+                .option_errors
+                .iter()
+                .any(|e| e.code.as_deref() == Some("E7003")),
+            "precondition: the fixture raises the warning"
+        );
+        assert!(parsed.is_valid(), "a warning-only ledger is valid");
+        assert!(
+            parsed.parse_errors.is_empty(),
+            "the gates read `parse_errors`; an option warning must not land \
+             there or every operation refuses to run while isValid() says true"
+        );
+    }
+
+    /// And an option ERROR must not disable them either: it does not make the
+    /// directive stream unsound, which is the only thing those gates mean.
+    /// `api::query` already behaves this way, so `ParsedLedger::query` doing
+    /// otherwise would be the same operation answering two ways.
+    #[test]
+    fn an_invalid_option_does_not_disable_operations() {
+        let src = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
+        let parsed = ParsedLedger::new(src);
+
+        assert!(!parsed.is_valid(), "precondition: E7001 makes it invalid");
+        assert!(
+            parsed.parse_errors.is_empty(),
+            "an invalid option is reported, but the directives are sound and \
+             a query over them must still run"
         );
     }
 
@@ -941,12 +1010,12 @@ mod option_warning_severity_tests {
 
         assert!(
             parsed
-                .parse_errors
+                .option_errors
                 .iter()
                 .any(|e| e.code.as_deref() == Some("E7001")),
             "E7001 must be reported; got {:?}",
             parsed
-                .parse_errors
+                .option_errors
                 .iter()
                 .map(|e| (&e.code, e.severity))
                 .collect::<Vec<_>>()
@@ -970,7 +1039,7 @@ mod option_warning_severity_tests {
 
         assert!(
             parsed
-                .parse_errors
+                .option_errors
                 .iter()
                 .any(|e| e.code.as_deref() == Some("E7001")),
             "precondition: the option error is reported"

--- a/crates/rustledger-wasm/tests/wasm_meta.rs
+++ b/crates/rustledger-wasm/tests/wasm_meta.rs
@@ -336,3 +336,98 @@ fn custom_directive_values_exposed_1168() {
         "TRUE arg must surface as a JS boolean inside `value`",
     );
 }
+
+/// The JS wire contract for an invalid option on the single-source entry
+/// points (#2299).
+///
+/// `parse` and `validateSource` are `wasm_bindgen` functions returning
+/// `JsValue`, so no native unit test can reach them: the helper and
+/// `ParsedLedger` tests would all still pass with either merge deleted. This
+/// is the only place the reported repro is actually pinned, and it belongs
+/// here rather than in `wasm.rs`, which is browser-only and skipped in CI.
+#[wasm_bindgen_test]
+fn invalid_option_reaches_js_from_parse_2299() {
+    let source = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
+
+    let result = rustledger_wasm::parse(source).expect("parse should not throw");
+    let errors = get_field(&result, "errors");
+    assert_eq!(
+        get_array_length(&errors),
+        1,
+        "an invalid option must be reported by `parse`"
+    );
+
+    let e = js_sys::Array::from(&errors).get(0);
+    assert_eq!(
+        get_field(&e, "code").as_string().as_deref(),
+        Some("E7001"),
+        "the code must arrive in the `code` field, not buried in the message"
+    );
+    assert_eq!(
+        get_field(&e, "severity").as_string().as_deref(),
+        Some("error"),
+        "E7001 is an error to `rledger check`, which exits 1 on this source"
+    );
+    assert_eq!(
+        get_field(&e, "phase").as_string().as_deref(),
+        Some("parse"),
+        "phase comes from `OptionWarning::phase`"
+    );
+}
+
+/// The same source through `validateSource`, which additionally has to report
+/// `valid: false` — the field a caller actually branches on.
+#[wasm_bindgen_test]
+fn invalid_option_reaches_js_from_validate_source_2299() {
+    let source = "option \"nonsense_option\" \"x\"\n2024-01-01 open Assets:Cash USD\n";
+
+    let result = rustledger_wasm::validate_source(source).expect("should not throw");
+    assert_eq!(
+        get_field(&result, "valid").as_bool(),
+        Some(false),
+        "a ledger the CLI exits 1 on must not validate clean"
+    );
+
+    let errors = js_sys::Array::from(&get_field(&result, "errors"));
+    let mut codes: Vec<String> = Vec::new();
+    for i in 0..errors.length() {
+        if let Some(c) = get_field(&errors.get(i), "code").as_string() {
+            codes.push(c);
+        }
+    }
+    assert!(
+        codes.iter().any(|c| c == "E7001"),
+        "E7001 must reach JS; got {codes:?}"
+    );
+}
+
+/// A duplicated option is a WARNING: `rledger check` exits 0 on it, so the
+/// ledger must validate clean while the diagnostic is still reported. This is
+/// the direction #2291 got wrong, pinned at the wire.
+#[wasm_bindgen_test]
+fn a_warning_option_still_validates_clean_2299() {
+    let source =
+        "option \"title\" \"a\"\noption \"title\" \"b\"\n2024-01-01 open Assets:Cash USD\n";
+
+    let result = rustledger_wasm::validate_source(source).expect("should not throw");
+    assert_eq!(
+        get_field(&result, "valid").as_bool(),
+        Some(true),
+        "a warning-only ledger is valid; `rledger check` exits 0 on it"
+    );
+
+    let errors = js_sys::Array::from(&get_field(&result, "errors"));
+    let mut found = false;
+    for i in 0..errors.length() {
+        let e = errors.get(i);
+        if get_field(&e, "code").as_string().as_deref() == Some("E7003") {
+            assert_eq!(
+                get_field(&e, "severity").as_string().as_deref(),
+                Some("warning"),
+                "E7003 is a warning (#2291)"
+            );
+            found = true;
+        }
+    }
+    assert!(found, "the warning must still be reported");
+}


### PR DESCRIPTION
An invalid option was completely invisible to `ParsedLedger`, `parse`, and `validateSource`, while `rledger check` reported E7001 and exited 1. The two WASM surfaces also disagreed with each other, since `Ledger::from_files` did report it.

```
option "nonsense_option" "x"
2024-01-01 open Assets:Cash USD
```

| | before | after |
|---|---|---|
| `rledger check` | `error[E7001]` exit 1 | unchanged |
| `Ledger::from_files` | E7001 reported | unchanged |
| `ParsedLedger::new` | *silent* | `E7001`, `isValid() == false` |
| `validateSource` | *silent* | `E7001`, `valid: false` |
| `parse` | *silent* | `E7001` |

## Two surfaces, two different causes

#2299 gave one cause for all three. Reviewing it found that wrong, in a way that pointed at the wrong fix — the issue body has been corrected.

- **`parse`** never builds a loader `Options`, so `Options::set` never ran and no warning was ever produced. It now validates the parsed option tuples directly. That is option-only work — no IO, no booking, no plugins — so a syntax-only entry point stays syntax-only in cost.
- **`load_and_book`** *does* run the loader, so E7001 was produced and then dropped on the floor: `extract_loader_options` lifts only `title` and `operating_currency` off `raw.options`, and nothing read `warnings`. They were even still there after `process()`, at the exact address the multi-file path reads.

## Why these are not in `ProcessedLedger::errors`

Because the obvious one-liner breaks validation. `run_validation` skips when `has_fatal(&load.errors)`, and that gate means *"the directive stream is unsound to work with"* — a parse or booking failure. An invalid option does not make directives unsound, so folding it in makes a typo'd option silently swallow a ledger's real validation errors:

```
validation errors, invalid option absent :  1
validation errors, E7001 pushed as fatal:   0
```

That is the drop #2292 fixed for plugin warnings, one field over. `option_errors` is therefore its own field: surfaces that *report* diagnostics merge it in, surfaces that gate on soundness do not. `an_invalid_option_does_not_suppress_validation` pins it — mutating the fix to fold them in fails that test and nothing else.

## One converter

`option_warnings_to_errors` moves to `helpers.rs` so both paths share it, carrying the #2291/#2292/#2297/#2298 history with it: severity, code, and phase each drifted once, when a surface decided them locally instead of reading them off the warning.

## Verification

By mutation, not by reading. Restoring the drop (`option_errors = Vec::new()`) fails 5 tests, including the parity test that pins the recomputed warnings against the loader's. And on the issue's own repro the surfaces now agree with the CLI field for field: code `E7001`, severity `error`, phase `parse`, same message.

Gates: `cargo test --workspace` 156 suites pass, `cargo +1.97.0 clippy --workspace --all-targets --all-features -D warnings` clean, `RUSTDOCFLAGS=-D warnings cargo doc` clean.

Fixes #2299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)