### PR TITLE
docs: an AI must not comment where another person is involved

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,75 @@ cargo llvm-cov --html
 - Don't add unnecessary error handling for impossible cases
 - Don't create abstractions for one-time operations
 - Don't add backwards-compatibility shims - just change the code
+
+## AI Commenting Policy
+
+**An AI assistant must not post a comment or reply into any Issue, Pull
+Request, or Discussion where a human other than the maintainer (`robcohen`) is
+involved.** It drafts the text to a file and hands over the path; the
+maintainer reads it and posts it himself.
+
+The point is that no AI-written text reaches another person under the
+maintainer's name without him having read it first.
+
+### Scope
+
+Every repository in the `rustledger` organization: `rustledger`, `rustfava`,
+`pta-standards`, `scoop-rustledger`, `homebrew-rustledger`, `oss-fuzz`, and
+`.github`.
+
+### What is still permitted
+
+| Action | Allowed | Why |
+|--------|---------|-----|
+| Commenting on a thread where `robcohen` is the only human | Yes | Nobody else is being written to |
+| Replying to and resolving a **bot** review thread | Yes | Bots are not people, and `main` requires conversation resolution — refusing to resolve would stall every PR |
+| Opening a new Issue | Yes | The restriction is comments and replies on existing threads |
+| Writing or editing a PR body / description | Yes | Same |
+| Commit messages, code, branches | Yes | These reach the maintainer through review before they reach anyone else |
+| Commenting on a thread any other human has touched | **No** | Draft it instead |
+
+### Checking before commenting
+
+Participation is checked, never assumed. Ask GitHub whether an account is a
+bot — `.user.type` and `is_bot` are authoritative — rather than matching on the
+name. The same reviewer appears as `Copilot` on one endpoint and
+`copilot-pull-request-reviewer[bot]` on another, so a name list silently
+misclassifies it as a person.
+
+```bash
+# Humans other than the maintainer involved in issue/PR <N>.
+# Empty output => the maintainer's alone => an AI may comment directly.
+#
+# `gh api` prints its error body to STDOUT on 404, and the two /pulls/
+# endpoints 404 for a plain issue — so each call is guarded by its exit status.
+# Without that, every issue looks like it has a participant named
+# `{"message":"Not Found"...}` and the check blocks on its own noise.
+others() {
+  repo="${1:-rustledger/rustledger}"; n="$2"
+  for ep in "issues/$n" "issues/$n/comments" "pulls/$n/comments" "pulls/$n/reviews"; do
+    case "$ep" in
+      "issues/$n") q='select(.user.type=="User") | .user.login' ;;
+      *)           q='.[] | select(.user.type=="User") | .user.login' ;;
+    esac
+    if out=$(gh api "repos/$repo/$ep" --jq "$q" 2>/dev/null); then
+      printf '%s\n' "$out"
+    fi
+  done | sort -u | grep -v '^robcohen$' | grep -v '^$'
+}
+```
+
+All four endpoints are needed. Issue comments and review-thread comments are
+separate APIs, and a human reviewer leaving an inline comment appears only in
+`pulls/<N>/comments` — exactly the case this policy exists for. The first call
+catches an issue opened by someone else that nobody has replied to yet.
+
+Verified against this repo: `#2300`, `#2302`, `#2303` return nothing (the
+maintainer plus bots), while `#1387` returns `bkuhn caesar`, `#923` returns
+`alensiljak`, and `#2264` / `#2295` return `petemounce`.
+
+### When the policy blocks a comment
+
+Write the intended comment to a file, then say plainly that it was not posted
+and where it is. Do not post a shortened version, and do not route the message
+through a bot thread.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,78 @@ The project is a Cargo workspace with 16 crates plus editor extensions:
 - Use `# Errors` section to document error conditions
 - Use `# Panics` section if function can panic
 
+## AI Commenting Policy
+
+**An AI assistant must not post a comment or reply into any Issue, Pull
+Request, or Discussion where a human other than the maintainer (`robcohen`) is
+involved.** It drafts the text to a file and hands over the path; the
+maintainer reads it and posts it himself.
+
+The point is that no AI-written text reaches another person under the
+maintainer's name without him having read it first.
+
+### Scope
+
+Every repository in the `rustledger` organization: `rustledger`, `rustfava`,
+`pta-standards`, `scoop-rustledger`, `homebrew-rustledger`, `oss-fuzz`, and
+`.github`.
+
+### What is still permitted
+
+| Action | Allowed | Why |
+|--------|---------|-----|
+| Commenting on a thread where `robcohen` is the only human | Yes | Nobody else is being written to |
+| Replying to and resolving a **bot** review thread | Yes | Bots are not people, and `main` requires conversation resolution — refusing to resolve would stall every PR |
+| Opening a new Issue | Yes | The restriction is comments and replies on existing threads |
+| Writing or editing a PR body / description | Yes | Same |
+| Commit messages, code, branches | Yes | These reach the maintainer through review before they reach anyone else |
+| Commenting on a thread any other human has touched | **No** | Draft it instead |
+
+### Checking before commenting
+
+Participation is checked, never assumed. Ask GitHub whether an account is a
+bot — `.user.type` and `is_bot` are authoritative — rather than matching on the
+name. The same reviewer appears as `Copilot` on one endpoint and
+`copilot-pull-request-reviewer[bot]` on another, so a name list silently
+misclassifies it as a person.
+
+```bash
+# Humans other than the maintainer involved in issue/PR <N>.
+# Empty output => the maintainer's alone => an AI may comment directly.
+#
+# `gh api` prints its error body to STDOUT on 404, and the two /pulls/
+# endpoints 404 for a plain issue — so each call is guarded by its exit status.
+# Without that, every issue looks like it has a participant named
+# `{"message":"Not Found"...}` and the check blocks on its own noise.
+others() {
+  repo="${1:-rustledger/rustledger}"; n="$2"
+  for ep in "issues/$n" "issues/$n/comments" "pulls/$n/comments" "pulls/$n/reviews"; do
+    case "$ep" in
+      "issues/$n") q='select(.user.type=="User") | .user.login' ;;
+      *)           q='.[] | select(.user.type=="User") | .user.login' ;;
+    esac
+    if out=$(gh api "repos/$repo/$ep" --jq "$q" 2>/dev/null); then
+      printf '%s\n' "$out"
+    fi
+  done | sort -u | grep -v '^robcohen$' | grep -v '^$'
+}
+```
+
+All four endpoints are needed. Issue comments and review-thread comments are
+separate APIs, and a human reviewer leaving an inline comment appears only in
+`pulls/<N>/comments` — exactly the case this policy exists for. The first call
+catches an issue opened by someone else that nobody has replied to yet.
+
+Verified against this repo: `#2300`, `#2302`, `#2303` return nothing (the
+maintainer plus bots), while `#1387` returns `bkuhn caesar`, `#923` returns
+`alensiljak`, and `#2264` / `#2295` return `petemounce`.
+
+### When the policy blocks a comment
+
+Write the intended comment to a file, then say plainly that it was not posted
+and where it is. Do not post a shortened version, and do not route the message
+through a bot thread.
+
 ## Pull Request Review Policy
 
 ### Review Checklist


### PR DESCRIPTION
Maintainer policy, 2026-09-12. **No AI-written text reaches another person under the maintainer's name without him having read it first.** An AI drafts the comment to a file and hands over the path; he posts it himself.

Added to both `CLAUDE.md` and `AGENTS.md`, since different tools read different files. Scoped to every repository in the org.

## Deliberately narrow in three places

Each was decided rather than assumed:

- **Bots are not people.** A PR with only the maintainer plus Copilot and CodeQL is his alone. This is load bearing: `main` requires conversation resolution, so an AI that refused to resolve bot threads would stall every PR.
- **Opening issues and writing PR bodies stay permitted.** The restriction is comments and replies on existing threads.
- **Commit messages and code are unaffected** — they reach him through review before they reach anyone else.

## The check asks GitHub, it does not match names

`.user.type` and `is_bot` are authoritative. A name list is already wrong on this repo: the same reviewer is `Copilot` on `pulls/<N>/comments` and `copilot-pull-request-reviewer[bot]` on `pulls/<N>/reviews`. Matching would classify one of them as a person and refuse to comment on the maintainer's own PR.

Four endpoints, because two details bite:

- Issue comments and review-thread comments are **separate APIs**. A human leaving an inline review comment appears only in `pulls/<N>/comments` — precisely the case this policy exists for. Querying `issues/<N>/comments` alone would miss them.
- Each call is guarded by its **exit status**, because `gh api` prints its 404 body to stdout and the `/pulls/` endpoints 404 on a plain issue. Unguarded, every issue appears to have a participant named `{"message":"Not Found"...}` and the check blocks on its own noise. I hit exactly that while testing.

## Verified

The snippet was extracted from the committed file and run as written:

| thread | result |
|---|---|
| #1387 | `bkuhn caesar` → draft only |
| #923 | `alensiljak` → draft only |
| #2264, #2295 | `petemounce` → draft only |
| #2300, #2302, #2303 | nothing → may comment |

## Note on this PR

Opening it is permitted under the policy — it is a PR body, not a comment on someone else's thread, and nobody else is involved yet. If you comment here, the policy starts applying to this PR and I will draft rather than reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)